### PR TITLE
Collect immutable quote totals when checking if the coupon is invalid  for the shipping address

### DIFF
--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -767,7 +767,7 @@ class ShippingMethods implements ShippingMethodsInterface
         $ignoredShippingAddressCoupons = $this->configHelper->getIgnoredShippingAddressCoupons($quote->getStoreId());
 
         return $parentQuoteCoupon &&
-               !$quote->getCouponCode() &&
-               in_array($parentQuoteCoupon, $ignoredShippingAddressCoupons);
+                in_array($parentQuoteCoupon, $ignoredShippingAddressCoupons) &&
+                !$quote->setTotalsCollectedFlag(false)->collectTotals()->getCouponCode();
     }
 }


### PR DESCRIPTION
**Issue:**
Getting the quote prevents the quote totals from being collected and it breaks the changes that we made in the past for adding the discount back to the shipping amount when the address doesn’t allow a discount. See the previous PR here https://github.com/BoltApp/bolt-magento2/pull/252.

**Proposed solution:**
Collect the totals when checking if the coupon is invalid for the shipping address

Asana task: https://app.asana.com/0/941920570700290/1116347704823454