### PR TITLE
M 2.3.x back-office redirect url secret / form key issue

### DIFF
--- a/Controller/Adminhtml/Order/Save.php
+++ b/Controller/Adminhtml/Order/Save.php
@@ -96,21 +96,20 @@ class Save extends Action
             // get the transaction reference parameter
             $reference = $this->getRequest()->getParam('reference');
             // call order save and update
-//            list($quote, $order) = $this->orderHelper->saveUpdateOrder($reference);
-//
-//            $orderId = $order->getId();
-//            // clear the session data
-//            if ($orderId) {
-//                //Clear quote session
-//                $this->clearQuoteSession($quote);
-//                //Clear order session
-//                $this->clearOrderSession($order);
-//            }
+            list($quote, $order) = $this->orderHelper->saveUpdateOrder($reference);
+
+            $orderId = $order->getId();
+            // clear the session data
+            if ($orderId) {
+                //Clear quote session
+                $this->clearQuoteSession($quote);
+                //Clear order session
+                $this->clearOrderSession($order);
+            }
             // return the success page redirect URL
             $result = $this->resultJsonFactory->create();
 
-//            $result->setData(['success_url' => $this->_url->getUrl('sales/order/view/', ['order_id' => $orderId])]);
-            $result->setData(['success_url' => $this->_url->getUrl('sales/order')]);
+            $result->setData(['success_url' => $this->_url->getUrl('sales/order/view/', ['order_id' => $orderId])]);
 
             return $result;
         } catch (Exception $e) {

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1119,6 +1119,8 @@ class Cart extends AbstractHelper
             $this->bugsnag->notifyError('Cart Totals Mismatch', "Totals adjusted by $diff.");
         }
 
+        $this->sessionHelper->cacheFormKey($immutableQuote);
+
         // $this->logHelper->addInfoLog(json_encode($cart, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES));
 
         return $cart;

--- a/Helper/Session.php
+++ b/Helper/Session.php
@@ -195,6 +195,6 @@ class Session extends AbstractHelper
     public function cacheFormKey($quote)
     {
         $cacheIdentifier = self::BOLT_SESSION_PREFIX_FORM_KEY . $quote->getId();
-        $this->cache->save($this->formKey->getFormKey(), $cacheIdentifier, [], 86400);
+        $this->cache->save($this->formKey->getFormKey(), $cacheIdentifier, [], 14400);
     }
 }


### PR DESCRIPTION
In order the redirect URL to work it needs to include the correct key a segment.
The URL is generated in vendor/magento/module-backend/Model/Url::getUrl() and calls
vendor/magento/module-backend/Model/Url::getSecretKey() which uses the form key as a salt for generating the hash (key), $salt = $this->formKey->getFormKey();

Form key is generated and stored in the session. We need to pass it to (session-less) CreateOrder API endpoint where the redirect URL is generated. The solution implemented is to use Magento cache on cart creation to store the form key with the immutable quote id as cache identifier. I tried to avoid adding another field to the quote table. I tested this and it works even with all the available Magento cache types disabled.