### PR TITLE
fix for order confirmation emails stopped going from magento

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -477,7 +477,7 @@ class Order extends AbstractHelper
         $order = $this->quoteManagement->submit($quote);
 
         if ($frontend) {
-            if (!$order->getEmailSent() && !$order->getCustomerNoteNotify()) {
+            if (!$order->getEmailSent()) {
                 // Send order confirmation email to customer.
                 $this->emailSender->send($order);
             }


### PR DESCRIPTION
Hot fix successfully applied to RS prod. The assumption was somewhere in a third party extension $order->setCustomerNoteNotify is set.