### PR TITLE
Skip hook notifications when voiding or refunding the order on magento

### DIFF
--- a/Model/Payment.php
+++ b/Model/Payment.php
@@ -286,7 +286,10 @@ class Payment extends AbstractMethod
             }
 
             //Get transaction data
-            $transactionData = ['transaction_id' => $transactionId];
+            $transactionData = [
+                'transaction_id' => $transactionId,
+                'skip_hook_notification' => true
+            ];
             $storeId = $payment->getOrder()->getStoreId();
             $apiKey = $this->configHelper->getApiKey($storeId);
 
@@ -475,7 +478,8 @@ class Payment extends AbstractMethod
             $refundData = [
                 'transaction_id' => $realTransactionId,
                 'amount'         => $refundAmount,
-                'currency'       => $orderCurrency
+                'currency'       => $orderCurrency,
+                'skip_hook_notification' => true
             ];
 
             $storeId = $order->getStoreId();

--- a/Test/Unit/Model/PaymentTest.php
+++ b/Test/Unit/Model/PaymentTest.php
@@ -223,6 +223,27 @@ class PaymentTest extends TestCase
     /**
      * @test
      */
+    public function voidPayment_skipHookNotification()
+    {
+        $this->mockApiResponse(
+            "merchant/transactions/void",
+            '{"status": "cancelled", "reference": "ABCD-1234-XXXX"}'
+        );
+        $this->apiHelper->expects($this->once())->method('buildRequest')
+            ->will($this->returnCallback(
+                function($data)  {
+                    $this->assertTrue($data->getApiData()['skip_hook_notification']);
+                }
+            )
+        );
+        $this->orderHelper->expects($this->once())->method('updateOrderPayment');
+
+        $this->currentMock->void($this->paymentMock);
+    }
+
+    /**
+     * @test
+     */
     public function voidPayment_throwExceptionWhenBoltRespondWithError()
     {
         $this->expectException(LocalizedException::class);
@@ -421,6 +442,27 @@ class PaymentTest extends TestCase
             '{"status": "completed", "reference": "ABCD-1234-XXXX"}'
         );
         $this->orderHelper->expects($this->once())->method('updateOrderPayment');
+
+        $this->currentMock->refund($this->paymentMock, 100);
+    }
+
+    /**
+     * @test
+     */
+    public function refundPayment_skipHookNotification(){
+        $this->orderMock->method('getOrderCurrencyCode')->willReturn('USD');
+        $this->mockApiResponse(
+            "merchant/transactions/credit",
+            '{"status": "completed", "reference": "ABCD-1234-XXXX"}'
+        );
+
+        $this->apiHelper->expects($this->once())->method('buildRequest')
+            ->will($this->returnCallback(
+                function($data)  {
+                    $this->assertTrue($data->getApiData()['skip_hook_notification']);
+                }
+            )
+        );
 
         $this->currentMock->refund($this->paymentMock, 100);
     }


### PR DESCRIPTION
# Description
This resolves the mismatch issue described in the following case:

1. The customer places an order (Bolt transaction and Magento order match)
2. The administrator updates the Magento order total to less than its original total (this functionality is provided by a custom module)
3. The administrator voids or refunds the payment online for the order on Magento
4. Magento sends the void or refund API to Bolt to update the payment
5. The payment is voided or refunded, Bolt sends back hook requests to Magento to update the order
6. Mismatch issue occurs.
On M1, we ignore the hook notification and the void or refund hook never gets sent back to Magento. This applies the same logic for voiding and refunding the order on Magento

Fixes: https://app.asana.com/0/564264490825835/1155179630570777



# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Asana task link and provided a changelog message if applicable.
