### PR TITLE
check if order was canceled when loading the existing order

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -738,6 +738,15 @@ class Order extends AbstractHelper
     {
         // check if the order has been created in the meanwhile
         if ($order = $this->getExistingOrder($quote->getReservedOrderId())) {
+
+            if($order->isCanceled()) {
+                throw new BoltException(
+                    __('Order has been canceled due to the previously declined payment'),
+                    null,
+                    CreateOrder::E_BOLT_REJECTED_ORDER
+                );
+            }
+
             if ($this->hasSamePrice($order, $transaction)) {
                 return $order;
             }

--- a/Model/Api/CreateOrder.php
+++ b/Model/Api/CreateOrder.php
@@ -212,14 +212,6 @@ class CreateOrder implements CreateOrderInterface
                 $createdOrder = $this->orderHelper->processNewOrder($quote, $transaction);
             }
 
-            if($createdOrder->isCanceled()){
-                throw new BoltException(
-                    __('Order has been canceled due to the previously declined payment'),
-                    null,
-                    self::E_BOLT_REJECTED_ORDER
-                );
-            }
-
             $this->sendResponse(200, [
                 'status'    => 'success',
                 'message'   => 'Order create was successful',


### PR DESCRIPTION
# Description
There was a potential bug in deleting and recreating a previously canceled order. Moving the canceled check up the flow.

Fixes:
https://app.asana.com/0/0/1139914171866907/f

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [ ] I have created or modified unit tests to sufficiently cover my changes.
