### PR TITLE
Unirgy_Giftcert plugin support

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -954,6 +954,20 @@ class Cart extends AbstractHelper
                 }
                 ///////////////////////////////////////////////////////////////////////////
 
+                ///////////////////////////////////////////////////////////////////////////
+                /// Was added a proper Unirgy_Giftcert Amount to the discount.
+                /// The GiftCert accumulate correct balance only after each collectTotals.
+                ///  The Unirgy_Giftcert add the only discount which covers only product price.
+                ///  We should get the whole balance at first of the Giftcert.
+                ///////////////////////////////////////////////////////////////////////////
+                if ($discount == Discount::UNIRGY_GIFT_CERT && $immutableQuote->getData('giftcert_code')) {
+                    $gcCode = $immutableQuote->getData('giftcert_code');
+                    $giftCertBalance = $this->discountHelper->getUnirgyGiftCertBalanceByCode($gcCode);
+                    if ($giftCertBalance > 0) {
+                        $amount = $giftCertBalance;
+                    }
+                }
+
                 $amount = abs($amount);
                 $roundedAmount = $this->getRoundAmount($amount);
 

--- a/Helper/Discount.php
+++ b/Helper/Discount.php
@@ -77,6 +77,11 @@ class Discount extends AbstractHelper
     protected $amastyAccountCollection;
 
     /**
+     * @var ThirdPartyModuleFactory|\Unirgy\Giftcert\Model\GiftcertRepository
+     */
+    protected $unirgyCertRepository;
+
+    /**
      * @var CartRepositoryInterface
      */
     protected $quoteRepository;
@@ -102,6 +107,7 @@ class Discount extends AbstractHelper
      * @param ThirdPartyModuleFactory $amastyQuoteResource
      * @param ThirdPartyModuleFactory $amastyQuoteRepository
      * @param ThirdPartyModuleFactory $amastyAccountCollection
+     * @param ThirdPartyModuleFactory $unirgyCertRepository
      * @param CartRepositoryInterface $quoteRepository
      * @param ConfigHelper $configHelper
      * @param Bugsnag $bugsnag
@@ -117,6 +123,7 @@ class Discount extends AbstractHelper
         ThirdPartyModuleFactory $amastyQuoteResource,
         ThirdPartyModuleFactory $amastyQuoteRepository,
         ThirdPartyModuleFactory $amastyAccountCollection,
+        ThirdPartyModuleFactory $unirgyCertRepository,
         CartRepositoryInterface $quoteRepository,
         ConfigHelper $configHelper,
         Bugsnag $bugsnag
@@ -129,6 +136,7 @@ class Discount extends AbstractHelper
         $this->amastyQuoteResource = $amastyQuoteResource;
         $this->amastyQuoteRepository = $amastyQuoteRepository;
         $this->amastyAccountCollection = $amastyAccountCollection;
+        $this->unirgyCertRepository = $unirgyCertRepository;
         $this->quoteRepository = $quoteRepository;
         $this->configHelper = $configHelper;
         $this->bugsnag = $bugsnag;
@@ -373,5 +381,26 @@ class Discount extends AbstractHelper
             ->getData();
 
         return array_sum(array_column($data, 'current_value'));
+    }
+
+
+    /**
+     * Get Unirgy_Giftcert balance.
+     *
+     * @param $giftcertCode
+     * @return float
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function getUnirgyGiftCertBalanceByCode($giftcertCode)
+    {
+        /** @var \Unirgy\Giftcert\Model\Cert $giftCert */
+        $giftCert = $this->unirgyCertRepository->getInstance()->get($giftcertCode);
+
+        $result = 0;
+        if ($giftCert && $giftCert->getStatus() === 'A' && $giftCert->getBalance() > 0) {
+            $result = $giftCert->getBalance();
+        }
+
+        return (float) $result;
     }
 }

