### PR TITLE
Bolt button missing in minicart fix

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -889,6 +889,13 @@ ob_start();
                         if (!position) {
                             $(element).hide();
                         }
+                        // if the replacement takes place after BoltCheckout.configure call
+                        // call it again to set up the button. Skip if BoltCheckout is not available,
+                        // ie. connect.js not loaded / executed yet,
+                        // the button will be processed after connect.js loads.
+                        if (window.BoltCheckout) {
+                            BoltCheckout.configure(cart, hints, callbacks);
+                        }
                     });
                     /////////////////////////////////////////////////////
                 }(selector);


### PR DESCRIPTION
# Description
If Bolt button (re)placement takes place after connect.js loads and  BoltCheckout.configure is called the button is not processed, ie visible on the page.

Solution: Additional / conditional call to BoltCheckout.configure after the button is injected.

Note: not sure if this is caused by recent plugin changes or some core / checkout related work. Anyway, this fixes it.

Fixes: https://app.asana.com/0/941920570700290/1162195122723316/f

(Optional: Add a changelog by writing a comment after "#changelog" on the next line)

\#changelog

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
