### PR TITLE
Modified coupon logic check to be case-insensitive

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -1094,7 +1094,13 @@ class Config extends AbstractHelper
      */
     public function getIgnoredShippingAddressCoupons($storeId)
     {
-        return (array)$this->getAdditionalConfigProperty('ignoredShippingAddressCoupons', $storeId);
+        $coupons = (array)$this->getAdditionalConfigProperty('ignoredShippingAddressCoupons', $storeId);
+
+        $coupons = array_map(function ($coupon) {
+            return strtolower($coupon);
+        }, $coupons);
+
+        return $coupons;
     }
 
     /**

--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -808,7 +808,7 @@ class ShippingMethods implements ShippingMethodsInterface
         $ignoredShippingAddressCoupons = $this->configHelper->getIgnoredShippingAddressCoupons($this->quote->getStoreId());
 
         return $parentQuoteCoupon &&
-                in_array($parentQuoteCoupon, $ignoredShippingAddressCoupons) &&
+                in_array(strtolower($parentQuoteCoupon), $ignoredShippingAddressCoupons) &&
                 !$this->quote->setTotalsCollectedFlag(false)->collectTotals()->getCouponCode();
     }
 }

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -513,4 +513,21 @@ class ConfigTest extends TestCase
 
         $this->assertInstanceOf(ScopeConfigInterface::class, $result, 'getScopeConfig() method: not working properly');
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function testGetIgnoredShippingAddressCoupons()
+    {
+        $configCouponsJson = '{"ignoredShippingAddressCoupons": ["IGNORED_SHIPPING_ADDRESS_COUPON"]}';
+
+        $this->scopeConfig->method('getValue')
+                ->with(BoltConfig::XML_PATH_ADDITIONAL_CONFIG)
+                ->will($this->returnValue($configCouponsJson));
+
+        $result = $this->currentMock->getIgnoredShippingAddressCoupons(null);
+        $expected = ['ignored_shipping_address_coupon'];
+
+        $this->assertEquals($expected, $result, 'getIgnoredShippingAddressCoupons() method: not working properly');
+    }
 }

--- a/Test/Unit/Model/Api/ShippingMethodsTest.php
+++ b/Test/Unit/Model/Api/ShippingMethodsTest.php
@@ -612,6 +612,35 @@ class ShippingMethodsTest extends TestCase
     }
 
     /**
+     * @test
+     * @throws \ReflectionException
+     */
+    public function testCouponInvalidForShippingAddress()
+    {
+        $parentQuoteCoupon = 'IGNORED_SHIPPING_ADDRESS_COUPON';
+        $configCoupons = ['BOLT_TEST', 'ignored_shipping_address_coupon'];
+        $immutableQuoteMock = $this->getQuoteMock([]);
+
+        $this->configHelper = $this->getMockBuilder(ConfigHelper::class)
+            ->setMethods(['getIgnoredShippingAddressCoupons'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->configHelper->method('getIgnoredShippingAddressCoupons')->with(null)->willReturn($configCoupons);
+
+        $currentTestObject = $this->getCurrentTestObject();
+
+        $reflection = new \ReflectionClass($currentTestObject);
+        $reflectionProperty = $reflection->getProperty('quote');
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue($currentTestObject, $immutableQuoteMock);
+
+        $testMethod = new \ReflectionMethod(BoltShippingMethods::class, 'couponInvalidForShippingAddress');
+        $testMethod->setAccessible(true);
+
+        $this->assertTrue($testMethod->invokeArgs($currentTestObject, [$parentQuoteCoupon]));
+    }
+
+    /**
      * Get quote mock with quote items
      *
      * @param $shippingAddress


### PR DESCRIPTION
Modified coupon logic check to be case-insensitive

Fixes: https://app.asana.com/0/564264490825835/1140469195577209

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] I have created or modified unit tests to sufficiently cover my changes.
