### PR TITLE
Product page checkout: add support for foreign currencies

### DIFF
--- a/Block/JsProductPage.php
+++ b/Block/JsProductPage.php
@@ -107,4 +107,9 @@ class JsProductPage extends Js {
     {
         return (int)$this->configHelper->isGuestCheckoutAllowed();
     }
+
+    public function getStoreCurrencyCode()
+    {
+        return $this->_storeManager->getStore()->getCurrentCurrencyCode();
+    }
 }

--- a/Test/Unit/Block/JsProductPageTest.php
+++ b/Test/Unit/Block/JsProductPageTest.php
@@ -33,6 +33,8 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
  */
 class JsProductPageTest extends \PHPUnit\Framework\TestCase
 {
+    const CURRENCY_CODE = 'USD';
+
     /**
      * @var HelperConfig
      */
@@ -131,6 +133,12 @@ class JsProductPageTest extends \PHPUnit\Framework\TestCase
             ->getMock();
 
         $this->contextMock->method('getRequest')->willReturn($this->requestMock);
+
+        $store = $this->createMock(\Magento\Store\Model\Store::class);
+        $store->method('getCurrentCurrencyCode')->willReturn(self::CURRENCY_CODE);
+        $storeManager = $this->getMockForAbstractClass(\Magento\Store\Model\StoreManagerInterface::class);
+        $storeManager->method('getStore')->willReturn($store);
+        $this->contextMock->method('getStoreManager')->willReturn($storeManager);
 
         $this->product = $this->getMockBuilder(Product::class)
             ->disableOriginalConstructor()
@@ -246,5 +254,13 @@ class JsProductPageTest extends \PHPUnit\Framework\TestCase
             [true,1],
             [false,0],
         ];
+    }
+
+    /**
+     * @test
+     */
+    public function getStoreCurrencyCode() {
+        $result = $this->block->getStoreCurrencyCode();
+        $this->assertEquals(self::CURRENCY_CODE, $result);
     }
 }

--- a/view/frontend/templates/button_product_page.phtml
+++ b/view/frontend/templates/button_product_page.phtml
@@ -174,7 +174,7 @@ if (!$block->isSupportableType()) return;
 
             var setupProductPage = function () {
                 var cart = {
-                    currency: "USD",
+                    currency: "<?= $block->getStoreCurrencyCode(); ?>",
                     items: [{
                         reference: '<?= $block->getProduct()->getId(); ?>',
                         price: <?= (int) $block->getProduct()->getFinalPrice(); ?>,


### PR DESCRIPTION
We support the only case when a store has one currency everywhere.
In this case, it's enough to add correct currency to **configureProductCheckout** to show correct currency on bolt modal
When we handle **cart.create** we don't need to do something special

Fixes: https://app.asana.com/0/0/1155768935724793/f

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
