### PR TITLE
Implement different success processing for pre-auth and non-pre-auth orders

### DIFF
--- a/Block/Js.php
+++ b/Block/Js.php
@@ -203,6 +203,7 @@ class Js extends Template
             'additional_checkout_button_class' => $this->getAdditionalCheckoutButtonClass(),
             'initiate_checkout'        => $this->getInitiateCheckout(),
             'toggle_checkout'          => $this->getToggleCheckout(),
+            'is_pre_auth'              => $this->getIsPreAuth(),
         ]);
     }
 
@@ -319,6 +320,19 @@ class Js extends Template
     {
         $toggleCheckout = $this->configHelper->getToggleCheckout();
         return $toggleCheckout && $toggleCheckout->active ? $toggleCheckout : null;
+    }
+
+    /**
+     * Get Is Pre-Auth configuration
+     *
+     * @return mixed
+     */
+    private function getIsPreAuth()
+    {
+        $storeId = $this->getStoreId();
+        $isPreAuth = $this->configHelper->getIsPreAuth($storeId);
+
+        return !empty($isPreAuth);
     }
 
     /**

--- a/Block/Js.php
+++ b/Block/Js.php
@@ -214,7 +214,6 @@ class Js extends Template
     public function isEnabled()
     {
         $storeId = $this->getStoreId();
-
         return $this->configHelper->isActive($storeId);
     }
 
@@ -325,14 +324,12 @@ class Js extends Template
     /**
      * Get Is Pre-Auth configuration
      *
-     * @return mixed
+     * @return bool
      */
     private function getIsPreAuth()
     {
         $storeId = $this->getStoreId();
-        $isPreAuth = $this->configHelper->getIsPreAuth($storeId);
-
-        return !empty($isPreAuth);
+        return $this->configHelper->getIsPreAuth($storeId);
     }
 
     /**

--- a/Controller/Adminhtml/Cart/Data.php
+++ b/Controller/Adminhtml/Cart/Data.php
@@ -105,6 +105,7 @@ class Data extends Action
 
             $storeId = $this->cartHelper->getSessionQuoteStoreId();
             $publishableKey = $this->configHelper->getPublishableKeyBackOffice($storeId);
+            $isPreAuth = $this->configHelper->getIsPreAuth($storeId);
 
             // format and send the response
             $cart = [
@@ -119,6 +120,7 @@ class Data extends Action
             $result->setData('hints', $hints);
             $result->setData('publishableKey', $publishableKey);
             $result->setData('storeId', $storeId);
+            $result->setData('isPreAuth', $isPreAuth);
 
             return $this->resultJsonFactory->create()->setData($result->getData());
         } catch (Exception $e) {

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -850,7 +850,7 @@ class Config extends AbstractHelper
      *
      * @return  boolean
      */
