### PR TITLE
Postpone checkout submit all after

### DIFF
--- a/Controller/ReceivedUrlTrait.php
+++ b/Controller/ReceivedUrlTrait.php
@@ -84,6 +84,8 @@ trait ReceivedUrlTrait
                 /** @var Quote $quote */
                 $quote = $this->getQuoteById($order->getQuoteId());
 
+                $this->orderHelper->dispatchPostCheckoutEvents($order, $quote);
+
                 $redirectUrl = $this->getRedirectUrl($order);
 
                 // add quote information to the session

--- a/Helper/Discount.php
+++ b/Helper/Discount.php
@@ -902,4 +902,18 @@ class Discount extends AbstractHelper
                     ->getInstance()
                     ->getCustomerStoreCreditBalance($customerId);
     }
+
+    /**
+     * Some 3rd party discounts are not stored with the quote / totals. They are held in other tables
+     * and applied to quote temporarily in checkout / customer session via magic set methods.
+     * There is need in API calls (shipping & tax and webhook) to explicitly fetch and set this data
+     * to have quote object in sync with the one used in session.
+     *
+     * @param Quote $quote
+     */
+    public function applyExternalDiscountData($quote) {
+        // Amasty reward points are held in a separate table
+        // and are not assigned to the quote / totals directly out of the customer session.
+        $this->setAmastyRewardPoints($quote);
+    }
 }

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -718,14 +718,25 @@ class Order extends AbstractHelper
     }
 
     /**
+     * Fetch and apply external quote data, not stored within the quote or totals
+     * (usually in 3rd party modules DB tables)
+     *
+     * @param Quote $quote
+     */
+    public function applyExternalQuoteData($quote) {
+        $this->discountHelper->applyExternalDiscountData($quote);
+    }
+
+    /**
      * @param OrderInterface $order
      * @param Quote $quote
      */
     public function dispatchPostCheckoutEvents($order, $quote) {
-
         // Use existing bolt_reserved_order_id quote field, not needed anymore for it's primary purpose,
         // as a flag to determine if the events were dispatched
         if (! $quote->getBoltReservedOrderId()) return; // already dispatched
+
+        $this->applyExternalQuoteData($quote);
 
         $this->logHelper->addInfoLog('[-= dispatchPostCheckoutEvents =-]');
         $this->_eventManager->dispatch(

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -920,7 +920,7 @@ class Order extends AbstractHelper
      * @param $orderIncrementId
      * @return OrderModel|false
      */
-    private function getExistingOrder($orderIncrementId)
+    protected function getExistingOrder($orderIncrementId)
     {
         /** @var OrderModel $order */
         return $this->cartHelper->getOrderByIncrementId($orderIncrementId, true);

--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -420,18 +420,16 @@ class ShippingMethods implements ShippingMethodsInterface
     }
 
     /**
-     * Apply external data applied to quote (third party modules DB tables)
+     * Fetch and apply external quote data, not stored within a quote or totals (third party modules DB tables)
      * If data is applied it is used as a part of the cache identifier.
      *
      * @param Quote $quote
      * @return string
      */
-    protected function applyExternalQuoteData($quote)
+    public function applyExternalQuoteData($quote)
     {
         $data = '';
-        // Amasty reward points are held in a separate table and are not assigned to a quote directly
-        // out of a customer session. We apply it here every time before the shipping and tax estimation.
-        $this->discountHelper->setAmastyRewardPoints($quote);
+        $this->discountHelper->applyExternalDiscountData($quote);
         if ($quote->getAmrewardsPoint()) {
             $data .= $quote->getAmrewardsPoint();
         }

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -75,7 +75,7 @@ class OrderTest extends TestCase
      */
     public function deleteOrderByIncrementId_noOrder()
     {
-        $this->currentMock->expects($this->once())->method('getExistingOrder')->with(self::INCREMENT_ID)
+        $this->currentMock->expects(static::once())->method('getExistingOrder')->with(self::INCREMENT_ID)
             ->willReturn(null);
         $this->expectException(BoltException::class);
         $this->expectExceptionCode(\Bolt\Boltpay\Model\Api\CreateOrder::E_BOLT_GENERAL_ERROR);
@@ -86,6 +86,7 @@ class OrderTest extends TestCase
                 self::QUOTE_ID
             )
         );
+        $this->currentMock->expects(static::never())->method('deleteOrder');
         $this->currentMock->deleteOrderByIncrementId(self::INCREMENT_ID." / ".self::QUOTE_ID);
     }
 
@@ -94,10 +95,10 @@ class OrderTest extends TestCase
      */
     public function deleteOrderByIncrementId_invalidState()
     {
-        $this->currentMock->expects($this->once())->method('getExistingOrder')->with(self::INCREMENT_ID)
+        $this->currentMock->expects(static::once())->method('getExistingOrder')->with(self::INCREMENT_ID)
             ->willReturn($this->orderMock);
         $state = Order::STATE_NEW;
-        $this->orderMock->expects($this->once())->method('getState')->willReturn($state);
+        $this->orderMock->expects(static::once())->method('getState')->willReturn($state);
         $this->expectException(BoltException::class);
         $this->expectExceptionCode(\Bolt\Boltpay\Model\Api\CreateOrder::E_BOLT_GENERAL_ERROR);
         $this->expectExceptionMessage(
@@ -108,6 +109,7 @@ class OrderTest extends TestCase
                 self::QUOTE_ID
             )
         );
+        $this->currentMock->expects(static::never())->method('deleteOrder');
         $this->currentMock->deleteOrderByIncrementId(self::INCREMENT_ID." / ".self::QUOTE_ID);
     }
 
