### PR TITLE
Set store's current currency in shipping tax hook

### DIFF
--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -341,6 +341,7 @@ class ShippingMethods implements ShippingMethodsInterface
 
             $this->preprocessHook();
 
+            $this->quote->getStore()->setCurrentCurrencyCode($this->quote->getQuoteCurrencyCode());
             $this->checkCartItems($cart);
 
             // Load logged in customer checkout and customer sessions from cached session id.


### PR DESCRIPTION
# Description
Shipping and tax needs Store's current currency to properly set as quote's currency so it can calculate product price properly
related magento code: https://github.com/magento/magento2/blob/1773f4184d00017a1636083610726c13964f2ae7/app/code/Magento/Directory/Model/PriceCurrency.php#L114

Fixes: https://app.asana.com/0/941920570700290/1130539126613441/f

\#changelog support multi currency in shipping and tax endpoint

# Type of change

- [x] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