-    public function getIsPreAUth($store = null)
+    public function getIsPreAuth($store = null)
     {
         return $this->getScopeConfig()->isSetFlag(
             self::XML_PATH_IS_PRE_AUTH,

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -101,6 +101,11 @@ class Config extends AbstractHelper
     const XML_PATH_AUTOMATIC_CAPTURE_MODE = 'payment/boltpay/automatic_capture_mode';
 
     /**
+     * Is pre-auth
+     */
+    const XML_PATH_IS_PRE_AUTH = 'payment/boltpay/is_pre_auth';
+
+    /**
      * Prefetch shipping
      */
     const XML_PATH_PREFETCH_SHIPPING = 'payment/boltpay/prefetch_shipping';
@@ -836,6 +841,22 @@ class Config extends AbstractHelper
     {
         $config = $this->getAdditionalConfigObject($storeId);
         return @$config->$name;
+    }
+
+    /**
+     * Get Is Pre-Auth from config
+     *
+     * @param int|string|Store $store
+     *
+     * @return  boolean
+     */
+    public function getIsPreAUth($store = null)
+    {
+        return $this->getScopeConfig()->isSetFlag(
+            self::XML_PATH_IS_PRE_AUTH,
+            ScopeInterface::SCOPE_STORE,
+            $store
+        );
     }
 
     /**

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -101,7 +101,7 @@ class Config extends AbstractHelper
     const XML_PATH_AUTOMATIC_CAPTURE_MODE = 'payment/boltpay/automatic_capture_mode';
 
     /**
-     * Is pre-auth
+     * Is pre-auth configuration path
      */
     const XML_PATH_IS_PRE_AUTH = 'payment/boltpay/is_pre_auth';
 
@@ -844,7 +844,7 @@ class Config extends AbstractHelper
     }
 
     /**
-     * Get Is Pre-Auth from config
+     * Get Is Pre-Auth flag from config
      *
      * @param int|string|Store $store
      *

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -85,7 +85,8 @@ class JsTest extends \PHPUnit\Framework\TestCase
             'isSandboxModeSet', 'isActive', 'getAnyPublishableKey',
             'getPublishableKeyPayment', 'getPublishableKeyCheckout', 'getPublishableKeyBackOffice',
             'getReplaceSelectors', 'getGlobalCSS', 'getPrefetchShipping', 'getQuoteIsVirtual',
-            'getTotalsChangeSelectors', 'getAdditionalCheckoutButtonClass', 'getAdditionalConfigString'
+            'getTotalsChangeSelectors', 'getAdditionalCheckoutButtonClass', 'getAdditionalConfigString',
+            'getIsPreAuth'
         ];
 
         $this->configHelper = $this->getMockBuilder(HelperConfig::class)
@@ -232,7 +233,7 @@ class JsTest extends \PHPUnit\Framework\TestCase
         $this->assertJson($result, 'The Settings config do not have a proper JSON format.');
 
         $array = json_decode($result, true);
-        $this->assertCount(15, $array, 'The number of keys in the settings is not correct');
+        $this->assertCount(16, $array, 'The number of keys in the settings is not correct');
 
         $message = 'Cannot find in the Settings the key: ';
         $this->assertArrayHasKey('connect_url', $array, $message . 'connect_url');

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -85,8 +85,7 @@ class JsTest extends \PHPUnit\Framework\TestCase
             'isSandboxModeSet', 'isActive', 'getAnyPublishableKey',
             'getPublishableKeyPayment', 'getPublishableKeyCheckout', 'getPublishableKeyBackOffice',
             'getReplaceSelectors', 'getGlobalCSS', 'getPrefetchShipping', 'getQuoteIsVirtual',
-            'getTotalsChangeSelectors', 'getAdditionalCheckoutButtonClass', 'getAdditionalConfigString',
-            'getIsPreAuth'
+            'getTotalsChangeSelectors', 'getAdditionalCheckoutButtonClass', 'getAdditionalConfigString', 'getIsPreAuth'
         ];
 
         $this->configHelper = $this->getMockBuilder(HelperConfig::class)

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -59,9 +59,9 @@
                     <comment>If enabled, payment will be captured as soon as order is approved by Bolt. Otherwise, payment is captured when invoice is created in magento.</comment>
                 </field>
                 <field id="is_pre_auth" translate="label" type="select" sortOrder="85" showInDefault="1" showInWebsite="1" showInStore="0">
-                    <label>Is Pre-Auth</label>
+                    <label>Pre-Auth order creation</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <comment>If enabled, order will be created in the store prior to transaction authorization. In other case, transaction has to be authorized before order is created in the store </comment>
+                    <comment><![CDATA[Yes - order gets created in the store prior to transaction authorization<br />No - transaction has to be authorized before order is created in the store]]></comment>
                 </field>
                 <field id="geolocation_api_key" translate="label" type="obscure" sortOrder="85" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Geolocation API Key</label>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -58,6 +58,11 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>If enabled, payment will be captured as soon as order is approved by Bolt. Otherwise, payment is captured when invoice is created in magento.</comment>
                 </field>
+                <field id="is_pre_auth" translate="label" type="select" sortOrder="85" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <label>Is Pre-Auth</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>If enabled, order will be created in the store prior to transaction authorization. In other case, transaction has to be authorized before order is created in the store </comment>
+                </field>
                 <field id="geolocation_api_key" translate="label" type="obscure" sortOrder="85" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Geolocation API Key</label>
                     <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -56,6 +56,7 @@ tr.shipping.totals td.amount span.price,
                 <bolt_order_caching>1</bolt_order_caching>
                 <api_emulate_session>1</api_emulate_session>
                 <should_minify_javascript>1</should_minify_javascript>
+                <is_pre_auth>0</is_pre_auth>
             </boltpay>
         </payment>
     </default>

--- a/view/adminhtml/templates/boltpay/js/replacejs.phtml
+++ b/view/adminhtml/templates/boltpay/js/replacejs.phtml
@@ -355,7 +355,6 @@ require([
         multi_step_css_class     = 'bolt-multi-step-checkout',
         billing_address_selector = '#bolt-billing-address',
         place_order_payload_id   = 'bolt-place-order-payload';
-    var is_pre_auth              = settings.is_pre_auth;
 
     // On multiple checkout open/close actions the success event remains registered
     // resulting in making the success call multiple times. This variable stores
@@ -378,13 +377,24 @@ require([
 
         success: function (transaction, callback) {
 
+            /**
+             * Success transaction handler.
+             * Sets the success url for the non-preauth flow.
+             * Calls the callback function
+             * that finishes the checkout modal operation.
+             *
+             * param object data    response from the non-preauth order/save controller, optional
+             * return void
+             */
             var processSuccess = function (data) {
-                callbacks.success_url = data.success_url;
+                if (typeof data !== 'undefined') {
+                    callbacks.success_url = data.success_url;
+                }
                 callback();
             };
 
-            if (is_pre_auth) {
-                callback();
+            if (settings.is_pre_auth) {
+                processSuccess();
                 return;
             }
 
@@ -394,7 +404,7 @@ require([
             var parameters = [];
             parameters.push('form_key=' + $('[name="form_key"]').val());
             parameters.push('reference=' + transaction.reference);
-            parameters.push('store_id=' + window.boltConfig.storeId);
+            parameters.push('store_id=' + settings.storeId);
             parameters = parameters.join('&');
             // update order ajax request callback
             // sets the success order page redirect url from received data
@@ -474,6 +484,7 @@ require([
             hints.prefill = prefill;
 
             window.boltConfig.storeId = data.storeId;
+            window.boltConfig.isPreAuth = data.isPreAuth;
 
             insertConnectScript(data.publishableKey);
         };

--- a/view/adminhtml/templates/boltpay/js/replacejs.phtml
+++ b/view/adminhtml/templates/boltpay/js/replacejs.phtml
@@ -384,7 +384,7 @@ require([
             };
 
             if (is_pre_auth) {
-                processSuccess(transaction);
+                callback();
                 return;
             }
 

--- a/view/adminhtml/templates/boltpay/js/replacejs.phtml
+++ b/view/adminhtml/templates/boltpay/js/replacejs.phtml
@@ -355,6 +355,7 @@ require([
         multi_step_css_class     = 'bolt-multi-step-checkout',
         billing_address_selector = '#bolt-billing-address',
         place_order_payload_id   = 'bolt-place-order-payload';
+    var is_pre_auth              = settings.is_pre_auth;
 
     // On multiple checkout open/close actions the success event remains registered
     // resulting in making the success call multiple times. This variable stores
@@ -376,6 +377,11 @@ require([
         },
 
         success: function (transaction, callback) {
+            if (is_pre_auth) {
+                processSuccess(transaction, callback);
+                return;
+            }
+
             // abort previously sent save order request.
             if (save_request) save_request.abort();
             // add the transaction reference and admin form key to the request parameters
@@ -389,8 +395,7 @@ require([
             // and calls the final Bolt defined callback
             var onSuccess = function(data){
 
-                callbacks.success_url = data.success_url;
-                callback();
+                processSuccess(data, callback);
             };
             // ajax call to the update order transaction data endpoint.
             // passes the bolt transaction reference
@@ -434,6 +439,10 @@ require([
             // return !!cart.orderToken;
         }
     };
+    var processSuccess = function(data, callback){
+        callbacks.success_url = data.success_url;
+        callback();
+    }
     ////////////////////////////////////
 
     /////////////////////////////////////////////////////

--- a/view/adminhtml/templates/boltpay/js/replacejs.phtml
+++ b/view/adminhtml/templates/boltpay/js/replacejs.phtml
@@ -377,8 +377,14 @@ require([
         },
 
         success: function (transaction, callback) {
+
+            var processSuccess = function (data) {
+                callbacks.success_url = data.success_url;
+                callback();
+            };
+
             if (is_pre_auth) {
-                processSuccess(transaction, callback);
+                processSuccess(transaction);
                 return;
             }
 
@@ -394,8 +400,7 @@ require([
             // sets the success order page redirect url from received data
             // and calls the final Bolt defined callback
             var onSuccess = function(data){
-
-                processSuccess(data, callback);
+                processSuccess(data);
             };
             // ajax call to the update order transaction data endpoint.
             // passes the bolt transaction reference
@@ -439,10 +444,7 @@ require([
             // return !!cart.orderToken;
         }
     };
-    var processSuccess = function(data, callback){
-        callbacks.success_url = data.success_url;
-        callback();
-    }
+
     ////////////////////////////////////
 
     /////////////////////////////////////////////////////

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -458,7 +458,6 @@ ob_start();
         var billing_address_selector = '#bolt-billing-address';
         var place_order_payload_id   = 'bolt-place-order-payload';
         var customer_email_selector  = '#checkoutSteps #customer-email';
-        var is_pre_auth              = settings.is_pre_auth;
 
         ////////////////////////////////////////////////////////
         // Toggle between Bolt button and magento checkout button
@@ -554,7 +553,17 @@ ob_start();
             },
 
             success: function (transaction, callback) {
-
+                /**
+                 * Success transaction handler.
+                 * Sets the success url for the non-preauth flow.
+                 * Calls additional javascript if defined in configuration.
+                 * Triggers on success track event handler.
+                 * Finally, calls the callback function
+                 * that finishes the checkout modal operation.
+                 *
+                 * param object data    response from the non-preauth order/save controller, optional
+                 * return void
+                 */
                 var processSuccess = function (data) {
                     try {
                         if (typeof data !== 'undefined') {
@@ -567,7 +576,7 @@ ob_start();
                     }
                 };
 
-                if (is_pre_auth) {
+                if (settings.is_pre_auth) {
                     processSuccess();
                     return;
                 }
@@ -590,10 +599,8 @@ ob_start();
                             // we need to call this; otherwise bolt modal show infinte spinner.
                             callback();
                         }
-
-                        return false;
+                        return;
                     }
-
                     processSuccess(data);
                 };
                 // ajax call to the update order transaction data endpoint.

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -458,6 +458,7 @@ ob_start();
         var billing_address_selector = '#bolt-billing-address';
         var place_order_payload_id   = 'bolt-place-order-payload';
         var customer_email_selector  = '#checkoutSteps #customer-email';
+        var is_pre_auth              = settings.is_pre_auth;
 
         ////////////////////////////////////////////////////////
         // Toggle between Bolt button and magento checkout button
@@ -553,6 +554,11 @@ ob_start();
             },
 
             success: function (transaction, callback) {
+                if (is_pre_auth) {
+                    processSuccess(transaction, callback);
+                    return;
+                }
+
                 // abort previously sent save order request.
                 if (save_request) save_request.abort();
                 // get thr transaction reference
@@ -574,14 +580,8 @@ ob_start();
 
                         return false;
                     }
-                    try {
-                        <?php echo $block->getJavascriptSuccess(); ?>
-                        callbacks.success_url = data.success_url;
 
-                        trackCallbacks.onSuccess();
-                    } finally {
-                        callback();
-                    }
+                    processSuccess(data, callback);
                 };
                 // ajax call to the update order transaction data endpoint.
                 // passes the bolt transaction reference
@@ -646,6 +646,17 @@ ob_start();
                 }
             }
         };
+
+        var processSuccess = function(data, callback){
+            try {
+                <?php echo $block->getJavascriptSuccess(); ?>
+                callbacks.success_url = data.success_url;
+
+                trackCallbacks.onSuccess();
+            } finally {
+                callback();
+            }
+        }
         ////////////////////////////////////
 
         /////////////////////////////////////////////////////

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -554,8 +554,21 @@ ob_start();
             },
 
             success: function (transaction, callback) {
+
+                var processSuccess = function (data) {
+                    try {
+                        if (typeof data !== 'undefined') {
+                            callbacks.success_url = data.success_url;
+                        }
+                        <?php echo $block->getJavascriptSuccess(); ?>
+                        trackCallbacks.onSuccess();
+                    } finally {
+                        callback();
+                    }
+                };
+
                 if (is_pre_auth) {
-                    processSuccess(transaction, callback);
+                    processSuccess();
                     return;
                 }
 
@@ -581,7 +594,7 @@ ob_start();
                         return false;
                     }
 
-                    processSuccess(data, callback);
+                    processSuccess(data);
                 };
                 // ajax call to the update order transaction data endpoint.
                 // passes the bolt transaction reference
@@ -647,16 +660,6 @@ ob_start();
             }
         };
 
-        var processSuccess = function(data, callback){
-            try {
-                <?php echo $block->getJavascriptSuccess(); ?>
-                callbacks.success_url = data.success_url;
-
-                trackCallbacks.onSuccess();
-            } finally {
-                callback();
-            }
-        }
         ////////////////////////////////////
 
         /////////////////////////////////////////////////////


### PR DESCRIPTION
# Description
There is a redundant order/save call from the non pre-auth flow still present when pre-auth is turned on. It throws and error on HUF. Removing it fixes the issue.

Removing the call via configuration option, Pre-Auth order creation.

Fixes:
https://app.asana.com/0/941920570700290/1133661540833258/f

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] I have created or modified unit tests to sufficiently cover my changes.
