### PR TITLE
reactivate session quote on order deletion upon failed payment hook

### DIFF
--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -345,7 +345,8 @@ class OrderTest extends TestCase
                 'setTaxAmount',
                 'setBaseGrandTotal',
                 'setGrandTotal',
-                'getOrderCurrency'
+                'getOrderCurrency',
+                'getQuoteId'
             ]
         );
         $this->orderConfigMock = $this->createPartialMock(
@@ -1602,7 +1603,12 @@ class OrderTest extends TestCase
             ->willReturn($this->orderMock);
         $state = Order::STATE_PENDING_PAYMENT;
         $this->orderMock->expects(static::once())->method('getState')->willReturn($state);
+        $this->orderMock->expects(static::once())->method('getQuoteId')->willReturn(self::QUOTE_ID);
         $this->currentMock->expects(static::once())->method('deleteOrder')->with($this->orderMock);
+        $this->cartHelper->expects(static::once())->method('getQuoteById')->with(self::QUOTE_ID)
+            ->willReturn($this->quoteMock);
+        $this->quoteMock->expects(static::once())->method('setIsActive')->with(true)->willReturnSelf();
+        $this->cartHelper->expects(static::once())->method('quoteResourceSave')->with($this->quoteMock);
         $this->currentMock->deleteOrderByIncrementId(self::DISPLAY_ID);
     }
 


### PR DESCRIPTION
# Description
 After you observe decline error message you could reload cart page and you'll see that cart is empty!

Fixes: https://app.asana.com/0/941920570700290/1158209273889109/f

(Optional: Add a changelog by writing a comment after "#changelog" on the next line)

\#changelog

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
