### PR TITLE
Cart data cloned quote id placeholder

### DIFF
--- a/Controller/Adminhtml/Cart/Data.php
+++ b/Controller/Adminhtml/Cart/Data.php
@@ -105,7 +105,7 @@ class Data extends Action
                 'authcapture' => true
             ];
 
-            $hints = $this->cartHelper->getHints($place_order_payload);
+            $hints = $this->cartHelper->getHints($place_order_payload, null);
 
             $result = $this->dataObjectFactory->create();
             $result->setData('cart', $cart);

--- a/Controller/Cart/Data.php
+++ b/Controller/Cart/Data.php
@@ -100,15 +100,15 @@ class Data extends Action
             $response = $boltpayOrder ? $boltpayOrder->getResponse() : null;
 
             // get immutable quote id stored with cart data
-            list(, $orderReference) = $response ? explode(' / ', $response->cart->display_id) : [null, ''];
+            list(, $cartReference) = $response ? explode(' / ', $response->cart->display_id) : [null, ''];
 
             $cart = [
                 'orderToken'  => $response ? $response->token : '',
                 'authcapture' => $this->configHelper->getAutomaticCaptureMode(),
-                'cartReference' => $orderReference,
+                'cartReference' => $cartReference,
             ];
 
-            $hints = $this->cartHelper->getHints($place_order_payload, $orderReference);
+            $hints = $this->cartHelper->getHints($place_order_payload, $cartReference);
 
             $result = $this->resultJsonFactory->create();
 

--- a/Controller/Cart/Data.php
+++ b/Controller/Cart/Data.php
@@ -99,12 +99,13 @@ class Data extends Action
             // format and send the response
             $response = $boltpayOrder ? $boltpayOrder->getResponse() : null;
 
-            $orderReference = $response ? $response->cart->order_reference : '';
+            // get immutable quote id stored with cart data
+            list(, $orderReference) = $response ? explode(' / ', $response->cart->display_id) : [null, ''];
 
             $cart = [
                 'orderToken'  => $response ? $response->token : '',
                 'authcapture' => $this->configHelper->getAutomaticCaptureMode(),
-                'orderReference' => $orderReference,
+                'cartReference' => $orderReference,
             ];
 
             $hints = $this->cartHelper->getHints($place_order_payload, $orderReference);

--- a/Controller/Shipping/Prefetch.php
+++ b/Controller/Shipping/Prefetch.php
@@ -134,7 +134,7 @@ class Prefetch extends Action
                 return;
             }
 
-            $quoteId = $this->getRequest()->getParam('orderReference');
+            $quoteId = $this->getRequest()->getParam('cartReference');
 
             /** @var Quote */
             $quote = $this->cartHelper->getQuoteById($quoteId);
@@ -144,7 +144,25 @@ class Prefetch extends Action
             }
 
             ///////////////////////////////////////////////////////////////////////////
-            // Prefetch shipping for geolocated address
+            // Prefetch Shipping and Tax for received location data
+            ///////////////////////////////////////////////////////////////////////////
+            $country  = $this->getRequest()->getParam('country');
+            $region   = $this->getRequest()->getParam('region');
+            $postcode = $this->getRequest()->getParam('postcode');
+
+            if ($country && $region && $postcode) {
+                $shipping_address = [
+                    'country_code' => $country,
+                    'postal_code'  => $postcode,
+                    'region'       => $region,
+                ];
+
+                $this->shippingMethods->shippingEstimation($quote, $shipping_address);
+            }
+            ///////////////////////////////////////////////////////////////////////////
+
+            ///////////////////////////////////////////////////////////////////////////
+            // Prefetch Shipping and Tax for geolocated address
             ///////////////////////////////////////////////////////////////////////////
             $ip = $this->getIpAddress();
 

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -305,15 +305,15 @@ class Cart extends AbstractHelper
      *
      * @param string $placeOrderPayload     additional data collected from the (one page checkout) page,
      *                                         i.e. billing address to be saved with the order
-     * @param string $orderReference        (immutable) quote id
+     * @param string $cartReference         (immutable) quote id
      *
      * @return array
      */
