### PR TITLE
pre-auth create order display id fix

### DIFF
--- a/Model/Api/CreateOrder.php
+++ b/Model/Api/CreateOrder.php
@@ -203,9 +203,9 @@ class CreateOrder implements CreateOrderInterface
                 );
             }
 
-            $quoteId = $this->getQuoteIdFromPayloadOrder($order);
+            $immutableQuoteId = $this->getQuoteIdFromPayloadOrder($order);
             /** @var Quote $immutableQuote */
-            $immutableQuote = $this->loadQuoteData($quoteId);
+            $immutableQuote = $this->loadQuoteData($immutableQuoteId);
 
             $this->preProcessWebhook($immutableQuote->getStoreId());
             $immutableQuote->getStore()->setCurrentCurrencyCode($immutableQuote->getQuoteCurrencyCode());
@@ -226,7 +226,7 @@ class CreateOrder implements CreateOrderInterface
             $this->sendResponse(200, [
                 'status'    => 'success',
                 'message'   => 'Order create was successful',
-                'display_id' => $createdOrder->getIncrementId() . ' / ' . $quote->getId(),
+                'display_id' => $createdOrder->getIncrementId() . ' / ' . $immutableQuoteId,
                 'total'      => CurrencyUtils::toMinor($createdOrder->getGrandTotal(), $currency),
                 'order_received_url' => $this->getReceivedUrl($immutableQuote),
             ]);


### PR DESCRIPTION
# Description
Display id gets changed to hold parent instead of immutable quote id. This is a subtle bug present for quote a while, luckily with no noticeable impact so far, spotted when checking this https://github.com/BoltApp/bolt-magento2/pull/523 which it would impact.

Fixes: https://app.asana.com/0/941920570700290/1162023400086868/f

(Optional: Add a changelog by writing a comment after "#changelog" on the next line)

\#changelog

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
