### PR TITLE
Add OrderConfirmation view on success page for A/B test

### DIFF
--- a/Block/Checkout/Success.php
+++ b/Block/Checkout/Success.php
@@ -16,6 +16,7 @@
  */
 namespace Bolt\Boltpay\Block\Checkout;
 
+use Bolt\Boltpay\Helper\Config;
 use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Element\Template\Context;
 use Magento\Framework\App\ProductMetadataInterface;
@@ -33,20 +34,28 @@ class Success extends Template
     private $productMetadata;
 
     /**
+     * @var Config
+     */
+    private $configHelper;
+
+    /**
      * Success constructor.
      *
      * @param ProductMetadataInterface $productMetadata
+     * @param Config          $configHelper
      * @param Context                  $context
      * @param array                    $data
      */
     public function __construct(
         ProductMetadataInterface $productMetadata,
+        Config $configHelper,
         Context $context,
         array $data = []
     ) {
         parent::__construct($context, $data);
 
         $this->productMetadata = $productMetadata;
+        $this->configHelper = $configHelper;
     }
 
     /**
@@ -56,6 +65,13 @@ class Success extends Template
     {
         // Workaround for known magento issue - https://github.com/magento/magento2/issues/12504
         return (bool) (version_compare($this->getMagentoVersion(), '2.2.0', '<'));
+    }
+
+    /**
+     * @return bool
+     */
+    public function shouldTrackCheckoutFunnel() {
+        return $this->configHelper->shouldTrackCheckoutFunnel();
     }
 
     /**

--- a/Test/Unit/Block/Checkout/SuccessTest.php
+++ b/Test/Unit/Block/Checkout/SuccessTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2018 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Test\Unit\Block\Checkout;
+
+use Bolt\Boltpay\Block\Checkout\Success;
+use Bolt\Boltpay\Helper\Config as HelperConfig;
+
+/**
+ * Class SuccessTest
+ *
+ * @package Bolt\Boltpay\Test\Unit\Block\Checkout
+ */
+class SuccessTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var HelperConfig
+     */
+    protected $configHelper;
+
+    /**
+     * @var Success
+     */
+    protected $block;
+
+    protected function setUp()
+    {
+        $helperContextMock = $this->createMock(\Magento\Framework\App\Helper\Context::class);
+        $contextMock = $this->createMock(\Magento\Framework\View\Element\Template\Context::class);
+        $requestMock = $this->getMockBuilder(Http::class)
+              ->disableOriginalConstructor()
+              ->setMethods(['getFullActionName'])
+              ->getMock();
+        $contextMock->method('getRequest')->willReturn($requestMock);
+
+        $this->configHelper = $this->getMockBuilder(HelperConfig::class)
+            ->setMethods(['shouldTrackCheckoutFunnel'])
+            ->setConstructorArgs(
+                [
+                    $helperContextMock,
+                    $this->createMock(\Magento\Framework\Encryption\EncryptorInterface::class),
+                    $this->createMock(\Magento\Framework\Module\ResourceInterface::class),
+                    $this->createMock(\Magento\Framework\App\ProductMetadataInterface::class),
+                    $this->createMock(\Magento\Framework\App\Request\Http::class)
+                ]
+            )
+            ->getMock();
+
+        $data = $this->createMock(\Magento\Framework\App\ProductMetadata::class);
+        $this->block = new Success($data, $this->configHelper, $contextMock);
+    }
+
+    /**
+     * @test
+     * @dataProvider shouldTrackCheckoutFunnelData
+     */
+    public function shouldTrackCheckoutFunnel_getValueFromConfig($config, $expected)
+    {
+        $this->configHelper->method("shouldTrackCheckoutFunnel")->willReturn($config);
+
+        $result = $this->block->shouldTrackCheckoutFunnel();
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function shouldTrackCheckoutFunnelData() {
+        return [
+            [ true, true ],
+            [ false, false ]
+        ];
+    }
+}

--- a/view/frontend/templates/checkout/success.phtml
+++ b/view/frontend/templates/checkout/success.phtml
@@ -1,4 +1,5 @@
 <?php /* @var $block Bolt\Boltpay\Block\Checkout\Success */ ?>
+
 <?php if ($block->isAllowInvalidateQuote()): ?>
 <script>
     require([
@@ -8,4 +9,10 @@
         customerData.invalidate(sections);
     });
 </script>
+<?php endif; ?>
+
+<?php if ($block->shouldTrackCheckoutFunnel()): ?>
+    <script type="text/javascript">
+        BoltTrack.recordEvent("OrderConfirmationView");
+    </script>
 <?php endif; ?>


### PR DESCRIPTION
# Description
This PR adds `BoltTrack.recordEvent("OrderConfirmationView")` to order confirmation page when config is enabled. This will be used when merchant A/B test.

Fixes: https://app.asana.com/0/941920570700290/1136465306941030/f

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
