### PR TITLE
Merchant metrics batching

### DIFF
--- a/Helper/MetricsClient.php
+++ b/Helper/MetricsClient.php
@@ -24,6 +24,8 @@ use Bolt\Boltpay\Helper\Config as ConfigHelper;
 use Magento\Framework\Filesystem\DirectoryList;
 use Magento\Store\Model\StoreManagerInterface;
 use Bolt\Boltpay\Helper\Log as LogHelper;
+use Magento\Framework\App\CacheInterface;
+
 
 
 /**
@@ -32,7 +34,9 @@ use Bolt\Boltpay\Helper\Log as LogHelper;
 
 class MetricsClient extends AbstractHelper
 {
-
+    const METRICS_TIMESTAMP_ID = 'bolt_metrics_timestamp';
+    // amount of ms between metrics posts
+    const METRICS_POST_INTERVAL_MICROS = 30000;
 
     /**
      * @var \GuzzleHttp\Client
@@ -70,13 +74,18 @@ class MetricsClient extends AbstractHelper
     private $bugsnag;
 
     /**
+     * @var CacheInterface
+     */
+    private $cache;
+
+    /**
      * @param Context $context
      * @param Config $configHelper
      * @param DirectoryList $directoryList
      * @param StoreManagerInterface $storeManager
      * @param Bugsnag $bugsnag
      * @param LogHelper $logHelper
-     *
+     * @param CacheInterface $cache
      *
      * @throws
      */
@@ -86,13 +95,15 @@ class MetricsClient extends AbstractHelper
         DirectoryList $directoryList,
         StoreManagerInterface $storeManager,
         Bugsnag $bugsnag,
-        LogHelper $logHelper
+        LogHelper $logHelper,
+        CacheInterface $cache
     ) {
         parent::__construct($context);
 
         $this->storeManager = $storeManager;
         $this->bugsnag = $bugsnag;
         $this->logHelper = $logHelper;
+        $this->cache = $cache;
         //////////////////////////////////////////
         // Composerless installation.
         // Make sure libraries are in place:
@@ -341,9 +352,19 @@ class MetricsClient extends AbstractHelper
         if (!$this->configHelper->shouldCaptureMetrics()) {
             return null;
         }
+        $previousPostTime = $this->loadFromCache(self::METRICS_TIMESTAMP_ID);
+        // checks if key exists
+        if (!$previousPostTime) {
+            $this->saveToCache(self::METRICS_TIMESTAMP_ID, round(microtime(true) * 1000));
+        } else {
+            $timeDiff = round(microtime(true) * 1000) - $previousPostTime;
+            // if its under 30 seconds since last key don't do anything
+            if ($timeDiff < self::METRICS_POST_INTERVAL) {
+                return null;
+            }
+        }
         $workingFile = null;
         try{
-            $output = "";
             if ($this->metricsFile == null) {
                 $this->metricsFile = $this->getFilePath();
             }
@@ -366,6 +387,7 @@ class MetricsClient extends AbstractHelper
                 // Clear File if successfully posted
                 if ($response->getStatusCode() == 200) {
                     file_put_contents($this->metricsFile, "");
+                    $this->saveToCache(self::METRICS_TIMESTAMP_ID, round(microtime(true) * 1000));
                 }
                 return $response->getStatusCode();
             } else {
@@ -380,5 +402,33 @@ class MetricsClient extends AbstractHelper
             }
         }
         return null;
+    }
+
+    /**
+     * Load data from Magento cache
+     *
+     * @param string $identifier
+     * @param bool $unserialize
+     * @return bool|mixed|string
+     */
+    protected function loadFromCache($identifier, $unserialize = true)
+    {
+        $cached = $this->cache->load($identifier);
+        if (!$cached) return false;
+        return $unserialize ? unserialize($cached) : $cached;
+    }
+    /**
+     * Save data to Magento cache
+     *
+     * @param mixed $data
+     * @param string $identifier
+     * @param int $lifeTime
+     * @param bool $serialize
+     * @param array $tags
+     */
+    protected function saveToCache($identifier, $data, $tags = [], $lifeTime = null, $serialize = true)
+    {
+        $data = $serialize ? serialize($data) : $data;
+        $this->cache->save($data, $identifier, $tags, $lifeTime);
     }
 }

