### PR TITLE
Ee rewards on cart page support

### DIFF
--- a/Block/Checkout/Cart/ComponentSwitcherProcessor.php
+++ b/Block/Checkout/Cart/ComponentSwitcherProcessor.php
@@ -29,13 +29,19 @@ class ComponentSwitcherProcessor extends LayoutProcessor
     /**
      * Process the layout
      *
-     * @param array $jsLayout
+     * @param  array $jsLayout
      * @return array
      */
-    public function process($jsLayout) {
+    public function process($jsLayout)
+    {
         // Store Credit
-        $jsLayout['components']['block-totals']['children']['storeCredit']['componentDisabled'] =
-            ! $this->configHelper->useStoreCreditConfig();
+        $useStoreCredit = $this->configHelper->useStoreCreditConfig();
+        $jsLayout['components']['block-totals']['children']['storeCredit']['componentDisabled'] = !$useStoreCredit;
+        $jsLayout['components']['block-totals']['children']['storeCredit']['config']['componentDisabled'] = !$useStoreCredit;
+        // Reward Points
+        $useRewardPoints = $this->configHelper->useRewardPointsConfig();
+        $jsLayout['components']['block-totals']['children']['rewardPoints']['componentDisabled'] = !$useRewardPoints;
+        $jsLayout['components']['block-totals']['children']['rewardPoints']['config']['componentDisabled'] = !$useRewardPoints;
 
         return $jsLayout;
     }

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -225,6 +225,11 @@ class Config extends AbstractHelper
     const XML_PATH_STORE_CREDIT = 'payment/boltpay/store_credit';
 
     /**
+     * Use Reward Points on Shopping Cart configuration path
+     */
+    const XML_PATH_REWARD_POINTS = 'payment/boltpay/reward_points';
+
+    /**
      * Payment Only Checkout Enabled configuration path
      */
     const XML_PATH_PAYMENT_ONLY_CHECKOUT = 'payment/boltpay/enable_payment_only_checkout';
@@ -1066,6 +1071,22 @@ class Config extends AbstractHelper
     {
         return $this->getScopeConfig()->isSetFlag(
             self::XML_PATH_STORE_CREDIT,
+            ScopeInterface::SCOPE_STORE,
+            $store
+        );
+    }
+
+    /**
+     * Get Use Reward Points on Shopping Cart configuration
+     *
+     * @param  int|string|Store $store
+     *
+     * @return bool
+     */
+    public function useRewardPointsConfig($store = null)
+    {
+        return $this->getScopeConfig()->isSetFlag(
+            self::XML_PATH_REWARD_POINTS,
             ScopeInterface::SCOPE_STORE,
             $store
         );

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -723,6 +723,10 @@ class Order extends AbstractHelper
         // do not verify inventory, it is already reserved
         $quote->setInventoryProcessed(true);
 
+        if ($order->getAppliedRuleIds() === null) {
+            $order->setAppliedRuleIds('');
+        }
+
         $this->logHelper->addInfoLog('[-= dispatchPostCheckoutEvents =-]');
         $this->_eventManager->dispatch(
             'checkout_submit_all_after', [

--- a/Test/Unit/Block/Checkout/Cart/ComponentSwitcherProcessorTest.php
+++ b/Test/Unit/Block/Checkout/Cart/ComponentSwitcherProcessorTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Bolt\Boltpay\Test\Unit\Block\Checkout\Cart;
+
+use Bolt\Boltpay\Block\Checkout\Cart\ComponentSwitcherProcessor;
+use Bolt\Boltpay\Helper\Config as ConfigHelper;
+use Magento\Framework\App\Helper\Context;
+use Magento\Framework\App\ProductMetadataInterface;
+use Magento\Framework\App\Request\Http;
+use Magento\Framework\Encryption\EncryptorInterface;
+use Magento\Framework\Module\ResourceInterface;
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject;
+
+/**
+ * @coversDefaultClass \Bolt\Boltpay\Block\Checkout\Cart\ComponentSwitcherProcessor
+ */
+class ComponentSwitcherProcessorTest extends TestCase
+{
+    /**
+     * Mocked instance of config helper
+     *
+     * @var PHPUnit_Framework_MockObject_MockObject|ConfigHelper
+     */
+    protected $configHelper;
+
+    /**
+     * Mocked instance of the Config Helper context
+     *
+     * @var PHPUnit_Framework_MockObject_MockObject|Context
+     */
+    protected $helperContextMock;
+
+    /**
+     * Mocked instance of the class being tested
+     *
+     * @var PHPUnit_Framework_MockObject_MockObject|ComponentSwitcherProcessor
+     */
+    protected $currentMock;
+
+    /**
+     * Setup test dependencies
+     *
+     * @return void
+     */
+    protected function setUp()
+    {
+        $this->helperContextMock = $this->createMock(Context::class);
+        $this->configHelper = $this->getMockBuilder(ConfigHelper::class)
+            ->setMethods(['useStoreCreditConfig', 'useRewardPointsConfig'])
+            ->setConstructorArgs(
+                [
+                    $this->helperContextMock,
+                    $this->createMock(EncryptorInterface::class),
+                    $this->createMock(ResourceInterface::class),
+                    $this->createMock(ProductMetadataInterface::class),
+                    $this->createMock(Http::class)
+                ]
+            )
+            ->getMock();
+        $this->currentMock = $this->getMockBuilder(ComponentSwitcherProcessor::class)
+            ->setMethods()
+            ->setConstructorArgs(
+                [
+                    $this->configHelper
+                ]
+            )
+            ->getMock();
+    }
+
+
+    /**
+     * Test process method sets componentDisabled property to inverse value of config
+     *
+     * @test
+     *
+     * @param bool $useStoreCreditConfig Configuration value for Store Credit
+     * @param bool $useRewardPointsConfig Configuration value for Reward Points
+     *
+     * @dataProvider process_withVariousConfigurationStates_returnsModifiedJsLayoutProvider
+     *
+     * @return void
+     */
+    public function process_withVariousConfigurationStates_returnsModifiedJsLayout($useStoreCreditConfig, $useRewardPointsConfig)
+    {
+        $this->configHelper->expects(self::once())->method('useStoreCreditConfig')
+            ->willReturn($useStoreCreditConfig);
+        $this->configHelper->expects(self::once())->method('useRewardPointsConfig')
+            ->willReturn($useRewardPointsConfig);
+        $jsLayout = [
+            'components' => [
+                'block-totals' => [
+                    'children' => [
+                        'storeCredit'  => [],
+                        'rewardPoints' => []
+                    ]
+                ]
+            ]
+        ];
+        $result = $this->currentMock->process($jsLayout);
+        $blockTotalsChildren = $result['components']['block-totals']['children'];
+        self::assertEquals(
+            $useStoreCreditConfig,
+            !$blockTotalsChildren['storeCredit']['componentDisabled']
+        );
+        self::assertEquals(
+            $useStoreCreditConfig,
+            !$blockTotalsChildren['storeCredit']['config']['componentDisabled']
+        );
+        self::assertEquals(
+            $useRewardPointsConfig,
+            !$blockTotalsChildren['rewardPoints']['componentDisabled']
+        );
+        self::assertEquals(
+            $useRewardPointsConfig,
+            !$blockTotalsChildren['rewardPoints']['config']['componentDisabled']
+        );
+    }
+
+    /**
+     * Provides all configuration combinations for Store Credit and Reward Points
+     *
+     * @return array of bool pairs
+     */
+    public function process_withVariousConfigurationStates_returnsModifiedJsLayoutProvider()
+    {
+        return [
+            [true, true],
+            [true, false],
+            [false, true],
+            [false, false]
+        ];
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -144,6 +144,12 @@
                 <field id="store_credit" translate="label" type="select" sortOrder="240" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Use Store Credit on Shopping Cart</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <if_module_enabled>Magento_CustomerBalance</if_module_enabled>
+                </field>
+                <field id="reward_points" translate="label" type="select" sortOrder="245" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Use Reward Points on Shopping Cart</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <if_module_enabled>Magento_Reward</if_module_enabled>
                 </field>
                 <field id="enable_payment_only_checkout" translate="label" type="select" sortOrder="250" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Enable Payment Only Checkout</label>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -51,6 +51,7 @@ tr.shipping.totals td.amount span.price,
                 <reset_shipping_calculation>0</reset_shipping_calculation>
                 <minicart_support>1</minicart_support>
                 <store_credit>0</store_credit>
+                <reward_points>0</reward_points>
                 <enable_payment_only_checkout>0</enable_payment_only_checkout>
                 <bolt_order_caching>1</bolt_order_caching>
                 <api_emulate_session>1</api_emulate_session>

--- a/view/frontend/layout/checkout_cart_index.xml
+++ b/view/frontend/layout/checkout_cart_index.xml
@@ -31,6 +31,9 @@
                                 <item name="storeCredit" xsi:type="array">
                                     <item name="component" xsi:type="string">Magento_CustomerBalance/js/view/payment/customer-balance</item>
                                 </item>
+                                <item name="rewardPoints" xsi:type="array">
+                                    <item name="component" xsi:type="string">Magento_Reward/js/view/payment/reward</item>
+                                </item>
                             </item>
                         </item>
                     </item>


### PR DESCRIPTION
# Description
Currently rewards can be used from the native checkout only.
Move reward points application to the shopping cart page.
As it was done with store credit. 

There's an exception thrown by Magento_Reward (Commerce Edition only) in success redirect call of pre-auth order creation flow.
Order::getAppliedRuleIds is expected to be a sting (empty string if no rules were applied). It is so in the legacy flow - all processing in one request / session. However, when empty, this field is saved to DB as null (by Magento, no alter at our plugin side) in the create order pre-auth call. When order is fetched later, in success redirect call, if the field is null the aforementioned error is thrown. Check for null and set it to empty string before further order processing (dispatch events).

Fixes: https://app.asana.com/0/941920570700290/1153383580699802/f

(Optional: Add a changelog by writing a comment after "#changelog" on the next line)

\#changelog Add support for EE Reward Points

# Type of change

- [x] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
