### PR TITLE
abandoned email hotfix

### DIFF
--- a/Controller/Cart/Email.php
+++ b/Controller/Cart/Email.php
@@ -23,9 +23,7 @@ use Magento\Checkout\Model\Session as CheckoutSession;
 use \Magento\Customer\Model\Session as CustomerSession;
 use Bolt\Boltpay\Helper\Bugsnag;
 use Magento\Framework\Exception\LocalizedException;
-use Bolt\Boltpay\Helper\Config as ConfigHelper;
 use Bolt\Boltpay\Helper\Cart as CartHelper;
-use Magento\Quote\Model\QuoteFactory;
 
 /**
  * Class Email.
@@ -45,23 +43,15 @@ class Email extends Action
     /** @var Bugsnag */
     private $bugsnag;
 
-    /** @var ConfigHelper */
-    private $configHelper;
-
     /** @var CartHelper */
     private $cartHelper;
-
-    /** @var QuoteFactory */
-    private $quoteFactory;
 
     /**
      * @param Context $context
      * @param CheckoutSession $checkoutSession
      * @param CustomerSession $customerSession
      * @param Bugsnag $bugsnag
-     * @param ConfigHelper $configHelper
      * @param CartHelper $cartHelper
-     * @param QuoteFactory $quoteFactory
      *
      * @codeCoverageIgnore
      */
@@ -70,17 +60,13 @@ class Email extends Action
         CheckoutSession $checkoutSession,
         CustomerSession $customerSession,
         Bugsnag $bugsnag,
-        ConfigHelper $configHelper,
-        CartHelper $cartHelper,
-        QuoteFactory $quoteFactory
+        CartHelper $cartHelper
     ) {
         parent::__construct($context);
         $this->checkoutSession = $checkoutSession;
         $this->customerSession = $customerSession;
         $this->bugsnag = $bugsnag;
-        $this->configHelper = $configHelper;
         $this->cartHelper = $cartHelper;
-        $this->quoteFactory = $quoteFactory;
     }
 
     /**
@@ -91,15 +77,11 @@ class Email extends Action
     {
         try {
 
-            $quoteId = $this->getRequest()->getParam('orderReference');
-
             /** @var Quote */
-            $quote = $this->quoteFactory->create()->load($quoteId);
+            $quote = $this->checkoutSession->getQuote();
 
             if (!$quote || !$quote->getId()) {
-                throw new LocalizedException(
-                    __('Unknown quote id: %1.', $quoteId)
-                );
+                throw new LocalizedException(__('Quote does not exist.'));
             }
 
             $email = $this->customerSession->isLoggedIn() ?

--- a/Controller/Shipping/Prefetch.php
+++ b/Controller/Shipping/Prefetch.php
@@ -20,7 +20,6 @@ namespace Bolt\Boltpay\Controller\Shipping;
 use Exception;
 use Magento\Framework\App\Action\Action;
 use Magento\Framework\App\Action\Context;
-use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\Quote\Model\Quote;
 use Magento\Framework\HTTP\ZendClientFactory;
 use Bolt\Boltpay\Model\Api\ShippingMethods;
@@ -40,9 +39,6 @@ use Magento\Quote\Model\QuoteFactory;
  */
 class Prefetch extends Action
 {
-    /** @var CheckoutSession */
-    private $checkoutSession;
-
     /** @var CustomerSession */
     private $customerSession;
 
@@ -81,7 +77,6 @@ class Prefetch extends Action
 
     /**
      * @param Context $context
-     * @param CheckoutSession $checkoutSession
      * @param ZendClientFactory $httpClientFactory
      * @param ShippingMethods $shippingMethods
      * @param CartHelper $cartHelper
@@ -94,7 +89,6 @@ class Prefetch extends Action
      */
     public function __construct(
         Context $context,
-        CheckoutSession $checkoutSession,
         ZendClientFactory $httpClientFactory,
         ShippingMethods $shippingMethods,
         CartHelper $cartHelper,
@@ -104,7 +98,6 @@ class Prefetch extends Action
         QuoteFactory $quoteFactory
     ) {
         parent::__construct($context);
-        $this->checkoutSession   = $checkoutSession;
         $this->httpClientFactory = $httpClientFactory;
         $this->shippingMethods   = $shippingMethods;
         $this->cartHelper        = $cartHelper;

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -399,7 +399,7 @@ window.boltConfig = <?php echo $block->getSettings(); ?>;
 
         onEmailEnter: function(email) {
             if (callbacks.email !== email) {
-                ajaxPost(settings.save_email_url, 'email='+encodeURIComponent(email)+'&orderReference='+cart.orderReference);
+                ajaxPost(settings.save_email_url, 'email='+encodeURIComponent(email));
                 callbacks.email = email;
             }
         }


### PR DESCRIPTION
Small fix, tested. The abandoned cart email was assigned to immutable quote (status active = false) instead of parent, active quote. No emails were sent. Reported on Capillus.

Should be propagated / merged into master.