### PR TITLE
Add catch for failed transaction status from Bolt

### DIFF
--- a/Model/Api/OrderManagement.php
+++ b/Model/Api/OrderManagement.php
@@ -217,7 +217,7 @@ class OrderManagement implements OrderManagementInterface
                 __('Missing required parameters.')
             );
         }
-        if ($type === 'failed_payment') {
+        if ($type === 'failed_payment' || $type === 'failed') {
             $this->orderHelper->deleteOrderByIncrementId($display_id);
 
             $this->response->setHttpResponseCode(200);


### PR DESCRIPTION
# Description
Adds `failed` to the `failed_payment` check, not allowing the Order Helper to error if it encountered the `failed` transaction status from Bolt.

Fixes: https://app.asana.com/0/941920570700290/1158440956322913/f

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
