### PR TITLE
Update the logic for module Mageplaza_GiftCard on the new version

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1684,7 +1684,7 @@ class Cart extends AbstractHelper
                 // Change giftcards balance as discount amount to giftcard balances to the discount amount
                 ///////////////////////////////////////////////////////////////////////////
                 if ($discount == Discount::MAGEPLAZA_GIFTCARD) {
-                    $giftCardCodes = $this->discountHelper->getMageplazaGiftCardCodesFromSession();
+                    $giftCardCodes = $this->discountHelper->getMageplazaGiftCardCodes($quote);
                     $amount = $this->discountHelper->getMageplazaGiftCardCodesCurrentValue($giftCardCodes);
                 }
 

--- a/Helper/Discount.php
+++ b/Helper/Discount.php
@@ -769,16 +769,23 @@ class Discount extends AbstractHelper
     }
 
     /**
-     * Get Mageplaza GiftCard Codes From the Session
+     * Get Mageplaza GiftCard Codes
      *
      * @param $quote
      * @return array
+     * @throws LocalizedException
      */
-    public function getMageplazaGiftCardCodesFromSession()
+    public function getMageplazaGiftCardCodes($quote)
     {
         $giftCardsData = $this->sessionHelper->getCheckoutSession()->getGiftCardsData();
+        $giftCardCodes = isset($giftCardsData[self::MAGEPLAZA_GIFTCARD_QUOTE_KEY]) ? array_keys($giftCardsData[self::MAGEPLAZA_GIFTCARD_QUOTE_KEY]) : [];
 
-        return isset($giftCardsData[self::MAGEPLAZA_GIFTCARD_QUOTE_KEY]) ? array_keys($giftCardsData[self::MAGEPLAZA_GIFTCARD_QUOTE_KEY]) : [];
+        $giftCardsQuote = $quote->getMpGiftCards();
+        if (!$giftCardCodes && $giftCardsQuote) {
+            $giftCardCodes = array_keys(json_decode($giftCardsQuote, true));
+        }
+
+        return $giftCardCodes;
     }
 
     /**

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -958,7 +958,7 @@ ORDER;
             ->method('getAmastyPayForEverything');
 
         $this->discountHelper->expects($this->never())
-            ->method('getMageplazaGiftCardCodesFromSession');
+            ->method('getMageplazaGiftCardCodes');
 
         $this->discountHelper->expects($this->never())
             ->method('getUnirgyGiftCertBalanceByCode');
@@ -1029,7 +1029,7 @@ ORDER;
             ->method('getAmastyPayForEverything');
 
         $this->discountHelper->expects($this->never())
-            ->method('getMageplazaGiftCardCodesFromSession');
+            ->method('getMageplazaGiftCardCodes');
 
         $this->discountHelper->expects($this->never())
             ->method('getUnirgyGiftCertBalanceByCode');
@@ -1109,7 +1109,7 @@ ORDER;
             ->method('getAmastyPayForEverything');
 
         $this->discountHelper->expects($this->never())
-            ->method('getMageplazaGiftCardCodesFromSession');
+            ->method('getMageplazaGiftCardCodes');
 
         $this->discountHelper->expects($this->never())
             ->method('getUnirgyGiftCertBalanceByCode');
@@ -1192,7 +1192,7 @@ ORDER;
             ->method('getAmastyPayForEverything');
 
         $this->discountHelper->expects($this->never())
-            ->method('getMageplazaGiftCardCodesFromSession');
+            ->method('getMageplazaGiftCardCodes');
 
         $this->discountHelper->expects($this->never())
             ->method('getUnirgyGiftCertBalanceByCode');
@@ -1274,7 +1274,7 @@ ORDER;
             ->method('getAmastyPayForEverything');
 
         $this->discountHelper->expects($this->never())
-            ->method('getMageplazaGiftCardCodesFromSession');
+            ->method('getMageplazaGiftCardCodes');
 
         $this->discountHelper->expects($this->never())
             ->method('getUnirgyGiftCertBalanceByCode');
@@ -1351,7 +1351,7 @@ ORDER;
             ->method('getAmastyPayForEverything');
 
         $this->discountHelper->expects($this->never())
-            ->method('getMageplazaGiftCardCodesFromSession');
+            ->method('getMageplazaGiftCardCodes');
 
         $this->discountHelper->expects($this->never())
             ->method('getUnirgyGiftCertBalanceByCode');
@@ -1435,7 +1435,7 @@ ORDER;
             ->method('getAmastyPayForEverything');
 
         $this->discountHelper->expects($this->never())
-            ->method('getMageplazaGiftCardCodesFromSession');
+            ->method('getMageplazaGiftCardCodes');
 
         $this->discountHelper->expects($this->never())
             ->method('getUnirgyGiftCertBalanceByCode');
@@ -1520,7 +1520,7 @@ ORDER;
             ->method('getAheadworksStoreCredit');
 
         $this->discountHelper->expects($this->never())
-            ->method('getMageplazaGiftCardCodesFromSession');
+            ->method('getMageplazaGiftCardCodes');
 
         $this->discountHelper->expects($this->never())
             ->method('getUnirgyGiftCertBalanceByCode');
@@ -1622,7 +1622,7 @@ ORDER;
         $mageplazaGiftCode = "12345";
 
         $this->discountHelper->expects($this->once())
-            ->method('getMageplazaGiftCardCodesFromSession')
+            ->method('getMageplazaGiftCardCodes')
             ->willReturn($mageplazaGiftCode);
 
         $this->discountHelper->expects($this->once())

--- a/Test/Unit/Helper/DiscountTest.php
+++ b/Test/Unit/Helper/DiscountTest.php
@@ -1,0 +1,278 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Test\Unit\Helper;
+
+use Bolt\Boltpay\Helper\Bugsnag;
+use Bolt\Boltpay\Helper\Session;
+use \PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Helper\Discount;
+use Magento\Framework\App\Helper\Context;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Model\Quote;
+use Bolt\Boltpay\Model\ThirdPartyModuleFactory;
+use Bolt\Boltpay\Helper\Config as ConfigHelper;
+use \Magento\Framework\App\State as AppState;
+use Bolt\Boltpay\Helper\Log as LogHelper;
+
+/**
+ * Class DiscountTest
+ *
+ * @package Bolt\Boltpay\Test\Unit\Helper
+ */
+class DiscountTest extends TestCase
+{
+
+    /**
+     * @var Quote
+     */
+    private $quote;
+
+    /**
+     * @var Context
+     */
+    private $context;
+
+    /**
+     * @var ResourceConnection
+     */
+    private $resource;
+
+    /**
+     * @var ThirdPartyModuleFactory
+     */
+    private $amastyAccountFactory;
+
+    /**
+     * @var ThirdPartyModuleFactory
+     */
+    private $amastyGiftCardManagement;
+
+    /**
+     * @var ThirdPartyModuleFactory
+     */
+    private $amastyQuoteFactory;
+
+    /**
+     * @var ThirdPartyModuleFactory
+     */
+    private $amastyQuoteResource;
+
+    /**
+     * @var ThirdPartyModuleFactory]
+     */
+    private $amastyQuoteRepository;
+
+    /**
+     * @var ThirdPartyModuleFactory
+     */
+    private $amastyAccountCollection;
+
+    /**
+     * @var ThirdPartyModuleFactory
+     */
+    private $unirgyCertRepository;
+
+    /**
+     * @var ThirdPartyModuleFactory
+     */
+    private $mirasvitStoreCreditHelper;
+
+    /**
+     * @var ThirdPartyModuleFactory
+     */
+    private $mirasvitStoreCreditCalculationHelper;
+
+    /**
+     * @var ThirdPartyModuleFactory
+     */
+    private $mirasvitStoreCreditCalculationConfig;
+
+    /**
+     * @var ThirdPartyModuleFactory
+     */
+    private $mirasvitStoreCreditConfig;
+
+    /**
+     * @var ThirdPartyModuleFactory
+     */
+    private $mirasvitRewardsPurchaseHelper;
+
+    /**
+     * @var ThirdPartyModuleFactory
+     */
+    private $mageplazaGiftCardCollection;
+
+    /**
+     * @var ThirdPartyModuleFactory
+     */
+    private $mageplazaGiftCardFactory;
+
+    /**
+     * @var ThirdPartyModuleFactory
+     */
+    private $amastyRewardsResourceQuote;
+
+    /**
+     * @var ThirdPartyModuleFactory
+     */
+    private $amastyRewardsQuote;
+
+    /**
+     * @var ThirdPartyModuleFactory
+     */
+    private $aheadworksCustomerStoreCreditManagement;
+
+    /**
+     * @var ThirdPartyModuleFactory
+     */
+    private $bssStoreCreditHelper;
+
+    /**
+     * @var ThirdPartyModuleFactory
+     */
+    private $bssStoreCreditCollection;
+
+    /**
+     * @var CartRepositoryInterface
+     */
+    private $quoteRepository;
+
+    /**
+     * @var ConfigHelper
+     */
+    private $configHelper;
+
+    /**
+     * @var Bugsnag
+     */
+    private $bugsnag;
+
+    /**
+     * @var AppState
+     */
+    private $appState;
+
+    /**
+     * @var Session
+     */
+    private $sessionHelper;
+
+    /**
+     * @var LogHelper
+     */
+    private $logHelper;
+
+    /**
+     * @inheritdoc
+     */
+    public function setUp()
+    {
+        $this->context = $this->createMock(Context::class);
+        $this->resource = $this->createMock(ResourceConnection::class);
+        $this->amastyAccountFactory = $this->createMock(ThirdPartyModuleFactory::class);
+        $this->amastyGiftCardManagement = $this->createMock(ThirdPartyModuleFactory::class);
+        $this->amastyQuoteFactory = $this->createMock(ThirdPartyModuleFactory::class);
+        $this->amastyQuoteResource = $this->createMock(ThirdPartyModuleFactory::class);
+        $this->amastyQuoteRepository = $this->createMock(ThirdPartyModuleFactory::class);
+        $this->amastyAccountCollection = $this->createMock(ThirdPartyModuleFactory::class);
+        $this->unirgyCertRepository = $this->createMock(ThirdPartyModuleFactory::class);
+        $this->mirasvitStoreCreditHelper = $this->createMock(ThirdPartyModuleFactory::class);
+        $this->mirasvitStoreCreditCalculationHelper = $this->createMock(ThirdPartyModuleFactory::class);
+        $this->mirasvitStoreCreditCalculationConfig = $this->createMock(ThirdPartyModuleFactory::class);
+        $this->mirasvitStoreCreditConfig = $this->createMock(ThirdPartyModuleFactory::class);
+        $this->mirasvitRewardsPurchaseHelper = $this->createMock(ThirdPartyModuleFactory::class);
+        $this->mageplazaGiftCardCollection = $this->createMock(ThirdPartyModuleFactory::class);
+        $this->mageplazaGiftCardFactory = $this->createMock(ThirdPartyModuleFactory::class);
+        $this->amastyRewardsResourceQuote = $this->createMock(ThirdPartyModuleFactory::class);
+        $this->amastyRewardsQuote = $this->createMock(ThirdPartyModuleFactory::class);
+        $this->aheadworksCustomerStoreCreditManagement = $this->createMock(ThirdPartyModuleFactory::class);
+        $this->bssStoreCreditHelper = $this->createMock(ThirdPartyModuleFactory::class);
+        $this->bssStoreCreditCollection = $this->createMock(ThirdPartyModuleFactory::class);
+        $this->quoteRepository = $this->createMock(CartRepositoryInterface::class);
+        $this->configHelper = $this->createMock(ConfigHelper::class);
+        $this->bugsnag = $this->createMock(Bugsnag::class);
+        $this->appState = $this->createMock(AppState::class);
+        $this->sessionHelper = $this->getMockBuilder(Session::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getCheckoutSession', 'getGiftCardsData'])
+            ->getMock();
+        $this->logHelper = $this->createMock(LogHelper::class);
+        $this->quote = $this->createPartialMock(Quote::class, ['getMpGiftCards']);
+    }
+
+    /**
+     * @test
+     * @param $data
+     * @dataProvider providerGetMageplazaGiftCardCodes
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function getMageplazaGiftCardCodes($data)
+    {
+        $currentMock = new Discount(
+            $this->context,
+            $this->resource,
+            $this->amastyAccountFactory,
+            $this->amastyGiftCardManagement,
+            $this->amastyQuoteFactory,
+            $this->amastyQuoteResource,
+            $this->amastyQuoteRepository,
+            $this->amastyAccountCollection,
+            $this->unirgyCertRepository,
+            $this->mirasvitStoreCreditHelper,
+            $this->mirasvitStoreCreditCalculationHelper,
+            $this->mirasvitStoreCreditCalculationConfig,
+            $this->mirasvitStoreCreditConfig,
+            $this->mirasvitRewardsPurchaseHelper,
+            $this->mageplazaGiftCardCollection,
+            $this->mageplazaGiftCardFactory,
+            $this->amastyRewardsResourceQuote,
+            $this->amastyRewardsQuote,
+            $this->aheadworksCustomerStoreCreditManagement,
+            $this->bssStoreCreditHelper,
+            $this->bssStoreCreditCollection,
+            $this->quoteRepository,
+            $this->configHelper,
+            $this->bugsnag,
+            $this->appState,
+            $this->sessionHelper,
+            $this->logHelper
+        );
+        $this->sessionHelper->expects(self::once())->method('getCheckoutSession')->willReturnSelf();
+        $this->sessionHelper->expects(self::once())->method('getGiftCardsData')->willReturn($data['gift_cards_data_session']);
+        $this->quote->method('getMpGiftCards')->willReturn($data['mp_gift_card_quote']);
+        $result = $currentMock->getMageplazaGiftCardCodes($this->quote);
+        $this->assertEquals(['gift_card'], $result);
+    }
+
+    public function providerGetMageplazaGiftCardCodes()
+    {
+        return [
+            ['data' => [
+                'gift_cards_data_session' => ['mp_gift_cards' => ['gift_card' => 1000]],
+                'mp_gift_card_quote' => null
+            ]
+            ],
+            ['data' => [
+                'gift_cards_data_session' => [],
+                'mp_gift_card_quote' => '{"gift_card":100}',
+            ]
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
# Description
In the new version of the Mageplaza_GiftCard module, the gift card amount isn’t applied to Bolt properly as they don’t use the session to get the gift codes, instead, they use the quote to get the gift codes.
This PR adds the ability to apply both the old logic to use the session and the new logic to use the quote to get the gift codes. 

Fixes: https://app.asana.com/0/564264490825835/1162214533019681

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
