### PR TITLE
Introduce toMajor method for currency conversion

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -420,10 +420,10 @@ class Order extends AbstractHelper
      */
     private function adjustTaxMismatch($transaction, $order, $quote)
     {
-        $boltTaxAmount = round($transaction->order->cart->tax_amount->amount / 100, 2);
-        $boltTotalAmount = round($transaction->order->cart->total_amount->amount / 100, 2);
-
-        $orderTaxAmount = round($order->getTaxAmount(), 2);
+        $precision = CurrencyUtils::getPrecisionForCurrencyCode("USD");
+        $boltTaxAmount = round(CurrencyUtils::toMajor($transaction->order->cart->tax_amount->amount, "USD"), $precision);
+        $boltTotalAmount = round(CurrencyUtils::toMajor($transaction->order->cart->total_amount->amount, "USD"), $precision);
+        $orderTaxAmount = round(CurrencyUtils::toMajor($order->getTaxAmount(), "USD"), $precision);
 
         if ($boltTaxAmount != $orderTaxAmount) {
             $order->setTaxAmount($boltTaxAmount);
@@ -1203,7 +1203,7 @@ class Order extends AbstractHelper
             $comment = __(
                 'BOLTPAY INFO :: THERE IS A MISMATCH IN THE ORDER PAID AND ORDER RECORDED.<br>
              Paid amount: %1 Recorded amount: %2<br>Bolt transaction: %3',
-                $boltTotal / 100,
+                CurrencyUtils::toMajor($boltTotal, "USD"),
                 $order->getGrandTotal(),
                 $this->formatReferenceUrl($transaction->reference)
             );
@@ -1611,8 +1611,8 @@ class Order extends AbstractHelper
 
         // We will create an invoice if we have zero amount or new capture.
         if ($this->isCaptureHookRequest($newCapture) || $this->isZeroAmountHook($transactionState)) {
-            $this->validateCaptureAmount($order, $amount / 100);
-            $invoice = $this->createOrderInvoice($order, $realTransactionId, $amount / 100);
+            $this->validateCaptureAmount($order, CurrencyUtils::toMajor($amount, "USD"));
+            $invoice = $this->createOrderInvoice($order, $realTransactionId, CurrencyUtils::toMajor($amount, "USD"));
         }
 
         if (!$order->getTotalDue()) {

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -421,9 +421,9 @@ class Order extends AbstractHelper
      */
     private function adjustTaxMismatch($transaction, $order, $quote)
     {
-        $precision = CurrencyUtils::getPrecisionForCurrencyCode("USD");
         $boltTaxAmount = CurrencyUtils::toMajor($transaction->order->cart->tax_amount->amount, "USD");
         $boltTotalAmount = CurrencyUtils::toMajor($transaction->order->cart->total_amount->amount, "USD");
+        $precision = CurrencyUtils::getPrecisionForCurrencyCode("USD");
         $orderTaxAmount = round($order->getTaxAmount(), $precision);
 
         if ($boltTaxAmount != $orderTaxAmount) {

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -422,8 +422,8 @@ class Order extends AbstractHelper
     private function adjustTaxMismatch($transaction, $order, $quote)
     {
         $precision = CurrencyUtils::getPrecisionForCurrencyCode("USD");
-        $boltTaxAmount = round(CurrencyUtils::toMajor($transaction->order->cart->tax_amount->amount, "USD"), $precision);
-        $boltTotalAmount = round(CurrencyUtils::toMajor($transaction->order->cart->total_amount->amount, "USD"), $precision);
+        $boltTaxAmount = CurrencyUtils::toMajor($transaction->order->cart->tax_amount->amount, "USD");
+        $boltTotalAmount = CurrencyUtils::toMajor($transaction->order->cart->total_amount->amount, "USD");
         $orderTaxAmount = round($order->getTaxAmount(), $precision);
 
         if ($boltTaxAmount != $orderTaxAmount) {

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -417,13 +417,14 @@ class Order extends AbstractHelper
      * @param \stdClass $transaction
      * @param OrderModel $order
      * @param Quote $quote
+     * @throws \Exception
      */
     private function adjustTaxMismatch($transaction, $order, $quote)
     {
         $precision = CurrencyUtils::getPrecisionForCurrencyCode("USD");
         $boltTaxAmount = round(CurrencyUtils::toMajor($transaction->order->cart->tax_amount->amount, "USD"), $precision);
         $boltTotalAmount = round(CurrencyUtils::toMajor($transaction->order->cart->total_amount->amount, "USD"), $precision);
-        $orderTaxAmount = round(CurrencyUtils::toMajor($order->getTaxAmount(), "USD"), $precision);
+        $orderTaxAmount = round($order->getTaxAmount(), $precision);
 
         if ($boltTaxAmount != $orderTaxAmount) {
             $order->setTaxAmount($boltTaxAmount);

--- a/Helper/Shared/CurrencyUtils.php
+++ b/Helper/Shared/CurrencyUtils.php
@@ -239,19 +239,20 @@ class CurrencyUtils {
 
     /**
      * Convert minor currency amount (eg cents) to major currency (eg dollar). For currencies that don't have minor unit
-     * (eg JPY), returns input as is.
+     * (eg JPY), returns input as is. Result is rounded with currency's precision.
      * Example:
      *   toMajor(1234, "USD") -> 12.34
      *   toMajor(1234, "JPY") -> 1234
+     *   toMajor(1234.5, "USD") -> 12.35
      *
      * @param float $amountInMinor
      * @param string $currencyCode 3-digit currency code
      *
-     * @return integer amount in minor currency
+     * @return float amount in major currency
      * @throws \Exception when unknown currency code is passed
      */
     public static function toMajor($amountInMinor, $currencyCode) {
         $precision = self::getPrecisionForCurrencyCode($currencyCode);
-        return $amountInMinor / pow(10, $precision);
+        return round($amountInMinor / (float) pow(10, $precision), $precision);
     }
 }

--- a/Helper/Shared/CurrencyUtils.php
+++ b/Helper/Shared/CurrencyUtils.php
@@ -205,7 +205,7 @@ class CurrencyUtils {
     }
 
     /**
-     * Convert major currency (eg dollar) to minor currency (eg cents). For currencies that don't have minor unit (eg JPY).
+     * Convert major currency (eg dollar) to minor currency (eg cents). For currencies that don't have minor unit (eg JPY),
      * returns input as is. Result will be rounded to integer.
      * Example:
      *   toMinor(12.34, "USD") -> 1234
@@ -235,5 +235,23 @@ class CurrencyUtils {
     public static function toMinorWithoutRounding($amountInMajor, $currencyCode) {
         $precision = self::getPrecisionForCurrencyCode($currencyCode);
         return $amountInMajor * pow(10, $precision);
+    }
+
+    /**
+     * Convert minor currency amount (eg cents) to major currency (eg dollar). For currencies that don't have minor unit
+     * (eg JPY), returns input as is.
+     * Example:
+     *   toMajor(1234, "USD") -> 12.34
+     *   toMajor(1234, "JPY") -> 1234
+     *
+     * @param float $amountInMinor
+     * @param string $currencyCode 3-digit currency code
+     *
+     * @return integer amount in minor currency
+     * @throws \Exception when unknown currency code is passed
+     */
+    public static function toMajor($amountInMinor, $currencyCode) {
+        $precision = self::getPrecisionForCurrencyCode($currencyCode);
+        return $amountInMinor / pow(10, $precision);
     }
 }

--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -680,7 +680,7 @@ class ShippingMethods implements ShippingMethodsInterface
 
             $diff = CurrencyUtils::toMinorWithoutRounding($cost, "USD") - $roundedCost;
 
-            $taxAmount = $this->cartHelper->getRoundAmount($shippingAddress->getTaxAmount() + CurrencyUtils::toMajor($diff, "USD"));
+            $taxAmount = round(CurrencyUtils::toMinorWithoutRounding($shippingAddress->getTaxAmount(), "USD") + $diff);
 
             if ($discountAmount) {
                 if ($cost == 0) {

--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -680,7 +680,7 @@ class ShippingMethods implements ShippingMethodsInterface
 
             $diff = CurrencyUtils::toMinorWithoutRounding($cost, "USD") - $roundedCost;
 
-            $taxAmount = $this->cartHelper->getRoundAmount($shippingAddress->getTaxAmount() + $diff / 100);
+            $taxAmount = $this->cartHelper->getRoundAmount($shippingAddress->getTaxAmount() + CurrencyUtils::toMajor($diff, "USD"));
 
             if ($discountAmount) {
                 if ($cost == 0) {

--- a/Test/Unit/Helper/Shared/CurrencyUtilsTest.php
+++ b/Test/Unit/Helper/Shared/CurrencyUtilsTest.php
@@ -96,6 +96,7 @@ class CurrencyUtilsTest extends TestCase {
         return [
             [ "USD", 1234, 12.34 ],
             [ "JPY", 1234, 1234 ],
+            [ "USD", 1234.5, 12.35 ],
         ];
     }
 }

--- a/Test/Unit/Helper/Shared/CurrencyUtilsTest.php
+++ b/Test/Unit/Helper/Shared/CurrencyUtilsTest.php
@@ -64,6 +64,14 @@ class CurrencyUtilsTest extends TestCase {
         $this->assertEquals( $expected, CurrencyUtils::toMinorWithoutRounding( $amount, $code ) );
     }
 
+    /**
+     * @test
+     * @dataProvider toMajorData
+     */
+    public function toMajor( $code, $amount, $expected ) {
+        $this->assertEquals( $expected, CurrencyUtils::toMajor( $amount, $code ) );
+    }
+
     public function currencyAndPrecisions() {
         return [
             [ "USD", 2 ],
@@ -81,6 +89,13 @@ class CurrencyUtilsTest extends TestCase {
             [ "USD", 12.345, 1235, 1234.5 ],
             [ "JPY", 1234.5, 1235, 1234.5 ],
             [ "USD", 0, 0, 0 ]
+        ];
+    }
+
+    public function toMajorData() {
+        return [
+            [ "USD", 1234, 12.34 ],
+            [ "JPY", 1234, 1234 ],
         ];
     }
 }


### PR DESCRIPTION
# Description
This PR introduces utility function toMajor to convert minor (cents) to major (dollar)

old code: $amount / 100
new code: toMajor($amount, "USD")

Note we still hard-code "USD" (so this PR shouldn't change any behaviour). In subsequent PRs I'll replace hardcoded "USD" into appropriate currency code.
See also: https://github.com/BoltApp/bolt-magento2/pull/450
Fixes: https://app.asana.com/0/941920570700290/1130539126613441/f

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
