### PR TITLE
Add custom address fields to order token cache identifier

### DIFF
--- a/Model/Api/CreateOrder.php
+++ b/Model/Api/CreateOrder.php
@@ -54,6 +54,7 @@ class CreateOrder implements CreateOrderInterface
     const E_BOLT_DISCOUNT_CANNOT_APPLY = 2001006;
     const E_BOLT_DISCOUNT_CODE_DOES_NOT_EXIST = 2001007;
     const E_BOLT_SHIPPING_EXPIRED = 2001008;
+    const E_BOLT_REJECTED_ORDER = 2001010;
 
     /**
      * @var HookHelper
@@ -208,6 +209,14 @@ class CreateOrder implements CreateOrderInterface
             if (! $createdOrder) {
                 $this->validateQuoteData($quote, $transaction);
                 $createdOrder = $this->orderHelper->processNewOrder($quote, $transaction);
+            }
+
+            if($createdOrder->isCanceled()){
+                throw new BoltException(
+                    __('Order has been canceled due to the previously declined payment',
+                    null,
+                    self::E_BOLT_REJECTED_ORDER
+                ));
             }
 
             $this->sendResponse(200, [

--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -472,6 +472,7 @@ class ShippingMethods implements ShippingMethodsInterface
             }
 
             $cacheIdentifier .= '_' . $this->cartHelper->convertCustomAddressFieldsToCacheIdentifier($quote);
+            $cacheIdentifier = md5($cacheIdentifier);
 
             if ($serialized = $this->cache->load($cacheIdentifier)) {
                 $address = $quote->isVirtual() ? $quote->getBillingAddress() : $quote->getShippingAddress();

--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -471,7 +471,9 @@ class ShippingMethods implements ShippingMethodsInterface
                 $cacheIdentifier .= '_'.$ruleIds;
             }
 
-            $cacheIdentifier .= '_' . $this->cartHelper->convertCustomAddressFieldsToCacheIdentifier($quote);
+            // extend cache identifier with custom address fields
+            $cacheIdentifier .= $this->cartHelper->convertCustomAddressFieldsToCacheIdentifier($quote);
+
             $cacheIdentifier = md5($cacheIdentifier);
 
             if ($serialized = $this->cache->load($cacheIdentifier)) {

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -470,7 +470,9 @@ class CartTest extends TestCase
             'boltCreateOrder',
             'saveToCache',
             'updateQuoteTimestamp',
-            'clearExternalData'
+            'clearExternalData',
+            'convertCustomAddressFieldsToCacheIdentifier',
+            'getCustomAddressFieldsPascalCaseArray'
         ];
 
         $mock = $this->createPartialMock(BoltHelperCart::class, $methods);

--- a/Test/Unit/Model/Api/ShippingMethodsTest.php
+++ b/Test/Unit/Model/Api/ShippingMethodsTest.php
@@ -159,12 +159,17 @@ class ShippingMethodsTest extends TestCase
             ->willReturnSelf();
 
         $this->cartHelper = $this->getMockBuilder(CartHelper::class)
-            ->setMethods(['getQuoteById', 'validateEmail', 'getRoundAmount'])
-            ->disableOriginalConstructor()
+            ->setMethods([
+                'getQuoteById', 'validateEmail', 'getRoundAmount', 'convertCustomAddressFieldsToCacheIdentifier'
+            ])->disableOriginalConstructor()
             ->getMock();
 
+        $this->cartHelper->expects($this->any())
+            ->method('convertCustomAddressFieldsToCacheIdentifier')
+            ->willReturn("");
+
         $this->configHelper = $this->getMockBuilder(ConfigHelper::class)
-            ->setMethods(['getPrefetchShipping', 'getPrefetchAddressFields', 'getResetShippingCalculation', 'getIgnoredShippingAddressCoupons'])
+            ->setMethods(['getPrefetchShipping', 'getResetShippingCalculation', 'getIgnoredShippingAddressCoupons'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->configHelper->method('getPrefetchShipping')
@@ -172,8 +177,6 @@ class ShippingMethodsTest extends TestCase
             ->willReturn(true);
         $this->configHelper->method('getIgnoredShippingAddressCoupons')
             ->willReturn([]);
-        $this->configHelper->method('getPrefetchAddressFields')
-            ->willReturn('');
         $this->configHelper->expects($this->any())
             ->method('getResetShippingCalculation')
             ->with(null)
@@ -495,11 +498,11 @@ class ShippingMethodsTest extends TestCase
             'city' => 'New York'
         ];
 
-        $this->cartHelper->expects($this->at(0))
+        $this->cartHelper->expects($this->at(1))
             ->method('getRoundAmount')
             ->with('5')
             ->will($this->returnValue((int)500));
-        $this->cartHelper->expects($this->at(1))
+        $this->cartHelper->expects($this->at(2))
             ->method('getRoundAmount')
             ->with(0)
             ->will($this->returnValue(0));


### PR DESCRIPTION
Custom address field (e.g. commercial / residential flag used by restaurant supply) does not get taken into account when creating bolt order / caching bolt order token.