### PR TITLE
Load the correct frontend division key configuration

### DIFF
--- a/Block/Js.php
+++ b/Block/Js.php
@@ -102,7 +102,11 @@ class Js extends Template
      */
     public function getCheckoutKey()
     {
-        return $this->configHelper->getAnyPublishableKey();
+        if($this->configHelper->isPaymentOnlyCheckoutEnabled() && $this->_request->getFullActionName() == Config::CHECKOUT_PAGE_ACTION){
+            return $this->configHelper->getPublishableKeyPayment();
+        }
+
+        return $this->configHelper->getPublishableKeyCheckout();
     }
 
     /**
@@ -112,7 +116,8 @@ class Js extends Template
      */
     public function getReplaceSelectors()
     {
-        $subject = trim($this->configHelper->getReplaceSelectors());
+        $isBoltUsedInCheckoutPage = $this->configHelper->isPaymentOnlyCheckoutEnabled() && $this->_request->getFullActionName() == Config::CHECKOUT_PAGE_ACTION;
+        $subject = ($isBoltUsedInCheckoutPage) ? '' : trim($this->configHelper->getReplaceSelectors());
 
         return array_filter(explode(',', preg_replace('/\s+/', ' ', $subject)));
     }

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -21,7 +21,7 @@ use Bolt\Boltpay\Block\Js as BlockJs;
 use Bolt\Boltpay\Helper\Bugsnag;
 use Bolt\Boltpay\Helper\Config as HelperConfig;
 use Bolt\Boltpay\Helper\Cart as CartHelper;
-
+use Magento\Framework\App\Request\Http;
 /**
  * Class JsTest
  *
@@ -41,6 +41,12 @@ class JsTest extends \PHPUnit\Framework\TestCase
      * @var \Magento\Framework\View\Element\Template\Context
      */
     protected $contextMock;
+
+    /**
+     * @var Http
+     */
+    private $requestMock;
+
     /**
      * @var \Magento\Checkout\Model\Session
      */
@@ -86,7 +92,7 @@ class JsTest extends \PHPUnit\Framework\TestCase
             'getPublishableKeyPayment', 'getPublishableKeyCheckout', 'getPublishableKeyBackOffice',
             'getReplaceSelectors', 'getGlobalCSS', 'getPrefetchShipping', 'getQuoteIsVirtual',
             'getTotalsChangeSelectors', 'getAdditionalCheckoutButtonClass', 'getAdditionalConfigString', 'getIsPreAuth',
-            'shouldTrackCheckoutFunnel'
+            'shouldTrackCheckoutFunnel','isPaymentOnlyCheckoutEnabled'
         ];
 
         $this->configHelper = $this->getMockBuilder(HelperConfig::class)
@@ -104,7 +110,12 @@ class JsTest extends \PHPUnit\Framework\TestCase
 
         $this->cartHelperMock = $this->createMock(CartHelper::class);
         $this->bugsnagHelperMock = $this->createMock(Bugsnag::class);
