### PR TITLE
Skip capture hook notification when creating an online invoice on Magento

### DIFF
--- a/Model/Payment.php
+++ b/Model/Payment.php
@@ -391,7 +391,8 @@ class Payment extends AbstractMethod
             $capturedData = [
                 'transaction_id' => $realTransactionId,
                 'amount'         => $captureAmount,
-                'currency'       => $order->getOrderCurrencyCode()
+                'currency'       => $order->getOrderCurrencyCode(),
+                'skip_hook_notification' => true
             ];
 
             $storeId = $order->getStoreId();

--- a/Test/Unit/Model/PaymentTest.php
+++ b/Test/Unit/Model/PaymentTest.php
@@ -280,6 +280,26 @@ class PaymentTest extends TestCase
     /**
      * @test
      */
+    public function capturePayment_skipHookNotification(){
+        $this->mockApiResponse(
+            "merchant/transactions/capture",
+            '{"status": "authorized", "reference": "ABCD-1234-XXXX"}'
+        );
+
+        $this->apiHelper->expects($this->once())->method('buildRequest')
+            ->will($this->returnCallback(
+                function($data)  {
+                    $this->assertTrue($data->getApiData()['skip_hook_notification']);
+                    }
+                )
+            );
+        $this->currentMock->capture($this->paymentMock, 100);
+    }
+
+
+    /**
+     * @test
+     */
     public function capturePayment_success_multicapture()
     {
         // status stays 'authorized' if merchant has auto-capture enabled and some amount remains uncaptured


### PR DESCRIPTION
Skip capture hook notification when creating an online invoice on Magento

# Description
This resolves the mismatch issue described in the following case:
1. The customer places an order (Bolt transaction and Magento order match)
2. The administrator updates the Magento order total to less than its original total (this functionality is provided by a custom module)
3. The administrator creates an online invoice for the order on Magento
4. Magento sends capture API to Bolt to capture the payment
5. The payment is captured, Bolt sends back a capture hook to Magento to create an invoice which is already created on #3
6. Mismatch issue occurs.
On M1, we ignore the hook notification and the capture hook never gets sent back to Magento. This applies the same logic for creating the online invoice on Magento.

Fixes: https://app.asana.com/0/564264490825835/1151178078437009

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Asana task link and provided a changelog message if applicable.
