### PR TITLE
Fix some bugs related to Product page checkout

### DIFF
--- a/Block/Js.php
+++ b/Block/Js.php
@@ -428,10 +428,7 @@ class Js extends Template
      */
     public function getStoreId()
     {
-        /** @var Quote $quote */
-        $quote = $this->getQuoteFromCheckoutSession();
-
-        return  $quote && $quote->getStoreId() ? $quote->getStoreId() : null;
+        return $this->_storeManager->getStore()->getId();
     }
 
     /**

--- a/Block/Js.php
+++ b/Block/Js.php
@@ -422,7 +422,7 @@ class Js extends Template
     }
 
     /**
-     * If we have multi-website, we need current quote store_id
+     * If we have multi-website, we need current store_id
      *
      * @return int
      */

--- a/Controller/ReceivedUrlTrait.php
+++ b/Controller/ReceivedUrlTrait.php
@@ -192,7 +192,7 @@ trait ReceivedUrlTrait
      */
     private function getOrderByIncrementId($incrementId)
     {
-        $order = $this->cartHelper->getOrderByIncrementId($incrementId);
+        $order = $this->orderHelper->getExistingOrder($incrementId);
 
         if (!$order) {
             throw new NoSuchEntityException(

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -702,7 +702,7 @@ class Order extends AbstractHelper
         ///////////////////////////////////////////////////////////////
 
         // check if the order exists
-        $order = $this->cartHelper->getOrderByIncrementId($incrementId) ?: $this->getOrderByQuoteId($parentQuoteId);
+        $order = $this->getExistingOrder($incrementId);
 
         // if not create the order
         if (!$order || !$order->getId()) {
@@ -981,10 +981,13 @@ class Order extends AbstractHelper
      * @param $orderIncrementId
      * @return OrderModel|false
      */
-    protected function getExistingOrder($orderIncrementId)
+    public function getExistingOrder($orderIncrementId)
     {
         /** @var OrderModel $order */
-        return $this->cartHelper->getOrderByIncrementId($orderIncrementId, true);
+        return $this->cartHelper->getOrderByIncrementId($orderIncrementId, true) ?:
+            // bypass missing increment id in PPC transaction data - temporary fix.
+            // TODO: remove
+            $this->getOrderByQuoteId($orderIncrementId);
     }
 
     /**
@@ -1889,7 +1892,7 @@ class Order extends AbstractHelper
         if (empty($incrementId)) {
             return null;
         }
-        $order = $this->cartHelper->getOrderByIncrementId(trim($incrementId));
+        $order = $this->getExistingOrder(trim($incrementId));
 
         return ($order && $order->getStoreId()) ? $order->getStoreId() : null;
     }

--- a/Model/Api/DiscountCodeValidation.php
+++ b/Model/Api/DiscountCodeValidation.php
@@ -44,6 +44,7 @@ use Magento\Checkout\Model\Session as CheckoutSession;
 use Bolt\Boltpay\Helper\Discount as DiscountHelper;
 use Magento\Directory\Model\Region as RegionModel;
 use Magento\Quote\Model\Quote\TotalsCollector;
+use Bolt\Boltpay\Helper\Order as OrderHelper;
 
 /**
  * Discount Code Validation class
@@ -161,6 +162,11 @@ class DiscountCodeValidation implements DiscountCodeValidationInterface
     private $totalsCollector;
 
     /**
+     * @var OrderHelper
+     */
+    protected $orderHelper;
+
+    /**
      * DiscountCodeValidation constructor.
      *
      * @param Request                 $request
@@ -185,6 +191,7 @@ class DiscountCodeValidation implements DiscountCodeValidationInterface
      * @param DiscountHelper          $discountHelper
      * @param RegionModel             $regionModel
      * @param TotalsCollector         $totalsCollector
+     * @param OrderHelper             $orderHelper
      */
     public function __construct(
         Request $request,
@@ -208,7 +215,8 @@ class DiscountCodeValidation implements DiscountCodeValidationInterface
         HookHelper $hookHelper,
         DiscountHelper $discountHelper,
         RegionModel $regionModel,
-        TotalsCollector $totalsCollector
+        TotalsCollector $totalsCollector,
+        OrderHelper $orderHelper
     ) {
         $this->request = $request;
         $this->response = $response;
@@ -232,6 +240,7 @@ class DiscountCodeValidation implements DiscountCodeValidationInterface
         $this->discountHelper = $discountHelper;
         $this->regionModel = $regionModel;
         $this->totalsCollector = $totalsCollector;
+        $this->orderHelper = $orderHelper;
     }
 
     /**
@@ -250,9 +259,6 @@ class DiscountCodeValidation implements DiscountCodeValidationInterface
                 $displayId = isset($requestArray['cart']['display_id']) ? $requestArray['cart']['display_id'] : '';
                 // check if the cart / quote exists and it is active
                 try {
-                    /** @var Quote $parentQuote */
-                    $parentQuote = $this->cartHelper->getActiveQuoteById($parentQuoteId);
-
                     // get parent quote id, order increment id and child quote id
                     // the latter two are transmitted as display_id field, separated by " / "
                     list($incrementId, $immutableQuoteId) = array_pad(
@@ -260,6 +266,18 @@ class DiscountCodeValidation implements DiscountCodeValidationInterface
                         2,
                         null
                     );
+
+                    if (!$immutableQuoteId) {
+                        $immutableQuoteId = $parentQuoteId;
+                    }
+
+                    /** @var Quote $parentQuote */
+                    If ($immutableQuoteId == $parentQuoteId) {
+                        // Product Page Checkout - quotes are created as inactive
+                        $parentQuote = $this->cartHelper->getQuoteById($parentQuoteId);
+                    } else {
+                        $parentQuote = $this->cartHelper->getActiveQuoteById($parentQuoteId);
+                    }
 
                     // check if cart identification data is sent
                     if (empty($parentQuoteId) || empty($incrementId) || empty($immutableQuoteId)) {
@@ -353,13 +371,12 @@ class DiscountCodeValidation implements DiscountCodeValidationInterface
             }
 
             // check if the order has already been created
-            if ($this->cartHelper->getOrderByIncrementId($incrementId)) {
+            if ($this->orderHelper->getExistingOrder($incrementId)) {
                 $this->sendErrorResponse(
                     BoltErrorResponse::ERR_INSUFFICIENT_INFORMATION,
                     sprintf('The order #%s has already been created.', $incrementId),
                     422
                 );
-
                 return false;
             }
 

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -32,6 +32,7 @@ class JsTest extends \PHPUnit\Framework\TestCase
 {
     // Number of settings in method getSettings()
     const SETTINGS_NUMBER = 18;
+    const STORE_ID = 1;
 
     /**
      * @var HelperConfig
@@ -121,12 +122,19 @@ class JsTest extends \PHPUnit\Framework\TestCase
         $this->cartHelperMock = $this->createMock(CartHelper::class);
         $this->bugsnagHelperMock = $this->createMock(Bugsnag::class);
         $this->decider = $this->createMock(Decider::class);
+
         $this->requestMock = $this->getMockBuilder(Http::class)
             ->disableOriginalConstructor()
             ->setMethods(['getFullActionName'])
             ->getMock();
-
         $this->contextMock->method('getRequest')->willReturn($this->requestMock);
+
+        $store = $this->getMockForAbstractClass(\Magento\Store\Api\Data\StoreInterface::class);
+        $store->method('getId')->willReturn(self::STORE_ID);
+        $storeManager = $this->getMockForAbstractClass(\Magento\Store\Model\StoreManagerInterface::class);
+        $storeManager->method('getStore')->willReturn($store);
+        $this->contextMock->method('getStoreManager')->willReturn($storeManager);
+
         $this->block = $this->getMockBuilder(BlockJs::class)
             ->setMethods(['configHelper', 'getUrl', 'getBoltPopupErrorMessage'])
             ->setConstructorArgs(
@@ -357,7 +365,7 @@ class JsTest extends \PHPUnit\Framework\TestCase
      */
     public function isEnabled()
     {
-        $storeId = 0;
+        $storeId = self::STORE_ID;
         $this->configHelper->expects($this->any())
             ->method('isActive')
             ->with($storeId)

--- a/Test/Unit/Controller/Order/ReceivedUrlTest.php
+++ b/Test/Unit/Controller/Order/ReceivedUrlTest.php
@@ -126,10 +126,6 @@ class ReceivedUrlTest extends TestCase
 
         $cartHelper = $this->createMock(CartHelper::class);
         $cartHelper->expects($this->once())
-            ->method('getOrderByIncrementId')
-            ->with(self::INCREMENT_ID)
-            ->willReturn($order);
-        $cartHelper->expects($this->once())
             ->method('getQuoteById')
             ->with(self::QUOTE_ID)
             ->willReturn($quote);
@@ -193,6 +189,10 @@ class ReceivedUrlTest extends TestCase
 
         $orderHelper = $this->createMock(OrderHelper::class);
         $orderHelper->expects($this->once())
+            ->method('getExistingOrder')
+            ->with(self::INCREMENT_ID)
+            ->willReturn($order);
+        $orderHelper->expects($this->once())
             ->method('formatReferenceUrl')
             ->with(self::TRANSACTION_REFERENCE)
             ->willReturn(self::FORMATTED_REFERENCE_URL);
@@ -247,8 +247,6 @@ class ReceivedUrlTest extends TestCase
         $url = $this->createUrlMock();
 
         $cartHelper = $this->createMock(CartHelper::class);
-        $cartHelper->method('getOrderByIncrementId')
-            ->willReturn($order);
         $cartHelper->method('getQuoteById')
             ->willReturn($quote);
 
@@ -300,6 +298,10 @@ class ReceivedUrlTest extends TestCase
         $configHelper->method('getSigningSecret')
             ->willReturn(self::SIGNING_SECRET);
 
+        $orderHelper = $this->createMock(OrderHelper::class);
+        $orderHelper->method('getExistingOrder')
+            ->willReturn($order);
+
         $context = $this->createMock(Context::class);
         $context->method('getUrl')
             ->willReturn($url);
@@ -319,7 +321,7 @@ class ReceivedUrlTest extends TestCase
             $bugsnag,
             $this->logHelper,
             $checkoutSession,
-            $this->orderHelper
+            $orderHelper
         );
 
         $receivedUrl->method('getRequest')
@@ -397,10 +399,6 @@ class ReceivedUrlTest extends TestCase
         $message->expects($this->once())
             ->method('addErrorMessage');
 
-        $cartHelper = $this->createMock(CartHelper::class);
-        $cartHelper->method('getOrderByIncrementId')
-            ->willReturn(null);
-
         $context = $this->createMock(Context::class);
         $context->method('getMessageManager')
             ->willReturn($message);
@@ -410,6 +408,10 @@ class ReceivedUrlTest extends TestCase
             ->method('getSigningSecret')
             ->with(self::STORE_ID)
             ->willReturn(self::SIGNING_SECRET);
+
+        $orderHelper = $this->createMock(OrderHelper::class);
+        $orderHelper->method('getExistingOrder')
+            ->willReturn(null);
 
         $bugsnag = $this->createMock(Bugsnag::class);
         $bugsnag->expects($this->once())
@@ -433,11 +435,11 @@ class ReceivedUrlTest extends TestCase
         $receivedUrl = $this->initReceivedUrlMock(
             $context,
             $configHelper,
-            $cartHelper,
+            $this->cartHelper,
             $bugsnag,
             $this->logHelper,
             $this->checkoutSession,
-            $this->orderHelper
+            $orderHelper
         );
 
         $receivedUrl->method('getRequest')
@@ -464,8 +466,8 @@ class ReceivedUrlTest extends TestCase
             ->method('addErrorMessage')
             ->with('Something went wrong. Please contact the seller.'); //Hardcoded string in class
 
-        $cartHelper = $this->createMock(CartHelper::class);
-        $cartHelper->method('getOrderByIncrementId')
+        $orderHelper = $this->createMock(OrderHelper::class);
+        $orderHelper->method('getExistingOrder')
             ->willThrowException($exception);
 
         $context = $this->createMock(Context::class);
@@ -501,11 +503,11 @@ class ReceivedUrlTest extends TestCase
         $receivedUrl = $this->initReceivedUrlMock(
             $context,
             $configHelper,
-            $cartHelper,
+            $this->cartHelper,
             $bugsnag,
             $logHelper,
             $this->checkoutSession,
-            $this->orderHelper
+            $orderHelper
         );
 
         $receivedUrl->method('getRequest')

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -1992,7 +1992,7 @@ ORDER;
 
     private function createCartByRequest_GetExpectedCartData() {
         return [
-            'order_reference' => NULL,
+            'order_reference' => SELF::QUOTE_ID,
             'display_id' => SELF::ORDER_ID.' / '.SELF::QUOTE_ID,
             'currency' => 'USD',
             'items' => [
@@ -2021,7 +2021,7 @@ ORDER;
                         'reference' => SELF::PRODUCT_ID,
                         'name' => 'Product name',
                         'description' => NULL,
-                        'options' => NULL,
+                        'options' => SELF::STORE_ID,
                         'total_amount' => SELF::PRODUCT_PRICE,
                         'unit_price' => SELF::PRODUCT_PRICE,
                         'tax_amount' => 0,
@@ -2081,13 +2081,18 @@ ORDER;
             ->getMock();
 
         $quote = $this->getMockBuilder(Quote::class)
-            ->setMethods(['addProduct','reserveOrderId','collectTotals','save','getId','getReservedOrderId','setBoltReservedOrderId','assignCustomer'])
+            ->setMethods(['addProduct','reserveOrderId','collectTotals','save','getId','getReservedOrderId','setBoltReservedOrderId','assignCustomer','setBoltParentQuoteId','setIsActive','setStoreId'])
             ->disableOriginalConstructor()
             ->getMock();
+        $quote->expects($this->once())
+            ->method('setBoltParentQuoteId')
+            ->with(SELF::QUOTE_ID);
         $quote->expects($this->onceOrAny($isSuccessfulCase))
             ->method('addProduct')
             ->with($product,1);
-
+        $quote->expects($this->onceOrAny($isSuccessfulCase))
+            ->method('setStoreId')
+            ->with(self::STORE_ID);
         $quote->expects($this->onceOrAny($isSuccessfulCase))
             ->method('reserveOrderId');
         $quote->expects($this->onceOrAny($isSuccessfulCase))
@@ -2096,15 +2101,14 @@ ORDER;
         $quote->expects($this->onceOrAny($isSuccessfulCase))
             ->method('setBoltReservedOrderId')
             ->with(self::ORDER_ID);
-
+        $quote->expects($this->onceOrAny($isSuccessfulCase))
+            ->method('setIsActive')
+            ->with(false);
         $quote->expects($this->onceOrAny($isSuccessfulCase))
             ->method('collectTotals')
             ->willReturnSelf();
         $quote->expects($this->onceOrAny($isSuccessfulCase))
             ->method('save');
-        $quote->expects($this->onceOrAny($isSuccessfulCase))
-            ->method('getId')
-            ->willReturn(SELF::QUOTE_ID);
 
         $this->quoteFactory = $this->getMockBuilder(QuoteFactory::class)
             ->setMethods(['create','load'])
@@ -2142,7 +2146,6 @@ ORDER;
             ->method('getCartData')
             ->with(false,'',$quote)
             ->willReturn($expectedCartData);
-        $expectedCartData['order_reference'] = SELF::QUOTE_ID;
 
         $this->assertEquals($expectedCartData, $cartMock->createCartByRequest($request));
     }
@@ -2186,7 +2189,6 @@ ORDER;
             ->method('getCartData')
             ->with(false,'',$quote)
             ->willReturn($expectedCartData);
-        $expectedCartData['order_reference'] = SELF::QUOTE_ID;
 
         $this->assertEquals($expectedCartData, $cartMock->createCartByRequest($request));
     }

--- a/view/frontend/templates/button_product_page.phtml
+++ b/view/frontend/templates/button_product_page.phtml
@@ -31,11 +31,10 @@ if (!$block->isSupportableType()) return;
             'Magento_Customer/js/model/authentication-popup',
             'Magento_Customer/js/customer-data',
             'mage/validation/validation',
-            'mage/cookies'
+            'mage/cookies',
+            'domReady!'
         ], function ($, authenticationPopup, customerData) {
             var customer = customerData.get('customer');
-            var shoppingCart = customerData.get('cart');
-            var $qty = jQuery('#qty');
             var max_qty = <?= $block->getProductQty(); ?>;
             var isGuestCheckoutAllowed = <?= $block->isGuestCheckoutAllowed(); ?>;
 
@@ -140,7 +139,7 @@ if (!$block->isSupportableType()) return;
                      */
 
                     //check if we have inventory on stock
-                    if ( (max_qty>=0) && $qty && (Number($qty.val()) > max_qty)) {
+                    if ( max_qty >= 0 && getQty() > max_qty ) {
                         window.alert("The requested qty is not available");
                         return false;
                     }
@@ -150,6 +149,10 @@ if (!$block->isSupportableType()) return;
                         // if authentication is required for checkout set a cookie
                         // for auto opening Bolt checkout after login
                         authenticationPopup.showModal();
+                        return false;
+                    }
+
+                    if (!hints) {
                         return false;
                     }
                     return true;
@@ -164,52 +167,47 @@ if (!$block->isSupportableType()) return;
                 }
             };
 
-            function setupProductPage() {
-                var quantity = 1;
-                if ($qty) {
-                    quantity = Number($qty.val());
-                }
+            var getQty = function() {
+                var quantity = Number($('#qty').val());
+                return quantity > 0 ? quantity : 1;
+            };
+
+            var setupProductPage = function () {
                 var cart = {
                     currency: "USD",
                     items: [{
                         reference: '<?= $block->getProduct()->getId() ?>',
                         price: <?= (int) $block->getProduct()->getFinalPrice() ?>,
                         name: '<?= $block->getProduct()->getName() ?>',
-                        quantity: quantity,
+                        quantity: getQty(),
                     }]
                 };
 
-                var buttonClass = "bolt-product-checkout-button";
-                var hints = {prefill:{}};
-
-                // We need to receive hints from server
-                // meanwhile initiate Bolt without hints to have button early
-                BoltCheckout.configureProductCheckout(cart, hints, callbacks, {checkoutButtonClassName: buttonClass});
-                if ( customer().firstname ) {
-                    $.post(
-                        settings.get_hints_url,
-                        function(result) {
-                            BoltCheckout.configureProductCheckout(cart, result.hints, callbacks, {checkoutButtonClassName: buttonClass});
-                        }
-                    );
-                }
-
-            }
-
-            if (
-                (document && document.readyState !== "loading") ||
-                (window && window.document && window.document.readyState !== "loading")
-            ) {
-                setupProductPage();
-            } else {
-                document.addEventListener("DOMContentLoaded", setupProductPage);
-            }
-            jQuery(document).ready(function () {
-                jQuery('#qty').on('change',
-                    function () {
-                        setupProductPage();
-                    }
+                BoltCheckout.configureProductCheckout(
+                    cart,
+                    hints,
+                    callbacks,
+                    {checkoutButtonClassName: buttonClass}
                 );
-            });
+            };
+
+            var buttonClass = "bolt-product-checkout-button";
+            var hints;
+
+            // wait for the hints to load
+            // the viable way to assign user to order
+            // TODO: pass store id this way as well
+            $.get(settings.get_hints_url)
+                .done(function(data) {
+                    hints = data.hints;
+                }).fail(function() {
+                    hints = {prefill:{}};
+                }).always(function() {
+                    setupProductPage();
+                    $('#qty').on('change', setupProductPage);
+                });
+
+            // early button display, not active untill hints are received
+            BoltCheckout.configureProductCheckout({},{}, callbacks, {checkoutButtonClassName: buttonClass});
         });
     </script>

--- a/view/frontend/templates/button_product_page.phtml
+++ b/view/frontend/templates/button_product_page.phtml
@@ -23,16 +23,9 @@
 if ($block->shouldDisableBoltCheckout()) return;
 
 if (!$block->isSupportableType()) return;
-
-$trackCallbacks = $block->getTrackCallbacks();
-
 ?>
     <div class="bolt-product-checkout-button bolt-multi-step-checkout <?=$block->getAdditionalCheckoutButtonClass();?>"></div>
     <script>
-        // Store the configuration parameters passed from the php block
-        // in the global object. Used in this file and on the payment page
-        // in payment method renderer, vendor/boltpay/bolt-magento2/view/frontend/web/js/view/payment/method-renderer/boltpay.js
-        window.boltConfig = <?php echo $block->getSettings(); ?>;
         require([
             'jquery',
             'Magento_Customer/js/model/authentication-popup',
@@ -47,58 +40,8 @@ $trackCallbacks = $block->getTrackCallbacks();
             var isGuestCheckoutAllowed = <?= $block->isGuestCheckoutAllowed(); ?>;
 
             var settings = window.boltConfig;
+            var trackCallbacks = settings.trackCallbacks;
 
-            var trackCallbacks = {
-                onCheckoutStart: function() {
-                    try {
-                        <?php echo $trackCallbacks['checkout_start']; ?>
-                    } catch (error) {
-                        console.error(error);
-                    }
-                },
-                onEmailEnter: function(email) {
-                    try {
-                        <?php echo $trackCallbacks['email_enter']; ?>
-                    } catch (error) {
-                        console.error(error);
-                    }
-                },
-                onShippingDetailsComplete: function() {
-                    try {
-                        <?php echo $trackCallbacks['shipping_details_complete']; ?>
-                    } catch (error) {
-                        console.error(error);
-                    }
-                },
-                onShippingOptionsComplete: function() {
-                    try {
-                        <?php echo $trackCallbacks['shipping_options_complete']; ?>
-                    } catch (error) {
-                        console.error(error);
-                    }
-                },
-                onPaymentSubmit: function() {
-                    try {
-                        <?php echo $trackCallbacks['payment_submit']; ?>
-                    } catch (error) {
-                        console.error(error);
-                    }
-                },
-                onSuccess: function() {
-                    try {
-                        <?php echo $trackCallbacks['success']; ?>
-                    } catch (error) {
-                        console.error(error);
-                    }
-                },
-                onClose: function() {
-                    try {
-                        <?php echo $trackCallbacks['close']; ?>
-                    } catch (error) {
-                        console.error(error);
-                    }
-                }
-            };
             // On multiple checkout open/close actions the success event remains registered
             // resulting in making the success call multiple times. This variable stores
             // the last request to be aborted before new one is sent.

--- a/view/frontend/templates/button_product_page.phtml
+++ b/view/frontend/templates/button_product_page.phtml
@@ -176,27 +176,20 @@ if (!$block->isSupportableType()) return;
                 var cart = {
                     currency: "USD",
                     items: [{
-                        reference: '<?= $block->getProduct()->getId() ?>',
-                        price: <?= (int) $block->getProduct()->getFinalPrice() ?>,
-                        name: '<?= $block->getProduct()->getName() ?>',
+                        reference: '<?= $block->getProduct()->getId(); ?>',
+                        price: <?= (int) $block->getProduct()->getFinalPrice(); ?>,
+                        name: '<?= $block->getProduct()->getName(); ?>',
                         quantity: getQty(),
+                        options: '<?= $block->getStoreId(); ?>'
                     }]
                 };
-
-                BoltCheckout.configureProductCheckout(
-                    cart,
-                    hints,
-                    callbacks,
-                    {checkoutButtonClassName: buttonClass}
-                );
+                BoltCheckout.configureProductCheckout(cart, hints, callbacks);
             };
 
-            var buttonClass = "bolt-product-checkout-button";
             var hints;
 
             // wait for the hints to load
             // the viable way to assign user to order
-            // TODO: pass store id this way as well
             $.get(settings.get_hints_url)
                 .done(function(data) {
                     hints = data.hints;
@@ -208,6 +201,6 @@ if (!$block->isSupportableType()) return;
                 });
 
             // early button display, not active untill hints are received
-            BoltCheckout.configureProductCheckout({},{}, callbacks, {checkoutButtonClassName: buttonClass});
+            BoltCheckout.configureProductCheckout({},{}, callbacks);
         });
     </script>

--- a/view/frontend/templates/button_product_page.phtml
+++ b/view/frontend/templates/button_product_page.phtml
@@ -185,7 +185,6 @@ if (!$block->isSupportableType()) return;
                 // We need to receive hints from server
                 // meanwhile initiate Bolt without hints to have button early
                 BoltCheckout.configureProductCheckout(cart, hints, callbacks, {checkoutButtonClassName: buttonClass});
-                customerData.init();
                 if ( customer().firstname ) {
                     $.post(
                         settings.get_hints_url,


### PR DESCRIPTION
- Add support for multistore
- Set PPC quote active to false (otherwise PPC quote for logged in user is tied to session and can become session quote when regular cart checkout complete
- In all cases when we need to check if an order exists check not only by order_id but for quote_id also (PPC case)

# Type of change

- [x] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Asana task link and provided a changelog message if applicable.
