### PR TITLE
Convert attribute to string if it's a boolean before sending to the Bolt API

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1033,9 +1033,11 @@ class Cart extends AbstractHelper
                 if(isset($item_options['attributes_info'])){
                     $properties = [];
                     foreach($item_options['attributes_info'] as $attribute_info){
+                        // Convert attribute to string if it's a boolean before sending to the Bolt API
+                        $attributeValue = is_bool($attribute_info['value']) ? var_export($attribute_info['value'], true) : $attribute_info['value'];
                         $properties[] = (object) [
                             "name" => $attribute_info['label'],
-                            "value" => $attribute_info['value']
+                            "value" => $attributeValue
                         ];
                     }
                     $product['properties'] = $properties;


### PR DESCRIPTION
When the attribute value is a boolean, Bolt recognizes it as an invalid JSON and doesn’t allow the order to be created on Bolt. This ensures the attribute value is converted to string if it's a boolean when sending it to Bolt.

Fixes: https://app.asana.com/0/564264490825835/1142017681006690

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [ ] I have created or modified unit tests to sufficiently cover my changes.
