### PR TITLE
Use order currency for showing amount in comment

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -1289,7 +1289,7 @@ class Order extends AbstractHelper
                 2
             ),
             'Reference' => $transaction->reference,
-            'Amount' => $order->getBaseCurrency()->formatTxt($amount / 100),
+            'Amount' => $order->getOrderCurrency()->formatTxt($amount / 100),
             'Transaction ID' => $transaction->id
         ];
     }
@@ -1594,7 +1594,7 @@ class Order extends AbstractHelper
         ];
 
         // format the price with currency symbol
-        $formattedPrice = $order->getBaseCurrency()->formatTxt($amount / 100);
+        $formattedPrice = $order->getOrderCurrency()->formatTxt($amount / 100);
 
         $message = __(
             'BOLTPAY INFO :: PAYMENT Status: %1 Amount: %2<br>Bolt transaction: %3',
@@ -1776,7 +1776,7 @@ class Order extends AbstractHelper
         $voidAmount = $order->getGrandTotal() - $order->getTotalPaid();
 
         $message = __('BOLT notification: Transaction authorization has been voided.');
-        $message .= ' ' .__('Amount: %1.', $order->getBaseCurrency()->formatTxt($voidAmount, array()));
+        $message .= ' ' .__('Amount: %1.', $order->getOrderCurrency()->formatTxt($voidAmount));
         $message .= ' ' .__('Transaction ID: %1.', $authorizationTransaction->getHtmlTxnId());
 
         return $message;

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -27,7 +27,9 @@ use Bolt\Boltpay\Helper\Session as SessionHelper;
 use Bolt\Boltpay\Model\Api\CreateOrder;
 use Bolt\Boltpay\Model\Service\InvoiceService;
 use Magento\Sales\Model\Order\Invoice as Invoice;
+use Magento\Sales\Model\Order as OrderModel;
 use Magento\Directory\Model\Region as RegionModel;
+use Magento\Directory\Model\Currency;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\App\Helper\Context;
 use Magento\Framework\App\ResourceConnection;
@@ -776,7 +778,24 @@ class OrderTest extends TestCase
         $state = $this->currentMock->getTransactionState($this->transactionMock, $this->paymentMock, NULL);
         $this->assertEquals($state, "cc_payment:pending");
     }
-    
+
+    /**
+     * @test
+     */
+    public function formatAmount()
+    {
+        $magentoOrderMock = $this->createMock(OrderModel::class);
+        $currencyMock = $this->createMock(Currency::class);
+        $currencyMock->expects($this->exactly(1))
+             ->method('formatTxt')
+             ->willReturn("$1.23");
+        $magentoOrderMock->expects($this->exactly(1))
+          ->method('getOrderCurrency')
+          ->willReturn($currencyMock);
+
+        $this->assertEquals("$1.23", $this->currentMock->formatAmountForDisplay($magentoOrderMock, 1.23));
+    }
+
     /**
      * @test
      * @covers ::createOrderInvoice
@@ -810,7 +829,7 @@ class OrderTest extends TestCase
             
         $this->invokeMethod($this->currentMock, 'createOrderInvoice', array($this->orderMock, 'ABCD-1234-XXXX', $amount));
     }
-    
+
     public function additionAmountTotalProvider() {
 		return [
             [ 12.25, 12.25, true ],


### PR DESCRIPTION
# Description
Base currency can be different than order currency. If you have USD store that also process EUR, before this PR we were displaying comment with wrong currency. This PR fixes that.

Fixes: https://app.asana.com/0/941920570700290/1130539126613441/f

#changelog update comment in order history (admin view) so we can properly handle different currency

![#000000018 : Orders : Operations : Sales : Magento Admin 2019-12-03 21-30-22](https://user-images.githubusercontent.com/980077/70115625-2d65ec00-1615-11ea-9722-6c4670e45d31.png)


# Type of change

- [ x ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ x ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [ x ] My code follows the style guidelines of this project.
- [ x ] I have performed a self-review of my own code.
- [ x ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ x ] I have added my Asana task link and provided a changelog message if applicable.
