### PR TITLE
Multiple, subsequent irreversible rejected hooks fix

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -119,7 +119,7 @@ class Order extends AbstractHelper
             self::TS_REJECTED_IRREVERSIBLE,
             self::TS_CANCELED
         ],
-        self::TS_REJECTED_IRREVERSIBLE => [],
+        self::TS_REJECTED_IRREVERSIBLE => [self::TS_REJECTED_IRREVERSIBLE],
         self::TS_CREDIT_COMPLETED => [
             self::TS_CREDIT_COMPLETED,
             self::TS_COMPLETED,
@@ -1374,6 +1374,14 @@ class Order extends AbstractHelper
                 $prevTransactionState,
                 $transactionState
             ));
+        }
+
+        // The order has already been canceled, i.e. PERMANENTLY REJECTED
+        // Discard subsequent REJECTED_IRREVERSIBLE hooks processing and return (resulting in 200 OK response to Bolt)
+        if ($transactionState == self::TS_REJECTED_IRREVERSIBLE &&
+            $prevTransactionState == self::TS_REJECTED_IRREVERSIBLE
+        ) {
+            return;
         }
 
         // preset default payment / transaction values


### PR DESCRIPTION
# Description
The rejection hook is accepted by the plugin for the firstly received transaction, but is not expected for the second one cause the order was already canceled.
So the second hook fails, though redundant.

Fixes:
https://app.asana.com/0/474713171217346/1133992781429888/f
https://app.asana.com/0/0/1132873196131387/f

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [ ] I have created or modified unit tests to sufficiently cover my changes.
