### PR TITLE
 Prevent dispatching sales_quote_save_after event for inactive quote

### DIFF
--- a/Plugin/QuotePlugin.php
+++ b/Plugin/QuotePlugin.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2018 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+namespace Bolt\Boltpay\Plugin;
+
+/**
+ * Class QuotePlugin
+ *
+ * @package Bolt\Boltpay\Plugin
+ */
+class QuotePlugin
+{
+    /**
+     * Override Quote afterSave method.
+     * Skip execution for inactive quotes, thus preventing dispatching the after save events.
+     *
+     * @param \Magento\Quote\Model\Quote $subject
+     * @param callable $proceed
+     * @return \Magento\Quote\Model\Quote
+     */
+    public function aroundAfterSave(\Magento\Quote\Model\Quote $subject, callable $proceed)
+    {
+        if ($subject->getIsActive()) {
+            return $proceed();
+        }
+        return $subject;
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -135,4 +135,7 @@
         </arguments>
     </type>
 
+    <type name="Magento\Quote\Model\Quote">
+        <plugin name="Bolt_Boltpay_Quote_Plugin" type="Bolt\Boltpay\Plugin\QuotePlugin" sortOrder="1" />
+    </type>
 </config>


### PR DESCRIPTION
Inactive quote is usually considered complete by Bronto and Magento. It is set to active->false only after order is created. It is dead after that waiting for the cleanup. No additional save called upon it, so no after save events fired.

However, our plugin depends on using inactive quotes to store immutable quote data. Multiple ones per parent. After save events get fired on every immutable quote generation and shipping and tax calls and Bronto started to receive junk, lots of it.
