### PR TITLE
Remove quantity check from PPC frontend

### DIFF
--- a/Block/JsProductPage.php
+++ b/Block/JsProductPage.php
@@ -65,27 +65,6 @@ class JsProductPage extends Js {
     }
 
     /**
-     * Get maximum available quantity of product
-     * It is used to show a warning if user tries to buy more then product quantity
-     * @return int -1 Ignore product quantity levels
-     *              0 if product is out of stock
-     *              positive value otherwise
-     */
-    public function getProductQty()
-    {
-        $stockItem = $this->getProduct()->getExtensionAttributes()->getStockItem();
-        if (!$stockItem->getManageStock()) {
-            return -1;
-        } elseif (!$stockItem->getIsInStock()) {
-            // Although we shouldn't show the bolt button if product is out of stock,
-            // it's better to have this check
-            return 0;
-        } else {
-            return $stockItem->getQty();
-        }
-    }
-
-    /**
      * Check if we support product page checkout for type of current product
      *
      * @return boolean

--- a/Test/Unit/Block/JsProductPageTest.php
+++ b/Test/Unit/Block/JsProductPageTest.php
@@ -172,42 +172,6 @@ class JsProductPageTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
-     * @dataProvider providerGetProductQty
-     */
-    public function getProductQty($getManageStock, $getIsInStock, $getQty, $expected_result)
-    {
-        $stockItem = $this->getMockForAbstractClass(
-            \Magento\CatalogInventory\Api\Data\StockItemInterface::class,
-            [],
-            '',
-            false,
-            true,
-            true,
-            ['getManageStock', 'getIsInStock', 'getQty']
-        );
-        $stockItem->method('getManageStock')->willReturn($getManageStock);
-        $stockItem->method('getIsInStock')->willReturn($getIsInStock);
-        $stockItem->method('getQty')->willReturn($getQty);
-
-        $this->product->method('getExtensionAttributes')->willReturnSelf();
-        $this->product->method('getStockItem')->willReturn($stockItem);
-
-        $result = $this->block->getProductQty();
-        $this->assertEquals($expected_result, $result);
-    }
-
-    public function providerGetProductQty()
-    {
-        return [
-            [false, true, 1, -1],
-            [true, false, 1, 0],
-            [true, true, 1, 1],
-            [true, true, 5, 5],
-        ];
-    }
-
-    /**
-     * @test
      * @dataProvider providerIsSupportableType
      */
     public function isSupportableType($typeId, $expected_result)

--- a/view/frontend/templates/button_product_page.phtml
+++ b/view/frontend/templates/button_product_page.phtml
@@ -35,7 +35,6 @@ if (!$block->isSupportableType()) return;
             'domReady!'
         ], function ($, authenticationPopup, customerData) {
             var customer = customerData.get('customer');
-            var max_qty = <?= $block->getProductQty(); ?>;
             var isGuestCheckoutAllowed = <?= $block->isGuestCheckoutAllowed(); ?>;
 
             var settings = window.boltConfig;
@@ -137,12 +136,6 @@ if (!$block->isSupportableType()) return;
                      * Magento customerData and authenticationPopup objects are
                      * used.
                      */
-
-                    //check if we have inventory on stock
-                    if ( max_qty >= 0 && getQty() > max_qty ) {
-                        window.alert("The requested qty is not available");
-                        return false;
-                    }
 
                     // check if login is required
                     if ( !customer().firstname && !isGuestCheckoutAllowed) {


### PR DESCRIPTION
Now we check if we have the necessary inventory on PPC frontend but it doesn't work correctly due to the caching issue.
As we discussed here https://docs.google.com/document/d/10cMe0LwsgrO0oWtM-bskIAg-1slZByJUtA3Wh8aoPXY/edit?usp=sharing the best solution is to do inventory checking on bolt server side.

Fixes: https://app.asana.com/0/0/1156147394609521/f

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