--- a/Helper/MetricsClient.php
+++ b/Helper/MetricsClient.php
@@ -405,7 +405,7 @@ class MetricsClient extends AbstractHelper
      * Load data from Magento cache
      *
      * @param string $identifier
-     * @param bool $unserialize
+     * @param bool $decode
      * @return bool|mixed|string
      */
     protected function loadFromCache($identifier, $decode = true)

--- a/Helper/MetricsClient.php
+++ b/Helper/MetricsClient.php
@@ -408,11 +408,11 @@ class MetricsClient extends AbstractHelper
      * @param bool $unserialize
      * @return bool|mixed|string
      */
-    protected function loadFromCache($identifier, $unserialize = true)
+    protected function loadFromCache($identifier, $decode = true)
     {
         $cached = $this->cache->load($identifier);
         if (!$cached) return false;
-        return $unserialize ? unserialize($cached) : $cached;
+        return $decode ? json_decode($cached) : $cached;
     }
     /**
      * Save data to Magento cache
@@ -420,12 +420,12 @@ class MetricsClient extends AbstractHelper
      * @param mixed $data
      * @param string $identifier
      * @param int $lifeTime
-     * @param bool $serialize
+     * @param bool $encode
      * @param array $tags
      */
-    protected function saveToCache($identifier, $data, $tags = [], $lifeTime = null, $serialize = true)
+    protected function saveToCache($identifier, $data, $tags = [], $lifeTime = null, $encode = true)
     {
-        $data = $serialize ? serialize($data) : $data;
+        $data = $encode ? json_encode($data) : $data;
         $this->cache->save($data, $identifier, $tags, $lifeTime);
     }
 }

