### PR TITLE
make emulate session in API calls configurable, on by default - backward compatible

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -236,6 +236,11 @@ class Config extends AbstractHelper
     const XML_PATH_BOLT_ORDER_CACHING = 'payment/boltpay/bolt_order_caching';
 
     /**
+     * Emulate Customer Session in API Calls configuration path
+     */
+    const XML_PATH_API_EMULATE_SESSION = 'payment/boltpay/api_emulate_session';
+
+    /**
      * Default whitelisted shopping cart and checkout pages "Full Action Name" identifiers, <router_controller_action>
      * Pages allowed to load Bolt javascript / show checkout button
      */
@@ -1102,6 +1107,21 @@ class Config extends AbstractHelper
     {
         return $this->getScopeConfig()->isSetFlag(
             self::XML_PATH_BOLT_ORDER_CACHING,
+            ScopeInterface::SCOPE_STORE,
+            $store
+        );
+    }
+    /**
+     * Get Emulate Customer Session in API Calls flag configuration
+     *
+     * @param int|string|Store $store
+     *
+     * @return  boolean
+     */
+    public function isSessionEmulationEnabled($store = null)
+    {
+        return $this->getScopeConfig()->isSetFlag(
+            self::XML_PATH_API_EMULATE_SESSION,
             ScopeInterface::SCOPE_STORE,
             $store
         );

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -153,6 +153,10 @@
                     <label>Cache Bolt Order Token (Performance Optimization)</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
+                <field id="api_emulate_session" translate="label" type="select" sortOrder="270" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <label>Emulate Customer Session in API Calls</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
             </group>
         </section>
     </system>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -54,6 +54,7 @@ tr.shipping.totals td.amount span.price,
                 <store_credit>0</store_credit>
                 <enable_payment_only_checkout>0</enable_payment_only_checkout>
                 <bolt_order_caching>1</bolt_order_caching>
+                <api_emulate_session>1</api_emulate_session>
             </boltpay>
         </payment>
     </default>


### PR DESCRIPTION
This method:

```php
private function setSession($session, $sessionID, $storeId)
{
    // close current session
    $session->writeClose();
    // set session id (to value loaded from cache)
    $session->setSessionId($sessionID);
    // re-start the session
    $session->start();
}
```

Invalidated logged in customer session when Stores -> Configuration -> General -> Web -> Session Validation Settings -> Validate HTTP_USER_AGENT option is turned ON (Scentlok websites).

This PR adds a configuration option so we can bypass this method when needed. It remains ON by default.