### PR TITLE
do not throw on failed_payment hook delete order if order is already deleted

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -888,6 +888,10 @@ class Order extends AbstractHelper
         $order = $this->getExistingOrder($incrementId);
 
         if (!$order) {
+            $this->bugsnag->notifyError(
+                "Order Delete Error",
+                "Order does not exist. Order #: $incrementId, Immutable Quote ID: $quoteId"
+            );
             return;
         }
 

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -888,15 +888,7 @@ class Order extends AbstractHelper
         $order = $this->getExistingOrder($incrementId);
 
         if (!$order) {
-            throw new BoltException(
-                __(
-                    'Order Delete Error. Order does not exist. Order #: %1 Immutable Quote ID: %2',
-                    $incrementId,
-                    $quoteId
-                ),
-                null,
-                CreateOrder::E_BOLT_GENERAL_ERROR
-            );
+            return;
         }
 
         $state = $order->getState();

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -77,15 +77,7 @@ class OrderTest extends TestCase
     {
         $this->currentMock->expects(static::once())->method('getExistingOrder')->with(self::INCREMENT_ID)
             ->willReturn(null);
-        $this->expectException(BoltException::class);
-        $this->expectExceptionCode(\Bolt\Boltpay\Model\Api\CreateOrder::E_BOLT_GENERAL_ERROR);
-        $this->expectExceptionMessage(
-            sprintf(
-                'Order Delete Error. Order does not exist. Order #: %s Immutable Quote ID: %s',
-                self::INCREMENT_ID,
-                self::QUOTE_ID
-            )
-        );
+        $this->orderMock->expects(static::never())->method('getState');
         $this->currentMock->expects(static::never())->method('deleteOrder');
         $this->currentMock->deleteOrderByIncrementId(self::INCREMENT_ID." / ".self::QUOTE_ID);
     }

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -17,7 +17,27 @@
 
 namespace Bolt\Boltpay\Test\Unit\Helper;
 
+use Bolt\Boltpay\Helper\Api as ApiHelper;
+use Bolt\Boltpay\Helper\Bugsnag;
+use Bolt\Boltpay\Helper\Cart as CartHelper;
+use Bolt\Boltpay\Helper\Config as ConfigHelper;
+use Bolt\Boltpay\Helper\Discount as DiscountHelper;
+use Bolt\Boltpay\Helper\Log as LogHelper;
+use Bolt\Boltpay\Helper\Session as SessionHelper;
+use Bolt\Boltpay\Model\Service\InvoiceService;
+use Magento\Directory\Model\Region as RegionModel;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\App\Helper\Context;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DataObjectFactory;
+use Magento\Framework\Stdlib\DateTime\DateTime;
+use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
+use Magento\Quote\Model\QuoteManagement;
+use Magento\Sales\Api\OrderRepositoryInterface as OrderRepository;
 use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Email\Sender\InvoiceSender;
+use Magento\Sales\Model\Order\Email\Sender\OrderSender;
+use Magento\Sales\Model\Order\Payment\Transaction\Builder as TransactionBuilder;
 use PHPUnit\Framework\TestCase;
 use Bolt\Boltpay\Helper\Order as OrderHelper;
 use Bolt\Boltpay\Exception\BoltException;
