### PR TITLE
php5.6 compatibility fix

### DIFF
--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -122,8 +122,7 @@ class Decider extends AbstractHelper {
      * @return bool
      */
     public function isSwitchEnabled($switchName) {
-        $defaultDef = isset(Definitions::DEFAULT_SWITCH_VALUES[$switchName]) ?
-            Definitions::DEFAULT_SWITCH_VALUES[$switchName] : null;
+        $defaultDef = @Definitions::DEFAULT_SWITCH_VALUES[$switchName];
         if (!$defaultDef) {
             throw new LocalizedException(__("Unknown feature switch"));
         }


### PR DESCRIPTION
# Description
\Bolt\Boltpay\Helper\FeatureSwitch\Decider::isSwitchEnabled
Fatal error: Cannot use isset() on the result of an expression

Fixes: https://app.asana.com/0/941920570700290/1159433394644281/f

(Optional: Add a changelog by writing a comment after "#changelog" on the next line)

\#changelog

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
