### PR TITLE
Do not save empty address fields

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -333,7 +333,7 @@ class Order extends AbstractHelper
 
         $region = $this->regionModel->loadByName(@$address->region, @$address->country_code);
 
-        $address_data = [
+        $addressData = [
             'firstname'    => @$address->first_name,
             'lastname'     => @$address->last_name,
             'street'       => trim(@$address->street_address1 . "\n" . @$address->street_address2),
@@ -347,11 +347,18 @@ class Order extends AbstractHelper
         ];
 
         if ($this->cartHelper->validateEmail(@$address->email_address)) {
-            $address_data['email'] = $address->email_address;
+            $addressData['email'] = $address->email_address;
+        }
+
+        // discard empty address fields
+        foreach ($addressData as $key => $value) {
+            if (empty($value)) {
+                unset($addressData[$key]);
+            }
         }
 
         $quoteAddress->setShouldIgnoreValidation(true);
-        $quoteAddress->addData($address_data)->save();
+        $quoteAddress->addData($addressData)->save();
     }
 
     /**


### PR DESCRIPTION
If a field, email for example, is empty, it used to clear what was already stored in quote address.
Missing emails had to be fixed on Bolt end. This way that could be done on store end as well.