### PR TITLE
Set property fromBolt to true when the shipping hook request is sent to Magento

### DIFF
--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -432,6 +432,7 @@ class ShippingMethods implements ShippingMethodsInterface
      */
     protected function preprocessHook()
     {
+        HookHelper::$fromBolt = true;
         $this->hookHelper->preProcessWebhook($this->quote->getStoreId());
     }
 

--- a/Test/Unit/Model/Api/ShippingMethodsTest.php
+++ b/Test/Unit/Model/Api/ShippingMethodsTest.php
@@ -395,14 +395,16 @@ class ShippingMethodsTest extends TestCase
         $this->configHelper->method('getStoreVersion')->willReturn('2.3.3');
 
         $methods = ['sendErrorResponse', 'checkCartItems', 'getQuoteById',
-            'shippingEstimation', 'preprocessHook', 'couponInvalidForShippingAddress'
+            'shippingEstimation', 'couponInvalidForShippingAddress'
         ];
 
         $this->sessionHelper->expects(self::once())->method('loadSession')->willReturn(null);
 
         $this->initCurrentMock($methods, false);
 
-        $this->currentMock->expects(self::once())->method('preprocessHook')->willReturn(null);
+        $this->hookHelper->method('preProcessWebhook')
+            ->withAnyParameters()
+            ->willReturnSelf();
         $this->currentMock->expects(self::once())->method('checkCartItems')->with($cart)->willReturn(null);
 
         $this->currentMock->expects(self::exactly(2))->method('getQuoteById')
@@ -421,6 +423,7 @@ class ShippingMethodsTest extends TestCase
 
         $result = $this->currentMock->getShippingMethods($cart, $shippingAddress);
 
+        $this->assertTrue(HookHelper::$fromBolt);
         $this->assertEquals($shippingOptions, $result);
     }
 


### PR DESCRIPTION
# Description
 Set property fromBolt to true when the shipping hook request is sent to Magento
Fixes: https://app.asana.com/0/564264490825835/1156190790999569


# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