-    public function getHints($placeOrderPayload, $orderReference)
+    public function getHints($placeOrderPayload, $cartReference)
     {
         /** @var Quote */
-        $quote = $orderReference ?
-            $this->getQuoteById($orderReference) :
+        $quote = $cartReference ?
+            $this->getQuoteById($cartReference) :
             $this->checkoutSession->getQuote();
 
         if ($placeOrderPayload) {

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -221,19 +221,6 @@ class Cart extends AbstractHelper
     }
 
     /**
-     * Load Quote by reserved_order_id
-     * @param $reservedOrderId
-     * @return \Magento\Quote\Api\Data\CartInterface|mixed
-     */
-    public function getQuoteByReservedOrderId($reservedOrderId)
-    {
-        $searchCriteria = $this->searchCriteriaBuilder
-            ->addFilter('reserved_order_id', $reservedOrderId, 'eq')->create();
-        $collection = $this->quoteRepository->getList($searchCriteria)->getItems();
-        return reset($collection);
-    }
-
-    /**
      * Load Order by increment id
      * @param $incrementId
      * @return \Magento\Sales\Api\Data\OrderInterface|mixed
@@ -417,8 +404,15 @@ class Cart extends AbstractHelper
      */
     public function getCartData($paymentOnly, $placeOrderPayload, $quote = null)
     {
+        // If the quote is passed to the method it is already cloned and immmutable,
+        // and the purpose of the call is not creating the order on Bolt side but
+        // collectiong the data for bugsnag report
+        // set the $immutableQuote to prevent additional redundant cloning
+        $immutableQuote = $quote;
+
         // If quote is not passed load it from the session.
         // The quote is passed from an API call (i.e. discount code validation)
+        /** @var Quote $quote */
         $quote = $quote ?: $this->checkoutSession->getQuote();
 
         $cart = [];
@@ -437,29 +431,34 @@ class Cart extends AbstractHelper
 
         ////////////////////////////////////////////////////////
         // CLONE THE QUOTE and quote billing / shipping  address
+        // if quote is not passed to the method - the cart data
+        // is being created for sending to Bolt create order API
+        // otherwise skip this step
         ////////////////////////////////////////////////////////
-        $immutableQuote = $this->quoteFactory->create();
+        if (!$immutableQuote) {
+            $immutableQuote = $this->quoteFactory->create();
 
-        $immutableQuote->merge($quote);
+            $immutableQuote->merge($quote);
 
-        foreach ($quote->getData() as $key => $value) {
-            $immutableQuote->setData($key, $value);
+            foreach ($quote->getData() as $key => $value) {
+                $immutableQuote->setData($key, $value);
+            }
+
+            $immutableQuote->setId(null);
+            $immutableQuote->setIsActive(false);
+            $this->quoteResource->save($immutableQuote);
+
+            foreach ($quote->getBillingAddress()->getData() as $key => $value) {
+                if ($key != 'address_id') $immutableQuote->getBillingAddress()->setData($key, $value);
+            }
+
+            foreach ($quote->getShippingAddress()->getData() as $key => $value) {
+                if ($key != 'address_id') $immutableQuote->getShippingAddress()->setData($key, $value);
+            }
+
+            $billingAddress  = $immutableQuote->getBillingAddress()->save();
+            $shippingAddress = $immutableQuote->getShippingAddress()->save();
         }
-
-        $immutableQuote->setId(null);
-        $immutableQuote->setIsActive(false);
-        $this->quoteResource->save($immutableQuote);
-
-        foreach ($quote->getBillingAddress()->getData() as $key => $value) {
-            if ($key != 'address_id') $immutableQuote->getBillingAddress()->setData($key, $value);
-        }
-
-        foreach ($quote->getShippingAddress()->getData() as $key => $value) {
-            if ($key != 'address_id') $immutableQuote->getShippingAddress()->setData($key, $value);
-        }
-
-        $billingAddress  = $immutableQuote->getBillingAddress()->save();
-        $shippingAddress = $immutableQuote->getShippingAddress()->save();
         ////////////////////////////////////////////////////////
 
         // Get array of all items what can be display directly
@@ -475,11 +474,13 @@ class Cart extends AbstractHelper
         $immutableQuote->collectTotals();
         $totals = $immutableQuote->getTotals();
 
-        // Order reference id
-        $cart['order_reference'] = $immutableQuote->getId();
+        // Set order_reference to parent quote id.
+        // This is the constraint field on Bolt side and this way
+        // duplicate payments / orders are prevented/
+        $cart['order_reference'] = $quote->getId();
 
-        //Set display_id as reserve order id
-        $cart['display_id'] = $immutableQuote->getReservedOrderId();
+        //Use display_id to hold and transmit, all the way back and forth, both reserved order id and immitable quote id
+        $cart['display_id'] = $immutableQuote->getReservedOrderId() . ' / ' . $immutableQuote->getId();
 
         //Currency
         $cart['currency'] = $immutableQuote->getQuoteCurrencyCode();

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -502,11 +502,11 @@ class Order extends AbstractHelper
         // get order id and immutable quote id stored with transaction
         list($incrementId, $quoteId) = explode(' / ', $transaction->order->cart->display_id);
 
+        // load (immutable) quote from entity id
+        $quote = $this->cartHelper->getQuoteById($quoteId);
+
         // check if the order exists
         $order = $this->cartHelper->getOrderByIncrementId($incrementId);
-
-        // Load (immutable) quote from entity id
-        $quote = $this->cartHelper->getQuoteById($quoteId);
 
         // if not create the order
         if (!$order || !$order->getId()) {

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -732,7 +732,7 @@ class Order extends AbstractHelper
                     }
                     break;
                 case 'credited':
-                    $order_state = OrderModel::STATE_PROCESSING;
+                    $order_state = OrderModel::STATE_HOLDED;
                     $transaction_type = Transaction::TYPE_REFUND;
                     $transaction_id = $transaction->id.'-capture-refund';
                     $parent_transaction_id = $transaction->id.'-capture';

--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -271,7 +271,7 @@ class ShippingMethods implements ShippingMethodsInterface
             // shipping_address is expected REST parameter name, must stay in snake_case.
             $addressData = $shipping_address;
 
-            $this->logHelper->addInfoLog($this->request->getContent());
+            //$this->logHelper->addInfoLog($this->request->getContent());
 
             if ($bolt_trace_id = $this->request->getHeader(ConfigHelper::BOLT_TRACE_ID_HEADER)) {
                 $this->bugsnag->registerCallback(function ($report) use ($bolt_trace_id) {
@@ -290,9 +290,10 @@ class ShippingMethods implements ShippingMethodsInterface
 
             $this->hookHelper->verifyWebhook();
 
-            // Load quote from entity id
-            $quoteId = $cart['order_reference'];
+            // get immutable quote id stored with transaction
+            list(, $quoteId) = explode(' / ', $cart['display_id']);
 
+            // Load quote from entity id
             $quote = $this->cartHelper->getQuoteById($quoteId);
 
             if (!$quote || !$quote->getId()) {

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -426,7 +426,7 @@ if (!$block->isEnabled()) return;
                         }
                         return false;
                     }
-                    
+
                     <?php echo $block->getjavascriptSuccess(); ?>
                     callbacks.success_url = data.success_url;
                     callback();
@@ -458,15 +458,20 @@ if (!$block->isEnabled()) return;
         /////////////////////////////////////////////////////
         var prefetchShipping = function() {
 
-            if (!settings.prefetch_shipping || !cart.orderReference) return;
+            if (!settings.prefetch_shipping || !cart.cartReference) return;
 
-            var xhr;
-            xhr = window.XMLHttpRequest ? new XMLHttpRequest() : new ActiveXObject('Microsoft.XMLHTTP');
+            var params = 'cartReference='+cart.cartReference;
 
-            xhr.open('GET', settings.shipping_prefetch_url+'?orderReference='+cart.orderReference);
-            xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+            // parse Estimate Shipping and Tax location fields
+            var country  = $('select[name=country_id]').val(),
+                region   = $('select[name=region_id] option:selected').text(),
+                postcode = $('input[name=postcode]').val();
 
-            xhr.send();
+            if (country && region && postcode) {
+                params += '&country='+country+'&region='+region+'&postcode='+postcode;
+            }
+
+            ajaxPost(settings.shipping_prefetch_url, params);
         };
         /////////////////////////////////////////////////////
 


### PR DESCRIPTION
Set the order_reference to the parent quote id, preventing order duplication on Bolt side, thus preventing it on Magento too.
Use cloned quote id (immutable quote) on Magento side to prevent cart data mismatches.
Transmit cloned quote id in display_id field alongside reserved order id, concatenated by ' / '.