@@ -116,12 +118,11 @@ class OrderTest extends TestCase
      */
     public function deleteOrderByIncrementId_noError()
     {
-        $this->currentMock->expects($this->once())->method('getExistingOrder')->with(self::INCREMENT_ID)
+        $this->currentMock->expects(static::once())->method('getExistingOrder')->with(self::INCREMENT_ID)
             ->willReturn($this->orderMock);
         $state = Order::STATE_PENDING_PAYMENT;
-        $this->orderMock->expects($this->once())->method('getState')->willReturn($state);
-        $this->currentMock->expects($this->once())->method('deleteOrder')->with($this->orderMock);
-
+        $this->orderMock->expects(static::once())->method('getState')->willReturn($state);
+        $this->currentMock->expects(static::once())->method('deleteOrder')->with($this->orderMock);
         $this->currentMock->deleteOrderByIncrementId(self::INCREMENT_ID." / ".self::QUOTE_ID);
     }
 }

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2019 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Test\Unit\Helper;
+
+use Magento\Sales\Model\Order;
+use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Helper\Order as OrderHelper;
+use Bolt\Boltpay\Exception\BoltException;
+
+/**
+ * Class ConfigTest
+ *
+ * @package Bolt\Boltpay\Test\Unit\Helper
+ */
+class OrderTest extends TestCase
+{
+    const INCREMENT_ID = 1234;
+    const QUOTE_ID = 5678;
+
+    /**
+     * @var PHPUnit_Framework_MockObject_MockObject
+     */
+    private $currentMock;
+
+    /**
+     * @var Order
+     */
+    private $orderMock;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->initRequiredMocks();
+        $this->initCurrentMock();
+    }
+
+    private function initCurrentMock()
+    {
+        $this->currentMock = $this->createPartialMock(
+            OrderHelper::class,
+            [
+                'getExistingOrder',
+                'deleteOrder'
+            ]);
+    }
+
+    private function initRequiredMocks()
+    {
+        $this->orderMock = $this->createPartialMock(
+            Order::class,
+            [
+                'getState'
+            ]);
+    }
+
+    /**
+     * @test
+     */
+    public function deleteOrderByIncrementId_noOrder()
+    {
+        $this->currentMock->expects($this->once())->method('getExistingOrder')->with(self::INCREMENT_ID)
+            ->willReturn(null);
+        $this->expectException(BoltException::class);
+        $this->expectExceptionCode(\Bolt\Boltpay\Model\Api\CreateOrder::E_BOLT_GENERAL_ERROR);
+        $this->expectExceptionMessage(
+            sprintf(
+                'Order Delete Error. Order does not exist. Order #: %s Immutable Quote ID: %s',
+                self::INCREMENT_ID,
+                self::QUOTE_ID
+            )
+        );
+        $this->currentMock->deleteOrderByIncrementId(self::INCREMENT_ID." / ".self::QUOTE_ID);
+    }
+
+    /**
+     * @test
+     */
+    public function deleteOrderByIncrementId_invalidState()
+    {
+        $this->currentMock->expects($this->once())->method('getExistingOrder')->with(self::INCREMENT_ID)
+            ->willReturn($this->orderMock);
+        $state = Order::STATE_NEW;
+        $this->orderMock->expects($this->once())->method('getState')->willReturn($state);
+        $this->expectException(BoltException::class);
+        $this->expectExceptionCode(\Bolt\Boltpay\Model\Api\CreateOrder::E_BOLT_GENERAL_ERROR);
+        $this->expectExceptionMessage(
+            sprintf(
+                'Order Delete Error. Order is in invalid state. Order #: %s State: %s Immutable Quote ID: %s',
+                self::INCREMENT_ID,
+                $state,
+                self::QUOTE_ID
+            )
+        );
+        $this->currentMock->deleteOrderByIncrementId(self::INCREMENT_ID." / ".self::QUOTE_ID);
+    }
+
+    /**
+     * @test
+     */
+    public function deleteOrderByIncrementId_noError()
+    {
+        $this->currentMock->expects($this->once())->method('getExistingOrder')->with(self::INCREMENT_ID)
+            ->willReturn($this->orderMock);
+        $state = Order::STATE_PENDING_PAYMENT;
+        $this->orderMock->expects($this->once())->method('getState')->willReturn($state);
+        $this->currentMock->expects($this->once())->method('deleteOrder')->with($this->orderMock);
+
+        $this->currentMock->deleteOrderByIncrementId(self::INCREMENT_ID." / ".self::QUOTE_ID);
+    }
+}


### PR DESCRIPTION
# Description
Postpone dispatching checkout_submit_all_after event to after order is approved. This has 2 purposes:
1. Prevent ERPs that listen to it to pull in the order that can potentially be deleted due to the failed_payment hook
2. Speed up pre-auth order creation by deferring the order post-processing to redirect_url (success) call

Fixes:
https://app.asana.com/0/941920570700290/1135919168579417/f

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] I have created or modified unit tests to sufficiently cover my changes.
