### PR TITLE
Crete order - minimum order amount validation

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -1143,4 +1143,19 @@ class Config extends AbstractHelper
             $store
         );
     }
+
+    /**
+     * Get minimum order amount configuration
+     *
+     * @param int|string|Store $storeId
+     * @return float|int
+     */
+    public function getMinimumOrderAmount($storeId = null)
+    {
+        return $this->getScopeConfig()->getValue(
+            'sales/minimum_order/amount',
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+    }
 }

--- a/Model/Api/CreateOrder.php
+++ b/Model/Api/CreateOrder.php
@@ -55,6 +55,7 @@ class CreateOrder implements CreateOrderInterface
     const E_BOLT_DISCOUNT_CODE_DOES_NOT_EXIST = 2001007;
     const E_BOLT_SHIPPING_EXPIRED = 2001008;
     const E_BOLT_REJECTED_ORDER = 2001010;
+    const E_BOLT_MINIMUM_PRICE_NOT_MET = 2001011;
 
     /**
      * @var HookHelper
@@ -413,11 +414,39 @@ class CreateOrder implements CreateOrderInterface
      */
     public function validateQuoteData($quote, $transaction)
     {
+        $this->validateMinimumAmount($quote);
         $this->validateCartItems($quote, $transaction);
-
         $this->validateTax($quote, $transaction);
         $this->validateShippingCost($quote, $transaction);
         $this->validateTotalAmount($quote, $transaction);
+    }
+
+    /**
+     * Validate minimum order amount
+     *
+     * @param Quote $quote
+     * @throws BoltException
+     */
+    public function validateMinimumAmount($quote)
+    {
+        if (!$quote->validateMinimumAmount()) {
+            $minAmount = $this->configHelper->getMinimumOrderAmount($quote->getStoreId());
+            $this->bugsnag->registerCallback(function ($report) use ($quote, $minAmount) {
+                $report->setMetaData([
+                    'Pre Auth' => [
+                        'Minimum order amount' => $minAmount,
+                        'Subtotal' => $quote->getSubtotal(),
+                        'Subtotal with discount' => $quote->getSubtotalWithDiscount(),
+                        'Total' => $quote->getGrandTotal(),
+                    ]
+                ]);
+            });
+            throw new BoltException(
+                __('The minimum order amount: %1 has not being met.', $minAmount),
+                null,
+                self::E_BOLT_MINIMUM_PRICE_NOT_MET
+            );
+        }
     }
 
     /**

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -23,7 +23,7 @@ use Bolt\Boltpay\Helper\Order as OrderHelper;
 use Bolt\Boltpay\Exception\BoltException;
 
 /**
- * Class ConfigTest
+ * Class OrderTest
  *
  * @package Bolt\Boltpay\Test\Unit\Helper
  */

