### PR TITLE
Introduce toMinor method for currency conversion

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1355,7 +1355,7 @@ class Cart extends AbstractHelper
      */
     public function getRoundAmount($amount)
     {
-        return (int)round(CurrencyUtils::toMinorWithoutRounding($amount, "USD"));
+        return CurrencyUtils::toMinor($amount, "USD");
     }
 
     /**

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -31,6 +31,7 @@ use Magento\Quote\Model\Quote\Address\Total as AddressTotal;
 use Magento\Sales\Api\Data\OrderInterface;
 use Zend_Http_Client_Exception;
 use Bolt\Boltpay\Helper\Log as LogHelper;
+use Bolt\Boltpay\Helper\Shared\CurrencyUtils;
 use Magento\Framework\DataObjectFactory;
 use Magento\Framework\View\Element\BlockFactory;
 use Magento\Store\Model\App\Emulation;
@@ -1009,7 +1010,7 @@ class Cart extends AbstractHelper
                 $roundedTotalAmount = $this->getRoundAmount($itemTotalAmount);
 
                 // Aggregate eventual total differences if prices are stored with more than 2 decimal places
-                $diff += $itemTotalAmount * 100 -$roundedTotalAmount;
+                $diff += CurrencyUtils::toMinorWithoutRounding($itemTotalAmount, "USD") -$roundedTotalAmount;
 
                 // Aggregate cart total
                 $totalAmount += $roundedTotalAmount;
@@ -1266,7 +1267,7 @@ class Cart extends AbstractHelper
                     $cost = $address->getShippingAmount();
                     $rounded_cost = $this->getRoundAmount($cost);
 
-                    $diff += $cost * 100 - $rounded_cost;
+                    $diff += CurrencyUtils::toMinorWithoutRounding($cost, "USD") - $rounded_cost;
                     $totalAmount += $rounded_cost;
 
                     $cart['shipments'] = [[
@@ -1289,7 +1290,7 @@ class Cart extends AbstractHelper
             $storeTaxAmount   = $address->getTaxAmount();
             $roundedTaxAmount = $this->getRoundAmount($storeTaxAmount);
 
-            $diff += $storeTaxAmount * 100 - $roundedTaxAmount;
+            $diff += CurrencyUtils::toMinorWithoutRounding($storeTaxAmount, "USD") - $roundedTaxAmount;
 
             $taxAmount    = $roundedTaxAmount;
             $totalAmount += $roundedTaxAmount;
@@ -1354,7 +1355,7 @@ class Cart extends AbstractHelper
      */
     public function getRoundAmount($amount)
     {
-        return (int)round($amount * 100);
+        return (int)round(CurrencyUtils::toMinorWithoutRounding($amount, "USD"));
     }
 
     /**
@@ -1422,7 +1423,7 @@ class Cart extends AbstractHelper
                 'reference'   => $address->getCouponCode()
             ];
 
-            $diff -= $amount * 100 - $roundedAmount;
+            $diff -= CurrencyUtils::toMinorWithoutRounding($amount, "USD") - $roundedAmount;
             $totalAmount -= $roundedAmount;
         }
         /////////////////////////////////////////////////////////////////////////////////
@@ -1439,7 +1440,7 @@ class Cart extends AbstractHelper
                     'amount'      => $roundedAmount,
                 ];
 
-                $diff -= $amount * 100 - $roundedAmount;
+                $diff -= CurrencyUtils::toMinorWithoutRounding($amount, "USD") - $roundedAmount;
                 $totalAmount -= $roundedAmount;
             } else {
                 $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
@@ -1461,7 +1462,7 @@ class Cart extends AbstractHelper
                         'type'        => 'fixed_amount',
                     ];
 
-                    $diff -= $amount * 100 - $roundedAmount;
+                    $diff -= CurrencyUtils::toMinorWithoutRounding($amount, "USD") - $roundedAmount;
                     $totalAmount -= $roundedAmount;
                 }
             }
@@ -1480,7 +1481,7 @@ class Cart extends AbstractHelper
                 'type'        => 'fixed_amount',
             ];
 
-            $diff -= $amount * 100 - $roundedAmount;
+            $diff -= CurrencyUtils::toMinorWithoutRounding($amount, "USD") - $roundedAmount;
             $totalAmount -= $roundedAmount;
         }
         /////////////////////////////////////////////////////////////////////////////////
@@ -1497,7 +1498,7 @@ class Cart extends AbstractHelper
                 'type'        => 'fixed_amount',
             ];
 
-            $diff -= $amount * 100 - $roundedAmount;
+            $diff -= CurrencyUtils::toMinorWithoutRounding($amount, "USD") - $roundedAmount;
             $totalAmount -= $roundedAmount;
 
         }
@@ -1519,7 +1520,7 @@ class Cart extends AbstractHelper
                 'type'        => 'fixed_amount',
             ];
 
-            $diff -= $amount * 100 - $roundedAmount;
+            $diff -= CurrencyUtils::toMinorWithoutRounding($amount, "USD") - $roundedAmount;
             $totalAmount -= $roundedAmount;
         }
         /////////////////////////////////////////////////////////////////////////////////
@@ -1536,7 +1537,7 @@ class Cart extends AbstractHelper
                     'amount'      => $roundedAmount,
                 ];
 
-                $diff -= $amount * 100 - $roundedAmount;
+                $diff -= CurrencyUtils::toMinorWithoutRounding($amount, "USD") - $roundedAmount;
                 $totalAmount -= $roundedAmount;
             } else {
                 $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
@@ -1558,7 +1559,7 @@ class Cart extends AbstractHelper
                         'type'        => 'fixed_amount',
                     ];
 
-                    $diff -= $amount * 100 - $roundedAmount;
+                    $diff -= CurrencyUtils::toMinorWithoutRounding($amount, "USD") - $roundedAmount;
                     $totalAmount -= $roundedAmount;
                 }
             }
@@ -1582,7 +1583,7 @@ class Cart extends AbstractHelper
                 'type'        => 'fixed_amount',
             ];
 
-            $diff -= $amount * 100 - $roundedAmount;
+            $diff -= CurrencyUtils::toMinorWithoutRounding($amount, "USD") - $roundedAmount;
             $totalAmount -= $roundedAmount;
         }
         /////////////////////////////////////////////////////////////////////////////////
@@ -1640,7 +1641,7 @@ class Cart extends AbstractHelper
                     // by plugin implementation, subtract it so this discount is shown separately and totals are in sync
                     $discounts[0]['amount'] -= $roundedAmount;
                 } else {
-                    $diff -= $amount * 100 - $roundedAmount;
+                    $diff -= CurrencyUtils::toMinorWithoutRounding($amount, "USD") - $roundedAmount;
                     $totalAmount -= $roundedAmount;
                 }
             }

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -20,6 +20,7 @@ namespace Bolt\Boltpay\Helper;
 use Bolt\Boltpay\Exception\BoltException;
 use Bolt\Boltpay\Helper\Api as ApiHelper;
 use Bolt\Boltpay\Helper\Config as ConfigHelper;
+use Bolt\Boltpay\Helper\Shared\CurrencyUtils;
 use Bolt\Boltpay\Model\Api\CreateOrder;
 use Bolt\Boltpay\Model\Payment;
 use Bolt\Boltpay\Model\Response;
@@ -1183,12 +1184,12 @@ class Order extends AbstractHelper
      *
      * @param OrderModel $order
      * @param \stdClass $transaction
-     * @return bool true if the order was placed on hold, otherwise false
+     * @throws \Exception
      */
     private function holdOnTotalsMismatch($order, $transaction)
     {
         $boltTotal = $transaction->order->cart->total_amount->amount;
-        $storeTotal = round($order->getGrandTotal() * 100);
+        $storeTotal = CurrencyUtils::toMinor($order->getGrandTotal(), "USD");
 
         // Stop if no mismatch
         if ($boltTotal == $storeTotal) {

--- a/Helper/Shared/CurrencyUtils.php
+++ b/Helper/Shared/CurrencyUtils.php
@@ -192,9 +192,9 @@ class CurrencyUtils {
      * Returns "precision" of currency. For instance USD has precision of 2 because $1.23 is valid amount white $1.234 is not
      * (there is no such thing as 0.1 cent). Likewise precision of JPY is 0 because there is no 0.1 yen.
      *
-     * @param $code 3-digit ISO currency code
+     * @param string $code 3-digit ISO currency code
      *
-     * @return precision in integer
+     * @return int precision in integer
      * @throws \Exception when unknown currency code is passed
      */
     public static function getPrecisionForCurrencyCode($code) {
@@ -202,5 +202,38 @@ class CurrencyUtils {
             throw new \Exception("unknown currency code: " . $code);
         }
         return CurrencyUtils::currencyToPrecisions[$code];
+    }
+
+    /**
+     * Convert major currency (eg dollar) to minor currency (eg cents). For currencies that don't have minor unit (eg JPY).
+     * returns input as is. Result will be rounded to integer.
+     * Example:
+     *   toMinor(12.34, "USD") -> 1234
+     *   toMinor(1234, "JPY") -> 1234
+     *   toMinor(12.345, "USD") -> 1235
+     *
+     * @param float $amountInMajor
+     * @param string $currencyCode 3-digit currency code
+     *
+     * @return integer amount in minor currency
+     * @throws \Exception when unknown currency code is passed
+     */
+    public static function toMinor($amountInMajor, $currencyCode) {
+        return (int) round(self::toMinorWithoutRounding($amountInMajor, $currencyCode));
+    }
+
+    /**
+     * This function behaves same as toMinor, but without rounding result.
+     * @see CurrencyUtils::toMinor()
+     *
+     * @param float $amountInMajor
+     * @param string $currencyCode 3-digit currency code
+     *
+     * @return float amount in minor currency
+     * @throws \Exception when unknown currency code is passed
+     */
+    public static function toMinorWithoutRounding($amountInMajor, $currencyCode) {
+        $precision = self::getPrecisionForCurrencyCode($currencyCode);
+        return $amountInMajor * pow(10, $precision);
     }
 }

--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -33,6 +33,7 @@ use Bolt\Boltpay\Api\Data\ShippingOptionInterfaceFactory;
 use Bolt\Boltpay\Helper\Bugsnag;
 use Bolt\Boltpay\Helper\MetricsClient;
 use Bolt\Boltpay\Helper\Log as LogHelper;
+use Bolt\Boltpay\Helper\Shared\CurrencyUtils;
 use Magento\Framework\Webapi\Rest\Response;
 use Bolt\Boltpay\Helper\Config as ConfigHelper;
 use Magento\Framework\Webapi\Rest\Request;
@@ -677,7 +678,7 @@ class ShippingMethods implements ShippingMethodsInterface
             $cost        = $shippingAddress->getShippingAmount() - $discountAmount;
             $roundedCost = $this->cartHelper->getRoundAmount($cost);
 
-            $diff = $cost * 100 - $roundedCost;
+            $diff = CurrencyUtils::toMinorWithoutRounding($cost, "USD") - $roundedCost;
 
             $taxAmount = $this->cartHelper->getRoundAmount($shippingAddress->getTaxAmount() + $diff / 100);
 

--- a/Model/Payment.php
+++ b/Model/Payment.php
@@ -39,6 +39,7 @@ use Magento\Payment\Model\Method\AbstractMethod;
 use Magento\Payment\Model\Method\Logger;
 use Magento\Sales\Model\Order as ModelOrder;
 use Magento\Sales\Model\Order\Payment\Transaction;
+use Bolt\Boltpay\Helper\Shared\CurrencyUtils;
 use Bolt\Boltpay\Helper\Bugsnag;
 use Bolt\Boltpay\Helper\MetricsClient;
 use Bolt\Boltpay\Helper\Cart as CartHelper;
@@ -385,7 +386,7 @@ class Payment extends AbstractMethod
                 );
             }
 