@@ -31,6 +51,100 @@ class OrderTest extends TestCase
 {
     const INCREMENT_ID = 1234;
     const QUOTE_ID = 5678;
+
+    /**
+     * @var ApiHelper
+     */
+    private $apiHelper;
+
+    /**
+     * @var ConfigHelper
+     */
+    private $configHelper;
+
+    /**
+     * @var RegionModel
+     */
+    private $regionModel;
+
+    /**
+     * @var QuoteManagement
+     */
+    private $quoteManagement;
+
+    /**
+     * @var OrderSender
+     */
+    private $emailSender;
+
+    /**
+     * @var InvoiceService
+     */
+    private $invoiceService;
+
+    /**
+     * @var InvoiceSender
+     */
+    private $invoiceSender;
+
+    /**
+     * @var TransactionBuilder
+     */
+    private $transactionBuilder;
+
+    /**
+     * @var TimezoneInterface
+     */
+    private $timezone;
+
+    /**
+     * @var SearchCriteriaBuilder
+     */
+    private $searchCriteriaBuilder;
+
+    /**
+     * @var OrderRepository
+     */
+    private $orderRepository;
+
+    /**
+     * @var DataObjectFactory
+     */
+    private $dataObjectFactory;
+
+    /**
+     * @var LogHelper
+     */
+    private $logHelper;
+
+    /**
+     * @var Bugsnag
+     */
+    private $bugsnag;
+
+    /**
+     * @var CartHelper
+     */
+    private $cartHelper;
+
+    /**
+     * @var \Magento\Payment\Model\Info
+     */
+    private $quotePaymentInfoInstance = null;
+
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    /** @var SessionHelper */
+    private $sessionHelper;
+
+    /** @var DiscountHelper */
+    private $discountHelper;
+
+    /** @var DateTime */
+    protected $date;
 
     /**
      * @var PHPUnit_Framework_MockObject_MockObject
@@ -53,16 +167,59 @@ class OrderTest extends TestCase
 
     private function initCurrentMock()
     {
-        $this->currentMock = $this->createPartialMock(
-            OrderHelper::class,
-            [
+        $this->currentMock = $this->getMockBuilder(OrderHelper::class)
+            ->setConstructorArgs([
+                $this->context,
+                $this->apiHelper,
+                $this->configHelper,
+                $this->regionModel,
+                $this->quoteManagement,
+                $this->emailSender,
+                $this->invoiceService,
+                $this->invoiceSender,
+                $this->searchCriteriaBuilder,
+                $this->orderRepository,
+                $this->transactionBuilder,
+                $this->timezone,
+                $this->dataObjectFactory,
+                $this->logHelper,
+                $this->bugsnag,
+                $this->cartHelper,
+                $this->resourceConnection,
+                $this->sessionHelper,
+                $this->discountHelper,
+                $this->date
+            ])
+            ->setMethods([
                 'getExistingOrder',
                 'deleteOrder'
-            ]);
+            ])
+            ->getMock();
     }
 
     private function initRequiredMocks()
     {
+        $this->context = $this->createMock(Context::class);
+        $this->apiHelper = $this->createMock(ApiHelper::class);
+        $this->configHelper = $this->createMock(ConfigHelper::class);
+        $this->regionModel = $this->createMock(RegionModel::class);
+        $this->quoteManagement = $this->createMock(QuoteManagement::class);
+        $this->emailSender = $this->createMock(OrderSender::class);
+        $this->invoiceService = $this->createMock(InvoiceService::class);
+        $this->invoiceSender = $this->createMock(InvoiceSender::class);
+        $this->transactionBuilder = $this->createMock(TransactionBuilder::class);
+        $this->timezone = $this->createMock(TimezoneInterface::class);
+        $this->searchCriteriaBuilder = $this->createMock(SearchCriteriaBuilder::class);
+        $this->orderRepository = $this->createMock(OrderRepository::class);
+        $this->dataObjectFactory = $this->createMock(DataObjectFactory::class);
+        $this->logHelper = $this->createMock(LogHelper::class);
+        $this->bugsnag = $this->createMock(Bugsnag::class);
+        $this->cartHelper = $this->createMock(CartHelper::class);
+        $this->resourceConnection = $this->createMock(ResourceConnection::class);
+        $this->sessionHelper = $this->createMock(SessionHelper::class);
+        $this->discountHelper = $this->createMock(DiscountHelper::class);
+        $this->date = $this->createMock(DateTime::class);
+
         $this->orderMock = $this->createPartialMock(
             Order::class,
             [


### PR DESCRIPTION
# Description
Multiple failed_payment hooks can come through, resulting in an error if the order has been deleted by previous hook. Solution: If the order does not exist do not throw, return OK.

Fixes:
https://app.asana.com/0/0/1138340753398482/f
https://app.asana.com/0/941920570700290/1138909039528777/f

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] I have created or modified unit tests to sufficiently cover my changes.
