### PR TITLE
MultiWebsite updates.

### DIFF
--- a/view/adminhtml/layout/sales_order_create_load_block_data.xml
+++ b/view/adminhtml/layout/sales_order_create_load_block_data.xml
@@ -18,11 +18,14 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <referenceBlock name="order_create_billing_form">
-            <action method="setMethodFormTemplate">
-                <argument name="method" xsi:type="string">boltpay</argument>
-                <argument name="template" xsi:type="string">Bolt_Boltpay::boltpay/button.phtml</argument>
-            </action>
+        <!--
+            Do not remove it or move to another place. This part work with payment section directly
+            and it is avoid many problems with incorrect store_id determination for admin side.
+        -->
+        <referenceBlock name="data">
+            <container name="additional_area">
+                <block class="Bolt\Boltpay\Block\Js" name="replacejs" template="Bolt_Boltpay::boltpay/js/replacejs.phtml" />
+            </container>
         </referenceBlock>
     </body>
 </page>

--- a/view/adminhtml/templates/boltpay/js/replacejs.phtml
+++ b/view/adminhtml/templates/boltpay/js/replacejs.phtml
@@ -450,7 +450,9 @@ require([
         var params = [];
 
         params.push('form_key=' + $('[name="form_key"]').val());
-        params.push('magento_sid=' + magentoStoreId);
+        if (!isNaN(magentoStoreId)) {
+            params.push('magento_sid=' + magentoStoreId);
+        }
         params.push('payment_only=true');
         params = params.join('&');
 


### PR DESCRIPTION
- reverted Daniel's commit to proper store_id determination for admin side.
- update magentoStoreId JS variable check.

The main problem was in layout file. The functionality of js or templates and etc should be inside order page scope. If we placed code to `js` container (out of scope of order content) it is out of scope and kill ability to determine store or update data for our plugin, when we choose another store or change some shipping data or address data.