### PR TITLE
Skip inventory verification in post checkout events

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -761,6 +761,9 @@ class Order extends AbstractHelper
 
         $this->applyExternalQuoteData($quote);
 
+        // do not verify inventory, it is already reserved
+        $quote->setInventoryProcessed(true);
+
         $this->logHelper->addInfoLog('[-= dispatchPostCheckoutEvents =-]');
         $this->_eventManager->dispatch(
             'checkout_submit_all_after', [


### PR DESCRIPTION
# Description
Skip inventory verification in success redirect call and hooks. At this point the order is already created and inventory reserved.

Magento core team intended the checkout_submit_all_after  event and $this->quoteManagement->submit($quote, $orderData) to be raised/called in the same execution.

Quote management submit method raises sales_model_service_quote_submit_before, which executes \Magento\CatalogInventory\Observer\SubtractQuoteInventoryObserver.

Event checkout_submit_all_after calls \Magento\CatalogInventory\Observer\CheckoutAllSubmitAfterObserver which, in turn calls \Magento\CatalogInventory\Observer\SubtractQuoteInventoryObserver.

Magento core team avoided  this by using inventory_processed data property on Quote object (if set, skip observer execution). Because we separated the two calls and because this property is not persistent in the quote table the inventory subtraction logic was executed twice.

Fixes: https://app.asana.com/0/474713171217346/1142870009972713/f

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [ ] I have created or modified unit tests to sufficiently cover my changes.
