### PR TITLE
Adds boilerplate code to insert code for checkout funnel tracking

### DIFF
--- a/Block/Js.php
+++ b/Block/Js.php
@@ -439,6 +439,10 @@ class Js extends Template
         return $this->configHelper->getModuleVersion();
     }
 
+    public function shouldTrackCheckoutFunnel() {
+        return $this->configHelper->shouldTrackCheckoutFunnel();
+    }
+
     /**
      * Takes a string containing javascript and removes unneeded characters in
      * order to shrink the code without altering it's functionality.

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -246,6 +246,8 @@ class Config extends AbstractHelper
 
     const XML_PATH_CAPTURE_MERCHANT_METRICS = 'payment/boltpay/capture_merchant_metrics';
 
+    const XML_PATH_TRACK_CHECKOUT_FUNNEL = 'payment/boltpay/track_checkout_funnel';
+
     /**
      * Default whitelisted shopping cart and checkout pages "Full Action Name" identifiers, <router_controller_action>
      * Pages allowed to load Bolt javascript / show checkout button
@@ -1181,6 +1183,22 @@ class Config extends AbstractHelper
             'sales/minimum_order/amount',
             ScopeInterface::SCOPE_STORE,
             $storeId
+        );
+    }
+
+    /**
+     * Check if plugin should track the funnel transition in magento's default checkout.
+     *
+     * @param int|string|Store $store
+     *
+     * @return  boolean
+     */
+    public function shouldTrackCheckoutFunnel($store = null)
+    {
+        return $this->getScopeConfig()->isSetFlag(
+            self::XML_PATH_ACTIVE,
+            ScopeInterface::SCOPE_STORE,
+            $store
         );
     }
 }

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -298,4 +298,17 @@ class JsTest extends \PHPUnit\Framework\TestCase
         $this->setBoltInitiateCheckout();
         $this->assertTrue($this->block->getInitiateCheckout(), 'getInitiateCheckout() method: not working properly');
     }
+
+    public function testShouldTrackCheckoutFunnel()
+    {
+        $storeId = 0;
+        $this->configHelper->expects($this->any())
+                           ->method('shouldTrackCheckoutFunnel')
+                           ->with($storeId)
+                           ->will($this->returnValue(true));
+
+        $result = $this->block->shouldTrackCheckoutFunnel();
+
+        $this->assertTrue($result, 'shouldTrackCheckoutFunnel() returns true when config is set to true');
+    }
 }

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -85,7 +85,8 @@ class JsTest extends \PHPUnit\Framework\TestCase
             'isSandboxModeSet', 'isActive', 'getAnyPublishableKey',
             'getPublishableKeyPayment', 'getPublishableKeyCheckout', 'getPublishableKeyBackOffice',
             'getReplaceSelectors', 'getGlobalCSS', 'getPrefetchShipping', 'getQuoteIsVirtual',
-            'getTotalsChangeSelectors', 'getAdditionalCheckoutButtonClass', 'getAdditionalConfigString', 'getIsPreAuth'
+            'getTotalsChangeSelectors', 'getAdditionalCheckoutButtonClass', 'getAdditionalConfigString', 'getIsPreAuth',
+            'shouldTrackCheckoutFunnel'
         ];
 
         $this->configHelper = $this->getMockBuilder(HelperConfig::class)
@@ -301,10 +302,8 @@ class JsTest extends \PHPUnit\Framework\TestCase
 
     public function testShouldTrackCheckoutFunnel()
     {
-        $storeId = 0;
         $this->configHelper->expects($this->any())
                            ->method('shouldTrackCheckoutFunnel')
-                           ->with($storeId)
                            ->will($this->returnValue(true));
 
         $result = $this->block->shouldTrackCheckoutFunnel();

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -165,6 +165,10 @@
                     <label>Capture Internal Merchant Metrics</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
+                <field id="track_checkout_funnel" translate="label" type="select" sortOrder="290" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <label>Track checkout funnel</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
             </group>
         </section>
     </system>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -57,7 +57,7 @@ tr.shipping.totals td.amount span.price,
                 <should_minify_javascript>1</should_minify_javascript>
                 <capture_merchant_metrics>0</capture_merchant_metrics>
                 <is_pre_auth>0</is_pre_auth>
-                <track_checkout_funnel>1</track_checkout_funnel>
+                <track_checkout_funnel>0</track_checkout_funnel>
             </boltpay>
         </payment>
     </default>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -57,6 +57,7 @@ tr.shipping.totals td.amount span.price,
                 <should_minify_javascript>1</should_minify_javascript>
                 <capture_merchant_metrics>0</capture_merchant_metrics>
                 <is_pre_auth>0</is_pre_auth>
+                <track_checkout_funnel>1</track_checkout_funnel>
             </boltpay>
         </payment>
     </default>

--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -58,5 +58,12 @@
                 </argument>
             </arguments>
         </referenceBlock>
+
+        <referenceContainer name="before.body.end">
+            <block class="Bolt\Boltpay\Block\Js"
+                   name="checkout_funnel.js"
+                   template="Bolt_Boltpay::js/checkout_funnel.js.phtml"
+                   ifconfig="payment/boltpay/track_checkout_funnel" />
+        </referenceContainer>
     </body>
 </page>

--- a/view/frontend/templates/js/checkout_funnel.js.phtml
+++ b/view/frontend/templates/js/checkout_funnel.js.phtml
@@ -1,0 +1,7 @@
+<?php
+if (!$block->shouldTrackCheckoutFunnel()) return;
+?>
+
+<script type="text/javascript">
+    // TODO: add logic here
+</script>


### PR DESCRIPTION
# Description
This PR adds boiler plate code for 1) new config named "Track checkout funnel" and 2) injecting JavaScript in magento's onepage checkout if config is set

Idea is we use this when we A/B test to track checkout funnel transition in onepage checkout.

# Type of change

- [ x ] New feature (change which adds functionality)



# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ x ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
