### PR TITLE
Revert "Remove state transition checks to support paypal (#367)"

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -83,6 +83,56 @@ class Order extends AbstractHelper
     const BOLT_ORDER_STATUS_PENDING = 'bolt_pending';
     const MAGENTO_ORDER_STATUS_PENDING = 'pending';
 
+    // Posible transation state transitions
+    private $validStateTransitions = [
+        null => [
+            self::TS_ZERO_AMOUNT,
+            self::TS_PENDING,
+            self::TS_COMPLETED, // back office
+            // for historic data (order placed before plugin update) does not have "previous state"
+            self::TS_CREDIT_COMPLETED
+        ],
+        self::TS_PENDING => [
+            self::TS_AUTHORIZED,
+            self::TS_COMPLETED,
+            self::TS_CANCELED,
+            self::TS_REJECTED_REVERSIBLE,
+            self::TS_REJECTED_IRREVERSIBLE,
+            self::TS_ZERO_AMOUNT
+        ],
+        self::TS_AUTHORIZED => [
+            self::TS_CAPTURED,
+            self::TS_CANCELED,
+            self::TS_COMPLETED
+        ],
+        self::TS_CAPTURED => [
+            self::TS_CAPTURED,
+            self::TS_CANCELED,
+            self::TS_COMPLETED,
+            self::TS_CREDIT_COMPLETED,
+            self::TS_PARTIAL_VOIDED
+        ],
+        self::TS_CANCELED => [self::TS_CANCELED],
+        self::TS_COMPLETED => [
+            self::TS_COMPLETED,
+            self::TS_CREDIT_COMPLETED
+        ],
+        self::TS_ZERO_AMOUNT => [],
+        self::TS_REJECTED_REVERSIBLE => [
+            self::TS_AUTHORIZED,
+            self::TS_COMPLETED,
+            self::TS_REJECTED_IRREVERSIBLE,
+            self::TS_CANCELED
+        ],
+        self::TS_REJECTED_IRREVERSIBLE => [self::TS_REJECTED_IRREVERSIBLE],
+        self::TS_CREDIT_COMPLETED => [
+            self::TS_CREDIT_COMPLETED,
+            self::TS_COMPLETED,
+            self::TS_CAPTURED,
+            self::TS_CANCELED
+        ]
+    ];
+
     /**
      * @var ApiHelper
      */
@@ -1110,6 +1160,18 @@ class Order extends AbstractHelper
     }
 
     /**
+     * Check if the transition from one transaction state to another is valid.
+     *
+     * @param string|null $prevTransactionState
+     * @param string $newTransactionState
+     * @return bool
+     */
+    private function validateTransition($prevTransactionState, $newTransactionState)
+    {
+        return in_array($newTransactionState, $this->validStateTransitions[$prevTransactionState]);
+    }
+
+    /**
      * Record total amount mismatch between magento and bolt order.
      * Log the error in order comments and report via bugsnag.
      * Put the order ON HOLD if it's a mismatch.
@@ -1376,6 +1438,14 @@ class Order extends AbstractHelper
                 $payment->setIsTransactionApproved(true);
             }
             return;
+        }
+
+        if (!$this->validateTransition($prevTransactionState, $transactionState)) {
+            throw new LocalizedException(__(
+                'Invalid transaction state transition: %1 -> %2',
+                $prevTransactionState,
+                $transactionState
+            ));
         }
 
         // The order has already been canceled, i.e. PERMANENTLY REJECTED


### PR DESCRIPTION
This reverts commit 8320dc1410adc1b923884d1901ee49a7ab516e92.

We believe something about these state transition checks was necessary to prevent Bolt from handling state transitions from non-Bolt payment methods. We're rolling back the changes as we investigate the issues.

# Description
Please include a summary of the change and which issue is fixed. Include the motivation for the changes, and comment on your PR if necessary for clarity.

Fixes: (link Asana Task)

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing unit tests pass locally with my changes
- [X] I have created or modified unit tests to sufficiently cover my changes.
