### PR TITLE
Void the Bolt transaction when its status is either authorized or canceled and the Magento quote is missing

### DIFF
--- a/Model/Payment.php
+++ b/Model/Payment.php
@@ -55,6 +55,7 @@ class Payment extends AbstractMethod
 {
     const TRANSACTION_AUTHORIZED = 'authorized';
     const TRANSACTION_COMPLETED = 'completed';
+    const TRANSACTION_CANCELLED = 'cancelled';
 
     const METHOD_CODE = 'boltpay';
 


### PR DESCRIPTION
# Description
Void the Bolt transaction when its status is either authorized or canceled and the Magento quote is missing

Fixes: https://app.asana.com/0/564264490825835/1157946616328022

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
