### PR TITLE
Create Magento offline credit memos for refund webhooks

### DIFF
--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -166,4 +166,8 @@ class Decider extends AbstractHelper {
     public function isLogMissingQuoteFailedHooksEnabled() {
         return $this->isSwitchEnabled(Definitions::M2_LOG_MISSING_QUOTE_FAILED_HOOKS);
     }
+
+    public function isCreatingCreditMemoFromWebHookEnabled(){
+        return $this->isSwitchEnabled(Definitions::M2_CREATING_CREDITMEMO_FROM_WEB_HOOK_ENABLED);
+    }
 }

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -50,6 +50,12 @@ class Definitions {
      */
     const M2_LOG_MISSING_QUOTE_FAILED_HOOKS = "M2_LOG_MISSING_QUOTE_FAILED_HOOKS";
 
+    /**
+     * Enable creating credit memo for webhook
+     *
+     */
+    const M2_CREATING_CREDITMEMO_FROM_WEB_HOOK_ENABLED = "M2_CREATING_CREDITMEMO_FROM_WEB_HOOK_ENABLED";
+
     const DEFAULT_SWITCH_VALUES = array(
         self::M2_SAMPLE_SWITCH_NAME =>  array(
           self::NAME_KEY            => self::M2_SAMPLE_SWITCH_NAME,
@@ -68,6 +74,12 @@ class Definitions {
             self::VAL_KEY             => true,
             self::DEFAULT_VAL_KEY     => false,
             self::ROLLOUT_KEY         => 100
+        ),
+        self::M2_CREATING_CREDITMEMO_FROM_WEB_HOOK_ENABLED =>  array(
+            self::NAME_KEY            => self::M2_CREATING_CREDITMEMO_FROM_WEB_HOOK_ENABLED,
+            self::VAL_KEY             => true,
+            self::DEFAULT_VAL_KEY     => false,
+            self::ROLLOUT_KEY         => 0
         )
     );
 }

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -54,6 +54,8 @@ use Bolt\Boltpay\Helper\Session as SessionHelper;
 use Magento\Sales\Api\Data\OrderPaymentInterface;
 use Bolt\Boltpay\Helper\Discount as DiscountHelper;
 use \Magento\Framework\Stdlib\DateTime\DateTime;
+use Magento\Sales\Model\Order\CreditmemoFactory;
+use Magento\Sales\Api\CreditmemoManagementInterface;
 use Bolt\Boltpay\Model\ResourceModel\WebhookLog\CollectionFactory as WebhookLogCollectionFactory;
 use Bolt\Boltpay\Model\WebhookLogFactory;
 use Bolt\Boltpay\Helper\FeatureSwitch\Decider;
@@ -216,7 +218,14 @@ class Order extends AbstractHelper
      */
     protected $customerCreditCardCollectionFactory;
 
+    /** @var CreditmemoFactory */
+    protected $creditmemoFactory;
+
+    /** @var CreditmemoManagementInterface  */
+    protected $creditmemoManagement;
+
     /**
+     * Order constructor.
      * @param Context $context
      * @param ApiHelper $apiHelper
      * @param Config $configHelper
@@ -225,21 +234,26 @@ class Order extends AbstractHelper
      * @param OrderSender $emailSender
      * @param InvoiceService $invoiceService
      * @param InvoiceSender $invoiceSender
-     * @param TransactionBuilder          $transactionBuilder
-     * @param TimezoneInterface           $timezone
-     * @param DataObjectFactory           $dataObjectFactory
-     * @param LogHelper                   $logHelper
-     * @param Bugsnag                     $bugsnag
-     * @param CartHelper                  $cartHelper
-     * @param ResourceConnection          $resourceConnection
-     * @param SessionHelper               $sessionHelper
-     * @param DiscountHelper              $discountHelper
-     * @param DateTime                    $date
+     * @param SearchCriteriaBuilder $searchCriteriaBuilder
+     * @param OrderRepository $orderRepository
+     * @param TransactionBuilder $transactionBuilder
+     * @param TimezoneInterface $timezone
+     * @param DataObjectFactory $dataObjectFactory
+     * @param Log $logHelper
+     * @param Bugsnag $bugsnag
+     * @param Cart $cartHelper
+     * @param ResourceConnection $resourceConnection
+     * @param Session $sessionHelper
+     * @param Discount $discountHelper
+     * @param DateTime $date
      * @param WebhookLogCollectionFactory $webhookLogCollectionFactory
-     * @param WebhookLogFactory           $webhookLogFactory
-     * @param Decider                     $featureSwitches
-     *
-     * @codeCoverageIgnore
+     * @param WebhookLogFactory $webhookLogFactory
+     * @param Decider $featureSwitches
+     * @param CheckboxesHandler $checkboxesHandler
+     * @param CustomerCreditCardFactory $customerCreditCardFactory
+     * @param CustomerCreditCardCollectionFactory $customerCreditCardCollectionFactory
+     * @param CreditmemoFactory $creditmemoFactory
+     * @param CreditmemoManagementInterface $creditmemoManagement
      */
     public function __construct(
         Context $context,
@@ -267,7 +281,9 @@ class Order extends AbstractHelper
         Decider $featureSwitches,
         CheckboxesHandler $checkboxesHandler,
         CustomerCreditCardFactory $customerCreditCardFactory,
-        CustomerCreditCardCollectionFactory $customerCreditCardCollectionFactory
+        CustomerCreditCardCollectionFactory $customerCreditCardCollectionFactory,
+        CreditmemoFactory $creditmemoFactory,
+        CreditmemoManagementInterface $creditmemoManagement
     )
     {
         parent::__construct($context);
@@ -296,6 +312,8 @@ class Order extends AbstractHelper
         $this->checkboxesHandler = $checkboxesHandler;
         $this->customerCreditCardFactory = $customerCreditCardFactory;
         $this->customerCreditCardCollectionFactory = $customerCreditCardCollectionFactory;
+        $this->creditmemoFactory = $creditmemoFactory;
+        $this->creditmemoManagement = $creditmemoManagement;
     }
 
     /**
@@ -1624,7 +1642,7 @@ class Order extends AbstractHelper
             self::TS_REJECTED_IRREVERSIBLE => OrderModel::STATE_CANCELED,
             // Refunds need to be initiated from the store admin (Invoice -> Credit Memo)
             // If called from Bolt merchant dashboard there is no enough info to sync the totals
-            self::TS_CREDIT_COMPLETED => Hook::$fromBolt ? OrderModel::STATE_HOLDED : OrderModel::STATE_PROCESSING
+            self::TS_CREDIT_COMPLETED => (Hook::$fromBolt && !$this->featureSwitches->isCreatingCreditMemoFromWebHookEnabled()) ? OrderModel::STATE_HOLDED : OrderModel::STATE_PROCESSING
         ][$transactionState];
     }
 
@@ -1764,7 +1782,12 @@ class Order extends AbstractHelper
             case self::TS_CREDIT_COMPLETED:
                 if (in_array($transaction->id, $processedRefunds)) return;
                 $transactionType = Transaction::TYPE_REFUND;
-                $transactionId = $transaction->id.'-refund';
+                $transactionId = $transaction->id . '-refund';
+
+                if ($this->featureSwitches->isCreatingCreditMemoFromWebHookEnabled()){
+                    $this->createCreditMemoForHookRequest($order, $transaction);
+                }
+
                 break;
 
             default:
@@ -1919,6 +1942,60 @@ class Order extends AbstractHelper
         )->setIsCustomerNotified(true);
 
         return $invoice;
+    }
+
+    /**
+     * @param OrderModel $order
+     * @param $transaction
+     * @throws \Exception
+     */
+    public function createCreditMemoForHookRequest(OrderModel $order, $transaction)
+    {
+        $currencyCode = $order->getOrderCurrencyCode();
+        $refundAmount = CurrencyUtils::toMajor($transaction->amount->amount, $currencyCode);
+        $this->validateRefundAmount($order, $refundAmount);
+
+        $boltTotal = CurrencyUtils::toMajor($transaction->order->cart->total_amount->amount, $currencyCode);
+        $adjustment = [];
+        if ($refundAmount < $boltTotal) {
+            $adjustment = [
+                'adjustment_positive' => $refundAmount,
+                'shipping_amount' => 0
+            ];
+
+            foreach ($order->getAllItems() as $item){
+                $adjustment['qtys'][$item->getId()] = 0;
+            }
+        }
+
+        $creditMemo = $this->creditmemoFactory->createByOrder($order, $adjustment);
+
+        $creditMemo->setAutomaticallyCreated(true)
+                    ->addComment(__('The credit memo has been created automatically.'));
+
+        $this->creditmemoManagement->refund($creditMemo, true);
+    }
+
+    /**
+     * @param OrderModel $order
+     * @param $refundAmount
+     * @throws \Exception
+     */
+    protected function validateRefundAmount(OrderModel $order, $refundAmount)
+    {
+        if (!isset($refundAmount) || !is_numeric($refundAmount) || $refundAmount < 0) {
+            throw new \Exception(__('Refund amount is invalid'));
+        }
+
+        $totalRefunded = $order->getTotalRefunded() ?: 0;
+        $totalPaid = $order->getTotalPaid();
+        $availableRefund = CurrencyUtils::toMinor($totalPaid - $totalRefunded, $order->getOrderCurrencyCode());
+
+        if ($availableRefund < $refundAmount) {
+            throw new \Exception(
+                __('Refund amount is invalid: refund amount [%1], available refund [%2]', $refundAmount, $availableRefund)
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
# Description
Create Magento offline credit memos for refund webhooks

Demo screenshot: https://www.screencast.com/t/qbv3wZ64bsdM
Fixes: https://app.asana.com/0/564264490825835/898124257920178

(Optional: Add a changelog by writing a comment after "#changelog" on the next line)

#changelog Create Magento offline credit memos for refund webhooks

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Asana task link and provided a changelog message if applicable.
