### PR TITLE
supress closing magento message notifications (section reloading) in customer-data.js aja…

### DIFF
--- a/Controller/Cart/Data.php
+++ b/Controller/Cart/Data.php
@@ -116,6 +116,7 @@ class Data extends Action
                 'status' => 'success',
                 'cart'   => $cart,
                 'hints'  => $hints,
+                'backUrl' => '',
             ]);
 
         } catch (Exception $e) {


### PR DESCRIPTION
…xComplete handler

Reported by RestaurantSupply:

```php
$(document).on('ajaxComplete', function (event, xhr, settings) {
        var sections,
            redirects;

        if (settings.type.match(/post|put|delete/i)) {
            sections = sectionConfig.getAffectedSections(settings.url);

            if (sections) {
                customerData.invalidate(sections);
                redirects = ['redirect', 'backUrl'];

                if (_.isObject(xhr.responseJSON) && !_.isEmpty(_.pick(xhr.responseJSON, redirects))) { //eslint-disable-line
                    return;
                }
                customerData.reload(sections, true);
            }
        }
    });
```