### PR TITLE
Remove CartHelper.getRoundAmount

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1008,7 +1008,7 @@ class Cart extends AbstractHelper
                 $unitPrice   = $item->getCalculationPrice();
                 $itemTotalAmount = $unitPrice * $item->getQty();
 
-                $roundedTotalAmount = $this->getRoundAmount($itemTotalAmount);
+                $roundedTotalAmount = CurrencyUtils::toMinor($itemTotalAmount, $currencyCode);
 
                 // Aggregate eventual total differences if prices are stored with more than 2 decimal places
                 $diff += CurrencyUtils::toMinorWithoutRounding($itemTotalAmount, $currencyCode) -$roundedTotalAmount;
@@ -1024,7 +1024,7 @@ class Cart extends AbstractHelper
                 $product['reference']    = $item->getProductId();
                 $product['name']         = $item->getName();
                 $product['total_amount'] = $roundedTotalAmount;
-                $product['unit_price']   = $this->getRoundAmount($unitPrice);
+                $product['unit_price']   = CurrencyUtils::toMinor($unitPrice, $currencyCode);
                 $product['quantity']     = round($item->getQty());
                 $product['sku']          = trim($item->getSku());
                 $product['type']         = $item->getIsVirtual() ? self::ITEM_TYPE_DIGITAL : self::ITEM_TYPE_PHYSICAL;
