### PR TITLE
 [Coverage] Add codecov to magento2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,10 @@ jobs:
       - run:
           name: PHP 7.2 Magento2.3
           command: |
+            mkdir ./artifacts
+            export TEST_ENV=php72
             MAGENTO_VERSION=2.3.0 Test/scripts/ci.sh
+
   unit-php71-magento22:
     docker:
       - image: circleci/php:7.1-apache-node-browsers-legacy
@@ -19,6 +22,8 @@ jobs:
       - run:
           name: PHP 7.1 Magento2.2
           command: |
+            mkdir ./artifacts
+            export TEST_ENV=php71
             MAGENTO_VERSION=2.2.0 Test/scripts/ci.sh
   unit-php70-magento22:
     docker:
@@ -29,6 +34,8 @@ jobs:
       - run:
           name: PHP 7.0 Magento2.2
           command: |
+            mkdir ./artifacts
+            export TEST_ENV=php70
             MAGENTO_VERSION=2.2.0 Test/scripts/ci.sh
   phpcs:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,8 @@ jobs:
             mkdir ./artifacts
             export TEST_ENV=php72
             MAGENTO_VERSION=2.3.0 Test/scripts/ci.sh
+      - store_artifacts:
+          path: ./artifacts
 
   unit-php71-magento22:
     docker:
@@ -25,6 +27,9 @@ jobs:
             mkdir ./artifacts
             export TEST_ENV=php71
             MAGENTO_VERSION=2.2.0 Test/scripts/ci.sh
+      - store_artifacts:
+          path: ./artifacts
+
   unit-php70-magento22:
     docker:
       - image: circleci/php:7.0-apache-node-browsers-legacy
@@ -37,6 +42,9 @@ jobs:
             mkdir ./artifacts
             export TEST_ENV=php70
             MAGENTO_VERSION=2.2.0 Test/scripts/ci.sh
+      - store_artifacts:
+          path: ./artifacts
+
   phpcs:
     docker:
       - image: circleci/php:7.2-cli

--- a/Test/scripts/ci.sh
+++ b/Test/scripts/ci.sh
@@ -13,4 +13,5 @@ mkdir -p magento/app/code/Bolt/Boltpay
 cp -r project/. magento/app/code/Bolt/Boltpay/
 cp magento/app/code/Bolt/Boltpay/Test/Unit/phpunit.xml magento/dev/tests/unit/bolt_phpunit.xml
 echo "Starting Bolt Unit Tests"
-php magento/vendor/phpunit/phpunit/phpunit --verbose -c magento/dev/tests/unit/bolt_phpunit.xml
+php magento/vendor/phpunit/phpunit/phpunit --verbose -c magento/dev/tests/unit/bolt_phpunit.xml --coverage-clover=./artifacts/coverage.xml
+bash <(curl -s https://bolt-devops.s3-us-west-2.amazonaws.com/testing/codecov_uploader) -f ./artifacts/coverage.xml -F $TEST_ENV


### PR DESCRIPTION
We will get coverage reports. The report for this branch will not be as accurate till we merge and have a run for the base branch (i.e. `develop`)

For an example look at hail or storm.