### PR TITLE
Add JavaScript to track checkout funnel in onepage checkout

### DIFF
--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -63,7 +63,8 @@
             <block class="Bolt\Boltpay\Block\Js"
                    name="checkout_funnel.js"
                    template="Bolt_Boltpay::js/checkout_funnel.js.phtml"
-                   ifconfig="payment/boltpay/track_checkout_funnel" />
+                   ifconfig="payment/boltpay/track_checkout_funnel" >
+            </block>
         </referenceContainer>
     </body>
 </page>

--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -63,8 +63,7 @@
             <block class="Bolt\Boltpay\Block\Js"
                    name="checkout_funnel.js"
                    template="Bolt_Boltpay::js/checkout_funnel.js.phtml"
-                   ifconfig="payment/boltpay/track_checkout_funnel" >
-            </block>
+                   ifconfig="payment/boltpay/track_checkout_funnel" />
         </referenceContainer>
     </body>
 </page>

--- a/view/frontend/templates/js/checkout_funnel.js.phtml
+++ b/view/frontend/templates/js/checkout_funnel.js.phtml
@@ -1,9 +1,5 @@
 <?php
 if (!$block->shouldTrackCheckoutFunnel()) return;
-
-$objectManager =  \Magento\Framework\App\ObjectManager::getInstance();
-$repo = $objectManager->get('\Magento\Framework\View\Asset\Repository');
-
 ?>
 
-<script type="text/javascript" src="<?php echo $repo->getUrl("Bolt_Boltpay::js/track-checkout.js") ?>"></script>
+<script type="text/x-magento-init"> { "*" : { "Bolt_Boltpay/js/track-checkout" : {} } } </script>

--- a/view/frontend/templates/js/checkout_funnel.js.phtml
+++ b/view/frontend/templates/js/checkout_funnel.js.phtml
@@ -1,7 +1,9 @@
 <?php
 if (!$block->shouldTrackCheckoutFunnel()) return;
+
+$objectManager =  \Magento\Framework\App\ObjectManager::getInstance();
+$repo = $objectManager->get('\Magento\Framework\View\Asset\Repository');
+
 ?>
 
-<script type="text/javascript">
-    // TODO: add logic here
-</script>
+<script type="text/javascript" src="<?php echo $repo->getUrl("Bolt_Boltpay::js/track-checkout.js") ?>"></script>

--- a/view/frontend/web/js/track-checkout.js
+++ b/view/frontend/web/js/track-checkout.js
@@ -20,8 +20,8 @@ function trackFunnel(step) {
         // prevent duplicate tracking
         return;
     }
-    currentStep = step;
     BoltTrack.recordEvent(step);
