### PR TITLE
remove InvoiceService constructor override

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -1658,12 +1658,16 @@ class Order extends AbstractHelper
      */
     private function createOrderInvoice($order, $transactionId, $amount)
     {
-        if ($order->getTotalInvoiced() + $amount == $order->getGrandTotal()) {
-            $invoice = $this->invoiceService->prepareInvoice($order);
-        } else {
-            $invoice = $this->invoiceService->prepareInvoiceWithoutItems($order, $amount);
+        try {
+            if ($order->getTotalInvoiced() + $amount == $order->getGrandTotal()) {
+                $invoice = $this->invoiceService->prepareInvoice($order);
+            } else {
+                $invoice = $this->invoiceService->prepareInvoiceWithoutItems($order, $amount);
+            }
+        } catch (\Exception $e) {
+            $this->bugsnag->notifyException($e);
+            throw $e;
         }
-
         $invoice->setRequestedCaptureCase(Invoice::CAPTURE_OFFLINE);
         $invoice->setTransactionId($transactionId);
         $invoice->setBaseGrandTotal($amount);

--- a/Model/Service/InvoiceService.php
+++ b/Model/Service/InvoiceService.php
@@ -7,37 +7,6 @@ use Magento\Sales\Api\Data\OrderInterface;
 class InvoiceService extends \Magento\Sales\Model\Service\InvoiceService
 {
     /**
-     * @var \Bolt\Boltpay\Helper\Bugsnag
-     */
-    protected $bugsnag;
-
-    /**
-     * Constructor
-     *
-     * @param \Magento\Sales\Api\InvoiceRepositoryInterface        $repository
-     * @param \Magento\Sales\Api\InvoiceCommentRepositoryInterface $commentRepository
-     * @param \Magento\Framework\Api\SearchCriteriaBuilder         $criteriaBuilder
-     * @param \Magento\Framework\Api\FilterBuilder                 $filterBuilder
-     * @param \Magento\Sales\Model\Order\InvoiceNotifier           $notifier
-     * @param \Magento\Sales\Api\OrderRepositoryInterface          $orderRepository
-     * @param \Magento\Sales\Model\Convert\Order                   $orderConverter
-     * @param \Bolt\Boltpay\Helper\Bugsnag                         $bugsnag
-     */
-    public function __construct(
-        \Magento\Sales\Api\InvoiceRepositoryInterface $repository,
-        \Magento\Sales\Api\InvoiceCommentRepositoryInterface $commentRepository,
-        \Magento\Framework\Api\SearchCriteriaBuilder $criteriaBuilder,
-        \Magento\Framework\Api\FilterBuilder $filterBuilder,
-        \Magento\Sales\Model\Order\InvoiceNotifier $notifier,
-        \Magento\Sales\Api\OrderRepositoryInterface $orderRepository,
-        \Magento\Sales\Model\Convert\Order $orderConverter,
-        Bugsnag $bugsnag
-    ) {
-        parent::__construct($repository, $commentRepository, $criteriaBuilder, $filterBuilder, $notifier, $orderRepository, $orderConverter);
-        $this->bugsnag = $bugsnag;
-    }
-
-    /**
      * Prepare order invoice without any items
      *
      * @param \Magento\Sales\Api\Data\OrderInterface $order
@@ -48,19 +17,14 @@ class InvoiceService extends \Magento\Sales\Model\Service\InvoiceService
      */
     public function prepareInvoiceWithoutItems(OrderInterface $order, $amount)
     {
-        try {
-            $invoice = $this->orderConverter->toInvoice($order);
-            $invoice->setBaseGrandTotal($amount);
-            $invoice->setSubtotal($amount);
-            $invoice->setBaseSubtotal($amount);
-            $invoice->setGrandTotal($amount);
+        $invoice = $this->orderConverter->toInvoice($order);
+        $invoice->setBaseGrandTotal($amount);
+        $invoice->setSubtotal($amount);
+        $invoice->setBaseSubtotal($amount);
+        $invoice->setGrandTotal($amount);
 
-            $order->getInvoiceCollection()->addItem($invoice);
+        $order->getInvoiceCollection()->addItem($invoice);
 
-            return $invoice;
-        } catch(\Exception $e) {
-            $this->bugsnag->notifyException($e);
-            throw $e;
-        }
+        return $invoice;
     }
 }


### PR DESCRIPTION
# Description
Bolt constructor isn’t working on Magento 2.3.3, Bolt\Boltpay\Model\Service\InvoiceService.
Remove overriding constructor.

Fixes: https://app.asana.com/0/941920570700290/1144761542527713/f

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [ ] I have created or modified unit tests to sufficiently cover my changes.
