### PR TITLE
keep and reuse cart promise, pass hints as externally resolved promise

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -218,6 +218,15 @@ ob_start();
     }());
     ////////////////////////////////////////////////////////////////////////
 
+    // barrier is externally-resolved promise
+    var boltBarrier = function() {
+        var resolveHolder;
+        var promise = new Promise(function(resolve){
+            resolveHolder = resolve;
+        });
+        return { promise, resolve: function(t){resolveHolder(t)}};
+    };
+
     ////////////////////////////////////////////////////
     // DI: Inserting required Magento objects
     // the code below is dependant on.
@@ -641,15 +650,6 @@ ob_start();
         /////////////////////////////////////////////////////
         var createRequest = false;
 
-        // barrier is externally-resolved promise
-        var barrier = function() {
-            var resolveHolder;
-            var promise = new Promise(function(resolve){
-                resolveHolder = resolve;
-            });
-            return { promise, resolve: function(t){resolveHolder(t)}};
-        }
-
         var createOrder = function () {
 
             // skip if there is already an ongoing request
@@ -704,7 +704,7 @@ ob_start();
             }
             params = params.join('&');
 
-            var hintBarrier = barrier();
+            var hintBarrier = boltBarrier();
 
             cart = new Promise(function (resolve, reject) {
 

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -449,7 +449,7 @@ ob_start();
         ////////////////////////////////////
         // BoltCheckout.configure parameters
         ////////////////////////////////////
-        var cart = {orderToken:''};
+        var cart = {};
 
         var hints = {prefill:{}};
 
@@ -640,6 +640,16 @@ ob_start();
         // Create Bolt order and configure BoltCheckout
         /////////////////////////////////////////////////////
         var createRequest = false;
+
+        // barrier is externally-resolved promise
+        var barrier = function() {
+            var resolveHolder;
+            var promise = new Promise(function(resolve){
+                resolveHolder = resolve;
+            });
+            return { promise, resolve: function(t){resolveHolder(t)}};
+        }
+
         var createOrder = function () {
 
             // skip if there is already an ongoing request
@@ -694,7 +704,9 @@ ob_start();
             }
             params = params.join('&');
 
-            var BC = BoltCheckout.configure(new Promise(function (resolve, reject) {
+            var hintBarrier = barrier();
+
+            cart = new Promise(function (resolve, reject) {
 
                 createRequest = true;
 
@@ -709,26 +721,25 @@ ob_start();
                         // Stop if Bolt checkout is restricted
                         if (boltRestricted) {
                             if (popUpOpen) reject(new Error(data.message));
+                            hintBarrier.resolve(hints);
                             return;
                         }
 
                         if (data.status !== 'success') {
                             reject(new Error(data.message || 'Network request failed'));
+                            hintBarrier.resolve(hints);
                             return;
                         }
 
-                        //////////////////////////
-                        // set cart and hints data
-                        //////////////////////////
-                        cart = data.cart;
-
-                        if (!cart) {
+                        if (!data.cart) {
                             reject(new Error('The cart info is missing.'));
+                            hintBarrier.resolve(hints);
                             return;
                         }
 
-                        // the cart is empty, exit gracefully without an error
-                        if (!cart.orderToken) {
+                        if (!data.cart.orderToken) {
+                            reject(new Error('The cart is empty.'));
+                            hintBarrier.resolve(hints);
                             return;
                         }
 
@@ -738,10 +749,8 @@ ob_start();
                         hints.prefill = prefill;
                         //////////////////////////
 
-                        // Ensure bolt checkout is configured with the hints updated from the response
-                        // TODO: Pass hints as a promise and load separately from cart
-                        BoltCheckout.configure(cart, hints, callbacks);
-                        resolve(cart);
+                        resolve(data.cart);
+                        hintBarrier.resolve(hints);
 
                         // open the checkout if auto-open flag is set
                         // one time only on page load
@@ -759,8 +768,9 @@ ob_start();
                     .always(function() {
                         createRequest = false;
                     })
+            });
 
-            }), hints, callbacks);
+            var BC = BoltCheckout.configure(cart, hintBarrier.promise, callbacks);
         };
         /////////////////////////////////////////////////////
 


### PR DESCRIPTION
# Description
Get a hold of cart promise reference and always pass it to BoltCheckout.configure.
Use barrier, an externally-resolved promise, to pass hints, updated with cart promise resolve,
to BoltCheckout.configure.

Fixes: (link Asana Task)

(Optional: Add a changelog by writing a comment after "#changelog" on the next line)

\#changelog

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Asana task link and provided a changelog message if applicable.
