### PR TITLE
fix automatic modal popup after forced login

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -640,6 +640,7 @@ ob_start();
         // Create Bolt order and configure BoltCheckout
         /////////////////////////////////////////////////////
         var createRequest = false;
+        var allowAutoOpen = true;
         var createOrder = function () {
 
             // skip if there is already an ongoing request
@@ -745,9 +746,9 @@ ob_start();
 
                         // open the checkout if auto-open flag is set
                         // one time only on page load
-                        if (initiateCheckout) {
+                        if (initiateCheckout && allowAutoOpen) {
                             BC.open();
-                            initiateCheckout = false;
+                            allowAutoOpen = false;
                         }
 
                         // prefetch Shipping and Tax for multi-step checkout


### PR DESCRIPTION
# Description
If guest checkout is not allowed clicking the Bolt button forces customer to log in or create an account. After login the customer is redirected to the shopping cart page and the bolt checkout is opened automatically. The last part did not work after changing createOrder call logic a while ago.

Fixes: (link Asana Task)

(Optional: Add a changelog by writing a comment after "#changelog" on the next line)

\#changelog

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Asana task link and provided a changelog message if applicable.
