### PR TITLE
Product page checkout: Remove temporary fix around display_id

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -1032,10 +1032,7 @@ class Order extends AbstractHelper
     public function getExistingOrder($orderIncrementId)
     {
         /** @var OrderModel $order */
-        return $this->cartHelper->getOrderByIncrementId($orderIncrementId, true) ?:
-            // bypass missing increment id in PPC transaction data - temporary fix.
-            // TODO: remove
-            $this->getOrderByQuoteId($orderIncrementId);
+        return $this->cartHelper->getOrderByIncrementId($orderIncrementId, true);
     }
 
     /**

--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -333,13 +333,7 @@ class ShippingMethods implements ShippingMethodsInterface
         $startTime = $this->metricsClient->getCurrentTime();
         try {
             // get immutable quote id stored with transaction
-            if (!$cart['display_id']) {
-                // Due bolt server issue display_id isn't saved when order created via remote_order_create
-                // TODO: Remove this code when issue is fixed https://app.asana.com/0/951157735838091/1155187242723681/f
-                $quoteId = $cart['order_reference'];
-            } else {
-                list(, $quoteId) = explode(' / ', $cart['display_id']);
-            }
+            list(, $quoteId) = explode(' / ', $cart['display_id']);
 
             // Load quote from entity id
             $this->quote = $this->getQuoteById($quoteId);

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -1630,30 +1630,6 @@ class OrderTest extends TestCase
     /**
      * @test
      *
-     * @covers ::getExistingOrder
-     *
-     * @throws ReflectionException
-     */
-    public function getExistingOrder_byQuoteId()
-    {
-        $this->initCurrentMock(
-            [
-                'getOrderByQuoteId',
-            ]
-        );
-        $this->cartHelper->expects(self::once())->method('getOrderByIncrementId')->with(self::INCREMENT_ID, true)
-            ->willReturn(false);
-        $this->currentMock->expects(self::once())->method('getOrderByQuoteId')->with(self::INCREMENT_ID)
-            ->willReturn($this->orderMock);
-        static::assertSame(
-            $this->orderMock,
-            TestHelper::invokeMethod($this->currentMock, 'getExistingOrder', [self::INCREMENT_ID])
-        );
-    }
-
-    /**
-     * @test
-     *
      * @covers ::quoteAfterChange
      *
      * @throws ReflectionException

--- a/Test/Unit/Model/Api/ShippingMethodsTest.php
+++ b/Test/Unit/Model/Api/ShippingMethodsTest.php
@@ -433,7 +433,7 @@ class ShippingMethodsTest extends TestCase
             ],self::PARENT_QUOTE_ID],
             // product page checkout case
             [[
-                'display_id'      => null,
+                'display_id'      => self::DISPLAY_ID,
                 'order_reference' => self::IMMUTABLE_QUOTE_ID
             ],self::IMMUTABLE_QUOTE_ID]
         ];


### PR DESCRIPTION
We have a temporary code to handle the issue: bolt server doesn't save display_id when cart is created via cart.create https://app.asana.com/0/941920570700290/1155187242723681/f

Now the bug is fixed and we can remove temporary code 

Fixes: https://app.asana.com/0/0/1159061667010227/f

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Refactoring


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.

