### PR TITLE
Don't empty cart after successful PPC checkout (w/o preauth)

### DIFF
--- a/Controller/Order/Save.php
+++ b/Controller/Order/Save.php
@@ -103,13 +103,20 @@ class Save extends Action
     public function execute()
     {
         try {
+            $sessionQuote = $this->checkoutSession->getQuote();
             // get the transaction reference parameter
             $reference = $this->getRequest()->getParam('reference');
             // call order save and update
             list($quote, $order) = $this->orderHelper->saveUpdateOrder($reference);
-
-            // clear the session data
-            $this->replaceQuote($quote);
+            if ($sessionQuote && $sessionQuote->getId() != $quote->getId()) {
+                // If we had quote linked to session and it's not immutableQuote
+                // then we in product page, non-pre-auth checkout flow
+                // Session quote represents regular cart and we want to save it and restore after order creation
+                $this->replaceQuote($sessionQuote);
+            } else {
+                // clear the session data
+                $this->replaceQuote($quote);
+            }
             //Clear quote session
             $this->clearQuoteSession($quote);
             //Clear order session


### PR DESCRIPTION
We already did it for pre-auth, https://github.com/BoltApp/bolt-magento2/pull/543/, need to do the same for non-preauth flow.

Fixes: https://app.asana.com/0/941920570700290/1162663341983417/f

(Optional: Add a changelog by writing a comment after "#changelog" on the next line)

#changelog Don't empty cart after successful PPC checkout (w/o preauth)

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