@@ -1267,14 +1267,14 @@ class Cart extends AbstractHelper
 
                 if ($this->isAddressComplete($shipAddress)) {
                     $cost = $address->getShippingAmount();
-                    $rounded_cost = $this->getRoundAmount($cost);
+                    $rounded_cost = CurrencyUtils::toMinor($cost, $currencyCode);
 
                     $diff += CurrencyUtils::toMinorWithoutRounding($cost, $currencyCode) - $rounded_cost;
                     $totalAmount += $rounded_cost;
 
                     $cart['shipments'] = [[
                         'cost' => $rounded_cost,
-                        'tax_amount' => $this->getRoundAmount($address->getShippingTaxAmount()),
+                        'tax_amount' => CurrencyUtils::toMinor($address->getShippingTaxAmount(), $currencyCode),
                         'shipping_address' => $shipAddress,
                         'service' => $shippingAddress->getShippingDescription(),
                         'reference' => $shippingAddress->getShippingMethod(),
@@ -1290,7 +1290,7 @@ class Cart extends AbstractHelper
             }
 
             $storeTaxAmount   = $address->getTaxAmount();
-            $roundedTaxAmount = $this->getRoundAmount($storeTaxAmount);
+            $roundedTaxAmount = CurrencyUtils::toMinor($storeTaxAmount, $currencyCode);
 
             $diff += CurrencyUtils::toMinorWithoutRounding($storeTaxAmount, $currencyCode) - $roundedTaxAmount;
 
@@ -1347,18 +1347,6 @@ class Cart extends AbstractHelper
         // $this->logHelper->addInfoLog(json_encode($cart, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES));
 
         return $cart;
-    }
-
-    /**
-     * Round amount helper
-     *
-     * @param $amount
-     * @return  int
-     */
-    // TODO remote this method
-    public function getRoundAmount($amount)
-    {
-        return CurrencyUtils::toMinor($amount, "USD");
     }
 
     /**
@@ -1419,7 +1407,7 @@ class Cart extends AbstractHelper
         // check if getCouponCode is not null
         /////////////////////////////////////////////////////////////////////////////////
         if ( ( $amount = abs( $address->getDiscountAmount() ) ) || $address->getCouponCode() ) {
-            $roundedAmount = $this->getRoundAmount($amount);
+            $roundedAmount = CurrencyUtils::toMinor($amount, $currencyCode);
 
             $discounts[] = [
                 'description' => trim(__('Discount ') . $address->getDiscountDescription()),
@@ -1437,7 +1425,7 @@ class Cart extends AbstractHelper
         /////////////////////////////////////////////////////////////////////////////////
         if ($quote->getUseCustomerBalance()) {
             if ($paymentOnly && $amount = abs($quote->getCustomerBalanceAmountUsed())) {
-                $roundedAmount = $this->getRoundAmount($amount);
+                $roundedAmount = CurrencyUtils::toMinor($amount, $currencyCode);
 
                 $discounts[] = [
                     'description' => 'Store Credit',
@@ -1458,7 +1446,7 @@ class Cart extends AbstractHelper
                 $balanceModel->loadByCustomer();
 
                 if ($amount = abs($balanceModel->getAmount())) {
-                    $roundedAmount = $this->getRoundAmount($amount);
+                    $roundedAmount = CurrencyUtils::toMinor($amount, $currencyCode);
 
                     $discounts[] = [
                         'description' => 'Store Credit',
@@ -1478,7 +1466,7 @@ class Cart extends AbstractHelper
         /////////////////////////////////////////////////////////////////////////////////
         if ($this->discountHelper->isMirasvitStoreCreditAllowed($quote)){
             $amount = abs($this->discountHelper->getMirasvitStoreCreditAmount($quote, $paymentOnly));
-            $roundedAmount = $this->getRoundAmount($amount);
+            $roundedAmount = CurrencyUtils::toMinor($amount, $currencyCode);
             $discounts[] = [
                 'description' => 'Store Credit',
                 'amount'      => $roundedAmount,
@@ -1495,7 +1483,7 @@ class Cart extends AbstractHelper
         /////////////////////////////////////////////////////////////////////////////////
         if (array_key_exists(Discount::AHEADWORKS_STORE_CREDIT, $totals)) {
             $amount = abs($this->discountHelper->getAheadworksStoreCredit($quote->getCustomerId()));
-            $roundedAmount = $this->getRoundAmount($amount);
+            $roundedAmount = CurrencyUtils::toMinor($amount, $currencyCode);
             $discounts[] = [
                 'description' => 'Store Credit',
                 'amount'      => $roundedAmount,
@@ -1517,7 +1505,7 @@ class Cart extends AbstractHelper
             && $this->discountHelper->isBssStoreCreditAllowed()
         ) {
             $amount = $this->discountHelper->getBssStoreCreditAmount($quote, $parentQuote);
-            $roundedAmount = $this->getRoundAmount($amount);
+            $roundedAmount = CurrencyUtils::toMinor($amount, $currencyCode);
             $discounts[] = [
                 'description' => 'Store Credit',
                 'amount'      => $roundedAmount,
@@ -1534,7 +1522,7 @@ class Cart extends AbstractHelper
         /////////////////////////////////////////////////////////////////////////////////
         if ($quote->getUseRewardPoints()) {
             if ($paymentOnly && $amount = abs($quote->getRewardCurrencyAmount())) {
-                $roundedAmount = $this->getRoundAmount($amount);
+                $roundedAmount = CurrencyUtils::toMinor($amount, $currencyCode);
 
                 $discounts[] = [
                     'description' => 'Reward Points',
@@ -1555,7 +1543,7 @@ class Cart extends AbstractHelper
                 $rewardModel->loadByCustomer();
 
                 if ($amount = abs($rewardModel->getCurrencyAmount())) {
-                    $roundedAmount = $this->getRoundAmount($amount);
+                    $roundedAmount = CurrencyUtils::toMinor($amount, $currencyCode);
 
                     $discounts[] = [
                         'description' => 'Reward Points',
@@ -1574,7 +1562,7 @@ class Cart extends AbstractHelper
         // Process Mirasvit Rewards Points
         /////////////////////////////////////////////////////////////////////////////////
         if ($amount = abs($this->discountHelper->getMirasvitRewardsAmount($parentQuote))){
-            $roundedAmount = $this->getRoundAmount($amount);
+            $roundedAmount = CurrencyUtils::toMinor($amount, $currencyCode);
 
             $discounts[] = [
                 'description' =>
@@ -1633,7 +1621,7 @@ class Cart extends AbstractHelper
                 }
 
                 $amount = abs($amount);
-                $roundedAmount = $this->getRoundAmount($amount);
+                $roundedAmount = CurrencyUtils::toMinor($amount, $currencyCode);
 
                 $discounts[] = [
                     'description' => $description . @$totals[$discount]->getTitle(),

--- a/Model/Api/CreateOrder.php
+++ b/Model/Api/CreateOrder.php
@@ -20,6 +20,7 @@ namespace Bolt\Boltpay\Model\Api;
 use Bolt\Boltpay\Api\CreateOrderInterface;
 use Bolt\Boltpay\Exception\BoltException;
 use Bolt\Boltpay\Helper\Cart;
+use Bolt\Boltpay\Helper\Shared\CurrencyUtils;
 use Magento\Framework\Exception\LocalizedException;
 use Bolt\Boltpay\Helper\Order as OrderHelper;
 use Bolt\Boltpay\Helper\Cart as CartHelper;
@@ -225,7 +226,7 @@ class CreateOrder implements CreateOrderInterface
                 'status'    => 'success',
                 'message'   => 'Order create was successful',
                 'display_id' => $createdOrder->getIncrementId() . ' / ' . $quote->getId(),
-                'total'      => $this->cartHelper->getRoundAmount($createdOrder->getGrandTotal()),
+                'total'      => CurrencyUtils::toMinor($createdOrder->getGrandTotal(), $currency),
                 'order_received_url' => $this->getReceivedUrl($immutableQuote),
             ]);
             $this->metricsClient->processMetric("order_creation.success", 1, "order_creation.latency", $startTime);
@@ -511,8 +512,7 @@ class CreateOrder implements CreateOrderInterface
         foreach ($quoteItems as $item) {
             /** @var QuoteItem $item */
             $sku = trim($item->getSku());
-            $productId = $item->getProductId();
-            $itemPrice = $this->cartHelper->getRoundAmount($item->getPrice());
+            $itemPrice = CurrencyUtils::toMinor($item->getPrice(), $quote->getQuoteCurrencyCode());
 
             $this->hasItemErrors($item);
             $this->validateItemPrice($sku, $itemPrice, $transactionItems);
@@ -609,7 +609,7 @@ class CreateOrder implements CreateOrderInterface
         $transactionTax = $this->getTaxAmountFromTransaction($transaction);
         /** @var Quote\Address $address */
         $address = $quote->isVirtual() ? $quote->getBillingAddress() : $quote->getShippingAddress();
-        $tax = $this->cartHelper->getRoundAmount($address->getTaxAmount());
+        $tax = CurrencyUtils::toMinor($address->getTaxAmount(), $quote->getQuoteCurrencyCode());
 
         if (abs($transactionTax - $tax) > OrderHelper::MISMATCH_TOLERANCE) {
             $this->bugsnag->registerCallback(function ($report) use ($tax, $transactionTax) {
@@ -641,7 +641,7 @@ class CreateOrder implements CreateOrderInterface
             if (! $this->isBackOfficeOrder($quote)) {
                 $amount -= $quote->getShippingAddress()->getShippingDiscountAmount();
             }
-            $storeCost = $this->cartHelper->getRoundAmount($amount);
+            $storeCost = CurrencyUtils::toMinor($amount, $quote->getQuoteCurrencyCode());
         } else {
             $storeCost = 0;
         }
@@ -673,7 +673,7 @@ class CreateOrder implements CreateOrderInterface
      */
     public function validateTotalAmount($quote, $transaction)
     {
-        $quoteTotal = $this->cartHelper->getRoundAmount($quote->getGrandTotal());
+        $quoteTotal = CurrencyUtils::toMinor($quote->getGrandTotal(), $quote->getQuoteCurrencyCode());
         $transactionTotal = $this->getTotalAmountFromTransaction($transaction);
 
         if ($quoteTotal != $transactionTotal) {

--- a/Model/Api/DiscountCodeValidation.php
+++ b/Model/Api/DiscountCodeValidation.php
@@ -34,6 +34,7 @@ use Bolt\Boltpay\Helper\Bugsnag;
 use Bolt\Boltpay\Helper\Cart as CartHelper;
 use Bolt\Boltpay\Helper\Config as ConfigHelper;
 use Bolt\Boltpay\Helper\Hook as HookHelper;
+use Bolt\Boltpay\Helper\Shared\CurrencyUtils;
 use Magento\Quote\Model\Quote;
 use Bolt\Boltpay\Model\ThirdPartyModuleFactory;
 use Magento\Framework\Webapi\Exception as WebApiException;
@@ -644,7 +645,7 @@ class DiscountCodeValidation implements DiscountCodeValidationInterface
         $result = [
             'status'          => 'success',
             'discount_code'   => $couponCode,
-            'discount_amount' => abs($this->cartHelper->getRoundAmount($address->getDiscountAmount())),
+            'discount_amount' => abs(CurrencyUtils::toMinor($address->getDiscountAmount(), $immutableQuote->getQuoteCurrencyCode())),
             'description'     => trim(__('Discount ') . $rule->getDescription()),
             'discount_type'   => $this->convertToBoltDiscountType($rule->getSimpleAction()),
         ];
@@ -745,7 +746,7 @@ class DiscountCodeValidation implements DiscountCodeValidationInterface
         $result = [
             'status'          => 'success',
             'discount_code'   => $code,
-            'discount_amount' => abs($this->cartHelper->getRoundAmount($giftAmount)),
+            'discount_amount' => abs(CurrencyUtils::toMinor($giftAmount, $immutableQuote->getQuoteCurrencyCode())),
             'description'     =>  __('Gift Card'),
             'discount_type'   => $this->convertToBoltDiscountType('by_fixed'),
         ];
@@ -984,7 +985,7 @@ class DiscountCodeValidation implements DiscountCodeValidationInterface
         return $result = [
             'status'          => 'success',
             'discount_code'   => $couponCode,
-            'discount_amount' => abs($this->cartHelper->getRoundAmount($address->getDiscountAmount())),
+            'discount_amount' => abs(CurrencyUtils::toMinor($address->getDiscountAmount(), $parentQuote->getQuoteCurrencyCode())),
             'description'     =>  __('Discount ') . $address->getDiscountDescription(),
             'discount_type'   => $this->convertToBoltDiscountType($rule->getSimpleAction()),
         ];

--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -254,7 +254,7 @@ class ShippingMethods implements ShippingMethodsInterface
             $quantity = round($item->getQty());
             $unitPrice = round($item->getCalculationPrice(), 2);
             @$quoteItems['quantity'][$sku] += $quantity;
-            @$quoteItems['total'][$sku] += $this->cartHelper->getRoundAmount($unitPrice * $quantity);
+            @$quoteItems['total'][$sku] += CurrencyUtils::toMinor($unitPrice * $quantity, $this->quote->getQuoteCurrencyCode());
         }
 
         if (!$quoteItems) {
@@ -372,7 +372,7 @@ class ShippingMethods implements ShippingMethodsInterface
             $parentQuote = $this->getQuoteById($cart['order_reference']);
             if ($this->couponInvalidForShippingAddress($parentQuote->getCouponCode())){
                 $address = $parentQuote->isVirtual() ? $parentQuote->getBillingAddress() : $parentQuote->getShippingAddress();
-                $additionalAmount = abs($this->cartHelper->getRoundAmount($address->getDiscountAmount()));
+                $additionalAmount = abs(CurrencyUtils::toMinor($address->getDiscountAmount(), $parentQuote->getQuoteCurrencyCode()));
 
                 $shippingOptionsModel->addAmountToShippingOptions($additionalAmount);
             }
@@ -622,7 +622,7 @@ class ShippingMethods implements ShippingMethodsInterface
             $quote->collectTotals();
 
             $this->totalsCollector->collectAddressTotals($quote, $billingAddress);
-            $taxAmount = $this->cartHelper->getRoundAmount($billingAddress->getTaxAmount());
+            $taxAmount = CurrencyUtils::toMinor($billingAddress->getTaxAmount(), $quote->getQuoteCurrencyCode());
 
             return [
                 $this->shippingOptionInterfaceFactory
@@ -677,7 +677,7 @@ class ShippingMethods implements ShippingMethodsInterface
             $discountAmount = $shippingAddress->getShippingDiscountAmount();
 
             $cost        = $shippingAddress->getShippingAmount() - $discountAmount;
-            $roundedCost = $this->cartHelper->getRoundAmount($cost);
+            $roundedCost = CurrencyUtils::toMinor($cost, $quote->getQuoteCurrencyCode());
 
             $currencyCode = $quote->getQuoteCurrencyCode();
             $diff = CurrencyUtils::toMinorWithoutRounding($cost, $currencyCode) - $roundedCost;

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -255,12 +255,7 @@ class OrderTest extends TestCase
         $this->dataObjectFactory = $this->createMock(DataObjectFactory::class);
         $this->logHelper = $this->createMock(LogHelper::class);
         $this->bugsnag = $this->createMock(Bugsnag::class);
-        $this->cartHelper = $this->createPartialMock(
-            CartHelper::class,
-            [
-                'getRoundAmount',
-            ]
-        );
+        $this->cartHelper = $this->createMock(CartHelper::class);
         $this->resourceConnection = $this->createMock(ResourceConnection::class);
         $this->sessionHelper = $this->createMock(SessionHelper::class);
         $this->discountHelper = $this->createMock(DiscountHelper::class);
@@ -285,6 +280,7 @@ class OrderTest extends TestCase
                 'getGrandTotal',
                 'getPayment',
                 'setIsCustomerNotified',
+                'getOrderCurrencyCode',
             ]
         );
         $this->orderConfigMock = $this->createPartialMock(
@@ -294,6 +290,7 @@ class OrderTest extends TestCase
             ]
         );
         $this->orderMock->method('getConfig')->willReturn($this->orderConfigMock);
+        $this->orderMock->method('getOrderCurrencyCode')->willReturn("USD");
     }
     
     /**
@@ -814,8 +811,6 @@ class OrderTest extends TestCase
                 'save',
             ]
         );
-        $this->cartHelper->method('getRoundAmount')
-                         ->will($this->returnCallback(function($amount) { return (int)round($amount * 100); }));
         $this->orderMock->expects(static::once())->method('getTotalInvoiced')->willReturn($totalInvoiced);
         $this->orderMock->expects(static::once())->method('getGrandTotal')->willReturn($grandTotal);
         $this->orderMock->method('addStatusHistoryComment')->willReturn($this->orderMock);

--- a/Test/Unit/Model/Api/CreateOrderTest.php
+++ b/Test/Unit/Model/Api/CreateOrderTest.php
@@ -183,8 +183,10 @@ class CreateOrderTest extends TestCase
                 'isVirtual',
                 'getShippingAddress',
                 'getBoltIsBackendOrder',
+                'getQuoteCurrencyCode'
             ]);
         $this->quoteMock->method('getStoreId')->willReturn(self::STORE_ID);
+        $this->quoteMock->method('getQuoteCurrencyCode')->willReturn("USD");
 
         $quoteItem = $this->getMockBuilder(\Magento\Quote\Model\Quote\Item::class)
             ->setMethods([
@@ -221,11 +223,6 @@ class CreateOrderTest extends TestCase
         $this->immutableQuoteMock->method('getStoreId')->willReturn(self::STORE_ID);
 
         $this->cartHelper = $this->createMock(CartHelper::class);
-        $this->cartHelper->method('getRoundAmount')->willReturnCallback(
-            function ($amount) {
-                return (int)round($amount * 100);
-            }
-        );
         $this->cartHelper->method('getQuoteById')->willReturnMap([
             [self::QUOTE_ID, $this->quoteMock],
             [self::IMMUTABLE_QUOTE_ID, $this->immutableQuoteMock],

--- a/Test/Unit/Model/Api/DiscountCodeValidationTest.php
+++ b/Test/Unit/Model/Api/DiscountCodeValidationTest.php
@@ -2099,7 +2099,7 @@ class DiscountCodeValidationTest extends TestCase
         $quote->method('isVirtual')->willReturn($isVirtual);
         $quote->method('getShippingAddress')->willReturn($shippingAddress);
         $quote->method('getBillingAddress')->willReturn($shippingAddress);
-        $quote->method('getQuoteCurrencyCode')->willReturn('$');
+        $quote->method('getQuoteCurrencyCode')->willReturn('USD');
         $quote->method('collectTotals')->willReturnSelf();
         $quote->method('getItemsCount')->willReturn(1);
         $quote->method('getCustomerId')->willReturn($customerId);
@@ -2204,18 +2204,11 @@ class DiscountCodeValidationTest extends TestCase
                     'getActiveQuoteById',
                     'handleSpecialAddressCases',
                     'validateEmail',
-                    'getRoundAmount',
                     'getCartData'
                 ]
             )
             ->disableOriginalConstructor()
             ->getMock();
-        $this->cartHelper->method('getRoundAmount')
-            ->willReturnCallback(
-                function ($amount) {
-                    return (int)round($amount * 100);
-                }
-            );
 
         $this->configHelper = $this->getMockBuilder(ConfigHelper::class)
             ->setMethods(['getIgnoredShippingAddressCoupons'])

--- a/Test/Unit/Model/Api/ShippingMethodsTest.php
+++ b/Test/Unit/Model/Api/ShippingMethodsTest.php
@@ -981,10 +981,10 @@ class ShippingMethodsTest extends TestCase
         $this->initCurrentMock();
 
         $quote = $this->getMockBuilder(Quote::class)
-            ->setMethods(['isVirtual', 'getBillingAddress', 'collectTotals'])
+            ->setMethods(['isVirtual', 'getBillingAddress', 'collectTotals', 'getQuoteCurrencyCode'])
             ->disableOriginalConstructor()
             ->getMock();
-
+        $quote->method("getQuoteCurrencyCode")->willReturn("USD");
         $quote->expects(self::once())->method('isVirtual')->willReturn(true);
 
         $billingAddress = $this->getMockBuilder(\Magento\Quote\Model\Quote\Address::class)


### PR DESCRIPTION
# Description
getRoundAmount implicitly assume USD. This PR replace it with CurrencyUtils::toMinor with proper currency code.

Fixes: https://app.asana.com/0/941920570700290/1130539126613441/f

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
