### PR TITLE
save cc type and last4 info to order payment

### DIFF
--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -941,7 +941,6 @@ class OrderTest extends TestCase
         $this->currentMock->expects(self::once())->method('getExistingOrder')
             ->with(self::INCREMENT_ID)->willReturn($this->orderMock);
         $this->orderMock->expects(self::once())->method('getId')->willReturn(self::ORDER_ID);
-        $this->orderMock->expects(self::once())->method('getState')->willReturn(Order::STATE_PENDING_PAYMENT);
         $this->discountHelper->expects(self::once())->method('deleteRedundantAmastyGiftCards')->with($this->quoteMock);
         $this->discountHelper->expects(self::once())->method('deleteRedundantAmastyRewardPoints')->with(
             $this->quoteMock
@@ -1024,7 +1023,6 @@ class OrderTest extends TestCase
             ->with($immutablequoteMock, $transaction, self::BOLT_TRACE_ID)->willReturn($this->orderMock);
 
         $this->orderMock->expects(self::never())->method('getId')->willReturn(self::ORDER_ID);
-        $this->orderMock->expects(self::atLeastOnce())->method('getState')->willReturn(Order::STATE_PENDING_PAYMENT);
         $this->orderMock->expects(self::atLeastOnce())->method('getGrandTotal')->willReturn(1);
         $this->currentMock->expects(self::once())->method('updateOrderPayment')
             ->with($this->orderMock, $transaction, null, $type = 'pending')->willReturn($this->orderMock);

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -1677,8 +1677,6 @@ class OrderTest extends TestCase
      * @dataProvider trueAndFalseDataProvider
      *
      * @covers ::prepareQuote
-     * @covers ::setQuotePaymentInfoData
-     * @covers ::getQuotePaymentInfoInstance
      * @covers ::addCustomerDetails
      * @covers ::setPaymentMethod
      *
@@ -1693,7 +1691,6 @@ class OrderTest extends TestCase
     {
         $this->initCurrentMock(
             [
-                'setQuotePaymentInfoData',
                 'addCustomerDetails',
                 'quoteAfterChange',
                 'setShippingAddress',
@@ -1754,23 +1751,11 @@ class OrderTest extends TestCase
         $parentQuote->expects(self::once())->method('setPaymentMethod')->with(Payment::METHOD_CODE);
 
         $quotePayment = $this->createMock(Quote\Payment::class);
-        $methodInstance = $this->createMock(Payment::class);
-        $infoInstance = $this->createPartialMock(
-            Info::class,
-            ['setData', 'save']
-        );
-
-        $methodInstance->expects(self::atLeastOnce())->method('getInfoInstance')->willReturn($infoInstance);
-        $quotePayment->expects(self::atLeastOnce())->method('getMethodInstance')->willReturn($methodInstance);
 
         $parentQuote->expects(self::atLeastOnce())->method('getPayment')->willReturn($quotePayment);
 
         $quotePayment->expects(self::once())->method('importData')->with(['method' => Payment::METHOD_CODE])
             ->willReturnSelf();
-
-        $infoInstance->expects(self::exactly(2))->method('setData')
-            ->withConsecutive(['cc_last_4', 1111], ['cc_type', 'visa'])->willReturnSelf();
-        $infoInstance->expects(self::exactly(2))->method('save');
 
         $quotePayment->expects(self::once())->method('save');
 


### PR DESCRIPTION
# Description
Credit card type and last4 digits info is missing in pre-auth. It is attempted to be saved to quote before the quote to order submission. ERP pulls the order without that info. It is expected to be there be some merchants. 

Fixes: https://app.asana.com/0/941920570700290/1162518950067666/f

(Optional: Add a changelog by writing a comment after "#changelog" on the next line)

\#changelog

# Type of change

- [x] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
