### PR TITLE
save transaction reference to order history

### DIFF
--- a/Controller/ReceivedUrlTrait.php
+++ b/Controller/ReceivedUrlTrait.php
@@ -91,7 +91,7 @@ trait ReceivedUrlTrait
                             'Bolt transaction: %1',
                             $this->orderHelper->formatReferenceUrl($this->getReferenceFromPayload($payloadArray))
                         )
-                    );
+                    )->save();
                 } else {
                     $this->bugsnag->notifyError(
                         "Pre-Auth redirect wrong order state",

--- a/Test/Unit/Controller/Order/ReceivedUrlTest.php
+++ b/Test/Unit/Controller/Order/ReceivedUrlTest.php
@@ -107,7 +107,11 @@ class ReceivedUrlTest extends TestCase
             ->willReturn(Order::STATE_PENDING_PAYMENT); //this is specifically for happy path
         $order->expects($this->once())
             ->method('addStatusHistoryComment')
-            ->with('Bolt transaction: ' . self::FORMATTED_REFERENCE_URL);
+            ->with('Bolt transaction: ' . self::FORMATTED_REFERENCE_URL)
+            ->willReturnSelf();
+        $order->expects($this->once())
+            ->method('save')
+            ->willReturnSelf();
         $order->expects($this->once())
             ->method('getStoreId')
             ->willReturn(self::STORE_ID);


### PR DESCRIPTION
# Description
We do addStatusHistoryComment to the order in Controller\ReceivedUrlTrait::execute but do not actually save the order.

This is useful to have on the order info page in case the hooks fail. It is shown as a direct link to transaction in merchant dashboard.

Fixes: https://app.asana.com/0/941920570700290/1162870276879154/f

(Optional: Add a changelog by writing a comment after "#changelog" on the next line)

\#changelog

# Type of change

- [x] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
