### PR TITLE
Use parent quote id as a fallback to get the existing order

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -740,7 +740,7 @@ class Order extends AbstractHelper
         ///////////////////////////////////////////////////////////////
 
         // check if the order exists
-        $order = $this->getExistingOrder($incrementId);
+        $order = $this->getExistingOrder($incrementId, $parentQuoteId);
 
         // if not create the order
         if (!$order || !$order->getId()) {
@@ -1133,12 +1133,19 @@ class Order extends AbstractHelper
 
     /**
      * @param $orderIncrementId
-     * @return OrderModel|false
+     * @param null $parentQuoteId
+     * @return false|OrderInterface|OrderModel
      */
-    public function getExistingOrder($orderIncrementId)
+    public function getExistingOrder($orderIncrementId, $parentQuoteId = null)
     {
         /** @var OrderModel $order */
-        return $this->cartHelper->getOrderByIncrementId($orderIncrementId, true);
+        $order = $this->cartHelper->getOrderByIncrementId($orderIncrementId, true);
+
+        if ($parentQuoteId && (!$order || !$order->getId())) {
+            $order = $this->getOrderByQuoteId($parentQuoteId);
+        }
+
+        return $order;
     }
 
     /**

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -1820,6 +1820,26 @@ class OrderTest extends TestCase
         );
     }
 
+    /**
+     * @test
+     *
+     * @covers ::getExistingOrder
+     *
+     * @throws ReflectionException
+     */
+    public function getExistingOrder_byParenQuoteId() {
+        $this->initCurrentMock(['getOrderByQuoteId']);
+        $this->cartHelper->expects(self::once())->method('getOrderByIncrementId')->with(self::INCREMENT_ID, true)
+            ->willReturn(null);
+        $this->currentMock->expects(self::once())->method('getOrderByQuoteId')->with(self::QUOTE_ID)
+            ->willReturn($this->orderMock);
+
+        static::assertSame(
+            $this->orderMock,
+            TestHelper::invokeMethod($this->currentMock, 'getExistingOrder', [self::INCREMENT_ID, self::QUOTE_ID])
+        );
+
+    }
 
     private function quoteAfterChange_baseAssertions()
     {


### PR DESCRIPTION
# Description
This PR resolves the following case by using the parent quote id to get the existing order:

1. The customer clicks the Pay button in the Bolt modal
2. The create_order hook is sent to Magento and receives a time out error
3. There is a third party that updates the Magento increment id for the created order
4. Because of #2, there isn’t any successful response sent back to Bolt, so the Bolt increment id isn’t updated on Bolt
5. The pending hook is sent to Magento, it isn’t able to get the existing order by the Bolt increment id, so it tries to create the order and then it throws an exception
=> The expected behavior for #5 is that the pending hook is able to get the existing order to authorize and update the order.

Fixes: https://app.asana.com/0/564264490825835/1163120708856513


# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
