### PR TITLE
postpone panding_payment to pending order status transition to webhook

### DIFF
--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -941,7 +941,6 @@ class OrderTest extends TestCase
         $this->currentMock->expects(self::once())->method('getExistingOrder')
             ->with(self::INCREMENT_ID)->willReturn($this->orderMock);
         $this->orderMock->expects(self::once())->method('getId')->willReturn(self::ORDER_ID);
-        $this->orderMock->expects(self::once())->method('getState')->willReturn(Order::STATE_PENDING_PAYMENT);
         $this->discountHelper->expects(self::once())->method('deleteRedundantAmastyGiftCards')->with($this->quoteMock);
         $this->discountHelper->expects(self::once())->method('deleteRedundantAmastyRewardPoints')->with(
             $this->quoteMock
@@ -1024,7 +1023,6 @@ class OrderTest extends TestCase
             ->with($immutablequoteMock, $transaction, self::BOLT_TRACE_ID)->willReturn($this->orderMock);
 
         $this->orderMock->expects(self::never())->method('getId')->willReturn(self::ORDER_ID);
-        $this->orderMock->expects(self::atLeastOnce())->method('getState')->willReturn(Order::STATE_PENDING_PAYMENT);
         $this->orderMock->expects(self::atLeastOnce())->method('getGrandTotal')->willReturn(1);
         $this->currentMock->expects(self::once())->method('updateOrderPayment')
             ->with($this->orderMock, $transaction, null, $type = 'pending')->willReturn($this->orderMock);


### PR DESCRIPTION
# Description
ERP systems can pull orders too early, when we set order state to new (status pending). If done in success redirect call, we don't have transaction info yet and can not save some required data, eg. cc type and last4.

Fixes: https://app.asana.com/0/941920570700290/1162518950067661/f

(Optional: Add a changelog by writing a comment after "#changelog" on the next line)

\#changelog

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
