### PR TITLE
Ignore before plugins if order payment isn't set

### DIFF
--- a/Plugin/OrderPlugin.php
+++ b/Plugin/OrderPlugin.php
@@ -35,7 +35,7 @@ class OrderPlugin
      */
     public function beforeSetState(Order $subject, $state)
     {
-        if ($subject->getPayment()->getMethod() != \Bolt\Boltpay\Model\Payment::METHOD_CODE) {
+        if (!$subject->getPayment() || $subject->getPayment()->getMethod() != \Bolt\Boltpay\Model\Payment::METHOD_CODE) {
             return [$state];
         }
         if ($state === \Bolt\Boltpay\Helper\Order::BOLT_ORDER_STATE_NEW) {
@@ -57,7 +57,7 @@ class OrderPlugin
      */
     public function beforeSetStatus(Order $subject, $status)
     {
-        if ($subject->getPayment()->getMethod() != \Bolt\Boltpay\Model\Payment::METHOD_CODE) {
+        if (!$subject->getPayment() || $subject->getPayment()->getMethod() != \Bolt\Boltpay\Model\Payment::METHOD_CODE) {
             return [$status];
         }
         if ($status === \Bolt\Boltpay\Helper\Order::BOLT_ORDER_STATUS_PENDING) {


### PR DESCRIPTION
# Description
Fatal error: Uncaught Error: Call to a member function getMethod() on null in app/code/Bolt/Boltpay/Plugin/OrderPlugin.php:60

Fixes: https://app.asana.com/0/564264490825835/1145190992675985

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have created or modified unit tests to sufficiently cover my changes.
