### PR TITLE
Call callback even when order creation AJAX fails

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -450,10 +450,12 @@ if (!$block->isEnabled()) return;
                 // sets the success order page redirect url from received data
                 // and calls the final Bolt defined callback
                 var onSuccess = function(data){
-                    // show alert message on error
                     if (data.status !== 'success') {
                         if (data.message) {
                             showBoltErrorMessage();
+                            // pretend order creation was success...
+                            // we need to call this; otherwise bolt modal show infinte spinner.
+                            callback();
                         }
 
                         return false;


### PR DESCRIPTION
Currently our custom dialog (`showBoltErrorMessage`) is hidden under Bolt checkout modal with infinite spinner.