### PR TITLE
hook context overriding oauth context fix

### DIFF
--- a/etc/webapi_rest/di.xml
+++ b/etc/webapi_rest/di.xml
@@ -22,7 +22,7 @@
             <argument name="userContexts" xsi:type="array">
                 <item name="hookContext" xsi:type="array">
                     <item name="type" xsi:type="object">Bolt\Boltpay\Model\Authorization\HookContext</item>
-                    <item name="sortOrder" xsi:type="string">40</item>
+                    <item name="sortOrder" xsi:type="string">90</item>
                 </item>
             </argument>
         </arguments>


### PR DESCRIPTION
This needs to be deployed to Taos as a Returnly (and others) oauth authorization fix.