### PR TITLE
Multi-website: fix disappearing Bolt button at first load in admin side

### DIFF
--- a/Block/Js.php
+++ b/Block/Js.php
@@ -22,7 +22,7 @@ use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Element\Template\Context;
 use Magento\Framework\Session\SessionManager as CheckoutSession;
 use Bolt\Boltpay\Helper\Cart as CartHelper;
-use Magento\Backend\Model\Session\Quote as BackendSessionQuote;
+use Magento\Quote\Model\Quote;
 
 /**
  * Js Block. The block class used in replace.phtml and track.phtml blocks.
@@ -443,11 +443,8 @@ class Js extends Template
      */
     public function getMagentoStoreId()
     {
-        if ($this->checkoutSession instanceof BackendSessionQuote) {
-            $quote = $this->checkoutSession->getQuote();
-        } else {
-            $quote = $this->checkoutSession->getQuote();
-        }
+        /** @var Quote $quote */
+        $quote = $this->checkoutSession->getQuote();
 
         return ($quote && $quote->getStoreId()) ?
             (int) $quote->getStoreId() : null;

--- a/Block/Js.php
+++ b/Block/Js.php
@@ -444,15 +444,13 @@ class Js extends Template
     public function getMagentoStoreId()
     {
         if ($this->checkoutSession instanceof BackendSessionQuote) {
-            $quote = $this->checkoutSession;
+            $quote = $this->checkoutSession->getQuote();
         } else {
             $quote = $this->checkoutSession->getQuote();
         }
 
-        // TODO: need to check and add unit tests for case when we return null instead of zero!
-        // Several time i caught when quote was created but do not have store_id - it was null.
-        return (int) (($quote && $quote->getStoreId()) ?
-            $quote->getStoreId() : 0);
+        return ($quote && $quote->getStoreId()) ?
+            (int) $quote->getStoreId() : null;
     }
 
     /**


### PR DESCRIPTION
Task - https://app.asana.com/0/941920570700290/1125041703113784/f

The problem was at returned 0 instead of null if we have clean quote.
Magento could not find store with id 0 in 1 case (see below).

We have several cases for multi-store which already covered:

- [x] 1. We do not have Bolt's api keys in default store view.
- [x] 2. We have Bolt's api keys in default store view.
- [x] 3. We have different Bolt's ApiKey and Signing Secret keys for different website/stores.