+        $this->requestMock = $this->getMockBuilder(Http::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getFullActionName'])
+            ->getMock();
 
+        $this->contextMock->method('getRequest')->willReturn($this->requestMock);
         $this->block = $this->getMockBuilder(BlockJs::class)
             ->setMethods(['configHelper', 'getUrl'])
             ->setConstructorArgs(
@@ -167,42 +178,113 @@ class JsTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @inheritdoc
+     * @test
+     * @param $data
+     * @dataProvider providerTestGetCheckoutKey
      */
-    public function testGetCheckoutKey()
+    public function testGetCheckoutKey($data)
     {
-        $storeId = 0;
-        $key = 'pKv_pOzRTEST.TESTkEIjTEST.TEST01f0d15501cd7548c1953f6666b2689f2e5a20198c5d7f886c004913TEST';
         $this->configHelper->expects($this->any())
-            ->method('getAnyPublishableKey')
-            ->will($this->returnValue($key));
+            ->method('isPaymentOnlyCheckoutEnabled')
+            ->will($this->returnValue($data['is_payment_only_checkout_enabled']));
+        $this->configHelper->expects($this->any())
+            ->method('getPublishableKeyPayment')
+            ->will($this->returnValue($data['publishable_key_payment']));
+        $this->configHelper->expects($this->any())
+            ->method('getPublishableKeyCheckout')
+            ->will($this->returnValue($data['publishable_key_checkout']));
 
+        $this->requestMock->method('getFullActionName')->willReturn($data['action']);
         $result = $this->block->getCheckoutKey();
+        $this->assertStringStartsWith('pKv_', $result, 'Publishable Key doesn\'t work properly');
+        $this->assertEquals(strlen($data['expected']), strlen($result), 'Publishable Key has an invalid length');
 
-        $this->assertStringStartsWith('pKv_', $result, '"Any Publishable Key" not working properly');
-        $this->assertEquals(strlen($key), strlen($result), '"Any Publishable Key" have invalid length');
+    }
+
+    public function providerTestGetCheckoutKey()
+    {
+        return [
+            ['data' => [
+                'is_payment_only_checkout_enabled' => true,
+                'publishable_key_payment' => 'pKv_pOzRTEST.TESTkEIjTEST.TEST01f0d15501cd7548c1953f6666b2689f2e5a20198c5d7f886c004913TESTCHECKOUTPAGE',
+                'publishable_key_checkout' => 'pKv_pOzRTEST.TESTkEIjTEST.TEST01f0d15501cd7548c1953f6666b2689f2e5a20198c5d7f886c004913TESTCARTPAGE',
+                'action' => HelperConfig::CHECKOUT_PAGE_ACTION,
+                'expected' => 'pKv_pOzRTEST.TESTkEIjTEST.TEST01f0d15501cd7548c1953f6666b2689f2e5a20198c5d7f886c004913TESTCHECKOUTPAGE'
+                ]
+            ],
+            ['data' => [
+                'is_payment_only_checkout_enabled' => true,
+                'publishable_key_payment' => 'pKv_pOzRTEST.TESTkEIjTEST.TEST01f0d15501cd7548c1953f6666b2689f2e5a20198c5d7f886c004913TESTCHECKOUTPAGE',
+                'publishable_key_checkout' => 'pKv_pOzRTEST.TESTkEIjTEST.TEST01f0d15501cd7548c1953f6666b2689f2e5a20198c5d7f886c004913TESTCARTPAGE',
+                'action' => HelperConfig::SHOPPING_CART_PAGE_ACTION,
+                'expected' => 'pKv_pOzRTEST.TESTkEIjTEST.TEST01f0d15501cd7548c1953f6666b2689f2e5a20198c5d7f886c004913TESTCARTPAGE'
+                ]
+            ],
+            ['data' => [
+                'is_payment_only_checkout_enabled' => true,
+                'publishable_key_payment' => 'pKv_pOzRTEST.TESTkEIjTEST.TEST01f0d15501cd7548c1953f6666b2689f2e5a20198c5d7f886c004913TESTCHECKOUTPAGE',
+                'publishable_key_checkout' => 'pKv_pOzRTEST.TESTkEIjTEST.TEST01f0d15501cd7548c1953f6666b2689f2e5a20198c5d7f886c004913TESTOTHERPAGES',
+                'action' => 'other_actions',
+                'expected' => 'pKv_pOzRTEST.TESTkEIjTEST.TEST01f0d15501cd7548c1953f6666b2689f2e5a20198c5d7f886c004913TESTOTHERPAGES'
+                ]
+            ],
+            ['data' => [
+                'is_payment_only_checkout_enabled' => false,
+                'publishable_key_payment' => 'pKv_pOzRTEST.TESTkEIjTEST.TEST01f0d15501cd7548c1953f6666b2689f2e5a20198c5d7f886c004913TESTCHECKOUTPAGE',
+                'publishable_key_checkout' => 'pKv_pOzRTEST.TESTkEIjTEST.TEST01f0d15501cd7548c1953f6666b2689f2e5a20198c5d7f886c004913TESTMINICART',
+                'action' => HelperConfig::CHECKOUT_PAGE_ACTION,
+                'expected' => 'pKv_pOzRTEST.TESTkEIjTEST.TEST01f0d15501cd7548c1953f6666b2689f2e5a20198c5d7f886c004913TESTMINICART'
+                ]
+            ],
+        ];
     }
 
     /**
-     * @inheritdoc
+     * @test
+     * @param $data
+     * @dataProvider providerGetReplaceSelectors
      */
-    public function testGetReplaceSelectors()
+    public function testGetReplaceSelectors($data)
     {
-        $value = '.replaceable-example-selector1|append
-.replaceable-example-selector2|prepend,.replaceable-example-selector3';
-
-        $correctResult = [
-            '.replaceable-example-selector1|append .replaceable-example-selector2|prepend',
-            '.replaceable-example-selector3'
-        ];
-
-        $this->configHelper->expects($this->once())
+        $this->configHelper->expects($this->any())
             ->method('getReplaceSelectors')
-            ->will($this->returnValue($value));
+            ->will($this->returnValue($data['value']));
+
+        $this->configHelper->expects($this->any())
+            ->method('isPaymentOnlyCheckoutEnabled')
+            ->will($this->returnValue($data['is_payment_only_checkout_enabled']));
+
+        $this->requestMock->method('getFullActionName')->willReturn($data['action']);
 
         $result = $this->block->getReplaceSelectors();
 
-        $this->assertEquals($correctResult, $result, 'getReplaceSelectors() method: not working properly');
+        $this->assertEquals($data['expected'], $result, 'getReplaceSelectors() method: not working properly');
+    }
+
+    public function providerGetReplaceSelectors(){
+        return [
+            ['data' => [
+                'value' => '.replaceable-example-selector1|append .replaceable-example-selector2|prepend,.replaceable-example-selector3',
+                'is_payment_only_checkout_enabled' => true,
+                'action' => HelperConfig::CHECKOUT_PAGE_ACTION,
+                'expected' => []
+                ]
+            ],
+            ['data' => [
+                'value' => '.replaceable-example-selector1|append .replaceable-example-selector2|prepend,.replaceable-example-selector3',
+                'is_payment_only_checkout_enabled' => true,
+                'action' => 'other_actions',
+                'expected' => ['.replaceable-example-selector1|append .replaceable-example-selector2|prepend', '.replaceable-example-selector3']
+                ]
+            ],
+            ['data' => [
+                'value' => '.replaceable-example-selector1|append .replaceable-example-selector2|prepend,.replaceable-example-selector3',
+                'is_payment_only_checkout_enabled' => false,
+                'action' => HelperConfig::CHECKOUT_PAGE_ACTION,
+                'expected' => ['.replaceable-example-selector1|append .replaceable-example-selector2|prepend', '.replaceable-example-selector3']
+                ]
+            ]
+        ];
     }
 
     /**


### PR DESCRIPTION
# Description
Currently, the logic to get the publishable key is to check the multi-step key and use it if it’s not empty. If it is empty then the payment only key will be used.

This causes an issue when we want to use both checkout divisions for the storefront. This PR loads the correct key based on the request. If the request is from the checkout page, then use the payment only key, otherwise, use the multiple-step key.

Fixes: https://app.asana.com/0/564264490825835/1148566476960345

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Asana task link and provided a changelog message if applicable.
