### PR TITLE
Force admin user to use Bolt checkout button instead of the Magento submit order button

### DIFF
--- a/view/adminhtml/templates/boltpay/button.phtml
+++ b/view/adminhtml/templates/boltpay/button.phtml
@@ -9,4 +9,5 @@ $code = $block->escapeHtml($block->getMethodCode());
     <input type="hidden" id="bolt-billing-address" value='<?php echo $block->getBillingAddress() ?>' />
     <input type="hidden" id="bolt-place-order-payload" value='<?php echo $block->getPlaceOrderPayload() ?>' />
     <div class="bolt-checkout-button with-cards"></div>
+    <input type="hidden" class="required-entry">
 </fieldset>


### PR DESCRIPTION
# Description
Instead of clicking on the Bolt checkout button to create an admin order, the administrator sometimes chooses Bolt as the payment method and then clicks on the default submit order button and that causes Bolt order to be created without a payment. This adds the validation logic to prevent the user from submitting the order using the default submit order button like Magento 1

Fixes: https://app.asana.com/0/564264490825835/1147246218770177

#changelog
Force admin user to use Bolt checkout button instead of the Magento submit order button

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
