### PR TITLE
Restock product quantity when the payment is irreversibly rejected

### DIFF
--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -259,6 +259,8 @@ class OrderTest extends TestCase
                 'setState',
                 'setStatus',
                 'isCanceled',
+                'canCancel',
+                'registerCancellation',
                 'addStatusHistoryComment',
             ]
         );
@@ -438,11 +440,48 @@ class OrderTest extends TestCase
     {
         $state = Order::STATE_CANCELED;
         $this->orderMock->expects(static::once())->method('getState')->willReturn($state);
+        $this->orderMock->expects(static::once())->method('canCancel')->willReturn(true);
         $this->currentMock->expects(static::once())->method('cancelOrder')->with($this->orderMock);
         $this->orderMock->expects(static::never())->method('hold');
         $this->orderMock->expects(static::never())->method('setState');
         $this->orderMock->expects(static::never())->method('setStatus');
         $this->orderMock->expects(static::never())->method('save');
+        $this->currentMock->setOrderState($this->orderMock, $state);
+    }
+
+    /**
+     * @test
+     * @covers ::setOrderState
+     */
+    public function setOrderState_canceledOrderForRejectedIrreversibleHook()
+    {
+        $state = Order::STATE_CANCELED;
+        $prevState = Order::STATE_PAYMENT_REVIEW;
+        $this->orderMock->expects(static::once())->method('getState')->willReturn($prevState);
+        $this->orderMock->expects(static::once())->method('canCancel')->willReturn(false);
+        $this->currentMock->expects(static::never())->method('cancelOrder')->with($this->orderMock);
+        $this->orderMock->expects(static::once())->method('registerCancellation')->willReturn($this->orderMock);
+        $this->orderMock->expects(static::never())->method('setState');
+        $this->orderMock->expects(static::never())->method('setStatus');
+        $this->orderMock->expects(static::once())->method('save');
+        $this->currentMock->setOrderState($this->orderMock, $state);
+    }
+
+    /**
+     * @test
+     * @covers ::setOrderState
+     */
+    public function setOrderState_canceledOrderForRejectedIrreversibleHookWithException()
+    {
+        $state = Order::STATE_CANCELED;
+        $prevState = Order::STATE_PAYMENT_REVIEW;
+        $this->orderMock->expects(static::once())->method('getState')->willReturn($prevState);
+        $this->orderMock->expects(static::once())->method('canCancel')->willReturn(false);
+        $this->currentMock->expects(static::never())->method('cancelOrder')->with($this->orderMock);
+        $this->orderMock->expects(static::once())->method('registerCancellation')->willThrowException(new \Exception());
+        $this->orderMock->expects(static::once())->method('setState');
+        $this->orderMock->expects(static::once())->method('setStatus');
+        $this->orderMock->expects(static::once())->method('save');
         $this->currentMock->setOrderState($this->orderMock, $state);
     }
 


### PR DESCRIPTION
# Description
When Bolt rejects the payment irreversibly, a webhook is sent to Magento to cancel the order. The order state and status are updated to canceled but the product isn’t restocked as the underlining logic for canceling the order isn’t run. More specifically, Magento doesn’t allow the order to cancel when its status is payment review. This PR adds the logic to restock the product quantity for the rejected irreversible hook.

Fixes: https://app.asana.com/0/564264490825835/1147250679267337

#changelog
Restock product quantity when the payment is irreversibly rejected

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
