### PR TITLE
Fix Config.shouldTrackCheckoutFunnel - was reading wrong config

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -1196,7 +1196,7 @@ class Config extends AbstractHelper
     public function shouldTrackCheckoutFunnel($store = null)
     {
         return $this->getScopeConfig()->isSetFlag(
-            self::XML_PATH_ACTIVE,
+            self::XML_PATH_TRACK_CHECKOUT_FUNNEL,
             ScopeInterface::SCOPE_STORE,
             $store
         );

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -530,4 +530,19 @@ class ConfigTest extends TestCase
 
         $this->assertEquals($expected, $result, 'getIgnoredShippingAddressCoupons() method: not working properly');
     }
+
+    /**
+     * @test
+     */
+    public function shouldTrackCheckoutFunnel()
+    {
+        $this->scopeConfig->method('isSetFlag')
+              ->with(BoltConfig::XML_PATH_TRACK_CHECKOUT_FUNNEL)
+              ->willReturn(true);
+
+
+        $result = $this->currentMock->shouldTrackCheckoutFunnel();
+
+        $this->assertTrue($result);
+    }
 }


### PR DESCRIPTION
# Description
shouldTrackCheckoutFunnel method was reading wrong config value. This PR fixes it

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

unit test

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
