### PR TITLE
duplicate item.reference fix, using the actual product id instead of the parent one

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -902,10 +902,10 @@ class Cart extends AbstractHelper
                 ////////////////////////////////////
                 // Load item product object
                 ////////////////////////////////////
-                /** @var \Magento\Catalog\Model\ProductFactory $_product */
+                /** @var \Magento\Catalog\Model\ProductFactory */
                 $productFactory = $this->productFactory->create();
                 $productId = $productFactory->getIdBySku($item->getSku());
-                /** @var \Magento\Catalog\Model\Product $_product */
+                /** @var \Magento\Catalog\Model\Product */
                 $_product = $productFactory->load($productId);
 
                 $product['reference']    = $productId;

--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -238,21 +238,7 @@ class ShippingMethods implements ShippingMethodsInterface
         if ($cartItems['quantity'] != $quoteItems['quantity'] || $cartItems['total'] != $quoteItems['total']) {
             $this->bugsnag->registerCallback(function ($report) use ($cart, $quote) {
 
-                $quoteItems = array_map(function ($item) {
-                    $product = [];
-                    $productId = $item->getProductId();
-                    $unitPrice   = $item->getCalculationPrice();
-                    $totalAmount = $unitPrice * $item->getQty();
-                    $roundedTotalAmount = $this->cartHelper->getRoundAmount($totalAmount);
-                    $product['reference']    = $productId;
-                    $product['name']         = $item->getName();
-                    $product['description']  = $item->getDescription();
-                    $product['total_amount'] = $roundedTotalAmount;
-                    $product['unit_price']   = $this->cartHelper->getRoundAmount($unitPrice);
-                    $product['quantity']     = round($item->getQty());
-                    $product['sku']          = trim($item->getSku());
-                    return $product;
-                }, $quote->getAllVisibleItems());
+                list($quoteItems) = $this->cartHelper->getCartItems($quote->getAllVisibleItems(), $quote->getStoreId());
 
                 $report->setMetaData([
                     'CART_MISMATCH' => [

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -414,10 +414,12 @@ class CartTest extends TestCase
     {
         $product = $this->getProductMock();
         $this->productFactory = $this->getMockBuilder(ProductFactory::class)
-            ->setMethods(['create', 'load'])
+            ->setMethods(['create', 'load', 'getIdBySku'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->productFactory->method('create')->willReturnSelf();
+        $this->productFactory->method('getIdBySku')
+            ->willReturn(self::PRODUCT_ID);
         $this->productFactory->method('load')
             ->with(self::PRODUCT_ID)
             ->willReturn($product);


### PR DESCRIPTION
https://app.asana.com/0/941920570700290/1125788326073905/f

Code refactored a bit to remove repeating in shipping and tax call.
This is the main change:
```php
/** @var \Magento\Catalog\Model\ProductFactory */
$productFactory = $this->productFactory->create();
$productId = $productFactory->getIdBySku($item->getSku());
/** @var \Magento\Catalog\Model\Product */
$_product = $productFactory->load($productId);
```