### PR TITLE
[WIP] Supporting Minimum order amount Rule with popup

### DIFF
--- a/Block/Js.php
+++ b/Block/Js.php
@@ -212,7 +212,6 @@ class Js extends Template
             'additional_checkout_button_class' => $this->getAdditionalCheckoutButtonClass(),
             'initiate_checkout'        => $this->getInitiateCheckout(),
             'toggle_checkout'          => $this->getToggleCheckout(),
-            'is_valid_minimum_amount_rule' => $this->isValidMinimumAmountRule(),
             'minimum_amount_rule_message'  => $this->getMinimumAmountRuleMessage()
         ]);
     }
@@ -239,32 +238,16 @@ class Js extends Template
     }
 
     /**
-     * Check is valid minimum amount rule for cart.
-     *
-     * @return bool
-     */
-    private function isValidMinimumAmountRule()
-    {
-        $quote = $this->getQuoteFromCheckoutSession();
-        return ($quote && $quote->validateMinimumAmount());
-    }
-
-    /**
-     *  Get minimum amount rule message text.
+     *  Get MinimumOrderAmount message text.
      *
      * @return string
      * @throws \Zend_Currency_Exception
      */
     private function getMinimumAmountRuleMessage()
     {
-        $message = '';
+        $minimumAmountMessage = $this->moaValidationMessage->getMessage();
 
-        if (!$this->isValidMinimumAmountRule()) {
-            $minimumAmountMessage = $this->moaValidationMessage->getMessage();
-            $message = $minimumAmountMessage->getText();
-        }
-
-        return $message;
+        return $minimumAmountMessage->getText();
     }
 
     /**

--- a/Controller/Cart/Data.php
+++ b/Controller/Cart/Data.php
@@ -99,6 +99,16 @@ class Data extends Action
                 throw new BoltException(__('Guest checkout is not allowed.'));
             }
 
+            if (!$this->cartHelper->hasValidMinimumOrderAmountForCart()) {
+                return $result->setData([
+                    'status' => 'success',
+                    'cart' => [],
+                    'hints' => [],
+                    'is_not_valid_minimum_amount' => true,
+                    'backUrl' => '',
+                ]);
+            }
+
             // flag to determinate the type of checkout / data sent to Bolt
             $payment_only = $this->getRequest()->getParam('payment_only');
             // additional data collected from the (one page checkout) page,

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1623,4 +1623,16 @@ class Cart extends AbstractHelper
         // no restrictions
         return false;
     }
+
+    /**
+     * Get is valid Minimum Order Amount value for the cart.
+     *
+     * @return bool
+     */
+    public function hasValidMinimumOrderAmountForCart()
+    {
+        $quote = $this->checkoutSession->getQuote();
+
+        return ($quote && $quote->validateMinimumAmount());
+    }
 }

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -21,6 +21,7 @@ use Bolt\Boltpay\Block\Js as BlockJs;
 use Bolt\Boltpay\Helper\Bugsnag;
 use Bolt\Boltpay\Helper\Config as HelperConfig;
 use Bolt\Boltpay\Helper\Cart as CartHelper;
+use Magento\Quote\Model\Quote\Validator\MinimumOrderAmount\ValidationMessage as MoaValidationMessage;
 
 /**
  * Class JsTest
@@ -60,6 +61,11 @@ class JsTest extends \PHPUnit\Framework\TestCase
      * @var Bugsnag
      */
     private $bugsnagHelperMock;
+
+    /**
+     * @var MoaValidationMessage
+     */
+    private $moaValidationMessage;
 
     private $magentoQuote;
 
@@ -101,6 +107,20 @@ class JsTest extends \PHPUnit\Framework\TestCase
             )
             ->getMock();
 
