### PR TITLE
Add Color and size properties to item return type

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1037,7 +1037,7 @@ class Cart extends AbstractHelper
                     foreach($item_options['attributes_info'] as $attribute_info){
                         // Convert attribute to string if it's a boolean before sending to the Bolt API
                         $attributeValue = is_bool($attribute_info['value']) ? var_export($attribute_info['value'], true) : $attribute_info['value'];
-                        $attriubuteLabel = $attribute_info['label'];
+                        $attributeLabel = $attribute_info['label'];
                         $properties[] = (object) [
                             "name" => $attributeLabel,
                             "value" => $attributeValue

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1042,12 +1042,12 @@ class Cart extends AbstractHelper
                             "name" => $attributeLabel,
                             "value" => $attributeValue
                         ];
-                        if (strcasecmp($attributeLabel, "color") == 0) {
-                            $product["color"] = $attributeValue;
+                        if (strcasecmp($attributeLabel, 'color') == 0) {
+                            $product['color'] = $attributeValue;
                         }
 
-                        if (strcasecmp($attributeLabel, "size") == 0) {
-                            $product["size"] = $attributeValue;
+                        if (strcasecmp($attributeLabel, 'size') == 0) {
+                            $product['size'] = $attributeValue;
                         }
                     }
                     $product['properties'] = $properties;

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1037,10 +1037,18 @@ class Cart extends AbstractHelper
                     foreach($item_options['attributes_info'] as $attribute_info){
                         // Convert attribute to string if it's a boolean before sending to the Bolt API
                         $attributeValue = is_bool($attribute_info['value']) ? var_export($attribute_info['value'], true) : $attribute_info['value'];
+                        $attriubuteLabel = $attribute_info['label'];
                         $properties[] = (object) [
-                            "name" => $attribute_info['label'],
+                            "name" => $attributeLabel,
                             "value" => $attributeValue
                         ];
+                        if (strcasecmp($attributeLabel, "color")) {
+                            $product["color"] = $attributeValue;
+                        }
+
+                        if (strcasecmp($attributeLabel, "size")) {
+                            $product["size"] = $attributeValue;
+                        }
                     }
                     $product['properties'] = $properties;
                 }

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1039,8 +1039,8 @@ class Cart extends AbstractHelper
                         $attributeValue = is_bool($attribute_info['value']) ? var_export($attribute_info['value'], true) : $attribute_info['value'];
                         $attributeLabel = $attribute_info['label'];
                         $properties[] = (object) [
-                            "name" => $attributeLabel,
-                            "value" => $attributeValue
+                            'name' => $attributeLabel,
+                            'value' => $attributeValue
                         ];
                         if (strcasecmp($attributeLabel, 'color') == 0) {
                             $product['color'] = $attributeValue;

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1042,11 +1042,11 @@ class Cart extends AbstractHelper
                             "name" => $attributeLabel,
                             "value" => $attributeValue
                         ];
-                        if (strcasecmp($attributeLabel, "color")) {
+                        if (strcasecmp($attributeLabel, "color") == 0) {
                             $product["color"] = $attributeValue;
                         }
 
-                        if (strcasecmp($attributeLabel, "size")) {
+                        if (strcasecmp($attributeLabel, "size") == 0) {
                             $product["size"] = $attributeValue;
                         }
                     }

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -1892,11 +1892,17 @@ ORDER;
      */
     public function getCartItems_AttributeInfoValue_Boolean()
     {
+        $color = "Blue";
+        $size = "S";
         $quoteItemOptions = [
             "attributes_info" => [
                 [
                     "label" => "Size",
-                    "value" => "S"
+                    "value" => $size
+                ],
+                [
+                    "label" => "Color",
+                    "value" => $color
                 ]
             ]
         ];
@@ -1919,9 +1925,10 @@ ORDER;
 
         $this->assertCount(1, $products);
         $this->assertArrayHasKey('properties', $products[0]);
-        $this->assertCount(1, $products[0]['properties']);
+        $this->assertCount(2, $products[0]['properties']);
         $this->assertInternalType('string', $products[0]['properties'][0]->value);
-        $this->assertEquals("S", $products[0]["size"]);
+        $this->assertEquals($size, $products[0]["size"]);
+        $this->assertEquals($color, $products[0]["color"]);
     }
 
     /**

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -1921,7 +1921,7 @@ ORDER;
         $this->assertArrayHasKey('properties', $products[0]);
         $this->assertCount(1, $products[0]['properties']);
         $this->assertInternalType('string', $products[0]['properties'][0]->value);
-        $this->assertEquals("S", $products[0]["color"]);
+        $this->assertEquals("S", $products[0]["size "]);
     }
 
     /**

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -1896,7 +1896,7 @@ ORDER;
             "attributes_info" => [
                 [
                     "label" => "Size",
-                    "value" => false
+                    "value" => "S"
                 ]
             ]
         ];
@@ -1921,6 +1921,7 @@ ORDER;
         $this->assertArrayHasKey('properties', $products[0]);
         $this->assertCount(1, $products[0]['properties']);
         $this->assertInternalType('string', $products[0]['properties'][0]->value);
+        $this->assertEquals("S", $products[0]["color"]);
     }
 
     /**

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -1921,7 +1921,7 @@ ORDER;
         $this->assertArrayHasKey('properties', $products[0]);
         $this->assertCount(1, $products[0]['properties']);
         $this->assertInternalType('string', $products[0]['properties'][0]->value);
-        $this->assertEquals("S", $products[0]["size "]);
+        $this->assertEquals("S", $products[0]["size"]);
     }
 
     /**

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -1892,17 +1892,17 @@ ORDER;
      */
     public function getCartItems_AttributeInfoValue_Boolean()
     {
-        $color = "Blue";
-        $size = "S";
+        $color = 'Blue';
+        $size = 'S';
         $quoteItemOptions = [
-            "attributes_info" => [
+            'attributes_info' => [
                 [
-                    "label" => "Size",
-                    "value" => $size
+                    'label' => 'Size',
+                    'value' => $size
                 ],
                 [
-                    "label" => "Color",
-                    "value" => $color
+                    'label' => 'Color',
+                    'value' => $color
                 ]
             ]
         ];
@@ -1921,14 +1921,14 @@ ORDER;
 
         $quoteItemMock = $this->getQuoteItemMock($productMock);
 
-        list($products, $totalAmount, $diff) = $this->getCurrentMock()->getCartItems("USD", [$quoteItemMock], self::STORE_ID);
+        list($products, $totalAmount, $diff) = $this->getCurrentMock()->getCartItems('USD', [$quoteItemMock], self::STORE_ID);
 
         $this->assertCount(1, $products);
         $this->assertArrayHasKey('properties', $products[0]);
         $this->assertCount(2, $products[0]['properties']);
         $this->assertInternalType('string', $products[0]['properties'][0]->value);
-        $this->assertEquals($size, $products[0]["size"]);
-        $this->assertEquals($color, $products[0]["color"]);
+        $this->assertEquals($size, $products[0]['size']);
+        $this->assertEquals($color, $products[0]['color']);
     }
 
     /**


### PR DESCRIPTION
# Description
This change adds two new properties color and size to item return type.
Currently these are within item properties in Magento2 with labels "Color" and "Size".
This would be used to be displayed in SideCart of Checkout

#changelog
Return color and size of items

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Asana task link and provided a changelog message if applicable.
