### PR TITLE
Update capture logic to handle different currency

### DIFF
--- a/Test/Unit/Model/PaymentTest.php
+++ b/Test/Unit/Model/PaymentTest.php
@@ -48,6 +48,9 @@ use Bolt\Boltpay\Helper\Cart as CartHelper;
 use \Magento\Sales\Model\Order;
 use \Magento\Sales\Model\Order\Payment\Transaction\Repository as TransactionRepository;
 use \Magento\Sales\Model\Order\Payment\Transaction;
+use Magento\Sales\Model\Order\Invoice;
+use Magento\Sales\Model\ResourceModel\Order\Collection;
+
 
 /**
  * Class PaymentTest
@@ -266,21 +269,57 @@ class PaymentTest extends TestCase
     /**
      * @test
      */
-    public function capturePayment_success()
-    {
+    public function capturePayment_success() {
+        $this->orderMock->method( 'getOrderCurrencyCode' )->willReturn( 'USD' );
         $this->mockApiResponse(
             "merchant/transactions/capture",
             '{"status": "completed", "reference": "ABCD-1234-XXXX"}'
         );
-        $this->orderHelper->expects($this->once())->method('updateOrderPayment');
+        $this->orderHelper->expects( $this->once() )->method( 'updateOrderPayment' );
+        $this->apiHelper->expects( $this->once() )->method( 'buildRequest' )
+                        ->will( $this->returnCallback(
+                            function ( $data ) {
+                                $this->assertEquals( "USD", $data->getApiData()['currency'] );
+                                $this->assertEquals( "10000", $data->getApiData()['amount'] );
+                            }
+                        )
+                        );
 
-        $this->currentMock->capture($this->paymentMock, 100);
+        $this->currentMock->capture( $this->paymentMock, 100 );
+    }
+
+    /**
+     * @test
+     */
+    public function capturePayment_withDifferentCurrency_success() {
+        $this->orderMock->method( "getOrderCurrencyCode" )->willReturn( "CAD" );
+        $invoiceMock = $this->createMock( Invoice::class );
+        $invoiceMock->method( "getGrandTotal" )->willReturn( 123.45 );
+        $collectionMock = $this->createMock( Collection::class );
+        $collectionMock->method( "getLastItem" )->willReturn( $invoiceMock );
+        $this->orderMock->method( "getInvoiceCollection" )->willReturn( $collectionMock );
+        $this->mockApiResponse(
+            "merchant/transactions/capture",
+            '{"status": "completed", "reference": "ABCD-1234-XXXX"}'
+        );
+        $this->orderHelper->expects( $this->once() )->method( 'updateOrderPayment' );
+        $this->apiHelper->expects( $this->once() )->method( 'buildRequest' )
+                        ->will( $this->returnCallback(
+                            function ( $data ) {
+                                $this->assertEquals( "CAD", $data->getApiData()['currency'] );
+                                $this->assertEquals( "12345", $data->getApiData()['amount'] );
+                            }
+                        )
+                        );
+
+        $this->currentMock->capture( $this->paymentMock, 100 );
     }
 
     /**
      * @test
      */
     public function capturePayment_skipHookNotification(){
+        $this->orderMock->method('getOrderCurrencyCode')->willReturn('USD');
         $this->mockApiResponse(
             "merchant/transactions/capture",
             '{"status": "authorized", "reference": "ABCD-1234-XXXX"}'
@@ -302,6 +341,7 @@ class PaymentTest extends TestCase
      */
     public function capturePayment_success_multicapture()
     {
+        $this->orderMock->method('getOrderCurrencyCode')->willReturn('USD');
         // status stays 'authorized' if merchant has auto-capture enabled and some amount remains uncaptured
         $this->mockApiResponse(
             "merchant/transactions/capture",
@@ -317,6 +357,7 @@ class PaymentTest extends TestCase
      */
     public function capturePayment_throwExceptionWhenBoltRespondWithError()
     {
+        $this->orderMock->method('getOrderCurrencyCode')->willReturn('USD');
         $this->expectException(LocalizedException::class);
 
         $this->mockApiResponse(
@@ -333,6 +374,7 @@ class PaymentTest extends TestCase
      */
     public function capturePayment_invalidAmount()
     {
+        $this->orderMock->method('getOrderCurrencyCode')->willReturn('USD');
         $this->expectException(LocalizedException::class);
         $this->expectExceptionMessage('Invalid amount for capture.');
         $this->currentMock->capture($this->paymentMock, 0);
@@ -343,6 +385,7 @@ class PaymentTest extends TestCase
      */
     public function capturePayment_noTransactionId()
     {
+        $this->orderMock->method('getOrderCurrencyCode')->willReturn('USD');
         $this->expectException(LocalizedException::class);
         $this->expectExceptionMessage('Please wait while transaction get updated from Bolt.');
 
@@ -358,6 +401,7 @@ class PaymentTest extends TestCase
      */
     public function capturePayment_noResponse()
     {
+        $this->orderMock->method('getOrderCurrencyCode')->willReturn('USD');
         $this->expectException(LocalizedException::class);
         $this->expectExceptionMessage('Bad capture response from boltpay');
 
@@ -676,6 +720,7 @@ class PaymentTest extends TestCase
 
         $this->orderMock = $this->getMockBuilder(Order::class)->disableOriginalConstructor()->getMock();
         $this->orderMock->method('getId')->willReturn('order-123');
+        $this->orderMock->method('getStoreCurrencyCode')->willReturn('USD');
         $this->paymentMock = $this->getMockBuilder(InfoInterface::class)
             ->setMethods(['getId', 'getOrder'])
             ->getMockForAbstractClass();


### PR DESCRIPTION
# Description
Magento's Payment class pass currency in store currency. This PR adds logic to get capture amount in proper (order's) currency when calling Bolt's capture API

Fixes: https://app.asana.com/0/1145430477677801/1152698132445867/f

\#changelog support invoice creation in different currency

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
