### PR TITLE
Update refund to handle multi-currency

### DIFF
--- a/Model/Payment.php
+++ b/Model/Payment.php
@@ -44,8 +44,6 @@ use Bolt\Boltpay\Helper\Bugsnag;
 use Bolt\Boltpay\Helper\MetricsClient;
 use Bolt\Boltpay\Helper\Cart as CartHelper;
 use \Magento\Sales\Model\Order\Payment\Transaction\Repository as TransactionRepository;
-use Magento\Setup\Exception;
-use u2flib_server\Error;
 
 /**
  * Class Payment.

--- a/Model/Payment.php
+++ b/Model/Payment.php
@@ -44,6 +44,8 @@ use Bolt\Boltpay\Helper\Bugsnag;
 use Bolt\Boltpay\Helper\MetricsClient;
 use Bolt\Boltpay\Helper\Cart as CartHelper;
 use \Magento\Sales\Model\Order\Payment\Transaction\Repository as TransactionRepository;
+use Magento\Setup\Exception;
+use u2flib_server\Error;
 
 /**
  * Class Payment.
@@ -468,13 +470,14 @@ class Payment extends AbstractMethod
                 );
             }
 
-            $refundAmount = CurrencyUtils::toMinor($amount, "USD");
+            $orderCurrency = $order->getOrderCurrencyCode();
+            // $amount argument of refund method is in store currency, we need to get amount from credit memo to get the value in order's currency.
+            $refundAmount = CurrencyUtils::toMinor( $payment->getCreditMemo()->getGrandTotal(), $orderCurrency );
 
-            //Get refund data
             $refundData = [
                 'transaction_id' => $realTransactionId,
                 'amount'         => $refundAmount,
-                'currency'       => $order->getOrderCurrencyCode()
+                'currency'       => $orderCurrency
             ];
 
             $storeId = $order->getStoreId();


### PR DESCRIPTION
# Description
Magento's refund method pass amount in store's currency. In order to handle different currency (eg US store that also sell things in CAD), this PR get currency from credit memo.

Fixes: https://app.asana.com/0/941920570700290/1130539126613441/f

\#changelog update refund to handle different currency

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
