### PR TITLE
unnested order note assignment

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -579,10 +579,9 @@ class Order extends AbstractHelper
 
             // Add the user_note to the order comments and make it visible for customer.
             if (isset($transaction->order->user_note)) {
-                $order
-                    ->addStatusHistoryComment($transaction->order->user_note)
-                    ->setIsVisibleOnFront(true)
-                    ->setIsCustomerNotified(false);
+
+                $this->setOrderUserNote($order, $transaction->order->user_note);
+
             }
         }
 
@@ -600,6 +599,25 @@ class Order extends AbstractHelper
         if ($frontend) {
             return [$quote, $order];
         }
+    }
+
+    /**
+     * Add user note as status history comment
+     *
+     * @param OrderModel $order
+     * @param \stdClass $transaction
+     *
+     * @return OrderModel
+     * 
+     */
+    public function setOrderUserNote($order, $userNote){
+
+        $order
+            ->addStatusHistoryComment($userNote)
+            ->setIsVisibleOnFront(true)
+            ->setIsCustomerNotified(false);
+
+        return $order;
     }
 
     public function formatReferenceUrl($reference) {


### PR DESCRIPTION
We need the ability to store an order comment in a different manner other than as a status history comment. In order to push to our ERP, we need to integrate this with an already defined order field. Unnesting the code that assigns the order comment to it's own function allows us to internally rewrite just that function and change where the comment is saved.