### PR TITLE
Discount validation implement with cloned quote

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -411,18 +411,13 @@ class Cart extends AbstractHelper
      * @param bool $paymentOnly             flag that represents the type of checkout
      * @param string $placeOrderPayload     additional data collected from the (one page checkout) page,
      *                                         i.e. billing address to be saved with the order
-     * @param Quote $immutableQuote
-     * @param bool $recreate                If set to `true` create a new clone. This is used when discount codes
-     *                                          are applied from the bolt checkout. Instead of updating the clone
-     *                                          create and return a new one, keeping the immutability prospect of clones
-     *                                          TODO: consider upadting existing clone instead of creating a new one
-     *                                                and change the name from $immutableQuote to something more
-     *                                                semantically correct
+     * @param Quote $immutableQuote         If passed do not create new clone, get data existing one data.
+     *                                          discount validation, bugsnag report
      *
      * @return array
      * @throws \Exception
      */
-    public function getCartData($paymentOnly, $placeOrderPayload, $immutableQuote = null, $recreate = false)
+    public function getCartData($paymentOnly, $placeOrderPayload, $immutableQuote = null)
     {
         $cart = [];
 
@@ -456,7 +451,7 @@ class Cart extends AbstractHelper
         // cart data is being created for sending to Bolt create
         // order API, otherwise skip this step
         ////////////////////////////////////////////////////////
-        if (!$immutableQuote || $recreate) {
+        if (!$immutableQuote) {
 
             $quote->setBoltParentQuoteId($quote->getId());
             $quote->reserveOrderId();

--- a/Model/Api/DiscountCodeValidation.php
+++ b/Model/Api/DiscountCodeValidation.php
@@ -20,8 +20,6 @@ namespace Bolt\Boltpay\Model\Api;
 use Bolt\Boltpay\Api\DiscountCodeValidationInterface;
 use Magento\Framework\Webapi\Rest\Request;
 use Magento\Framework\Webapi\Rest\Response;
-use Magento\Quote\Model\CouponManagement;
-use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\SalesRule\Model\CouponFactory;
 use Magento\SalesRule\Model\RuleFactory;
 use Bolt\Boltpay\Helper\Log as LogHelper;
@@ -33,7 +31,6 @@ use Bolt\Boltpay\Helper\Bugsnag;
 use Bolt\Boltpay\Helper\Cart as CartHelper;
 use Bolt\Boltpay\Helper\Config as ConfigHelper;
 use Bolt\Boltpay\Helper\Hook as HookHelper;
-use Magento\Framework\Exception\LocalizedException;
 use Magento\Quote\Model\Quote;
 
 /**
@@ -62,16 +59,6 @@ class DiscountCodeValidation implements DiscountCodeValidationInterface
      * @var Response
      */
     private $response;
-
-    /**
-     * @var CouponManagement
-     */
-    private $couponManagement;
-
-    /**
-     * @var CartRepositoryInterface
-     */
-    private $quoteRepository;
 
     /**
      * @var CouponFactory
@@ -131,8 +118,6 @@ class DiscountCodeValidation implements DiscountCodeValidationInterface
     /**
      * @param Request $request
      * @param Response $response
-     * @param CouponManagement $couponManagement
-     * @param CartRepositoryInterface $quoteRepository
      * @param CouponFactory $couponFactory
      * @param RuleFactory $ruleFactory
      * @param LogHelper $logHelper
@@ -148,8 +133,6 @@ class DiscountCodeValidation implements DiscountCodeValidationInterface
     public function __construct(
         Request $request,
         Response $response,
-        CouponManagement $couponManagement,
-        CartRepositoryInterface $quoteRepository,
         CouponFactory $couponFactory,
         RuleFactory $ruleFactory,
         LogHelper $logHelper,
@@ -164,8 +147,6 @@ class DiscountCodeValidation implements DiscountCodeValidationInterface
     ) {
         $this->request = $request;
         $this->response = $response;
-        $this->couponManagement = $couponManagement;
-        $this->quoteRepository = $quoteRepository;
         $this->couponFactory = $couponFactory;
         $this->ruleFactory = $ruleFactory;
         $this->logHelper = $logHelper;

--- a/Model/Api/DiscountCodeValidation.php
+++ b/Model/Api/DiscountCodeValidation.php
@@ -202,7 +202,7 @@ class DiscountCodeValidation implements DiscountCodeValidationInterface
                 'X-Bolt-Plugin-Version' => $this->configHelper->getModuleVersion()
             ]);
 
-            //$this->hookHelper->verifyWebhook();
+            $this->hookHelper->verifyWebhook();
 
             $request = json_decode($this->request->getContent());
 

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -314,7 +314,7 @@ if (!$block->isEnabled()) return;
             var elements = document.querySelectorAll(selector);
             for (var i = 0, length = elements.length; i < length; i++) {
                 var element = elements[i];
-                fn.call(element, element)
+                fn.call(element, element);
             }
         };
 
@@ -538,7 +538,7 @@ if (!$block->isEnabled()) return;
                 )) return;
 
                 if (settings && !!settings.publishable_key_payment) {
-                    params.push('payment_only=true')
+                    params.push('payment_only=true');
                 } else {
                     return;
                 }
@@ -714,7 +714,7 @@ if (!$block->isEnabled()) return;
                                 fn(element);
                             }
                         });
-                    })
+                    });
 
                 }(selector);
             }
@@ -741,7 +741,7 @@ if (!$block->isEnabled()) return;
                                 fn(element);
                             }
                         });
-                    })
+                    });
 
                 }(selector);
             }


### PR DESCRIPTION
Error might or might not nullify the previously applied discount. it depends when it happens.

The cart data is returned in error response whenever it is available so the checkout cart could be updated accordingly.

Removed payment_only cart creation option. will add it later when we start to support it.