### PR TITLE
remove hardcoded button CSS

### DIFF
--- a/view/frontend/templates/css/boltcss.phtml
+++ b/view/frontend/templates/css/boltcss.phtml
@@ -23,10 +23,6 @@
 if ($block->shouldDisableBoltCheckout()) return;
 ?>
 <style>
-    /* Fit checkout button in containter */
-    .bolt-checkout-button {
-        max-width: 100%;
-    }
     /**************************************************************
      * Standard checkout Bolt payment radio and button
      * Can be overridden from Global CSS
@@ -35,11 +31,6 @@ if ($block->shouldDisableBoltCheckout()) return;
         padding: 8px;
         border: 1px solid #cccccc;
         width:200px;
-    }
-    .bolt-checkout-button.disabled {
-        opacity: 0.5;
-        cursor: default;
-        pointer-events: none;
     }
     /***************************************************************/
     <?php echo $block->getGlobalCSS(); ?>


### PR DESCRIPTION
# Description
As discussed, hardcoded Bolt checkout and button related CSS should be removed from the plugin, "disabled" class included. 

Fixes: (link Asana Task)

(Optional: Add a changelog by writing a comment after "#changelog" on the next line)

\#changelog

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Asana task link and provided a changelog message if applicable.
