### PR TITLE
Optimize Circle build pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
             MAGENTO_VERSION=2.2.0 Test/scripts/ci.sh
   unit-php70-magento22:
     docker:
-      - image: circleci/php:7.0-apache-node-browsers-legacy
+      - image: boltdev/m2-plugin-ci-php70:v1
       - image: circleci/mysql:5.7
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,30 +6,57 @@ jobs:
       - image: circleci/mysql:5.7
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - v1-php72mag23-composer-lock-{{ arch }}-{{ checksum "composer.json" }}
+            - v1-php72mag23-composer-lock-{{ arch }}
+            - v1-php72mag23-composer-lock
       - run:
           name: PHP 7.2 Magento2.3
           command: |
             MAGENTO_VERSION=2.3.0 Test/scripts/ci.sh
+      - save_cache:
+          key: v1-php72mag23-composer-lock-{{ arch }}-{{ checksum "composer.json" }}
+          paths:
+            - /home/circleci/.composer/cache/
   unit-php71-magento22:
     docker:
       - image: boltdev/m2-plugin-ci-php71:v1
       - image: circleci/mysql:5.7
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - v1-php71mag22-composer-lock-{{ arch }}-{{ checksum "composer.json" }}
+            - v1-php71mag22-composer-lock-{{ arch }}
+            - v1-php71mag22-composer-lock
       - run:
           name: PHP 7.1 Magento2.2
           command: |
             MAGENTO_VERSION=2.2.0 Test/scripts/ci.sh
+      - save_cache:
+          key: v1-php71mag22-composer-lock-{{ arch }}-{{ checksum "composer.json" }}
+          paths:
+            - /home/circleci/.composer/cache/
   unit-php70-magento22:
     docker:
       - image: boltdev/m2-plugin-ci-php70:v1
       - image: circleci/mysql:5.7
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - v1-php70mag22-composer-lock-{{ arch }}-{{ checksum "composer.json" }}
+            - v1-php70mag22-composer-lock-{{ arch }}
+            - v1-php70mag22-composer-lock
       - run:
           name: PHP 7.0 Magento2.2
           command: |
             MAGENTO_VERSION=2.2.0 Test/scripts/ci.sh
+      - save_cache:
+          key: v1-php70mag22-composer-lock-{{ arch }}-{{ checksum "composer.json" }}
+          paths:
+            - /home/circleci/.composer/cache/
   phpcs:
     docker:
       - image: circleci/php:7.2-cli

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   unit-php72-magento23:
     docker:
-      - image: circleci/php:7.2-apache-node-browsers-legacy
+      - image: boltdev/m2-plugin-ci-php72:v1
       - image: circleci/mysql:5.7
     steps:
       - checkout
@@ -12,7 +12,7 @@ jobs:
             MAGENTO_VERSION=2.3.0 Test/scripts/ci.sh
   unit-php71-magento22:
     docker:
-      - image: circleci/php:7.1-apache-node-browsers-legacy
+      - image: boltdev/m2-plugin-ci-php71:v1
       - image: circleci/mysql:5.7
     steps:
       - checkout

--- a/Test/scripts/install_magento.sh
+++ b/Test/scripts/install_magento.sh
@@ -22,20 +22,6 @@ set -x
 
 trap '>&2 echo Error: Command \`$BASH_COMMAND\` on line $LINENO failed with exit code $?' ERR
 
-echo "Installing dependencies..."
-sudo apt-get update && sudo apt-get -y install curl mysql-client libmcrypt-dev mcrypt libpng-dev libjpeg-dev libxml2-dev libxslt-dev
-sudo pecl channel-update pecl.php.net
-sudo pecl install zip && sudo docker-php-ext-enable zip
-sudo pecl install xdebug && sudo docker-php-ext-enable xdebug
-sudo docker-php-ext-configure gd --with-jpeg-dir=/usr/include/
-sudo docker-php-ext-install gd
-sudo docker-php-ext-install soap
-sudo docker-php-ext-install xsl
-sudo docker-php-ext-install mcrypt && sudo docker-php-ext-enable mcrypt
-sudo docker-php-ext-install bcmath && sudo docker-php-ext-enable bcmath
-sudo docker-php-ext-install pdo_mysql && sudo docker-php-ext-enable pdo_mysql
-
-sudo composer self-update -q
 composer show -i
 echo "{\"http-basic\":{\"repo.magento.com\":{\"username\":\"${MAGENTO_PUBLIC_KEY}\",\"password\":\"${MAGENTO_PRIVATE_KEY}\"}}}" > $HOME/.composer/auth.json
 cd ..