+    currentStep = step;
 }
 
 function setupListnerForShippingForm() {

--- a/view/frontend/web/js/track-checkout.js
+++ b/view/frontend/web/js/track-checkout.js
@@ -4,15 +4,17 @@
 
 var currentStep = '';
 
-function waitFor(condition, doWhenReady) {
-    var checkCondition = function () {
+function waitFor(condition, doWhenReady, pollIntervalMillis) {
+    var defaultPollIntervalMillis = 100;
+    var maxRetryCount = 30;
+    var checkCondition = function (retryCount) {
         if (condition()) {
             doWhenReady();
-        } else {
-            setTimeout(checkCondition, 50);
+        } else if (retryCount < maxRetryCount) {
+            setTimeout(function(){checkCondition(retryCount + 1)}, pollIntervalMillis || defaultPollIntervalMillis);
         }
     };
-    checkCondition();
+    checkCondition(0);
 }
 
 function trackFunnel(step) {
@@ -50,7 +52,7 @@ function init() {
 
     waitFor(
         // wait for shipping form to be fully rendered, ie., we have 9 required fields in the page.
-        function() { return jQuery("#shipping-new-address-form .field._required input,select").length === 9; },
+        function() { return jQuery("#shipping-new-address-form .field._required input,select").length >= 9; },
         setupListnerForShippingForm
     );
 

--- a/view/frontend/web/js/track-checkout.js
+++ b/view/frontend/web/js/track-checkout.js
@@ -1,5 +1,23 @@
 /* Track checkout funnel transition in magento's default checkout */
 
-var currentStep = 'onCheckoutStart';
-BoltTrack.recordEvent("onCheckoutStart");
+var currentStep = '';
 
+function trackFunnel(step) {
+    if (step === currentStep) {
+        // prevent duplicate tracking
+        return;
+    }
+    currentStep = step;
+    BoltTrack.recordEvent(step);
+}
+
+trackFunnel("onCheckoutStart");
+
+// TODO: track onShippingAddressComplete when user complete filling in addresses
+// TODO: track onPaymentSubmit when user clicks pay
+
+window.addEventListener("hashchange", function() {
+   if (location.hash === "#payment") {
+       trackFunnel("onShippingOptionsComplete");
+   }
+});

--- a/view/frontend/web/js/track-checkout.js
+++ b/view/frontend/web/js/track-checkout.js
@@ -47,6 +47,7 @@ function init() {
     trackFunnel("onCheckoutStart");
 
     waitFor(
+        // wait for shipping form to be fully rendered, ie., we have 9 required fields in the page.
         function() { return jQuery("#shipping-new-address-form .field._required input,select").length === 9; },
         setupListnerForShippingForm
     );

--- a/view/frontend/web/js/track-checkout.js
+++ b/view/frontend/web/js/track-checkout.js
@@ -5,12 +5,14 @@
 var currentStep = '';
 
 function waitFor(condition, doWhenReady) {
-    var waitForInterval = setInterval(function () {
+    var checkCondition = function () {
         if (condition()) {
             doWhenReady();
-            clearInterval(waitForInterval);
+        } else {
+            setTimeout(condition, 50);
         }
-    }, 50);
+    };
+    checkCondition();
 }
 
 function trackFunnel(step) {

--- a/view/frontend/web/js/track-checkout.js
+++ b/view/frontend/web/js/track-checkout.js
@@ -9,7 +9,7 @@ function waitFor(condition, doWhenReady) {
         if (condition()) {
             doWhenReady();
         } else {
-            setTimeout(condition, 50);
+            setTimeout(checkCondition, 50);
         }
     };
     checkCondition();

--- a/view/frontend/web/js/track-checkout.js
+++ b/view/frontend/web/js/track-checkout.js
@@ -1,0 +1,5 @@
+/* Track checkout funnel transition in magento's default checkout */
+
+var currentStep = 'onCheckoutStart';
+BoltTrack.recordEvent("onCheckoutStart");
+

--- a/view/frontend/web/js/track-checkout.js
+++ b/view/frontend/web/js/track-checkout.js
@@ -65,6 +65,6 @@ function init() {
     });
 }
 
-require(["jquery"], function(){
+require(["jquery"], init);
     init();
 });

--- a/view/frontend/web/js/track-checkout.js
+++ b/view/frontend/web/js/track-checkout.js
@@ -1,5 +1,7 @@
 /* Track checkout funnel transition in magento's default checkout */
 
+// TODO: support logged in user
+
 var currentStep = '';
 
 function waitFor(condition, doWhenReady) {
@@ -35,7 +37,7 @@ function setupListnerForShippingForm() {
                }
            }
            if (complete) {
-               trackFunnel("onShippingAddressComplete")
+               trackFunnel("onShippingAddressComplete");
            }
         });
     });
@@ -62,7 +64,6 @@ function init() {
     });
 }
 
-waitFor(
-    function() { return typeof jQuery != 'undefined'; },
-    init
-);
+require(["jquery"], function(){
+    init();
+});

--- a/view/frontend/web/js/track-checkout.js
+++ b/view/frontend/web/js/track-checkout.js
@@ -66,5 +66,3 @@ function init() {
 }
 
 require(["jquery"], init);
-    init();
-});


### PR DESCRIPTION
# Description
This PR adds a JavaScript running on one page checkout. Lots of (hacky) DOM scraping to detect checkout funnel transition and send it to Bolt via `BoltTrack.recordEvent`. 

I was looking for better way to hook into native magento's event but wasn't able to find - welcome for comment and suggestions

I'll add test with subsequent PR. We currently don't have JavaScript test so adding test requires good amount of new code and config files.

# Type of change
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
