### PR TITLE
Fix Bug - the invoice is created with no item

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -1666,7 +1666,7 @@ class Order extends AbstractHelper
     private function createOrderInvoice($order, $transactionId, $amount)
     {
         try {
-            if ($this->cartHelper->getRoundAmount($order->getTotalInvoiced() + $amount) === $this->cartHelper->getRoundAmount($order->getGrandTotal())) {
+            if (round(($order->getTotalInvoiced() + $amount), 2) == round($order->getGrandTotal(), 2)) {
                 $invoice = $this->invoiceService->prepareInvoice($order);
             } else {
                 $invoice = $this->invoiceService->prepareInvoiceWithoutItems($order, $amount);

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -1666,7 +1666,7 @@ class Order extends AbstractHelper
     private function createOrderInvoice($order, $transactionId, $amount)
     {
         try {
-            if (round(($order->getTotalInvoiced() + $amount), 2) == round($order->getGrandTotal(), 2)) {
+            if ($this->cartHelper->getRoundAmount($order->getTotalInvoiced() + $amount) === $this->cartHelper->getRoundAmount($order->getGrandTotal())) {
                 $invoice = $this->invoiceService->prepareInvoice($order);
             } else {
                 $invoice = $this->invoiceService->prepareInvoiceWithoutItems($order, $amount);

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -1666,7 +1666,7 @@ class Order extends AbstractHelper
     private function createOrderInvoice($order, $transactionId, $amount)
     {
         try {
-            if ($order->getTotalInvoiced() + $amount == $order->getGrandTotal()) {
+            if (round(($order->getTotalInvoiced() + $amount), 2) == round($order->getGrandTotal(), 2)) {
                 $invoice = $this->invoiceService->prepareInvoice($order);
             } else {
                 $invoice = $this->invoiceService->prepareInvoiceWithoutItems($order, $amount);

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -775,7 +775,7 @@ class OrderTest extends TestCase
     /**
      * @test
      * @covers ::createOrderInvoice
-     * @dataProvider additionUpdateTransactionStatusProvider
+     * @dataProvider additionAmountTotalProvider
      */
     public function createOrderInvoice_amountWithDifferentDecimals($amount, $grandTotal, $isSame) {
         $totalInvoiced = 0;

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -796,11 +796,9 @@ class OrderTest extends TestCase
         $this->orderMock->method('setIsCustomerNotified')->willReturn($this->orderMock);
         if($isSame){
             $this->invoiceService->expects(static::once())->method('prepareInvoice')->willReturn($invoice);
-            $this->invoiceService->expects(static::never())->method('prepareInvoiceWithoutItems');
         }
         else{
             $this->invoiceService->expects(static::once())->method('prepareInvoiceWithoutItems')->willReturn($invoice);
-            $this->invoiceService->expects(static::never())->method('prepareInvoice');
         }        
             
         $this->invokeMethod($this->currentMock, 'createOrderInvoice', array($this->orderMock, 'ABCD-1234-XXXX', $amount));

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -253,7 +253,12 @@ class OrderTest extends TestCase
         $this->dataObjectFactory = $this->createMock(DataObjectFactory::class);
         $this->logHelper = $this->createMock(LogHelper::class);
         $this->bugsnag = $this->createMock(Bugsnag::class);
-        $this->cartHelper = $this->createMock(CartHelper::class);
+        $this->cartHelper = $this->createPartialMock(
+            CartHelper::class,
+            [
+                'getRoundAmount',
+            ]
+        );
         $this->resourceConnection = $this->createMock(ResourceConnection::class);
         $this->sessionHelper = $this->createMock(SessionHelper::class);
         $this->discountHelper = $this->createMock(DiscountHelper::class);
@@ -790,6 +795,8 @@ class OrderTest extends TestCase
                 'save',
             ]
         );
+        $this->cartHelper->method('getRoundAmount')
+                         ->will($this->returnCallback(function($amount) { return (int)round($amount * 100); }));
         $this->orderMock->expects(static::once())->method('getTotalInvoiced')->willReturn($totalInvoiced);
         $this->orderMock->expects(static::once())->method('getGrandTotal')->willReturn($grandTotal);
         $this->orderMock->method('addStatusHistoryComment')->willReturn($this->orderMock);
@@ -807,16 +814,16 @@ class OrderTest extends TestCase
     public function additionAmountTotalProvider() {
 		return [
             [ 12.25, 12.25, true ],
-			[ 12.00, 12.001, true ],
+            [ 12.00, 12.001, true ],
             [ 12.001, 12.00, true ],
-			[ 12.1225, 12.1234, true ],
-			[ 12.1234, 12.1225, true ],
+            [ 12.1225, 12.1234, true ],
+            [ 12.1234, 12.1225, true ],
             [ 12.13, 12.14, false ],
             [ 12.14, 12.13, false ],
             [ 12.123, 12.126, false ],
             [ 12.126, 12.123, false ],
-			[ 12.1264, 12.1225, false ],
-			[ 12.1225, 12.1264, false ],
+            [ 12.1264, 12.1225, false ],
+            [ 12.1225, 12.1264, false ],
 		];
 	}
 }


### PR DESCRIPTION
# Description
When creating order invoice, the plugin would first compare ($order->getTotalInvoiced() + $amount) with $order->getGrandTotal() , but neither of the two values get rounded before comparison, so for some instance, eg. $order->getTotalInvoiced() + $amount = 121.64 and $order->getGrandTotal() = 121.6406, they are not equal and we call function $this->invoiceService->prepareInvoiceWithoutItems($order, $amount); to create inoivce without item.

Solution: round the value before comparison.

Fixes: https://app.asana.com/0/941920570700290/1148920165401345/f

(Optional: Add a changelog by writing a comment after "#changelog" on the next line)

\#changelog

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Asana task link and provided a changelog message if applicable.
