### PR TITLE
Add m2 codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Automatically request reviews from M2 code-owners
+* @matt-thomason @danac-gs @YevhenShBolt @ethanwayda22


### PR DESCRIPTION
Adding `CODEOWNERS` file to automatically request reviews.
https://github.blog/2017-07-06-introducing-code-owners/