### PR TITLE
Use explicit flag to check if there is on-going request to server

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -378,7 +378,7 @@ window.boltConfig = <?php echo $block->getSettings(); ?>;
 
         check: function () {
             if (createRequest || !cart.orderToken) {
-                console.log("Retrieving order token from server... not ready to checkout yet."):
+                console.log("Retrieving order token from server... not ready to checkout yet.");
                 return false;
             }
             return true;
@@ -448,7 +448,7 @@ window.boltConfig = <?php echo $block->getSettings(); ?>;
         };
         var onError = function(error) {
             createRequest = null;
-        }
+        };
         // send create order request
         createRequest = ajaxPost(settings.create_order_url, params, onSuccess, onError);
     };

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -376,11 +376,12 @@ window.boltConfig = <?php echo $block->getSettings(); ?>;
             save_request = ajaxPost(settings.save_order_url, parameters, onSuccess);
         },
 
-        // the Bolt order is created right after the checkout button is clicked
-        // and the checkout modal popup is opened only if order creation was successfull
         check: function () {
-            // if orderToken is set the checkout window will open
-            return !!cart.orderToken;
+            if (createRequest || !cart.orderToken) {
+                console.log("Retrieving order token from server... not ready to checkout yet."):
+                return false;
+            }
+            return true;
         },
 
         onEmailEnter: function(email) {
@@ -412,11 +413,9 @@ window.boltConfig = <?php echo $block->getSettings(); ?>;
     /////////////////////////////////////////////////////
     // Create Bolt order and configure BoltCheckout
     /////////////////////////////////////////////////////
-    var create_request;
+    var createRequest;
     var createOrder = function () {
-        if (create_request) create_request.abort();
-        // preset success condition to false
-        cart.orderToken = '';
+        if (createRequest) createRequest.abort();
         // define the params sent with the request variable
         var params = [];
         // check and set payment_only flag
@@ -434,6 +433,7 @@ window.boltConfig = <?php echo $block->getSettings(); ?>;
         // set cart and hints data in a response callback
         var onSuccess = function(data){
             cart = data.cart;
+            createRequest = null;
 
             var prefill = isObject(data.hints.prefill) ? deepMergeObjects(hints.prefill, data.hints.prefill) : hints.prefill;
             hints = deepMergeObjects(hints, data.hints);
@@ -446,8 +446,11 @@ window.boltConfig = <?php echo $block->getSettings(); ?>;
             // prefetch Shipping and Tax for multi-step checkout
             if (getCheckoutType() === 'checkout') prefetchShipping();
         };
+        var onError = function(error) {
+            createRequest = null;
+        }
         // send create order request
-        create_request = ajaxPost(settings.create_order_url, params, onSuccess);
+        createRequest = ajaxPost(settings.create_order_url, params, onSuccess, onError);
     };
     /////////////////////////////////////////////////////
 


### PR DESCRIPTION
Before this PR, we use `cart.orderToken` as flag and set empty value to indicate "there is ongoing request" but it was problematic because race condition can lead bolt to read empty order token.