### PR TITLE
Fix DiscountAmount for Magento 2.3 Cloud

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -825,7 +825,8 @@ class Cart extends AbstractHelper
         $child,
         $save = true,
         $emailFields = ['customer_email', 'email'],
-        $excludeFields = ['entity_id', 'address_id', 'reserved_order_id']
+        $excludeFields = ['entity_id', 'address_id', 'reserved_order_id',
+            'address_sales_rule_id', 'cart_fixed_rules', 'cached_items_all']
     ) {
         foreach ($parent->getData() as $key => $value) {
             if (in_array($key, $excludeFields)) continue;


### PR DESCRIPTION
# Description
The issue is in copy data from parentQuote to immutableQuote.
In plugin we tried to copy data from Magento parentQuote to our new immutableQuote. 

Inside one of the `ShippingAddress` child objects in immutableQuote I found an object that is a copy of parentQuote, instead of an immutableQuote object.

So, the Cloud Magento 2.3.x  for discount process use some parameter from address object and here we have an issue because Magento found incorrect object with incorrect data.

The problem touch such calls:
- `\Magento\Quote\Model\Quote\Address::getAllItems()` - there is a cache key which also copied
- `\Magento\SalesRule\Model\Validator::_getRules` - which consist an `address_sales_rule_id` cache key.  Which also be copied.
- Hidden address object field `cart_fixed_rules` which contain . copy of SalesRule config.

Fixes: https://app.asana.com/0/0/1137344940208209/f

Tested on **Magento CE**: 2.2.8, 2.3.0, 2.3.2, **Cloud**: 2.3.2, 2.2.6.


_P.S: I think we can be exposed also to the problem of an incorrect quota object in quote (means immutable quote) items._ I will research it in separate PR.

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [x] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have created or modified unit tests to sufficiently cover my changes.
