### PR TITLE
remove heredoc from phtml

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -27,15 +27,14 @@ if ($block->shouldDisableBoltCheckout()) return;
 $trackCallbackCode = $block->getTrackCallbacks();
 
 function wrapWithCatch($jsCode, $argName='') {
-echo <<<JavaScript
+echo "
 function($argName) {
     try {
         $jsCode
     } catch (error) {
         console.error(error);
     }
-}
-JavaScript;
+}";
 }
 
 ob_start();


### PR DESCRIPTION
# Description
Seems like Magento minifies php portions of  .phtml templates, at least removes new lines. This breaks heredoc string syntax. 

Fixes: https://app.asana.com/0/941920570700290/1153919575235679/f

(Optional: Add a changelog by writing a comment after "#changelog" on the next line)

\#changelog

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Asana task link and provided a changelog message if applicable.
