### PR TITLE
Remove redundant BoltCheckout.configure

### DIFF
--- a/view/frontend/templates/js/boltjs.phtml
+++ b/view/frontend/templates/js/boltjs.phtml
@@ -40,9 +40,3 @@ $checkoutKey  = $block->getCheckoutKey();
     src="<?php echo $connectJsUrl; ?>"
     data-publishable-key="<?php echo $checkoutKey; ?>">
 </script>
-<script>
-    // Prevent checkout to pop up until reconfigured in replacejs.html
-    // Checkout may be restricted, i.e. guest checkout not allowed
-    // The status is unknown at this point
-    BoltCheckout.configure({},{},{check:function(){return false}});
-</script>


### PR DESCRIPTION
# Description
Kill BoltCheckout.configure({}, {}, {check: function(){return false;})

https://github.com/BoltApp/bolt-magento2/blob/fab9d021a57089f64ffe2ddf9f54d46d34c451ae/view/frontend/templates/js/boltjs.phtml#L47

Can we get rid of this? I think if merchant clicks too soon we should show error (which will be default behaviour if you don't call configure) rather than silently swallowing click

Fixes: (link Asana Tank)
https://app.asana.com/0/941920570700290/1131786986588439/f

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [ ] I have created or modified unit tests to sufficiently cover my changes.
