### PR TITLE
remove console error on empty cart

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -668,8 +668,8 @@ $trackCallbacks = $block->getTrackCallbacks();
         var createRequest = false;
         var createOrder = function () {
 
-            // do not call Bolt API if the cart is empty
-            if (shoppingCart().summary_count === 0) return;
+            // do not call Bolt API if there is no cart
+            if (!shoppingCart().data_id) return;
 
             // skip if there is already an ongoing request
             if (createRequest) return;
@@ -745,11 +745,18 @@ $trackCallbacks = $block->getTrackCallbacks();
                             return;
                         }
 
+                        //////////////////////////
                         // set cart and hints data
+                        //////////////////////////
                         cart = data.cart;
 
-                        if (!cart || !cart.orderToken) {
-                            reject(new Error('Cart info is missing or the cart is empty'));
+                        if (!cart) {
+                            reject(new Error('The cart info is missing.'));
+                            return;
+                        }
+
+                        // the cart is empty, exit gracefully without an error
+                        if (!cart.orderToken) {
                             return;
                         }
 
@@ -758,6 +765,7 @@ $trackCallbacks = $block->getTrackCallbacks();
                         hints = deepMergeObjects(hints, data.hints);
                         hints.prefill = prefill;
                         hints.publishableKey = getCheckoutKey();
+                        //////////////////////////
 
                         resolve(cart);
 


### PR DESCRIPTION
Create order is called on js load on every page. When the cart is empty the cart promise gets rejected with an error shown in the console. 