### PR TITLE
Multiple Bolt transactions associated with same order fix

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -804,7 +804,7 @@ class Order extends AbstractHelper
 
             if ($order->getState() === OrderModel::STATE_PENDING_PAYMENT) {
                 throw new BoltException(
-                    __('Order is in the initial state. Waiting for the hook update. Order #: %1 Quote ID: %2',
+                    __('Order is in pending payment. Waiting for the hook update. Order #: %1 Quote ID: %2',
                         $quote->getReservedOrderId(),
                         $quote->getId()),
                     null,

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -794,9 +794,21 @@ class Order extends AbstractHelper
 
             if($order->isCanceled()) {
                 throw new BoltException(
-                    __('Order has been canceled due to the previously declined payment'),
+                    __('Order has been canceled due to the previously declined payment. Order #: %1 Quote ID: %2',
+                        $quote->getReservedOrderId(),
+                        $quote->getId()),
                     null,
                     CreateOrder::E_BOLT_REJECTED_ORDER
+                );
+            }
+
+            if ($order->getState() === OrderModel::STATE_PENDING_PAYMENT) {
+                throw new BoltException(
+                    __('Order is in the initial state. Waiting for the hook update. Order #: %1 Quote ID: %2',
+                        $quote->getReservedOrderId(),
+                        $quote->getId()),
+                    null,
+                    CreateOrder::E_BOLT_GENERAL_ERROR
                 );
             }
 

--- a/Model/Api/OrderManagement.php
+++ b/Model/Api/OrderManagement.php
@@ -157,7 +157,13 @@ class OrderManagement implements OrderManagementInterface
                     __('Missing required parameters.')
                 );
             }
-            if ($type === 'failed_payment') {
+            if ($type === 'rejected_irreversible' && $this->orderHelper->tryDeclinedPaymentCancelation($display_id)) {
+                $this->response->setHttpResponseCode(200);
+                $this->response->setBody(json_encode([
+                    'status' => 'success',
+                    'message' => 'Order was canceled due to declined payment: ' . $display_id,
+                ]));
+            } elseif ($type === 'failed_payment') {
                 $this->orderHelper->deleteOrderByIncrementId($display_id);
 
                 $this->response->setHttpResponseCode(200);

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -431,7 +431,7 @@ class OrderTest extends TestCase
         $this->orderMock->expects(static::never())->method('hold');
         $this->orderMock->expects(static::never())->method('setState');
         $this->orderMock->expects(static::never())->method('setStatus');
-        $this->orderMock->expects(static::once())->method('save');
+        $this->orderMock->expects(static::never())->method('save');
         $this->currentMock->setOrderState($this->orderMock, $state);
     }
 

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -339,11 +339,11 @@ class OrderTest extends TestCase
     public function tryDeclinedPaymentCancelation_pendingOrder()
     {
         $state = Order::STATE_PENDING_PAYMENT;
-        $this->orderMock->expects(static::once())->method('getState')->willReturn($state);
+        $this->orderMock->expects(static::exactly(2))->method('getState')
+            ->willReturnOnConsecutiveCalls($state, Order::STATE_CANCELED);
         $this->currentMock->expects(static::once())->method('getExistingOrder')->with(self::INCREMENT_ID)
             ->willReturn($this->orderMock);
         $this->currentMock->expects(static::once())->method('cancelOrder')->with($this->orderMock);
-        $this->orderMock->expects(static::once())->method('save');
 
         self::assertTrue($this->currentMock->tryDeclinedPaymentCancelation(self::DISPLAY_ID));
     }

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -24,6 +24,7 @@ use Bolt\Boltpay\Helper\Config as ConfigHelper;
 use Bolt\Boltpay\Helper\Discount as DiscountHelper;
 use Bolt\Boltpay\Helper\Log as LogHelper;
 use Bolt\Boltpay\Helper\Session as SessionHelper;
+use Bolt\Boltpay\Model\Api\CreateOrder;
 use Bolt\Boltpay\Model\Service\InvoiceService;
 use Magento\Directory\Model\Region as RegionModel;
 use Magento\Framework\Api\SearchCriteriaBuilder;
@@ -35,6 +36,8 @@ use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
 use Magento\Quote\Model\QuoteManagement;
 use Magento\Sales\Api\OrderRepositoryInterface as OrderRepository;
 use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order as OrderModel;
+use Magento\Sales\Model\Order\Config;
 use Magento\Sales\Model\Order\Email\Sender\InvoiceSender;
 use Magento\Sales\Model\Order\Email\Sender\OrderSender;
 use Magento\Sales\Model\Order\Payment\Transaction\Builder as TransactionBuilder;
@@ -51,6 +54,7 @@ class OrderTest extends TestCase
 {
     const INCREMENT_ID = 1234;
     const QUOTE_ID = 5678;
+    const DISPLAY_ID = self::INCREMENT_ID . " / " . self::QUOTE_ID;
 
     /**
      * @var ApiHelper
@@ -147,14 +151,18 @@ class OrderTest extends TestCase
     protected $date;
 
     /**
-     * @var PHPUnit_Framework_MockObject_MockObject
+     * @var PHPUnit_Framework_MockObject_MockObject|OrderHelper
      */
     private $currentMock;
 
     /**
-     * @var Order
+     * @var \PHPUnit\Framework\MockObject\MockObject|Order
      */
     private $orderMock;
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|Config
+     */
+    private $orderConfigMock;
 
     /**
      * @inheritdoc
@@ -192,7 +200,8 @@ class OrderTest extends TestCase
             ])
             ->setMethods([
                 'getExistingOrder',
-                'deleteOrder'
+                'deleteOrder',
+                'cancelOrder'
             ])
             ->getMock();
     }
@@ -223,8 +232,21 @@ class OrderTest extends TestCase
         $this->orderMock = $this->createPartialMock(
             Order::class,
             [
-                'getState'
-            ]);
+                'getConfig',
+                'getState',
+                'save',
+                'hold',
+                'setState',
+                'setStatus'
+            ]
+        );
+        $this->orderConfigMock = $this->createPartialMock(
+            Config::class,
+            [
+                'getStateDefaultStatus'
+            ]
+        );
+        $this->orderMock->method('getConfig')->willReturn($this->orderConfigMock);
     }
 
     /**
@@ -236,7 +258,7 @@ class OrderTest extends TestCase
             ->willReturn(null);
         $this->orderMock->expects(static::never())->method('getState');
         $this->currentMock->expects(static::never())->method('deleteOrder');
-        $this->currentMock->deleteOrderByIncrementId(self::INCREMENT_ID." / ".self::QUOTE_ID);
+        $this->currentMock->deleteOrderByIncrementId(self::DISPLAY_ID);
     }
 
     /**
@@ -259,7 +281,7 @@ class OrderTest extends TestCase
             )
         );
         $this->currentMock->expects(static::never())->method('deleteOrder');
-        $this->currentMock->deleteOrderByIncrementId(self::INCREMENT_ID." / ".self::QUOTE_ID);
+        $this->currentMock->deleteOrderByIncrementId(self::DISPLAY_ID);
     }
 
     /**
@@ -272,6 +294,123 @@ class OrderTest extends TestCase
         $state = Order::STATE_PENDING_PAYMENT;
         $this->orderMock->expects(static::once())->method('getState')->willReturn($state);
         $this->currentMock->expects(static::once())->method('deleteOrder')->with($this->orderMock);
-        $this->currentMock->deleteOrderByIncrementId(self::INCREMENT_ID." / ".self::QUOTE_ID);
+        $this->currentMock->deleteOrderByIncrementId(self::DISPLAY_ID);
+    }
+
+    /**
+     * @test
+     */
+    public function tryDeclinedPaymentCancelation_noOrder()
+    {
+        $this->expectException(\Bolt\Boltpay\Exception\BoltException::class);
+        $this->expectExceptionMessage(
+            sprintf(
+                'Order Cancelation Error. Order does not exist. Order #: %s Immutable Quote ID: %s',
+                self::INCREMENT_ID,
+                self::QUOTE_ID
+            )
+        );
+        $this->expectExceptionCode(CreateOrder::E_BOLT_GENERAL_ERROR);
+        $this->currentMock->expects(static::once())->method('getExistingOrder')->with(self::INCREMENT_ID)
+            ->willReturn(false);
+
+        $this->currentMock->tryDeclinedPaymentCancelation(self::DISPLAY_ID);
+    }
+
+    /**
+     * @test
+     */
+    public function tryDeclinedPaymentCancelation_pendingOrder()
+    {
+        $state = OrderModel::STATE_PENDING_PAYMENT;
+        $this->orderMock->expects(static::once())->method('getState')->willReturn($state);
+        $this->currentMock->expects(static::once())->method('getExistingOrder')->with(self::INCREMENT_ID)
+            ->willReturn($this->orderMock);
+        $this->currentMock->expects(static::once())->method('cancelOrder')->with($this->orderMock);
+        $this->orderMock->expects(static::once())->method('save');
+
+        self::assertTrue($this->currentMock->tryDeclinedPaymentCancelation(self::DISPLAY_ID));
+    }
+
+    /**
+     * @test
+     */
+    public function tryDeclinedPaymentCancelation_canceledOrder()
+    {
+        $state = OrderModel::STATE_CANCELED;
+        $this->orderMock->expects(static::exactly(2))->method('getState')->willReturn($state);
+        $this->currentMock->expects(static::once())->method('getExistingOrder')->with(self::INCREMENT_ID)
+            ->willReturn($this->orderMock);
+        $this->currentMock->expects(static::never())->method('cancelOrder')->with($this->orderMock);
+        $this->orderMock->expects(static::never())->method('save');
+
+        self::assertTrue($this->currentMock->tryDeclinedPaymentCancelation(self::DISPLAY_ID));
+    }
+
+    /**
+     * @test
+     */
+    public function tryDeclinedPaymentCancelation_completeOrder()
+    {
+        $state = OrderModel::STATE_COMPLETE;
+        $this->orderMock->expects(static::exactly(2))->method('getState')->willReturn($state);
+        $this->currentMock->expects(static::once())->method('getExistingOrder')->with(self::INCREMENT_ID)
+            ->willReturn($this->orderMock);
+        $this->currentMock->expects(static::never())->method('cancelOrder')->with($this->orderMock);
+        $this->orderMock->expects(static::never())->method('save');
+
+        self::assertFalse($this->currentMock->tryDeclinedPaymentCancelation(self::DISPLAY_ID));
+    }
+
+    /**
+     * @test
+     */
+    public function setOrderState_holdedOrder()
+    {
+        $state = OrderModel::STATE_HOLDED;
+        $prevState = OrderModel::STATE_PENDING_PAYMENT;
+        $this->orderMock->expects(static::once())->method('getState')->willReturn($prevState);
+        $this->orderMock->expects(static::once())->method('hold');
+        $this->orderMock->expects(static::once())->method('setState')->with(OrderModel::STATE_PROCESSING);
+        $this->orderConfigMock->expects(static::once())->method('getStateDefaultStatus')
+            ->with(OrderModel::STATE_PROCESSING)->willReturn(OrderModel::STATE_PROCESSING);
+        $this->orderMock->expects(static::once())->method('setStatus')->with(OrderModel::STATE_PROCESSING);
+        $this->orderMock->expects(static::once())->method('save');
+        $this->currentMock->setOrderState($this->orderMock, $state);
+    }
+
+    /**
+     * @test
+     */
+    public function setOrderState_holdedOrderWithException()
+    {
+        $state = OrderModel::STATE_HOLDED;
+        $prevState = OrderModel::STATE_PENDING_PAYMENT;
+        $this->orderMock->expects(static::once())->method('getState')->willReturn($prevState);
+        $this->orderMock->expects(static::once())->method('hold')->willThrowException(new \Exception());
+        $this->orderMock->expects(static::exactly(2))->method('setState')
+            ->withConsecutive([OrderModel::STATE_PROCESSING], [OrderModel::STATE_HOLDED]);
+        $this->orderConfigMock->expects(static::exactly(2))->method('getStateDefaultStatus')
+            ->withConsecutive([OrderModel::STATE_PROCESSING], [OrderModel::STATE_HOLDED])
+            ->willReturnArgument(0);
+        $this->orderMock->expects(static::exactly(2))->method('setStatus')
+            ->withConsecutive([OrderModel::STATE_PROCESSING], [OrderModel::STATE_HOLDED]);
+        $this->orderMock->expects(static::once())->method('save');
+        $this->currentMock->setOrderState($this->orderMock, $state);
+    }
+
+    /**
+     * @test
+     */
+    public function setOrderState_canceledOrder()
+    {
+        $state = OrderModel::STATE_CANCELED;
+        $this->currentMock->expects(static::once())->method('cancelOrder')->with($this->orderMock);
+        $this->orderMock->expects(static::once())->method('getState')->willReturn($state);
+        $this->orderMock->expects(static::never())->method('hold');
+        $this->orderMock->expects(static::never())->method('setState');
+        $this->orderMock->expects(static::never())->method('setStatus');
+        $this->orderMock->expects(static::once())->method('save');
+        $this->currentMock->setOrderState($this->orderMock, $state);
     }
 }

--- a/Test/Unit/Model/Api/OrderManagementTest.php
+++ b/Test/Unit/Model/Api/OrderManagementTest.php
@@ -1,0 +1,372 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2019 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Test\Unit\Model\Api;
+
+use Bolt\Boltpay\Exception\BoltException;
+use Bolt\Boltpay\Helper\Bugsnag;
+use Bolt\Boltpay\Helper\Config as ConfigHelper;
+use Bolt\Boltpay\Helper\Hook as HookHelper;
+use Bolt\Boltpay\Helper\Log as LogHelper;
+use Bolt\Boltpay\Helper\MetricsClient;
+use Bolt\Boltpay\Model\Api\CreateOrder;
+use Bolt\Boltpay\Model\Api\OrderManagement;
+use Magento\Framework\Phrase;
+use Magento\Framework\Webapi\Rest\Request;
+use Magento\Framework\Webapi\Rest\Response;
+use Magento\Quote\Model\Quote;
+use Magento\Sales\Model\Order;
+use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Helper\Order as OrderHelper;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Class OrderManagementTest
+ *
+ * @package Bolt\Boltpay\Test\Unit\Model\Api
+ * @coversDefaultClass \Bolt\Boltpay\Model\Api\OrderManagement
+ */
+class OrderManagementTest extends TestCase
+{
+    const ORDER_ID = 123;
+    const QUOTE_ID = 456;
+    const STORE_ID = 1;
+    const ID = "AAAABBBBCCCCD";
+    const REFERENCE = "AAAA-BBBB-CCCC";
+    const AMOUNT = 11800;
+    const CURRENCY = "USD";
+    const DISPLAY_ID = "000000123 / 456";
+    const REQUEST_HEADER_TRACE_ID = 'aaaabbbbcccc';
+    const TYPE = 'pending';
+    const STATUS = 'pending';
+
+    /**
+     * @var MockObject|HookHelper
+     */
+    private $hookHelper;
+
+    /**
+     * @var MockObject|OrderHelper
+     */
+    private $orderHelperMock;
+
+    /**
+     * @var MockObject|LogHelper
+     */
+    private $logHelper;
+
+    /**
+     * @var MockObject|Request
+     */
+    private $request;
+
+    /**
+     * @var MockObject|Bugsnag
+     */
+    private $bugsnag;
+
+    /**
+     * @var MockObject|MetricsClient
+     */
+    private $metricsClient;
+
+    /**
+     * @var MockObject|Response
+     */
+    private $response;
+
+    /**
+     * @var MockObject|ConfigHelper
+     */
+    private $configHelper;
+
+    /**
+     * @var MockObject|OrderManagement
+     */
+    private $currentMock;
+
+    /**
+     * @var MockObject|Quote
+     */
+    private $quoteMock;
+    /**
+     * @var string
+     */
+    private $requestContent;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->initRequiredMocks();
+        $this->initCurrentMock();
+
+        $this->requestContent = json_encode(
+            [
+                "id" => self::ID, "reference" => self::REFERENCE, "order" => self::ORDER_ID, "type" => self::TYPE,
+                "amount" => self::AMOUNT, "currency" => self::CURRENCY, "status" => self::STATUS, "display_id" => self::DISPLAY_ID
+            ]
+        );
+    }
+
+    private function initRequiredMocks()
+    {
+        $this->hookHelper = $this->createMock(HookHelper::class);
+        $this->orderHelperMock = $this->createMock(OrderHelper::class);
+        $this->logHelper = $this->createMock(LogHelper::class);
+        $this->request = $this->createMock(Request::class);
+        $this->bugsnag = $this->createMock(Bugsnag::class);
+        $this->metricsClient = $this->createMock(MetricsClient::class);
+        $this->response = $this->createMock(Response::class);
+        $this->configHelper = $this->createMock(ConfigHelper::class);
+
+        $this->quoteMock = $this->createMock(Quote::class);
+
+        $this->orderHelperMock->expects(self::once())->method('getStoreIdByQuoteId')
+            ->with(self::ORDER_ID)->willReturn(self::STORE_ID);
+    }
+
+    private function initCurrentMock()
+    {
+        $this->currentMock = $this->getMockBuilder(OrderManagement::class)
+            ->setConstructorArgs([
+                $this->hookHelper,
+                $this->orderHelperMock,
+                $this->logHelper,
+                $this->request,
+                $this->bugsnag,
+                $this->metricsClient,
+                $this->response,
+                $this->configHelper
+            ])
+            ->enableProxyingToOriginalMethods()
+            ->getMock();
+    }
+
+    /**
+     * @test
+     * @covers ::manage
+     */
+    public function manage_common()
+    {
+        $startTime = microtime(true) * 1000;
+
+        $this->metricsClient->expects(self::once())->method('getCurrentTime')->willReturn($startTime);
+        $this->request->expects(self::once())->method('getContent')->willReturn($this->requestContent);
+        $this->logHelper->expects(self::exactly(2))->method('addInfoLog')
+            ->withConsecutive([$this->requestContent], ['StoreId: ' . self::STORE_ID]);
+        $this->hookHelper->expects(self::once())->method('preProcessWebhook')->with(self::STORE_ID);
+        $this->metricsClient->expects(self::once())->method('processMetric')
+            ->with(self::anything(), 1, 'webhooks.latency', $startTime);
+        $this->response->expects(self::once())->method('sendResponse');
+
+        $this->currentMock->manage(
+            self::ID,
+            self::REFERENCE,
+            self::ORDER_ID,
+            null,
+            self::AMOUNT,
+            self::CURRENCY,
+            null,
+            self::DISPLAY_ID
+        );
+    }
+
+    /**
+     * @test
+     * @depends manage_common
+     * @covers ::manage
+     */
+    public function manage_rejectedIrreversible_success()
+    {
+        $type = "rejected_irreversible";
+
+        $this->orderHelperMock->expects(self::once())->method('tryDeclinedPaymentCancelation')
+            ->willReturn(true);
+        $this->response->expects(self::once())->method('setHttpResponseCode')->with(200);
+        $this->response->expects(self::once())->method('setBody')->with(json_encode([
+            'status' => 'success',
+            'message' => 'Order was canceled due to declined payment: ' . self::DISPLAY_ID,
+        ]));
+
+        $this->currentMock->manage(
+            self::ID,
+            self::REFERENCE,
+            self::ORDER_ID,
+            $type,
+            self::AMOUNT,
+            self::CURRENCY,
+            $type,
+            self::DISPLAY_ID
+        );
+    }
+
+    /**
+     * @test
+     * @depends manage_common
+     * @covers ::manage
+     */
+    public function manage_rejectedIrreversible_fail()
+    {
+        $type = "rejected_irreversible";
+
+        $this->orderHelperMock->expects(self::once())->method('tryDeclinedPaymentCancelation')
+            ->willReturn(false);
+        $this->request->expects(self::once())->method('getHeader')->with(ConfigHelper::BOLT_TRACE_ID_HEADER)
+            ->willReturn(self::REQUEST_HEADER_TRACE_ID);
+        $this->orderHelperMock->expects(self::once())->method('saveUpdateOrder')
+            ->with(self::REFERENCE, self::STORE_ID, self::REQUEST_HEADER_TRACE_ID, $type);
+        $this->response->expects(self::once())->method('setHttpResponseCode')->with(200);
+        $this->response->expects(self::once())->method('setBody')->with(json_encode([
+            'status' => 'success',
+            'message' => 'Order creation / update was successful',
+        ]));
+
+        $this->currentMock->manage(
+            self::ID,
+            self::REFERENCE,
+            self::ORDER_ID,
+            $type,
+            self::AMOUNT,
+            self::CURRENCY,
+            $type,
+            self::DISPLAY_ID
+        );
+    }
+
+    /**
+     * @test
+     * @depends manage_common
+     * @covers ::manage
+     */
+    public function manage_rejectedIrreversible_exception()
+    {
+        $type = "rejected_irreversible";
+        $exception = new BoltException(
+            new Phrase(
+                'Order Cancelation Error. Order does not exist. Order #: %1 Immutable Quote ID: %2',
+                [
+                    self::ORDER_ID,
+                    self::QUOTE_ID
+                ]
+            ),
+            null,
+            CreateOrder::E_BOLT_GENERAL_ERROR
+        );
+
+        $this->orderHelperMock->expects(self::once())->method('tryDeclinedPaymentCancelation')
+            ->with(self::DISPLAY_ID)->willThrowException(
+                $exception
+            );
+        $this->bugsnag->expects(self::once())->method('notifyException')->with($exception);
+        $this->metricsClient->expects(self::once())->method('processMetric')
+            ->with('webhooks.failure', 1, "webhooks.latency", self::anything());
+        $this->response->expects(self::once())->method('setHttpResponseCode')->with(422);
+        $this->response->expects(self::once())->method('setBody')->with(json_encode([
+            'status' => 'error',
+            'code' => '6009',
+            'message' => 'Unprocessable Entity: ' . $exception->getMessage(),
+        ]));
+
+        $this->currentMock->manage(
+            self::ID,
+            self::REFERENCE,
+            self::ORDER_ID,
+            $type,
+            self::AMOUNT,
+            self::CURRENCY,
+            $type,
+            self::DISPLAY_ID
+        );
+    }
+
+    /**
+     * @test
+     * @depends manage_common
+     * @covers ::manage
+     */
+    public function manage_failedPayment_success()
+    {
+        $type = "failed_payment";
+
+        $this->orderHelperMock->expects(self::once())->method('deleteOrderByIncrementId')
+            ->with(self::DISPLAY_ID);
+        $this->response->expects(self::once())->method('setHttpResponseCode')->with(200);
+        $this->response->expects(self::once())->method('setBody')->with(json_encode([
+            'status' => 'success',
+            'message' => 'Order was deleted: ' . self::DISPLAY_ID,
+        ]));
+        $this->metricsClient->expects(self::once())->method('processMetric')
+            ->with('webhooks.success', 1, "webhooks.latency", self::anything());
+
+        $this->currentMock->manage(
+            self::ID,
+            self::REFERENCE,
+            self::ORDER_ID,
+            $type,
+            self::AMOUNT,
+            self::CURRENCY,
+            $type,
+            self::DISPLAY_ID
+        );
+    }
+
+    /**
+     * @test
+     * @depends manage_common
+     * @covers ::manage
+     */
+    public function manage_failedPayment_exception()
+    {
+        $type = "failed_payment";
+        $exception = new BoltException(
+            new Phrase(
+                'Order Delete Error. Order is in invalid state. Order #: %1 State: %2 Immutable Quote ID: %3',
+                [
+                    self::ORDER_ID,
+                    Order::STATE_PROCESSING,
+                    self::QUOTE_ID
+                ]
+            ),
+            null,
+            CreateOrder::E_BOLT_GENERAL_ERROR
+        );
+
+        $this->orderHelperMock->expects(self::once())->method('deleteOrderByIncrementId')
+            ->with(self::DISPLAY_ID)->willThrowException($exception);
+        $this->response->expects(self::once())->method('setHttpResponseCode')->with(422);
+        $this->response->expects(self::once())->method('setBody')->with(json_encode([
+            'status' => 'error',
+            'code' => '6009',
+            'message' => 'Unprocessable Entity: ' . $exception->getMessage(),
+        ]));
+        $this->metricsClient->expects(self::once())->method('processMetric')
+            ->with('webhooks.failure', 1, "webhooks.latency", self::anything());
+
+        $this->currentMock->manage(
+            self::ID,
+            self::REFERENCE,
+            self::ORDER_ID,
+            $type,
+            self::AMOUNT,
+            self::CURRENCY,
+            $type,
+            self::DISPLAY_ID
+        );
+    }
+}


### PR DESCRIPTION
# Description
After overriding the initial order statuses and split the order processing into initial order creation and hook processing, due to ERP support and checkout speed up, some edge case flows were broken leading to unwanted results. Check the description in Asana task linked below.

Fixes: https://app.asana.com/0/941920570700290/1144813337953035/f

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] I have created or modified unit tests to sufficiently cover my changes.
