### PR TITLE
Add merchant exp admins

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Automatically request reviews from M2 code-owners
-* @matt-thomason @danac-gs @YevhenShBolt @ethanwayda22
+* @matt-thomason @danac-gs @YevhenShBolt @ethanwayda22 @BoltApp/merchant-exp-admins


### PR DESCRIPTION
The group has @daisy1754 and @akshayas. This reduces the number of admins to only a few people. if this works, we will move all but matt into the group and remove them from the file. also makes adding and removing owners easily