+        $this->moaValidationMessage = $this->getMockBuilder(MoaValidationMessage::class)
+            ->setMethods(['getMessage'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $phrase = $this->getMockBuilder(\Magento\Framework\Phrase::class)
+            ->setMethods(['getText'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $phrase->method('getText')
+            ->willReturn($this->returnValue('test text'));
+        $this->moaValidationMessage->method('getMessage')
+            ->willReturn($phrase);
+
         $this->cartHelperMock = $this->createMock(CartHelper::class);
         $this->bugsnagHelperMock = $this->createMock(Bugsnag::class);
 
@@ -112,7 +132,8 @@ class JsTest extends \PHPUnit\Framework\TestCase
                     $this->configHelper,
                     $this->checkoutSessionMock,
                     $this->cartHelperMock,
-                    $this->bugsnagHelperMock
+                    $this->bugsnagHelperMock,
+                    $this->moaValidationMessage
                 ]
             )
             ->getMock();
@@ -232,7 +253,7 @@ class JsTest extends \PHPUnit\Framework\TestCase
         $this->assertJson($result, 'The Settings config do not have a proper JSON format.');
 
         $array = json_decode($result, true);
-        $this->assertCount(15, $array, 'The number of keys in the settings is not correct');
+        $this->assertCount(17, $array, 'The number of keys in the settings is not correct');
 
         $message = 'Cannot find in the Settings the key: ';
         $this->assertArrayHasKey('connect_url', $array, $message . 'connect_url');
@@ -250,6 +271,8 @@ class JsTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey('additional_checkout_button_class', $array, $message . 'additional_checkout_button_class');
         $this->assertArrayHasKey('initiate_checkout', $array, $message . 'initiate_checkout');
         $this->assertArrayHasKey('toggle_checkout', $array, $message . 'toggle_checkout');
+        $this->assertArrayHasKey('is_valid_minimum_amount_rule', $array, $message . 'is_valid_minimum_amount_rule');
+        $this->assertArrayHasKey('minimum_amount_rule_message', $array, $message . 'minimum_amount_rule_message');
     }
 
     /**

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -253,7 +253,7 @@ class JsTest extends \PHPUnit\Framework\TestCase
         $this->assertJson($result, 'The Settings config do not have a proper JSON format.');
 
         $array = json_decode($result, true);
-        $this->assertCount(17, $array, 'The number of keys in the settings is not correct');
+        $this->assertCount(16, $array, 'The number of keys in the settings is not correct');
 
         $message = 'Cannot find in the Settings the key: ';
         $this->assertArrayHasKey('connect_url', $array, $message . 'connect_url');
@@ -271,7 +271,6 @@ class JsTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey('additional_checkout_button_class', $array, $message . 'additional_checkout_button_class');
         $this->assertArrayHasKey('initiate_checkout', $array, $message . 'initiate_checkout');
         $this->assertArrayHasKey('toggle_checkout', $array, $message . 'toggle_checkout');
-        $this->assertArrayHasKey('is_valid_minimum_amount_rule', $array, $message . 'is_valid_minimum_amount_rule');
         $this->assertArrayHasKey('minimum_amount_rule_message', $array, $message . 'minimum_amount_rule_message');
     }
 

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -634,6 +634,14 @@ ob_start();
                     }
                 }
 
+                // Is valid minimum amount for cart.
+                if (settings.length && settings.is_valid_minimum_amount_rule) {
+                    console.error(settings.minimum_amount_rule_message);
+                    showBoltErrorMessage(settings.minimum_amount_rule_message);
+
+                    return false;
+                }
+
                 popUpOpen = true;
                 return true;
             },

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -754,7 +754,6 @@ ob_start();
                 // send create order request
                 $.post(settings.create_order_url, params)
                     .done(function (data) {
-
                         var boltRestricted = !!data.restrict;
 
                         toggleCheckoutIfNeeded(boltRestricted);
@@ -767,6 +766,11 @@ ob_start();
 
                         if (data.status !== 'success') {
                             reject(new Error(data.message || 'Network request failed'));
+                            return;
+                        }
+
+                        if (data.status === 'success' && data.is_not_valid_minimum_amount === true) {
+                            reject(new Error(data.message || 'Minimum Amount not reached'));
                             return;
                         }
 

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -635,7 +635,7 @@ ob_start();
                 }
 
                 // Is valid minimum amount for cart.
-                if (settings.length && settings.is_valid_minimum_amount_rule) {
+                if (typeof settings !== undefined && !settings.is_valid_minimum_amount_rule) {
                     console.error(settings.minimum_amount_rule_message);
                     showBoltErrorMessage(settings.minimum_amount_rule_message);
 

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -510,7 +510,8 @@ ob_start();
         unsetInitiateCheckoutCookie();
 
         // the open status of checkout modal
-        var popUpOpen = false;
+        var popUpOpen = false,
+            needToShowErrorPopup = false;
 
         ////////////////////////////////////
         // BoltCheckout.configure parameters
@@ -635,9 +636,13 @@ ob_start();
                 }
 
                 // Is valid minimum amount for cart.
-                if (typeof settings !== undefined && !settings.is_valid_minimum_amount_rule) {
+                if (typeof settings !== undefined
+                    && needToShowErrorPopup
+                    && settings.minimum_amount_rule_message
+                ) {
                     console.error(settings.minimum_amount_rule_message);
                     showBoltErrorMessage(settings.minimum_amount_rule_message);
+                    needToShowErrorPopup = false;
 
                     return false;
                 }
@@ -770,6 +775,7 @@ ob_start();
                         }
 
                         if (data.status === 'success' && data.is_not_valid_minimum_amount === true) {
+                            needToShowErrorPopup = true;
                             reject(new Error(data.message || 'Minimum Amount not reached'));
                             return;
                         }


### PR DESCRIPTION
# Description
Added support of `Minimum Order Amount`. You can find it in Stores->Configuration->Sales->Sales->Minimum Order Amount.
This `Minimum Order Amount` blocking checkout process (and shows Bolt error popup) until customer reach required price in cart.

Fixes: https://app.asana.com/0/0/1133560231774834/f

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [x] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] I have created or modified unit tests to sufficiently cover my changes.
