### PR TITLE
wait for form validation module initialization

### DIFF
--- a/view/frontend/templates/button_product_page.phtml
+++ b/view/frontend/templates/button_product_page.phtml
@@ -154,12 +154,16 @@ if (!$block->isSupportableType()) return;
                         return false;
                     }
 
-                    var validator = $( '#product_addtocart_form' ).validate();
-                    if ( !validator.checkForm() ) {
-                        validator.showErrors();
+                    // wait for validation module init
+                    try {
+                        $('#product_addtocart_form').validation('isValid');
+                    } catch (e) {
                         return false;
                     }
-                    validator.showErrors();
+                    // validate form and show error messages
+                    if ( ! $('#product_addtocart_form').validate().form()) {
+                        return false;
+                    }
 
                     return true;
                 },
@@ -203,7 +207,10 @@ if (!$block->isSupportableType()) return;
                         options: JSON.stringify(options)
                     }]
                 };
-                BoltCheckout.configureProductCheckout(cart, hints, callbacks);
+                // if connect.js is not loaded postpone until it is
+                whenDefined(window, 'BoltCheckout', function(){
+                    BoltCheckout.configureProductCheckout(cart, hints, callbacks);
+                });
             };
 
             var hints;
@@ -221,7 +228,10 @@ if (!$block->isSupportableType()) return;
                 });
 
             // early button display, not active untill hints are received
-            BoltCheckout.configureProductCheckout({},{}, callbacks);
+            // do not run if connect.js is not loaded yet
+            if (window.BoltCheckout) {
+                BoltCheckout.configureProductCheckout({},{}, callbacks);
+            }
 
             <?php if ($block->isConfigurable()): ?>
             $(document).on( 'updatePrice', function (event, data) {


### PR DESCRIPTION
# Description
Buy Now - Modal not opening if button clicked too early.
The required Magento module, mage/validation/validation hasn't been loaded on the time of the button click. Happens mainly on a first page load, before it's cached.

Fixes: https://app.asana.com/0/941920570700290/1162870276879145/f

(Optional: Add a changelog by writing a comment after "#changelog" on the next line)

\#changelog

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
