### PR TITLE
Remove redundant resetOrderState from ReceivedUrlTrait, call it from hook only

### DIFF
--- a/Controller/ReceivedUrlTrait.php
+++ b/Controller/ReceivedUrlTrait.php
@@ -92,7 +92,6 @@ trait ReceivedUrlTrait
                             $this->orderHelper->formatReferenceUrl($this->getReferenceFromPayload($payloadArray))
                         )
                     );
-                    $this->orderHelper->resetOrderState($order);
                 } else {
                     $this->bugsnag->notifyError(
                         "Pre-Auth redirect wrong order state",


### PR DESCRIPTION
# Description
Always call it from the hook allows us to inject additional processing here, one time only on the first status change. Required for https://github.com/BoltApp/bolt-magento2/pull/511

Fixes: https://app.asana.com/0/941920570700290/1162195122723305/f

(Optional: Add a changelog by writing a comment after "#changelog" on the next line)

\#changelog

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
