### PR TITLE
remove active quote restriction on order creation

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -598,7 +598,7 @@ class Cart extends AbstractHelper
         try {
             /** @var Quote $quote */
             $quote = $immutableQuote ?
-                $this->getActiveQuoteById($immutableQuote->getBoltParentQuoteId()) :
+                $this->getQuoteById($immutableQuote->getBoltParentQuoteId()) :
                 $this->checkoutSession->getQuote();
         } catch (NoSuchEntityException $e) {
             // getActiveQuoteById(): Order has already been processed and parent quote inactive / deleted.

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -477,7 +477,7 @@ class Order extends AbstractHelper
     {
         // Load and prepare parent quote
         /** @var Quote $quote */
-        $quote = $this->cartHelper->getActiveQuoteById($immutableQuote->getBoltParentQuoteId());
+        $quote = $this->cartHelper->getQuoteById($immutableQuote->getBoltParentQuoteId());
         $this->cartHelper->replicateQuoteData($immutableQuote, $quote);
 
         $this->cartHelper->quoteResourceSave($quote);


### PR DESCRIPTION
Backend quotes don't have active flag set. The execution failed at the beginning of Helper\Order::createOrder(). Loosening active restriction is harmless due to the duplicate order creation check some lines below.