### PR TITLE
Use Generic.Files.LineLength instead of Magento2.Files.LineLength

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -172,7 +172,7 @@
         <exclude-pattern>*/Test/*</exclude-pattern>
         <exclude-pattern>*Test.php</exclude-pattern>
     </rule>
-    <rule ref="Magento2.Files.LineLength">
+    <rule ref="Generic.Files.LineLength">
         <severity>8</severity>
         <type>warning</type>
         <exclude-pattern>*.phtml</exclude-pattern>


### PR DESCRIPTION
# Description

It seems Magento2.Files.LineLength was removed? CI was failing https://circleci.com/gh/BoltApp/bolt-magento2/6155?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

This PR replaces Magento2.Files.LineLength with Generic.Files.LineLength.

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
