### PR TITLE
Fix multi-store pre-auth back-office success page redirect

### DIFF
--- a/Controller/Adminhtml/Order/ReceivedUrl.php
+++ b/Controller/Adminhtml/Order/ReceivedUrl.php
@@ -86,7 +86,8 @@ class ReceivedUrl extends Action
             'order_id' => $order->getId(),
             'store_id' => $storeId
         ];
-        $this->_backendUrl->setScope($storeId);
+        // Set admin scope
+        $this->_backendUrl->setScope(0);
 
         return $this->_backendUrl->getUrl('sales/order/view', $params);
     }

--- a/Model/Api/CreateOrder.php
+++ b/Model/Api/CreateOrder.php
@@ -359,8 +359,14 @@ class CreateOrder implements CreateOrderInterface
 
         $this->logHelper->addInfoLog('[-= getReceivedUrl =-]');
         $storeId = $quote->getStoreId();
-        $urlInterface = $this->isBackOfficeOrder($quote) ? $this->backendUrl : $this->url;
-        $urlInterface->setScope($storeId);
+        if ($this->isBackOfficeOrder($quote)) {
+            $urlInterface = $this->backendUrl;
+            // Set admin scope
+            $urlInterface->setScope(0);
+        } else {
+            $urlInterface = $this->url;
+            $urlInterface->setScope($storeId);
+        }
         $params = [
             '_secure' => true,
             'store_id' => $storeId

--- a/Test/Unit/Model/Api/CreateOrderTest.php
+++ b/Test/Unit/Model/Api/CreateOrderTest.php
@@ -651,7 +651,7 @@ class CreateOrderTest extends TestCase
         $this->logHelper->expects(self::exactly(2))->method('addInfoLog')
             ->withConsecutive(['[-= getReceivedUrl =-]'], ['---> ' . $url]);
         $this->quoteMock->expects(self::once())->method('getBoltIsBackendOrder')->willReturn(true);
-        $this->backendUrl->expects(self::once())->method('setScope')->with(self::STORE_ID);
+        $this->backendUrl->expects(self::once())->method('setScope')->with(0);
         $this->backendUrl->expects(self::once())->method('getUrl')->with('boltpay/order/receivedurl', [
             '_secure' => true,
             'store_id' => self::STORE_ID


### PR DESCRIPTION
# Description
Back-office success page redirect does not work for pre-auth configured stores that are not under the default website.

Fixes: https://app.asana.com/0/941920570700290/1154082745428809/f

(Optional: Add a changelog by writing a comment after "#changelog" on the next line)

\#changelog

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