--- a/Helper/Discount.php
+++ b/Helper/Discount.php
@@ -384,11 +384,14 @@ class Discount extends AbstractHelper
     public function getUnirgyGiftCertBalanceByCode($giftcertCode)
     {
         /** @var \Unirgy\Giftcert\Model\Cert $giftCert */
-        $giftCert = $this->unirgyCertRepository->getInstance()->get($giftcertCode);
+        $unirgyInstance = $this->unirgyCertRepository->getInstance();
 
         $result = 0;
-        if ($giftCert && $giftCert->getStatus() === 'A' && $giftCert->getBalance() > 0) {
-            $result = $giftCert->getBalance();
+        if ($unirgyInstance) {
+            $giftCert = $unirgyInstance->get($giftcertCode);
+            if ($giftCert && $giftCert->getStatus() === 'A' && $giftCert->getBalance() > 0) {
+                $result = $giftCert->getBalance();
+            }
         }
 
         return (float) $result;

--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -636,7 +636,7 @@ class ShippingMethods implements ShippingMethodsInterface
 
             if ($discountAmount) {
                 if ($cost == 0) {
-                    // Added Unirgy_Giftcert amount to the message if gc balance is more than grand_total
+                    // Added Unirgy_Giftcert amount to the message if Giftcert balance is more than grand_total
                     if ($shippingAddress->getGiftcertCode() && $shippingAddress->getGiftcertAmount() > 0) {
                         $discount = $this->priceHelper->currency($discountAmount, true, false);
                         $service .= " [$discount" . "&nbsp;giftcert]";

--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -615,18 +615,6 @@ class ShippingMethods implements ShippingMethodsInterface
 
             $discountAmount = $shippingAddress->getShippingDiscountAmount();
 
-            // Checked if Unirgy_Giftcert code present in the quote and added discount amount.
-            if (!$discountAmount
-                && $shippingAddress->getGiftcertCode()
-                && (float)$shippingAddress->getGiftcertAmount() > 0
-            ) {
-                if ($shippingAddress->getGrandTotal() == 0) {
-                    $discountAmount = $shippingAddress->getShippingAmount();
-                } else {
-                    $discountAmount = $shippingAddress->getShippingAmount() - $shippingAddress->getGrandTotal();
-                }
-            }
-
             $cost        = $shippingAddress->getShippingAmount() - $discountAmount;
             $roundedCost = $this->cartHelper->getRoundAmount($cost);
 
@@ -636,22 +624,10 @@ class ShippingMethods implements ShippingMethodsInterface
 
             if ($discountAmount) {
                 if ($cost == 0) {
-                    // Added Unirgy_Giftcert amount to the message if Giftcert balance is more than grand_total
-                    if ($shippingAddress->getGiftcertCode() && $shippingAddress->getGiftcertAmount() > 0) {
-                        $discount = $this->priceHelper->currency($discountAmount, true, false);
-                        $service .= " [$discount" . "&nbsp;giftcert]";
-                    } else {
-                        $service .= ' [free&nbsp;shipping&nbsp;discount]';
-                    }
+                    $service .= ' [free&nbsp;shipping&nbsp;discount]';
                 } else {
                     $discount = $this->priceHelper->currency($discountAmount, true, false);
-
-                    // Added Unirgy_Giftcert amount to the message.
-                    if ($shippingAddress->getGiftcertCode() && (float)$shippingAddress->getGiftcertAmount() > 0) {
-                        $service .= " [$discount" . "&nbsp;giftcert]";
-                    } else {
-                        $service .= " [$discount" . "&nbsp;discount]";
-                    }
+                    $service .= " [$discount" . "&nbsp;discount]";
                 }
                 $service = html_entity_decode($service);
             }

--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -636,9 +636,10 @@ class ShippingMethods implements ShippingMethodsInterface
 
             if ($discountAmount) {
                 if ($cost == 0) {
-                    // Added Unirgy_Giftcert amount to the message.
-                    if ((float)$shippingAddress->getGiftcertAmount() > 0 && $shippingAddress->getGrandTotal() == 0) {
-                        $service .= " [$discountAmount$" . "&nbsp;giftcert]";
+                    // Added Unirgy_Giftcert amount to the message if gc balance is more than grand_total
+                    if ($shippingAddress->getGiftcertCode() && $shippingAddress->getGiftcertAmount() > 0) {
+                        $discount = $this->priceHelper->currency($discountAmount, true, false);
+                        $service .= " [$discount" . "&nbsp;giftcert]";
                     } else {
                         $service .= ' [free&nbsp;shipping&nbsp;discount]';
                     }
@@ -646,10 +647,8 @@ class ShippingMethods implements ShippingMethodsInterface
                     $discount = $this->priceHelper->currency($discountAmount, true, false);
 
                     // Added Unirgy_Giftcert amount to the message.
-                    if ($shippingAddress->getGiftcertCode()
-                        && (float)$shippingAddress->getGiftcertAmount() > 0
-                    ) {
-                        $service .= " [$discount$" . "&nbsp;giftcert]";
+                    if ($shippingAddress->getGiftcertCode() && (float)$shippingAddress->getGiftcertAmount() > 0) {
+                        $service .= " [$discount" . "&nbsp;giftcert]";
                     } else {
                         $service .= " [$discount" . "&nbsp;discount]";
                     }

--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -615,6 +615,18 @@ class ShippingMethods implements ShippingMethodsInterface
 
             $discountAmount = $shippingAddress->getShippingDiscountAmount();
 
+            // Checked if Unirgy_Giftcert code present in the quote and added discount amount.
+            if (!$discountAmount
+                && $shippingAddress->getGiftcertCode()
+                && (float)$shippingAddress->getGiftcertAmount() > 0
+            ) {
+                if ($shippingAddress->getGrandTotal() == 0) {
+                    $discountAmount = $shippingAddress->getShippingAmount();
+                } else {
+                    $discountAmount = $shippingAddress->getShippingAmount() - $shippingAddress->getGrandTotal();
+                }
+            }
+
             $cost        = $shippingAddress->getShippingAmount() - $discountAmount;
             $roundedCost = $this->cartHelper->getRoundAmount($cost);
 
@@ -624,10 +636,23 @@ class ShippingMethods implements ShippingMethodsInterface
 
             if ($discountAmount) {
                 if ($cost == 0) {
-                    $service .= ' [free&nbsp;shipping&nbsp;discount]';
+                    // Added Unirgy_Giftcert amount to the message.
+                    if ((float)$shippingAddress->getGiftcertAmount() > 0 && $shippingAddress->getGrandTotal() == 0) {
+                        $service .= " [$discountAmount$" . "&nbsp;giftcert]";
+                    } else {
+                        $service .= ' [free&nbsp;shipping&nbsp;discount]';
+                    }
                 } else {
                     $discount = $this->priceHelper->currency($discountAmount, true, false);
-                    $service .= " [$discount" . "&nbsp;discount]";
+
+                    // Added Unirgy_Giftcert amount to the message.
+                    if ($shippingAddress->getGiftcertCode()
+                        && (float)$shippingAddress->getGiftcertAmount() > 0
+                    ) {
+                        $service .= " [$discount$" . "&nbsp;giftcert]";
+                    } else {
+                        $service .= " [$discount" . "&nbsp;discount]";
+                    }
                 }
                 $service = html_entity_decode($service);
             }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -124,6 +124,13 @@
         </arguments>
     </virtualType>
 
+    <virtualType name="boltUnirgyCertRepository" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
+        <arguments>
+            <argument name="moduleName" xsi:type="string">Unirgy_Giftcert</argument>
+            <argument name="className" xsi:type="string">Unirgy\Giftcert\Model\GiftcertRepository</argument>
+        </arguments>
+    </virtualType>
+
     <type name="Bolt\Boltpay\Helper\Discount">
         <arguments>
             <argument name="amastyAccountFactory" xsi:type="object">boltAmastyAccountFactory</argument>
@@ -132,6 +139,7 @@
             <argument name="amastyQuoteResource" xsi:type="object">boltAmastyQuoteResource</argument>
             <argument name="amastyQuoteRepository" xsi:type="object">boltAmastyQuoteRepository</argument>
             <argument name="amastyAccountCollection" xsi:type="object">boltAmastyAccountCollection</argument>
+            <argument name="unirgyCertRepository" xsi:type="object">boltUnirgyCertRepository</argument>
         </arguments>
     </type>
 


### PR DESCRIPTION
The Unirgy_Giftcert add a discount which covers only product price (subtotal).
The Unirgy_Giftcert accumulate correct balance only after address collectTotals, but if i am trying to get  Unirgy_Giftcert balance at shipping_methods step i have no correct price value - i have only product price discount.
We should get the whole balance at first of the Unirgy_Giftcert.

P.S.: Unirgy_Giftcert - also want to mention that some part of the module is encoded (the part like "add the Giftcert to the quote/cart" and some save "after update quote" event)