### PR TITLE
Ensure Miravist reward points are applied to the immutable quote before the totals are calculated in webhook requests

### DIFF
--- a/Helper/Discount.php
+++ b/Helper/Discount.php
@@ -943,5 +943,42 @@ class Discount extends AbstractHelper
         // Amasty reward points are held in a separate table
         // and are not assigned to the quote / totals directly out of the customer session.
         $this->setAmastyRewardPoints($quote);
+        // Miravist reward points are held in a separate table
+        // and are not assigned to the quote
+        $this->applyMiravistRewardPoint($quote);
+    }
+
+    /**
+     * Copy Miravist Reward Point data from parent quote to immutable quote.
+     * The reward points are fetched from the 3rd party module DB table (mst_rewards_purchase)
+     * and assigned to the parent quote temporarily (they are not persisted in the quote table).
+     * The data needs to be set on the immutable quote before the quote totals are calculated
+     * in the Shipping and Tax call in order to get correct tax
+     *
+     * @param $immutableQuote
+     */
+    public function applyMiravistRewardPoint($immutableQuote)
+    {
+        $parentQuoteId = $immutableQuote->getBoltParentQuoteId();
+        /** @var \Mirasvit\Rewards\Helper\Purchase $mirasvitRewardsPurchaseHelper */
+        $mirasvitRewardsPurchaseHelper = $this->mirasvitRewardsPurchaseHelper->getInstance();
+        if (!$mirasvitRewardsPurchaseHelper || !$parentQuoteId) {
+            return;
+        }
+
+        try {
+            $parentPurchase = $mirasvitRewardsPurchaseHelper->getByQuote($parentQuoteId);
+            if(abs($parentPurchase->getSpendAmount()) > 0){
+                $mirasvitRewardsPurchaseHelper->getByQuote($immutableQuote)
+                    ->setSpendPoints($parentPurchase->getSpendPoints())
+                    ->setSpendMinAmount($parentPurchase->getSpendMinAmount())
+                    ->setSpendMaxAmount($parentPurchase->getSpendMaxAmount())
+                    ->setSpendAmount($parentPurchase->getSpendAmount())
+                    ->setBaseSpendAmount($parentPurchase->getBaseSpendAmount())
+                    ->save();
+            }
+        } catch (\Exception $e) {
+            $this->bugsnag->notifyException($e);
+        }
     }
 }

--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -445,6 +445,9 @@ class ShippingMethods implements ShippingMethodsInterface
         if ($quote->getAmrewardsPoint()) {
             $data .= $quote->getAmrewardsPoint();
         }
+        if($rewardsAmount = $this->discountHelper->getMirasvitRewardsAmount($quote)){
+            $data .=$rewardsAmount;
+        }
         return $data;
     }
 


### PR DESCRIPTION

# Description
Ensure Miravist reward points are applied to the immutable quote before the totals are calculated in webhook requests

Fixes: https://app.asana.com/0/1125081140214268/1146933633809759




# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Asana task link and provided a changelog message if applicable.
