### PR TITLE
Fixed validation of capture amount by using correct rounding algorithm

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -1654,45 +1654,10 @@ class Order extends AbstractHelper
         $isInvalidAmount = !isset($captureAmount) || !is_numeric($captureAmount) || $captureAmount < 0;
 
         /**
-         * Due to grand total sent to Bolt is rounded,
-         * the same operation should be used when validating captured amount.
-         *
-         * The rounding operations are applied to each operand to avoid cases when grand total
-         * is formally lower than the sum of captured amount and total invoiced.
-         *
-         * ---------
-         * Example 1.
-         *
-         * As of the previous behavior, we had:
-         *
-         * $captureAmount: 203.29
-         * $order->getTotalInvoiced(): [empty]
-         * $order->getGrandTotal(): 203.2874
-         *
-         *      203.29 > 203.2874 [ = true ] -> leads to raise an exception
-         *
-         * After applying rounding, got:
-         *
-         * getRoundAmount($order->getTotalInvoiced()) [0] + getRoundAmount($captureAmount) [20329]: 20329
-         * getRoundAmount($order->getGrandTotal()): 20329
-         *
-         *      20329 > 20329 [ = false ] -> validation passed
-         *
-         * ---------
-         * Example 2.
-         *
-         * $captureAmount: 203.49
-         * $order->getTotalInvoiced(): 2.49
-         * $order->getGrandTotal(): 205.9877
-         *
-         *      203.49 + 2.49 ( = 205.98 ) > 205.9877 [ = false ] -> validation passed
-         *
-         * Applying rounding, we got:
-         *
-         * getRoundAmount($order->getTotalInvoiced()) [249] + getRoundAmount($captureAmount) [20349]: 20598
-         * getRoundAmount($order->getGrandTotal()): 20599
-         *
-         *      20598 > 20599 [ = false ] -> validation also passed
+         * Due to grand total sent to Bolt is rounded, the same operation should be used
+         * when validating captured amount.
+         * Rounding operations are applied to each operand in order to avoid cases when the grand total
+         * is formally less (before it has been rounded) than the sum of the captured amount and the total invoiced.
          */
         $isInvalidAmountRange = $this->cartHelper->getRoundAmount($order->getTotalInvoiced())
             + $this->cartHelper->getRoundAmount($captureAmount)

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -1644,15 +1644,20 @@ class Order extends AbstractHelper
 
     /**
      * @param OrderInterface $order
-     * @param                                        $captureAmount
+     * @param float          $captureAmount
      *
+     * @return void
      * @throws \Exception
      */
-    protected function validateCaptureAmount(OrderInterface $order, $captureAmount) {
+    protected function validateCaptureAmount(OrderInterface $order, $captureAmount)
+    {
         $isInvalidAmount = !isset($captureAmount) || !is_numeric($captureAmount) || $captureAmount < 0;
-        $isInvalidAmountRange = $order->getTotalInvoiced() + $captureAmount > $order->getGrandTotal();
 
-        if($isInvalidAmount || $isInvalidAmountRange) {
+        $isInvalidAmountRange = $this->cartHelper->getRoundAmount($order->getTotalInvoiced())
+            + $this->cartHelper->getRoundAmount($captureAmount)
+            > $this->cartHelper->getRoundAmount($order->getGrandTotal());
+
+        if ($isInvalidAmount || $isInvalidAmountRange) {
             throw new \Exception( __('Capture amount is invalid'));
         }
     }

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -1653,6 +1653,47 @@ class Order extends AbstractHelper
     {
         $isInvalidAmount = !isset($captureAmount) || !is_numeric($captureAmount) || $captureAmount < 0;
 
+        /**
+         * Due to grand total sent to Bolt is rounded,
+         * the same operation should be used when validating captured amount.
+         *
+         * The rounding operations are applied to each operand to avoid cases when grand total
+         * is formally lower than the sum of captured amount and total invoiced.
+         *
+         * ---------
+         * Example 1.
+         *
+         * As of the previous behavior, we had:
+         *
+         * $captureAmount: 203.29
+         * $order->getTotalInvoiced(): [empty]
+         * $order->getGrandTotal(): 203.2874
+         *
+         *      203.29 > 203.2874 [ = true ] -> leads to raise an exception
+         *
+         * After applying rounding, got:
+         *
+         * getRoundAmount($order->getTotalInvoiced()) [0] + getRoundAmount($captureAmount) [20329]: 20329
+         * getRoundAmount($order->getGrandTotal()): 20329
+         *
+         *      20329 > 20329 [ = false ] -> validation passed
+         *
+         * ---------
+         * Example 2.
+         *
+         * $captureAmount: 203.49
+         * $order->getTotalInvoiced(): 2.49
+         * $order->getGrandTotal(): 205.9877
+         *
+         *      203.49 + 2.49 ( = 205.98 ) > 205.9877 [ = false ] -> validation passed
+         *
+         * Applying rounding, we got:
+         *
+         * getRoundAmount($order->getTotalInvoiced()) [249] + getRoundAmount($captureAmount) [20349]: 20598
+         * getRoundAmount($order->getGrandTotal()): 20599
+         *
+         *      20598 > 20599 [ = false ] -> validation also passed
+         */
         $isInvalidAmountRange = $this->cartHelper->getRoundAmount($order->getTotalInvoiced())
             + $this->cartHelper->getRoundAmount($captureAmount)
             > $this->cartHelper->getRoundAmount($order->getGrandTotal());


### PR DESCRIPTION
# Description
I faced a rounding issue in the validation method when working on merchant integration and saw an exception was raised. Debug let me see the values of an order object might not be rounded.

---------
Example 1.

As of the previous behavior, we had:

```
$captureAmount: 203.29
$order->getTotalInvoiced(): [empty]
$order->getGrandTotal(): 203.2874

    203.29 + 0 > 203.2874 [ = true ] -> leads to raise an exception
```

This way, an exception is raised here. To avoid it, the same rounding algorithm was applied on each of operands and now it works well. The webhook was failed but it shouldn't. After the fix has been applied the webhook succeeded.

Now it works as it should:

```
getRoundAmount($order->getTotalInvoiced()) [0] + getRoundAmount($captureAmount) [20329]: 20329
getRoundAmount($order->getGrandTotal()): 20329

    20329 > 20329 [ = false ] -> validation passed
```

---------
Example 2.

```
$captureAmount: 203.49
$order->getTotalInvoiced(): 2.49
$order->getGrandTotal(): 205.9877

    203.49 + 2.49 ( = 205.98 ) > 205.9877 [ = false ] -> validation passed
```

Applying rounding, we got:

```
getRoundAmount($order->getTotalInvoiced()) [249] + getRoundAmount($captureAmount) [20349]: 20598
getRoundAmount($order->getGrandTotal()): 20599

    20598 > 20599 [ = false ] -> validation also passed
```
---
There was no Asana task created for this issue.

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [x] Successfully tested on a merchant's staging server

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have created or modified unit tests to sufficiently cover my changes.