### PR TITLE
Remove authcapture settings

### DIFF
--- a/Controller/Adminhtml/Cart/Data.php
+++ b/Controller/Adminhtml/Cart/Data.php
@@ -110,7 +110,6 @@ class Data extends Action
             // format and send the response
             $cart = [
                 'orderToken'  => $boltpayOrder ? $responseData['token'] : '',
-                'authcapture' => true
             ];
 
             $hints = $this->cartHelper->getHints();

--- a/Controller/Cart/Data.php
+++ b/Controller/Cart/Data.php
@@ -121,7 +121,6 @@ class Data extends Action
 
             $cart = array_merge($responseData['cart'], [
                 'orderToken'    => $response ? $responseData['token'] : '',
-                'authcapture'   => $this->configHelper->getAutomaticCaptureMode(),
                 'cartReference' => $cartReference,
             ]);
 

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -96,11 +96,6 @@ class Config extends AbstractHelper
     const XML_PATH_JAVASCRIPT_SUCCESS = 'payment/boltpay/javascript_success';
 
     /**
-     * Automatic capture mode
-     */
-    const XML_PATH_AUTOMATIC_CAPTURE_MODE = 'payment/boltpay/automatic_capture_mode';
-
-    /**
      * Is pre-auth configuration path
      */
     const XML_PATH_IS_PRE_AUTH = 'payment/boltpay/is_pre_auth';
@@ -566,22 +561,6 @@ class Config extends AbstractHelper
             self::XML_PATH_JAVASCRIPT_SUCCESS,
             ScopeInterface::SCOPE_STORE,
             $storeId
-        );
-    }
-
-    /**
-     * Get Automatic Capture mode from config
-     *
-     * @param int|string|Store $store
-     *
-     * @return  boolean
-     */
-    public function getAutomaticCaptureMode($store = null)
-    {
-        return $this->getScopeConfig()->isSetFlag(
-            self::XML_PATH_AUTOMATIC_CAPTURE_MODE,
-            ScopeInterface::SCOPE_STORE,
-            $store
         );
     }
 

--- a/README.md
+++ b/README.md
@@ -51,11 +51,6 @@ used to open the Bolt Payment Popup typically on Shopping cart and product pages
 used to open the Bolt Payment Popup typically on checkout pages
 + **Sandbox Mode**
 setting up testing vs. production execution environment
-+ **Automatic Capture Mode**
-capturing funds configuration
->> **YES** - both authorization and capture are done in a single step
->>
->> **NO** - the funds are captured in a separate request, initiated either from the store admin panel or from the Bolt merchant dashboard
 + **Replace Button Selectors**
 comma separated list of CSS selectors matching the elements to be replaced with Bolt checkout buttons, or Bolt checkout buttons placed alongside them
 >> `no suffix` - the default, inserts the Bolt button in place of the element and removes the element

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -358,18 +358,6 @@ class ConfigTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function testGetAutomaticCaptureMode()
-    {
-        $this->scopeConfig->method('isSetFlag')
-            ->with(BoltConfig::XML_PATH_AUTOMATIC_CAPTURE_MODE)
-            ->will($this->returnValue(false));
-
-        $this->assertFalse($this->currentMock->getAutomaticCaptureMode(), 'getAutomaticCaptureMode() method: not working properly');
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function testGetPrefetchShipping()
     {
         $this->scopeConfig->method('isSetFlag')

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -53,11 +53,6 @@
                     <label>Sandbox Mode</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="automatic_capture_mode" translate="label" type="select" sortOrder="80" showInDefault="1" showInWebsite="1" showInStore="0">
-                    <label>Automatic Capture Mode</label>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <comment>If enabled, payment will be captured as soon as order is approved by Bolt. Otherwise, payment is captured when invoice is created in magento.</comment>
-                </field>
                 <field id="is_pre_auth" translate="label" type="select" sortOrder="85" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Pre-Auth order creation</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -27,7 +27,6 @@
                 <checkout_type>payment_only_checkout</checkout_type>
                 <sandbox_mode>1</sandbox_mode>
                 <debug>0</debug>
-                <automatic_capture_mode>0</automatic_capture_mode>
                 <allowspecific>0</allowspecific>
                 <order_status>new</order_status>
                 <currency>USD</currency>


### PR DESCRIPTION
# Description
Removes authcapture settings from plugin, allowing admin dash settings to be the only source for this toggle.

Fixes: https://app.asana.com/0/941920570700290/1129108918946356/f

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] I have created or modified unit tests to sufficiently cover my changes.