--- a/Test/Unit/Model/Api/CreateOrderTest.php
+++ b/Test/Unit/Model/Api/CreateOrderTest.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2019 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Test\Unit\Model\Api;
+
+use Bolt\Boltpay\Helper\Bugsnag;
+use Bolt\Boltpay\Helper\Cart as CartHelper;
+use Bolt\Boltpay\Helper\Config as ConfigHelper;
+use Bolt\Boltpay\Helper\Hook as HookHelper;
+use Bolt\Boltpay\Helper\Log as LogHelper;
+use Bolt\Boltpay\Helper\Session as SessionHelper;
+use Magento\Backend\Model\UrlInterface as BackendUrl;
+use Magento\CatalogInventory\Api\StockRegistryInterface;
+use Magento\Framework\UrlInterface;
+use Magento\Framework\Webapi\Rest\Request;
+use Magento\Framework\Webapi\Rest\Response;
+use Magento\Quote\Model\Quote;
+use Magento\Sales\Model\Order;
+use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Helper\Order as OrderHelper;
+use Bolt\Boltpay\Exception\BoltException;
+use Bolt\Boltpay\Model\Api\CreateOrder;
+
+/**
+ * Class CreateOrderTest
+ *
+ * @package Bolt\Boltpay\Test\Unit\Model\Api
+ */
+class CreateOrderTest extends TestCase
+{
+    const STORE_ID = 1;
+
+    /**
+     * @var HookHelper
+     */
+    private $hookHelper;
+
+    /**
+     * @var OrderHelper
+     */
+    private $orderHelper;
+
+    /**
+     * @var LogHelper
+     */
+    private $logHelper;
+
+    /**
+     * @var Request
+     */
+    private $request;
+
+    /**
+     * @var Bugsnag
+     */
+    private $bugsnag;
+
+    /**
+     * @var Response
+     */
+    private $response;
+
+    /**
+     * @var ConfigHelper
+     */
+    private $configHelper;
+
+    /**
+     * @var CartHelper
+     */
+    private $cartHelper;
+
+    /**
+     * @var UrlInterface
+     */
+    private $url;
+
+    /**
+     * @var BackendUrl
+     */
+    private $backendUrl;
+
+    /**
+     * @var StockRegistryInterface
+     */
+    private $stockRegistry;
+
+    /**
+     * @var SessionHelper
+     */
+    private $sessionHelper;
+
+    /**
+     * @var PHPUnit_Framework_MockObject_MockObject
+     */
+    private $currentMock;
+
+    /**
+     * @var Quote
+     */
+    private $quoteMock;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->hookHelper = $this->createMock(HookHelper::class);
+        $this->orderHelper = $this->createMock(OrderHelper::class);
+        $this->cartHelper = $this->createMock(CartHelper::class);
+        $this->logHelper = $this->createMock(LogHelper::class);
+        $this->request = $this->createMock(Request::class);
+        $this->bugsnag = $this->createMock(Bugsnag::class);
+        $this->response = $this->createMock(Response::class);
+        $this->url = $this->createMock(UrlInterface::class);
+        $this->backendUrl = $this->createMock(BackendUrl::class);
+        $this->configHelper = $this->createMock(ConfigHelper::class);
+        $this->stockRegistry = $this->createMock(StockRegistryInterface::class);
+        $this->sessionHelper = $this->createMock(SessionHelper::class);
+
+        $this->quoteMock = $this->createMock(Quote::class);
+
+        $this->initCurrentMock();
+    }
+
+    private function initCurrentMock()
+    {
+        $this->currentMock = new CreateOrder(
+            $this->hookHelper,
+            $this->orderHelper,
+            $this->cartHelper,
+            $this->logHelper,
+            $this->request,
+            $this->bugsnag,
+            $this->response,
+            $this->url,
+            $this->backendUrl,
+            $this->configHelper,
+            $this->stockRegistry,
+            $this->sessionHelper
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function validateMinimumAmount_valid()
+    {
+        $this->quoteMock->expects(static::once())->method('validateMinimumAmount')->willReturn(true);
+        $this->currentMock->validateMinimumAmount($this->quoteMock);
+    }
+
+    /**
+     * @test
+     */
+    public function validateMinimumAmount_invalid()
+    {
+        $minAmount = 50;
+        $this->quoteMock->expects(static::once())->method('validateMinimumAmount')->willReturn(false);
+        $this->quoteMock->expects(static::once())->method('getStoreId')->willReturn(static::STORE_ID);
+        $this->configHelper->expects(static::once())->method('getMinimumOrderAmount')->with(static::STORE_ID)->willReturn($minAmount);
+        $this->bugsnag->expects(static::once())->method('registerCallback');
+        $this->expectException(BoltException::class);
+        $this->expectExceptionCode(\Bolt\Boltpay\Model\Api\CreateOrder::E_BOLT_MINIMUM_PRICE_NOT_MET);
+        $this->expectExceptionMessage(
+            sprintf(
+                'The minimum order amount: %s has not being met.', $minAmount
+            )
+        );
+        $this->currentMock->validateMinimumAmount($this->quoteMock);
+    }
+}


### PR DESCRIPTION
# Description
For orders that cannot be created because a minimum price is not met we should use 2001011 instead of General Error

Fixes:
https://app.asana.com/0/1118494470563243/1138306608527986/f
https://app.asana.com/0/0/1138306608527988/f

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] I have created or modified unit tests to sufficiently cover my changes.