--- a/operations/docker/php70/Dockerfile
+++ b/operations/docker/php70/Dockerfile
@@ -1,0 +1,23 @@
+# Dockerfile
+FROM circleci/php:7.0-apache-node-browsers-legacy
+
+USER root
+ENV LANG=C.UTF-8
+
+RUN MAGENTO_VERSION=2.3.0
+
+RUN apt-get update && apt-get -y install curl mysql-client libmcrypt-dev mcrypt libpng-dev libjpeg-dev libxml2-dev libxslt-dev
+RUN pecl channel-update pecl.php.net
+RUN pecl install zip &&  docker-php-ext-enable zip
+RUN pecl install xdebug &&  docker-php-ext-enable xdebug
+RUN docker-php-ext-configure gd --with-jpeg-dir=/usr/include/
+RUN docker-php-ext-install gd
+RUN docker-php-ext-install soap
+RUN docker-php-ext-install xsl
+RUN docker-php-ext-install mcrypt && docker-php-ext-enable mcrypt
+RUN docker-php-ext-install bcmath && docker-php-ext-enable bcmath
+RUN docker-php-ext-install pdo_mysql && docker-php-ext-enable pdo_mysql
+
+RUN  composer self-update -q
+
+USER circleci

--- a/operations/docker/php71/Dockerfile
+++ b/operations/docker/php71/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile
-FROM circleci/php:7.0-apache-node-browsers-legacy
+FROM circleci/php:7.1-apache-node-browsers-legacy
 
 USER root
 ENV LANG=C.UTF-8
@@ -9,7 +9,7 @@ RUN MAGENTO_VERSION=2.2.0
 RUN apt-get update && apt-get -y install curl mysql-client libmcrypt-dev mcrypt libpng-dev libjpeg-dev libxml2-dev libxslt-dev
 RUN pecl channel-update pecl.php.net
 RUN pecl install zip &&  docker-php-ext-enable zip
-RUN pecl install xdebug &&  docker-php-ext-enable xdebug
+RUN docker-php-ext-enable xdebug
 RUN docker-php-ext-configure gd --with-jpeg-dir=/usr/include/
 RUN docker-php-ext-install gd
 RUN docker-php-ext-install soap

--- a/operations/docker/php72/Dockerfile
+++ b/operations/docker/php72/Dockerfile
@@ -1,20 +1,22 @@
 # Dockerfile
-FROM circleci/php:7.0-apache-node-browsers-legacy
+FROM circleci/php:7.2-apache-node-browsers-legacy
 
 USER root
 ENV LANG=C.UTF-8
 
-RUN MAGENTO_VERSION=2.2.0
+RUN MAGENTO_VERSION=2.3.0
 
 RUN apt-get update && apt-get -y install curl mysql-client libmcrypt-dev mcrypt libpng-dev libjpeg-dev libxml2-dev libxslt-dev
 RUN pecl channel-update pecl.php.net
 RUN pecl install zip &&  docker-php-ext-enable zip
-RUN pecl install xdebug &&  docker-php-ext-enable xdebug
+RUN docker-php-ext-enable xdebug
 RUN docker-php-ext-configure gd --with-jpeg-dir=/usr/include/
 RUN docker-php-ext-install gd
 RUN docker-php-ext-install soap
 RUN docker-php-ext-install xsl
-RUN docker-php-ext-install mcrypt && docker-php-ext-enable mcrypt
+RUN apt-get install -y libmcrypt-dev
+RUN pecl install mcrypt-1.0.2
+RUN docker-php-ext-enable mcrypt
 RUN docker-php-ext-install bcmath && docker-php-ext-enable bcmath
 RUN docker-php-ext-install pdo_mysql && docker-php-ext-enable pdo_mysql
 


### PR DESCRIPTION
- cache composer packages
- re-use image with needed packages installed.

rough saving ~5 to 6 mins per workflow (and ~2 minutes per build) 

prior to optimization: 
![image](https://user-images.githubusercontent.com/678239/59960184-3e60dd80-9479-11e9-821b-21ba15be2046.png)

post optimization
![image](https://user-images.githubusercontent.com/678239/59960181-39039300-9479-11e9-957e-769c2cecab58.png)
