### PR TITLE
Create order from parent quote

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -512,6 +512,32 @@ class Cart extends AbstractHelper
     }
 
     /**
+     * Clone quote data from source to destination
+     *
+     * @param Quote $source
+     * @param Quote $destination
+     * @throws \Magento\Framework\Exception\AlreadyExistsException
+     * @throws \Zend_Validate_Exception
+     */
+    public function replicateQuoteData($source, $destination)
+    {
+        $destinationId = $destination->getId();
+        $destinationActive = (bool)$destination->getIsActive();
+        $destination->removeAllItems();
+        $destination->merge($source);
+        $destination->getBillingAddress()->setShouldIgnoreValidation(true);
+        $this->transferData($source->getBillingAddress(), $destination->getBillingAddress());
+        $destination->getShippingAddress()->setShouldIgnoreValidation(true);
+        $this->transferData($source->getShippingAddress(), $destination->getShippingAddress());
+        $this->transferData($source, $destination, false);
+        $destination->setId($destinationId);
+        $destination->setIsActive($destinationActive);
+        $this->quoteResourceSave($destination);
+        // If Amasty Gif Cart Extension is present clone applied gift cards
+        $this->discountHelper->cloneAmastyGiftCards($source->getId(), $destination->getId());
+    }
+
+    /**
      * Get cart data.
      * The reference of total methods: dev/tests/api-functional/testsuite/Magento/Quote/Api/CartTotalRepositoryTest.php
      *
@@ -566,23 +592,7 @@ class Cart extends AbstractHelper
             /** @var Quote $immutableQuote */
             $immutableQuote = $this->quoteFactory->create();
 
-            $immutableQuote->merge($quote);
-
-            $immutableQuote->getBillingAddress()->setShouldIgnoreValidation(true);
-            $this->transferData($quote->getBillingAddress(), $immutableQuote->getBillingAddress());
-
-            $immutableQuote->getShippingAddress()->setShouldIgnoreValidation(true);
-            $this->transferData($quote->getShippingAddress(), $immutableQuote->getShippingAddress());
-
-            $this->transferData($quote, $immutableQuote, false);
-
-            $immutableQuote->setId(null);
-            $immutableQuote->setIsActive(false);
-
-            $this->quoteResourceSave($immutableQuote);
-
-            // If Amasty Gif Cart Extension is present clone applied gift cards to the immutable quote
-            $this->discountHelper->cloneAmastyGiftCards($quote->getId(), $immutableQuote->getId());
+            $this->replicateQuoteData($quote, $immutableQuote);
         }
         $billingAddress  = $immutableQuote->getBillingAddress();
         $shippingAddress = $immutableQuote->getShippingAddress();

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -523,16 +523,24 @@ class Cart extends AbstractHelper
     {
         $destinationId = $destination->getId();
         $destinationActive = (bool)$destination->getIsActive();
+
         $destination->removeAllItems();
+
         $destination->merge($source);
+
         $destination->getBillingAddress()->setShouldIgnoreValidation(true);
         $this->transferData($source->getBillingAddress(), $destination->getBillingAddress());
+
         $destination->getShippingAddress()->setShouldIgnoreValidation(true);
         $this->transferData($source->getShippingAddress(), $destination->getShippingAddress());
+
         $this->transferData($source, $destination, false);
+
         $destination->setId($destinationId);
         $destination->setIsActive($destinationActive);
+
         $this->quoteResourceSave($destination);
+
         // If Amasty Gif Cart Extension is present clone applied gift cards
         $this->discountHelper->cloneAmastyGiftCards($source->getId(), $destination->getId());
     }

