### PR TITLE
Add apple pay prefill hints fix

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -689,6 +689,11 @@ class Cart extends AbstractHelper
                 }
             }
 
+            // Skip pre-fill for Apple Pay related data.
+            if (!($prefill['email'] == 'fake@email.com' || $prefill['phone'] == '1111111111')) {
+                $hints['prefill'] = $prefill;
+            }
+
             $hints['prefill'] = array_merge($hints['prefill'], $prefill);
         };
 


### PR DESCRIPTION
Fix for apple pay incorrect prefill.
Reference: https://github.com/BoltApp/bolt-magento1/pull/399/files
https://app.asana.com/0/932047656377869/1129810277275150