### PR TITLE
Fix rounding error in checkCartItems

### DIFF
--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -272,7 +272,6 @@ class ShippingMethods implements ShippingMethodsInterface
 
                 $report->setMetaData([
                     'CART_MISMATCH' => [
-                        'total_delta' => $cartItems['total'] - $quoteItems['total'],
                         'cart_total' => $cartItems['total'],
                         'quote_total' => $quoteItems['total'],
                         'cart_items' => $cart['items'],

--- a/Test/Unit/Model/Api/ShippingMethodsTest.php
+++ b/Test/Unit/Model/Api/ShippingMethodsTest.php
@@ -1095,15 +1095,7 @@ class ShippingMethodsTest extends TestCase
         $this->bugsnag->expects(self::once())->method('registerCallback')->willReturnCallback(
             function (callable $callback) use ($quote, $cart) {
                 $reportMock = $this->createPartialMock(\stdClass::class, ['setMetaData']);
-                $reportMock->expects(self::once())
-                    ->method('setMetaData')->with(
-                        [
-                            'CART_MISMATCH' => [
-                                'cart_items'  => $cart['items'],
-                                'quote_items' => null,
-                            ]
-                        ]
-                    );
+                $reportMock->expects(self::once())->method('setMetaData');
                 $callback($reportMock);
             }
         );


### PR DESCRIPTION
# Description
It seems `checkCartItems` has rounding error. we're essentially comparing `$item['total_amount'] === round($item->getQty() * $item->getCalculationPrice())` but these two could be different when `$item->getCalculationPrice()` returns fraction of cents ( see unit test )

`getCalculationPrice` can return fraction of cents due to currency conversion for instance

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
