### PR TITLE
Add depth 1 when cloning integraiotn test repo

### DIFF
--- a/Test/scripts/ci-integration.sh
+++ b/Test/scripts/ci-integration.sh
@@ -63,7 +63,7 @@ mkdir log
 sudo service apache2 restart
 echo "restarted apache2"
 
-git clone git@github.com:BoltApp/integration-tests.git
+git clone --depth 1 git@github.com:BoltApp/integration-tests.git
 cd integration-tests
 npm install
 TEST_ENV=plugin_ci WDIO_CONFIG=localChrome npm run test-spec bolt/integration-tests/checkout/specs/magento2/magento2QuickCheckout.spec.ts


### PR DESCRIPTION
# Description
When running integration test there is no need to copy entire history of repo. Adding depth=1 param for better performance

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ x ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ x ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] I have created or modified unit tests to sufficiently cover my changes.
