### PR TITLE
coupon_code undefined / not evaluated if amount exists fix

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -922,14 +922,14 @@ class Cart extends AbstractHelper
         // selecting specific shipping option, so the conditional statement should also
         // check if getCouponCode is not null
         /////////////////////////////////////////////////////////////////////////////////
-        if ( ( $amount = @$address->getDiscountAmount() ) || ( $coupon_code = @$address->getCouponCode() ) ) {
+        if ( ($amount = $address->getDiscountAmount()) || $address->getCouponCode() ) {
             $amount         = abs($amount);
             $roundedAmount = $this->getRoundAmount($amount);
 
             $cart['discounts'][] = [
                 'description' => trim(__('Discount ') . $address->getDiscountDescription()),
                 'amount'      => $roundedAmount,
-                'reference'   => $coupon_code
+                'reference'   => $address->getCouponCode()
             ];
 
             $diff -= $amount * 100 - $roundedAmount;


### PR DESCRIPTION
```php
if (( $amount = @$address->getDiscountAmount()) || ( $coupon_code = @$address->getCouponCode()))
```
If the first part of the condition ($amount) evaluates to true, evaluating of the second one is skipped throwing an error here:
```php
$cart['discounts'][] = [
    ...
    'reference'   => $coupon_code
];
```