-            $captureAmount = $amount * 100;
+            $captureAmount = CurrencyUtils::toMinor($amount, "USD");
 
             //Get capture data
             $capturedData = [
@@ -457,7 +458,7 @@ class Payment extends AbstractMethod
                 );
             }
 
-            $refundAmount = $amount * 100;
+            $refundAmount = CurrencyUtils::toMinor($amount, "USD");
 
             //Get refund data
             $refundData = [

--- a/Test/Unit/Helper/Shared/CurrencyUtilsTest.php
+++ b/Test/Unit/Helper/Shared/CurrencyUtilsTest.php
@@ -48,6 +48,21 @@ class CurrencyUtilsTest extends TestCase {
         CurrencyUtils::getPrecisionForCurrencyCode( "XXX" );
     }
 
+    /**
+     * @test
+     * @dataProvider toMinorData
+     */
+    public function toMinor( $code, $amount, $expected, $unused ) {
+        $this->assertEquals( $expected, CurrencyUtils::toMinor( $amount, $code ) );
+    }
+
+    /**
+     * @test
+     * @dataProvider toMinorData
+     */
+    public function toMinorWithoutRounding( $code, $amount, $unused, $expected ) {
+        $this->assertEquals( $expected, CurrencyUtils::toMinorWithoutRounding( $amount, $code ) );
+    }
 
     public function currencyAndPrecisions() {
         return [
@@ -55,6 +70,17 @@ class CurrencyUtilsTest extends TestCase {
             [ "JPY", 0 ],
             [ "EUR", 2 ],
             [ "CAD", 2 ]
+        ];
+    }
+
+    public function toMinorData() {
+        return [
+            // code, amount, toMinor, toMinorWithoutRounding
+            [ "USD", 12.34, 1234, 1234 ],
+            [ "JPY", 1234, 1234, 1234 ],
+            [ "USD", 12.345, 1235, 1234.5 ],
+            [ "JPY", 1234.5, 1235, 1234.5 ],
+            [ "USD", 0, 0, 0 ]
         ];
     }
 }


### PR DESCRIPTION
# Description
This PR introduces utility function `toMinor` to convert major (dollar) to minor (cents).

old code: `$amount * 100`
new code: `toMinor($amount, "USD")`

Note we still hard-code "USD" (so this PR shouldn't change any behaviour). In subsequent PRs I'll replace hardcoded "USD" into appropriate currency code. 

Fixes: https://app.asana.com/0/941920570700290/1130539126613441/f

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
