### PR TITLE
Refactor replace.js - move php code into one place

### DIFF
--- a/Block/Js.php
+++ b/Block/Js.php
@@ -209,6 +209,7 @@ class Js extends Template
             'initiate_checkout'        => $this->getInitiateCheckout(),
             'toggle_checkout'          => $this->getToggleCheckout(),
             'is_pre_auth'              => $this->getIsPreAuth(),
+            'default_error_message'    => $this->getBoltPopupErrorMessage(),
         ]);
     }
 

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -315,7 +315,7 @@ class JsTest extends \PHPUnit\Framework\TestCase
         $this->assertJson($result, 'The Settings config do not have a proper JSON format.');
 
         $array = json_decode($result, true);
-        $this->assertCount(16, $array, 'The number of keys in the settings is not correct');
+        $this->assertCount(17, $array, 'The number of keys in the settings is not correct');
 
         $message = 'Cannot find in the Settings the key: ';
         $this->assertArrayHasKey('connect_url', $array, $message . 'connect_url');

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -117,7 +117,7 @@ class JsTest extends \PHPUnit\Framework\TestCase
 
         $this->contextMock->method('getRequest')->willReturn($this->requestMock);
         $this->block = $this->getMockBuilder(BlockJs::class)
-            ->setMethods(['configHelper', 'getUrl'])
+            ->setMethods(['configHelper', 'getUrl', 'getBoltPopupErrorMessage'])
             ->setConstructorArgs(
                 [
                     $this->contextMock,

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -333,6 +333,7 @@ class JsTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey('additional_checkout_button_class', $array, $message . 'additional_checkout_button_class');
         $this->assertArrayHasKey('initiate_checkout', $array, $message . 'initiate_checkout');
         $this->assertArrayHasKey('toggle_checkout', $array, $message . 'toggle_checkout');
+        $this->assertArrayHasKey('default_error_message', $array, $message . 'default_error_message');
     }
 
     /**

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -47,7 +47,7 @@ ob_start();
     // in payment method renderer, vendor/boltpay/bolt-magento2/view/frontend/web/js/view/payment/method-renderer/boltpay.js
     window.boltConfig = <?php echo $block->getSettings(); ?>;
 
-    var trackCallbacks = {
+    window.boltConfig.trackCallbacks = {
         onCheckoutStart: <?php wrapWithCatch($trackCallbackCode['checkout_start']); ?>,
         onEmailEnter: <?php wrapWithCatch($trackCallbackCode['email_enter'], 'email'); ?>,
         onShippingDetailsComplete: <?php wrapWithCatch($trackCallbackCode['shipping_details_complete']); ?>,
@@ -428,6 +428,7 @@ ob_start();
         var billing_address_selector = '#bolt-billing-address';
         var place_order_payload_id   = 'bolt-place-order-payload';
         var customer_email_selector  = '#checkoutSteps #customer-email';
+        var trackCallbacks = settings.trackCallbacks;
 
         ////////////////////////////////////////////////////////
         // Toggle between Bolt button and magento checkout button

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -35,6 +35,62 @@ ob_start();
     // in payment method renderer, vendor/boltpay/bolt-magento2/view/frontend/web/js/view/payment/method-renderer/boltpay.js
     window.boltConfig = <?php echo $block->getSettings(); ?>;
 
+    var trackCallbacks = {
+        onCheckoutStart: function() {
+            try {
+                <?php echo $trackCallbacks['checkout_start']; ?>
+            } catch (error) {
+                console.error(error);
+            }
+        },
+        onEmailEnter: function(email) {
+            try {
+                <?php echo $trackCallbacks['email_enter']; ?>
+            } catch (error) {
+                console.error(error);
+            }
+        },
+        onShippingDetailsComplete: function() {
+            try {
+                <?php echo $trackCallbacks['shipping_details_complete']; ?>
+            } catch (error) {
+                console.error(error);
+            }
+        },
+        onShippingOptionsComplete: function() {
+            try {
+                <?php echo $trackCallbacks['shipping_options_complete']; ?>
+            } catch (error) {
+                console.error(error);
+            }
+        },
+        onPaymentSubmit: function() {
+            try {
+                <?php echo $trackCallbacks['payment_submit']; ?>
+            } catch (error) {
+                console.error(error);
+            }
+        },
+        onSuccess: function() {
+            try {
+                <?php echo $trackCallbacks['success']; ?>
+            } catch (error) {
+                console.error(error);
+            }
+        },
+        onClose: function() {
+            try {
+                <?php echo $trackCallbacks['close']; ?>
+            } catch (error) {
+                console.error(error);
+            }
+        }
+    };
+    var defaultErrorMessage = "<?php echo $block->getBoltPopupErrorMessage() ?>";
+    var successCallback = function(data) {
+        <?php echo $block->getJavascriptSuccess(); ?>
+    };
+
     ///////////////////////
     // String.trim Polyfill
     ///////////////////////
@@ -210,61 +266,9 @@ ob_start();
         var customer = customerData.get('customer');
         var shoppingCart = customerData.get('cart');
 
-        var trackCallbacks = {
-            onCheckoutStart: function() {
-                try {
-                    <?php echo $trackCallbacks['checkout_start']; ?>
-                } catch (error) {
-                    console.error(error);
-                }
-            },
-            onEmailEnter: function(email) {
-                try {
-                    <?php echo $trackCallbacks['email_enter']; ?>
-                } catch (error) {
-                    console.error(error);
-                }
-            },
-            onShippingDetailsComplete: function() {
-                try {
-                    <?php echo $trackCallbacks['shipping_details_complete']; ?>
-                } catch (error) {
-                    console.error(error);
-                }
-            },
-            onShippingOptionsComplete: function() {
-                try {
-                    <?php echo $trackCallbacks['shipping_options_complete']; ?>
-                } catch (error) {
-                    console.error(error);
-                }
-            },
-            onPaymentSubmit: function() {
-                try {
-                    <?php echo $trackCallbacks['payment_submit']; ?>
-                } catch (error) {
-                    console.error(error);
-                }
-            },
-            onSuccess: function() {
-                try {
-                    <?php echo $trackCallbacks['success']; ?>
-                } catch (error) {
-                    console.error(error);
-                }
-            },
-            onClose: function() {
-                try {
-                    <?php echo $trackCallbacks['close']; ?>
-                } catch (error) {
-                    console.error(error);
-                }
-            }
-        };
-
         var showBoltErrorMessage = function(messsage, order_reference) {
             var boltModal = $('#bolt-modal'),
-                errorMsg = messsage || "<?php echo $block->getBoltPopupErrorMessage() ?>" + " Order reference: " + order_reference;
+                errorMsg = messsage || defaultErrorMessage + " Order reference: " + order_reference;
 
             boltModal.find('.bolt-modal-content').html(errorMsg);
             boltModal.modal("openModal");
@@ -569,7 +573,7 @@ ob_start();
                         if (typeof data !== 'undefined') {
                             callbacks.success_url = data.success_url;
                         }
-                        <?php echo $block->getJavascriptSuccess(); ?>
+                        successCallback(data);
                         trackCallbacks.onSuccess();
                     } finally {
                         callback();

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -24,7 +24,19 @@
  */
 if ($block->shouldDisableBoltCheckout()) return;
 
-$trackCallbacks = $block->getTrackCallbacks();
+$trackCallbackCode = $block->getTrackCallbacks();
+
+function wrapWithCatch($jsCode, $argName='') {
+echo <<<JavaScript
+function($argName) {
+    try {
+        $jsCode
+    } catch (error) {
+        console.error(error);
+    }
+}
+JavaScript;
+}
 
 ob_start();
 ?>
@@ -36,59 +48,13 @@ ob_start();
     window.boltConfig = <?php echo $block->getSettings(); ?>;
 
     var trackCallbacks = {
-        onCheckoutStart: function() {
-            try {
-                <?php echo $trackCallbacks['checkout_start']; ?>
-            } catch (error) {
-                console.error(error);
-            }
-        },
-        onEmailEnter: function(email) {
-            try {
-                <?php echo $trackCallbacks['email_enter']; ?>
-            } catch (error) {
-                console.error(error);
-            }
-        },
-        onShippingDetailsComplete: function() {
-            try {
-                <?php echo $trackCallbacks['shipping_details_complete']; ?>
-            } catch (error) {
-                console.error(error);
-            }
-        },
-        onShippingOptionsComplete: function() {
-            try {
-                <?php echo $trackCallbacks['shipping_options_complete']; ?>
-            } catch (error) {
-                console.error(error);
-            }
-        },
-        onPaymentSubmit: function() {
-            try {
-                <?php echo $trackCallbacks['payment_submit']; ?>
-            } catch (error) {
-                console.error(error);
-            }
-        },
-        onSuccess: function() {
-            try {
-                <?php echo $trackCallbacks['success']; ?>
-            } catch (error) {
-                console.error(error);
-            }
-        },
-        onClose: function() {
-            try {
-                <?php echo $trackCallbacks['close']; ?>
-            } catch (error) {
-                console.error(error);
-            }
-        }
-    };
-    var defaultErrorMessage = "<?php echo $block->getBoltPopupErrorMessage() ?>";
-    var successCallback = function(data) {
-        <?php echo $block->getJavascriptSuccess(); ?>
+        onCheckoutStart: <?php wrapWithCatch($trackCallbackCode['checkout_start']); ?>,
+        onEmailEnter: <?php wrapWithCatch($trackCallbackCode['email_enter'], 'email'); ?>,
+        onShippingDetailsComplete: <?php wrapWithCatch($trackCallbackCode['shipping_details_complete']); ?>,
+        onShippingOptionsComplete: <?php wrapWithCatch($trackCallbackCode['shipping_options_complete']); ?>,
+        onPaymentSubmit: <?php wrapWithCatch($trackCallbackCode['payment_submit']); ?>,
+        onSuccess: <?php wrapWithCatch( $block->getJavascriptSuccess() . $trackCallbackCode['success'], 'data') ?>,
+        onClose: <?php wrapWithCatch($trackCallbackCode['close']); ?>,
     };
 
     ///////////////////////
@@ -268,7 +234,7 @@ ob_start();
 
         var showBoltErrorMessage = function(messsage, order_reference) {
             var boltModal = $('#bolt-modal'),
-                errorMsg = messsage || defaultErrorMessage + " Order reference: " + order_reference;
+                errorMsg = messsage || window.boltConfig.defaultErrorMessage + " Order reference: " + order_reference;
 
             boltModal.find('.bolt-modal-content').html(errorMsg);
             boltModal.modal("openModal");
@@ -573,8 +539,7 @@ ob_start();
                         if (typeof data !== 'undefined') {
                             callbacks.success_url = data.success_url;
                         }
-                        successCallback(data);
-                        trackCallbacks.onSuccess();
+                        trackCallbacks.onSuccess(data);
                     } finally {
                         callback();
                     }


### PR DESCRIPTION
# Description
Move all php code in replacejs.phtml into top of file so in subsequent PR I can move js into separate file

Fixes: (link Asana Task)
https://app.asana.com/0/941920570700290/1147770190679403/f

# Type of change

Refactoring. It changes scope of variables a bit but shouldn't change any functionality.


# How Has This Been Tested?
- [ ] Successfully tested locally (or docker image)
- [ x ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
