### PR TITLE
Missing Bolt error message popup fix

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -273,7 +273,7 @@ ob_start();
 
         var showBoltErrorMessage = function(messsage, order_reference) {
             var boltModal = $('#bolt-modal'),
-                errorMsg = messsage || window.boltConfig.defaultErrorMessage + " Order reference: " + order_reference;
+                errorMsg = messsage || window.boltConfig.default_error_message + " Order reference: " + order_reference;
 
             boltModal.find('.bolt-modal-content').html(errorMsg);
             boltModal.modal("openModal");
@@ -562,19 +562,23 @@ ob_start();
                 var onSuccess = function(data){
                     if (data.status !== 'success') {
                         if (data.message) {
-                            showBoltErrorMessage('', data.reference);
-                            // pretend order creation was success...
-                            // we need to call this; otherwise bolt modal show infinte spinner.
-                            callback();
+                            showError();
                         }
                         return;
                     }
                     processSuccess(data);
                 };
+                var showError = function() {
+                    showBoltErrorMessage('', transaction.reference);
+                    // pretend order creation was success...
+                    // we need to call this; otherwise bolt modal show infinte spinner.
+                    callback();
+                };
                 // ajax call to the update order transaction data endpoint.
                 // passes the bolt transaction reference
                 save_request = $.post(settings.save_order_url, parameters)
-                                .done(onSuccess);
+                                .done(onSuccess)
+                                .fail(showError);
             },
 
             check: function () {


### PR DESCRIPTION
# Description
Legacy (post auth) flow: the pop up message is missing on failed save order call, checkout popup remains open indefinitely.

Fixes: https://app.asana.com/0/941920570700290/1162195122723324/f

(Optional: Add a changelog by writing a comment after "#changelog" on the next line)

\#changelog

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