--- a/Helper/Discount.php
+++ b/Helper/Discount.php
@@ -260,14 +260,17 @@ class Discount extends AbstractHelper
         $connection->beginTransaction();
         try {
             $giftCardTable = $this->resource->getTableName('amasty_amgiftcard_quote');
+
             // Clear previously applied gift cart codes from the immutable quote
             $sql = "DELETE FROM {$giftCardTable} WHERE quote_id = :destination_quote_id";
             $connection->query($sql, ['destination_quote_id' => $destinationQuoteId]);
+
             // Copy all gift cart codes applied to the parent quote to the immutable quote
             $sql = "INSERT INTO {$giftCardTable} (quote_id, code_id, account_id, base_gift_amount, code) 
                     SELECT :destination_quote_id, code_id, account_id, base_gift_amount, code
                     FROM {$giftCardTable} WHERE quote_id = :source_quote_id";
             $connection->query($sql, ['destination_quote_id' => $destinationQuoteId, 'source_quote_id' => $sourceQuoteId]);
+
             $connection->commit();
         } catch (\Zend_Db_Statement_Exception $e) {
             $connection->rollBack();
@@ -289,9 +292,11 @@ class Discount extends AbstractHelper
         try {
             $giftCardTable = $this->resource->getTableName('amasty_amgiftcard_quote');
             $quoteTable = $this->resource->getTableName('quote');
+
             $sql = "DELETE FROM {$giftCardTable} WHERE quote_id IN 
                     (SELECT entity_id FROM {$quoteTable} 
                     WHERE bolt_parent_quote_id = :bolt_parent_quote_id AND entity_id != :entity_id)";
+
             $connection->query($sql, ['entity_id' => $quote->getId(), 'bolt_parent_quote_id' => $quote->getId()]);
         } catch (\Zend_Db_Statement_Exception $e) {
             $this->bugsnag->notifyException($e);

--- a/Helper/Discount.php
+++ b/Helper/Discount.php
@@ -246,12 +246,12 @@ class Discount extends AbstractHelper
     }
 
     /**
-     * Try to copy Amasty Gift Cart data from parent to immutable quote
+     * Copy Amasty Gift Cart data from source to destination quote
      *
-     * @param int|string $parentQuoteId
-     * @param int|string $immutableQuoteId
+     * @param int|string $sourceQuoteId
+     * @param int|string $destinationQuoteId
      */
-    public function cloneAmastyGiftCards($parentQuoteId, $immutableQuoteId)
+    public function cloneAmastyGiftCards($sourceQuoteId, $destinationQuoteId)
     {
         if (! $this->isAmastyGiftCardAvailable()) {
             return;
@@ -260,17 +260,14 @@ class Discount extends AbstractHelper
         $connection->beginTransaction();
         try {
             $giftCardTable = $this->resource->getTableName('amasty_amgiftcard_quote');
-
             // Clear previously applied gift cart codes from the immutable quote
-            $sql = "DELETE FROM {$giftCardTable} WHERE quote_id = :quote_id";
-            $connection->query($sql, ['quote_id' => $immutableQuoteId]);
-
+            $sql = "DELETE FROM {$giftCardTable} WHERE quote_id = :destination_quote_id";
+            $connection->query($sql, ['destination_quote_id' => $destinationQuoteId]);
             // Copy all gift cart codes applied to the parent quote to the immutable quote
             $sql = "INSERT INTO {$giftCardTable} (quote_id, code_id, account_id, base_gift_amount, code) 
-                    SELECT :immutable_quote_id, code_id, account_id, base_gift_amount, code 
-                    FROM {$giftCardTable} WHERE quote_id = :quote_id";
-            $connection->query($sql, ['immutable_quote_id' => $immutableQuoteId, 'quote_id' => $parentQuoteId]);
-
+                    SELECT :destination_quote_id, code_id, account_id, base_gift_amount, code
+                    FROM {$giftCardTable} WHERE quote_id = :source_quote_id";
+            $connection->query($sql, ['destination_quote_id' => $destinationQuoteId, 'source_quote_id' => $sourceQuoteId]);
             $connection->commit();
         } catch (\Zend_Db_Statement_Exception $e) {
             $connection->rollBack();
@@ -279,12 +276,11 @@ class Discount extends AbstractHelper
     }
 
     /**
-     * Try to clear Amasty Gift Cart data for the unused immutable quotes and the parent quote
+     * Try to clear Amasty Gift Cart data for the unused immutable quotes
      *
-     * @param int|string $immutableQuoteId
-     * @param int|string $parentQuoteId
+     * @param Quote $quote parent quote
      */
-    public function deleteRedundantAmastyGiftCards($immutableQuoteId, $parentQuoteId)
+    public function deleteRedundantAmastyGiftCards($quote)
     {
         if (! $this->isAmastyGiftCardAvailable()) {
             return;
@@ -293,12 +289,10 @@ class Discount extends AbstractHelper
         try {
             $giftCardTable = $this->resource->getTableName('amasty_amgiftcard_quote');
             $quoteTable = $this->resource->getTableName('quote');
-
             $sql = "DELETE FROM {$giftCardTable} WHERE quote_id IN 
                     (SELECT entity_id FROM {$quoteTable} 
                     WHERE bolt_parent_quote_id = :bolt_parent_quote_id AND entity_id != :entity_id)";
-
-            $connection->query($sql, ['entity_id' => $immutableQuoteId, 'bolt_parent_quote_id' => $parentQuoteId]);
+            $connection->query($sql, ['entity_id' => $quote->getId(), 'bolt_parent_quote_id' => $quote->getId()]);
         } catch (\Zend_Db_Statement_Exception $e) {
             $this->bugsnag->notifyException($e);
         }

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -443,6 +443,7 @@ class Order extends AbstractHelper
         // Load logged in customer checkout and customer sessions from cached session id.
         // Replace quote in checkout session.
         $this->sessionHelper->loadSession($quote);
+
         $this->setShippingAddress($quote, $transaction);
         $this->setBillingAddress($quote, $transaction);
         $this->cartHelper->quoteResourceSave($quote);

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -423,7 +423,7 @@ class Order extends AbstractHelper
     /**
      * Transform Quote to Order and send email to the customer.
      *
-     * @param Quote $quote
+     * @param Quote $immutableQuote
      * @param \stdClass $transaction
      *
      * @param string|null $boltTraceId
@@ -431,24 +431,31 @@ class Order extends AbstractHelper
      * @throws LocalizedException
      * @throws \Exception
      */
-    private function createOrder($quote, $transaction, $boltTraceId = null)
+    private function createOrder($immutableQuote, $transaction, $boltTraceId = null)
     {
-        // Load logged in customer checkout and customer sessions from cached session id.
-        // Replace parent quote with immutable quote in checkout session.
-        $this->sessionHelper->loadSession($quote);
+        // Load and prepare parent quote
+        /** @var Quote $parentQuote */
+        $quote = $this->cartHelper->getActiveQuoteById($immutableQuote->getBoltParentQuoteId());
+        $this->cartHelper->replicateQuoteData($immutableQuote, $quote);
 
+        $this->cartHelper->quoteResourceSave($quote);
+
+        // Load logged in customer checkout and customer sessions from cached session id.
+        // Replace quote in checkout session.
+        $this->sessionHelper->loadSession($quote);
         $this->setShippingAddress($quote, $transaction);
         $this->setBillingAddress($quote, $transaction);
+        $this->cartHelper->quoteResourceSave($quote);
+
         $this->setShippingMethod($quote, $transaction);
+        $this->cartHelper->quoteResourceSave($quote);
 
         $email = @$transaction->order->cart->billing_address->email_address ?:
             @$transaction->order->cart->shipments[0]->shipping_address->email_address;
-
         $this->addCustomerDetails($quote, $email);
 
         $this->setPaymentMethod($quote);
-
-        $this->cartHelper->saveQuote($quote);
+        $this->cartHelper->quoteResourceSave($quote);
 
         // assign credit card info to the payment info instance
         $this->setQuotePaymentInfoData(
@@ -511,7 +518,7 @@ class Order extends AbstractHelper
     private function setQuotePaymentInfoData($quote, $data)
     {
         foreach ($data as $key => $value) {
-            $this->getQuotePaymentInfoInstance($quote)->setData($key, $value);
+            $this->getQuotePaymentInfoInstance($quote)->setData($key, $value)->save();
         }
     }
 
@@ -528,13 +535,12 @@ class Order extends AbstractHelper
     }
 
     /**
-     * Delete redundant clones and parent quote.
+     * Delete redundant immutable quotes.
      *
      * @param Quote $quote
      */
     private function deleteRedundantQuotes($quote)
     {
-
         $connection = $this->resourceConnection->getConnection();
 
         // get table name with prefix
@@ -542,34 +548,11 @@ class Order extends AbstractHelper
 
         $sql = "DELETE FROM {$tableName} WHERE bolt_parent_quote_id = :bolt_parent_quote_id AND entity_id != :entity_id";
         $bind = [
-            'bolt_parent_quote_id' => $quote->getBoltParentQuoteId(),
+            'bolt_parent_quote_id' => $quote->getId(),
             'entity_id' => $quote->getId()
         ];
 
         $connection->query($sql, $bind);
-    }
-
-    /**
-     * Set parent quote as inactive.
-     *
-     * @param Quote $quote
-     */
-    public function deactivateParentQuote($quote)
-    {
-        try {
-            $parentQuote = $this->cartHelper->getQuoteById($quote->getBoltParentQuoteId());
-            $parentQuote->setIsActive(false);
-        } catch (NoSuchEntityException $e) {
-            $this->bugsnag->registerCallback(function ($report) use ($quote) {
-                $report->setMetaData([
-                    'QUOTE' => [
-                        'quoteId' => $quote->getId(),
-                        'parentId' => $quote->getBoltParentQuoteId(),
-                        'orderId' => $quote->getReservedOrderId()
-                    ]
-                ]);
-            });
-        }
     }
 
     /**
@@ -646,12 +629,9 @@ class Order extends AbstractHelper
 
             // If Amasty Gif Cart Extension is present delete gift carts
             // applied to parent quote and unused immutable quotes
-            $this->discountHelper->deleteRedundantAmastyGiftCards($quoteId, $parentQuoteId);
+            $this->discountHelper->deleteRedundantAmastyGiftCards($quote);
 
-            // Set parent quote as inactive
-            $this->deactivateParentQuote($quote);
-
-            // Delete redundant clones and parent quote
+            // Delete redundant cloned quotes
             $this->deleteRedundantQuotes($quote);
         }
 


### PR DESCRIPTION
All cart manipulation from Bolt side was previously done to the immutable quote - saving address, shipping method, user data (email) and payment method. And the order was created out of that quote, deleting the parent and all other immutable quotes. 

On the other hand, only one (the parent) quote can have the active status for the cart / session. There are event listeners to cart events on the active quote. Third party plugins use them, Bronto among them. 

The solution provided here is to replicate immutable quote data back into the parent before order creation and then do the save on the parent quote model after any particular change (address, method, payment..) so the listened events get fired in the expected sequence. And, naturally, transform the parent quote into order and delete all the clones.

The logic behind this should be conceptually right, the code is tested with a pretty complex cart (5 different discount types applied) on the test store and also one quick and simple order with store credit on Coastal Business merchant staging. From a regression testing standpoint It does not break anything but the whole set of production readiness tests should be done before the release.

How does this work in practice with Bronto is yet to be discovered.
