### PR TITLE
Add variant image rather than main product image

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1048,11 +1048,24 @@ class Cart extends AbstractHelper
                 // Get product description and image
                 ////////////////////////////////////
                 $product['description'] = strip_tags($_product->getDescription());
+                $variantProductToGetImage = $_product;
+
+                // This will override the $_product with the variant product to get the variant image rather than the main product image.
                 try {
-                    $productImage = $imageBlock->getImage($_product, 'product_small_image');
+                    $variantProductToGetImage = $this->productRepository->get($item->getSku(), false, $storeId);
+                } catch (\Exception $e) {
+                    $this->bugsnag->registerCallback(function ($report) use ($product) {
+                        $report->setMetaData([
+                            'ITEM' => $product
+                        ]);
+                    });
+                    $this->bugsnag->notifyError('Could not retrieve product from repository', "SKU: {$product['sku']}");
+                }
+                try {
+                    $productImage = $imageBlock->getImage($variantProductToGetImage, 'product_small_image');
                 } catch (\Exception $e) {
                     try {
-                        $productImage = $imageBlock->getImage($_product, 'product_image');
+                        $productImage = $imageBlock->getImage($variantProductToGetImage, 'product_image');
                     } catch (\Exception $e) {
                         $this->bugsnag->registerCallback(function ($report) use ($product) {
                             $report->setMetaData([


### PR DESCRIPTION
# Description
Currently variant images are not populated correctly. It still shows the main product image rather than the configurable image

(Optional: Add a changelog by writing a comment after "#changelog" on the next line)

\#changelog
Return variant image is exists rather than the main product image.

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [ ] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Asana task link and provided a changelog message if applicable.


Before:
<img width="830" alt="Screen Shot 2019-12-30 at 1 16 03 PM" src="https://user-images.githubusercontent.com/5201724/71601119-f1845080-2b06-11ea-8b62-c7a898eeee2a.png">

After:
<img width="920" alt="Screen Shot 2019-12-30 at 1 12 19 PM" src="https://user-images.githubusercontent.com/5201724/71601141-07921100-2b07-11ea-9e11-52b56fdfe1d9.png">

