### PR TITLE
Remove state transition checks to support paypal

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -79,6 +79,10 @@ class Order extends AbstractHelper
 
     const MISMATCH_TOLERANCE = 1;
 
+    const BOLT_ORDER_STATE_NEW = 'bolt_new';
+    const BOLT_ORDER_STATUS_PENDING = 'bolt_pending';
+    const MAGENTO_ORDER_STATUS_PENDING = 'pending';
+
     /**
      * @var ApiHelper
      */

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -79,60 +79,6 @@ class Order extends AbstractHelper
 
     const MISMATCH_TOLERANCE = 1;
 
-    const BOLT_ORDER_STATE_NEW = 'bolt_new';
-    const BOLT_ORDER_STATUS_PENDING = 'bolt_pending';
-    const MAGENTO_ORDER_STATUS_PENDING = 'pending';
-
-    // Posible transation state transitions
-    private $validStateTransitions = [
-        null => [
-            self::TS_ZERO_AMOUNT,
-            self::TS_PENDING,
-            self::TS_COMPLETED, // back office
-            // for historic data (order placed before plugin update) does not have "previous state"
-            self::TS_CREDIT_COMPLETED
-        ],
-        self::TS_PENDING => [
-            self::TS_AUTHORIZED,
-            self::TS_COMPLETED,
-            self::TS_CANCELED,
-            self::TS_REJECTED_REVERSIBLE,
-            self::TS_REJECTED_IRREVERSIBLE,
-            self::TS_ZERO_AMOUNT
-        ],
-        self::TS_AUTHORIZED => [
-            self::TS_CAPTURED,
-            self::TS_CANCELED,
-            self::TS_COMPLETED
-        ],
-        self::TS_CAPTURED => [
-            self::TS_CAPTURED,
-            self::TS_CANCELED,
-            self::TS_COMPLETED,
-            self::TS_CREDIT_COMPLETED,
-            self::TS_PARTIAL_VOIDED
-        ],
-        self::TS_CANCELED => [self::TS_CANCELED],
-        self::TS_COMPLETED => [
-            self::TS_COMPLETED,
-            self::TS_CREDIT_COMPLETED
-        ],
-        self::TS_ZERO_AMOUNT => [],
-        self::TS_REJECTED_REVERSIBLE => [
-            self::TS_AUTHORIZED,
-            self::TS_COMPLETED,
-            self::TS_REJECTED_IRREVERSIBLE,
-            self::TS_CANCELED
-        ],
-        self::TS_REJECTED_IRREVERSIBLE => [self::TS_REJECTED_IRREVERSIBLE],
-        self::TS_CREDIT_COMPLETED => [
-            self::TS_CREDIT_COMPLETED,
-            self::TS_COMPLETED,
-            self::TS_CAPTURED,
-            self::TS_CANCELED
-        ]
-    ];
-
     /**
      * @var ApiHelper
      */
@@ -1155,18 +1101,6 @@ class Order extends AbstractHelper
     }
 
     /**
-     * Check if the transition from one transaction state to another is valid.
-     *
-     * @param string|null $prevTransactionState
-     * @param string $newTransactionState
-     * @return bool
-     */
-    private function validateTransition($prevTransactionState, $newTransactionState)
-    {
-        return in_array($newTransactionState, $this->validStateTransitions[$prevTransactionState]);
-    }
-
-    /**
      * Record total amount mismatch between magento and bolt order.
      * Log the error in order comments and report via bugsnag.
      * Put the order ON HOLD if it's a mismatch.
@@ -1433,14 +1367,6 @@ class Order extends AbstractHelper
                 $payment->setIsTransactionApproved(true);
             }
             return;
-        }
-
-        if (!$this->validateTransition($prevTransactionState, $transactionState)) {
-            throw new LocalizedException(__(
-                'Invalid transaction state transition: %1 -> %2',
-                $prevTransactionState,
-                $transactionState
-            ));
         }
 
         // The order has already been canceled, i.e. PERMANENTLY REJECTED


### PR DESCRIPTION
# Description
This PR removes state transition checks. The reason being that as we add more processors and introduce new state, keeping the state in check involves releasing a new version of the plugin making roll outs harder.

In this new flow, we will not check state transitions and rather implicitly trust the bolt modal.

Fixes: https://app.asana.com/0/1120201793092521/1135349256216762


# Type of change

- [ ] Bug fix (change which fixes an issue)
- [X] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [X] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] I have created or modified unit tests to sufficiently cover my changes.