--- a/Helper/MetricsClient.php
+++ b/Helper/MetricsClient.php
@@ -35,8 +35,8 @@ use Magento\Framework\App\CacheInterface;
 class MetricsClient extends AbstractHelper
 {
     const METRICS_TIMESTAMP_ID = 'bolt_metrics_timestamp';
-    // amount of ms between metrics posts
-    const METRICS_POST_INTERVAL_MICROS = 30000;
+    // amount of microseconds between metrics posts
+    const METRICS_POST_INTERVAL_MICROS = 30000000;
 
     /**
      * @var \GuzzleHttp\Client
@@ -354,12 +354,9 @@ class MetricsClient extends AbstractHelper
         }
         $previousPostTime = $this->loadFromCache(self::METRICS_TIMESTAMP_ID);
         // checks if key exists
-        if (!$previousPostTime) {
-            $this->saveToCache(self::METRICS_TIMESTAMP_ID, round(microtime(true) * 1000));
-        } else {
-            $timeDiff = round(microtime(true) * 1000) - $previousPostTime;
-            // if its under 30 seconds since last key don't do anything
-            if ($timeDiff < self::METRICS_POST_INTERVAL) {
+        if ($previousPostTime) {
+            $timeDiff = 1000000 * (microtime(true)  - $previousPostTime);
+            if ($timeDiff < self::METRICS_POST_INTERVAL_MICROS) {
                 return null;
             }
         }
@@ -387,7 +384,7 @@ class MetricsClient extends AbstractHelper
                 // Clear File if successfully posted
                 if ($response->getStatusCode() == 200) {
                     file_put_contents($this->metricsFile, "");
-                    $this->saveToCache(self::METRICS_TIMESTAMP_ID, round(microtime(true) * 1000));
+                    $this->saveToCache(self::METRICS_TIMESTAMP_ID, microtime(true));
                 }
                 return $response->getStatusCode();
             } else {

--- a/Test/Unit/Helper/MetricsClientTest.php
+++ b/Test/Unit/Helper/MetricsClientTest.php
@@ -21,6 +21,7 @@ namespace Bolt\Boltpay\Test\Unit\Helper;
 use Bolt\Boltpay\Helper\Config;
 use Bolt\Boltpay\Helper\Config as ConfigHelper;
 use Bolt\Boltpay\Helper\Metric;
+use Magento\Framework\App\CacheInterface;
 use PHPUnit\Framework\TestCase;
 use Magento\Store\Model\StoreManagerInterface;
 use Bolt\Boltpay\Helper\Bugsnag;
@@ -114,6 +115,11 @@ class MetricsClientTest extends TestCase
      */
     private $directoryList;
 
+    /**
+     * @var CacheInterface
+     */
+    private $cache;
+
 
 
     /**
@@ -145,6 +151,7 @@ class MetricsClientTest extends TestCase
             ->getMock();
         $this->logHelper = $this->createMock(LogHelper::class);
         $this->bugsnag = $this->createMock(Bugsnag::class);
+        $this->cache = $this->createMock(CacheInterface::class);
 
         // Partially Mock the Class we are tesing
         $methods = ['unlockFile', 'lockFile', 'getCurrentTime'];
@@ -158,7 +165,8 @@ class MetricsClientTest extends TestCase
                     $this->directoryList,
                     $this->storeManager,
                     $this->bugsnag,
-                    $this->logHelper
+                    $this->logHelper,
+                    $this->cache
                 ]
             )
             ->getMock();
@@ -228,7 +236,8 @@ class MetricsClientTest extends TestCase
                     $this->directoryList,
                     $this->storeManager,
                     $this->bugsnag,
-                    $this->logHelper
+                    $this->logHelper,
+                    $this->cache
                 ]
             )
             ->getMock();
@@ -268,7 +277,8 @@ class MetricsClientTest extends TestCase
                     $this->directoryList,
                     $this->storeManager,
                     $this->bugsnag,
-                    $this->logHelper
+                    $this->logHelper,
+                    $this->cache
                 ]
             )
             ->getMock();
@@ -305,7 +315,8 @@ class MetricsClientTest extends TestCase
                     $this->directoryList,
                     $this->storeManager,
                     $this->bugsnag,
-                    $this->logHelper
+                    $this->logHelper,
+                    $this->cache
                 ]
             )
             ->getMock();
@@ -632,6 +643,7 @@ class MetricsClientTest extends TestCase
         $this->assertNull($this->currentMock->postMetrics());
     }
 
+
     private function initWriteMetricToFile() {
         $methods = ['getFilePath', 'waitForFile', 'unlockFile', 'getCurrentTime'];
         $this->currentMock = $this->getMockBuilder(MetricsClient::class)
@@ -644,7 +656,8 @@ class MetricsClientTest extends TestCase
                     $this->directoryList,
                     $this->storeManager,
                     $this->bugsnag,
-                    $this->logHelper
+                    $this->logHelper,
+                    $this->cache
                 ]
             )
             ->getMock();
@@ -662,7 +675,8 @@ class MetricsClientTest extends TestCase
                     $this->directoryList,
                     $this->storeManager,
                     $this->bugsnag,
-                    $this->logHelper
+                    $this->logHelper,
+                    $this->cache
                 ]
             )
             ->getMock();
@@ -680,7 +694,8 @@ class MetricsClientTest extends TestCase
                     $this->directoryList,
                     $this->storeManager,
                     $this->bugsnag,
-                    $this->logHelper
+                    $this->logHelper,
+                    $this->cache
                 ]
             )
             ->getMock();


### PR DESCRIPTION
# Description
Added Batching to Merchant Metrics. Allowing us to specify the frequency for which these metrics are uploaded to not overwhelm the server. This approach leverages magento class to keep a global timestamp to accomplish this. 


# Type of change

- [ ] Bug fix (change which fixes an issue)
- [X] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [X] Successfully tested locally (or docker image)
- [X] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing unit tests pass locally with my changes
- [X] I have created or modified unit tests to sufficiently cover my changes.
