### PR TITLE
Reserve Order ID for the child quote, copy it to parent just before the quote to order submit

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -533,7 +533,7 @@ class Cart extends AbstractHelper
      * Defer setting ReservedOrderId on the parent quote
      * until the quote to order submission.
      * Reason: Some 3rd party plugins read this value and if set
-     * consider the quote to bo a complete order.
+     * consider the quote to be a complete order.
      *
      * @param Quote $immutableQuote
      * @param Quote $quote

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -480,7 +480,7 @@ class Cart extends AbstractHelper
         $child,
         $save = true,
         $emailFields = ['customer_email', 'email'],
-        $excludeFields = ['entity_id', 'address_id']
+        $excludeFields = ['entity_id', 'address_id', 'reserved_order_id']
     ) {
         foreach ($parent->getData() as $key => $value) {
 
@@ -524,6 +524,56 @@ class Cart extends AbstractHelper
 
         // If Amasty Gif Cart Extension is present clone applied gift cards
         $this->discountHelper->cloneAmastyGiftCards($source->getId(), $destination->getId());
+    }
+
+    /**
+     * Reserve Order Id for the first immutable quote created.
+     * Store it in BoltReservedOrderId field in the parent quote
+     * as well as in any subsequently created immutable quote.
+     * Defer setting ReservedOrderId on the parent quote
+     * until the quote to order submission.
+     * Reason: Some 3rd party plugins read this value and if set
+     * consider the quote to bo a complete order.
+     *
+     * @param Quote $immutableQuote
+     * @param Quote $quote
+     * @throws \Magento\Framework\Exception\AlreadyExistsException
+     */
+    protected function reserveOrderId($immutableQuote, $quote)
+    {
+        $reservedOrderId = $immutableQuote->getBoltReservedOrderId();
+        if (!$reservedOrderId) {
+            $reservedOrderId = $immutableQuote->reserveOrderId()->getReservedOrderId();
+            $immutableQuote->setBoltReservedOrderId($reservedOrderId);
+            $quote->setBoltReservedOrderId($reservedOrderId);
+            $this->quoteResourceSave($quote);
+        } else {
+            $immutableQuote->setReservedOrderId($reservedOrderId);
+        }
+        $this->quoteResourceSave($immutableQuote);
+    }
+
+    /**
+     * Create an immutable quote.
+     * Set the BoltParentQuoteId to the parent quote, if not set already,
+     * so it can be replicated to immutable quote in replicateQuoteData.
+     *
+     * @param Quote $quote
+     * @throws \Magento\Framework\Exception\AlreadyExistsException
+     * @throws \Zend_Validate_Exception
+     */
+    protected function createImmutableQuote($quote)
+    {
+        if (!$quote->getBoltParentQuoteId()) {
+            $quote->setBoltParentQuoteId($quote->getId());
+            $this->quoteResourceSave($quote);
+        }
+        /** @var Quote $immutableQuote */
+        $immutableQuote = $this->quoteFactory->create();
+
+        $this->replicateQuoteData($quote, $immutableQuote);
+
+        return $immutableQuote;
     }
 
     /**
@@ -574,15 +624,10 @@ class Cart extends AbstractHelper
         // order API, otherwise skip this step
         ////////////////////////////////////////////////////////
         if (!$immutableQuote) {
-            $quote->setBoltParentQuoteId($quote->getId());
-            $quote->reserveOrderId();
-            $this->quoteResourceSave($quote);
-
-            /** @var Quote $immutableQuote */
-            $immutableQuote = $this->quoteFactory->create();
-
-            $this->replicateQuoteData($quote, $immutableQuote);
+            $immutableQuote = $this->createImmutableQuote($quote);
+            $this->reserveOrderId($immutableQuote, $quote);
         }
+
         $billingAddress  = $immutableQuote->getBillingAddress();
         $shippingAddress = $immutableQuote->getShippingAddress();
         ////////////////////////////////////////////////////////
@@ -592,8 +637,6 @@ class Cart extends AbstractHelper
 
         if (!$items) {
             // This is the case when customer empties the cart.
-            // Not an error. Commenting out bugsnag report for now.
-            // $this->bugsnag->notifyError('Get Cart Data Error', 'The cart is empty');
             return $cart;
         }
 

--- a/Helper/Discount.php
+++ b/Helper/Discount.php
@@ -287,8 +287,12 @@ class Discount extends AbstractHelper
             $sql = "DELETE FROM {$giftCardTable} WHERE quote_id IN 
                     (SELECT entity_id FROM {$quoteTable} 
                     WHERE bolt_parent_quote_id = :bolt_parent_quote_id AND entity_id != :entity_id)";
+            $bind = [
+                'bolt_parent_quote_id' => $quote->getBoltParentQuoteId(),
+                'entity_id' => $quote->getBoltParentQuoteId()
+            ];
 
-            $connection->query($sql, ['entity_id' => $quote->getId(), 'bolt_parent_quote_id' => $quote->getId()]);
+            $connection->query($sql, $bind);
         } catch (\Zend_Db_Statement_Exception $e) {
             $this->bugsnag->notifyException($e);
         }

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -508,6 +508,10 @@ class Order extends AbstractHelper
                 'cc_type' => @$transaction->from_credit_card->network
             ]
         );
+        $this->cartHelper->quoteResourceSave($quote);
+
+        $quote->setReservedOrderId($quote->getBoltReservedOrderId());
+        $this->cartHelper->quoteResourceSave($quote);
 
         // check if the order has been created in the meanwhile
         /** @var OrderModel $order */
@@ -616,8 +620,8 @@ class Order extends AbstractHelper
 
         $sql = "DELETE FROM {$tableName} WHERE bolt_parent_quote_id = :bolt_parent_quote_id AND entity_id != :entity_id";
         $bind = [
-            'bolt_parent_quote_id' => $quote->getId(),
-            'entity_id' => $quote->getId()
+            'bolt_parent_quote_id' => $quote->getBoltParentQuoteId(),
+            'entity_id' => $quote->getBoltParentQuoteId()
         ];
 
         $connection->query($sql, $bind);

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -46,6 +46,17 @@ class UpgradeSchema implements UpgradeSchemaInterface
             ]
         );
 
+        $setup->getConnection()->addColumn(
+            $setup->getTable('quote'),
+            'bolt_reserved_order_id',
+            [
+                'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                'length' => 64,
+                'nullable' => true,
+                'comment' => 'Bolt Reserved Order Id'
+            ]
+        );
+
         $setup->getConnection()->addIndex(
             $setup->getTable('quote'),
             $setup->getIdxName('quote', ['bolt_parent_quote_id']),


### PR DESCRIPTION
Some 3rd party plugins read Quote::getReservedOrderId() value and if set consider the quote to be a complete order. It is set by calling Quote::reserveOrderId(). We used to call it on the parent quote before creating the immutable quote. Now it is called on the first created immutable quote and stored in the separate field added to the quote model to be set on the parent quote just before order creation.