### PR TITLE
fix for send store order notiffications to email collected from Bolt checkout

### DIFF
--- a/Controller/Cart/Email.php
+++ b/Controller/Cart/Email.php
@@ -85,9 +85,7 @@ class Email extends Action
                 throw new LocalizedException(__('Quote does not exist.'));
             }
 
-            $email = $this->customerSession->isLoggedIn() ?
-                $this->customerSession->getCustomer()->getEmail() :
-                $this->getRequest()->getParam('email');
+            $email = $this->getRequest()->getParam('email');
 
             if (!$email) {
                 throw new LocalizedException(__('No email received.'));


### PR DESCRIPTION
Note: after merging to master re-tag should be done for the current release or creating a new one and merge master into develop. This addresses the request from Coastal Business so it probably should not wait for the next release cycle.