### PR TITLE
trigger a custom JS event when hints are set (button ready)

### DIFF
--- a/view/frontend/templates/button_product_page.phtml
+++ b/view/frontend/templates/button_product_page.phtml
@@ -225,6 +225,7 @@ if (!$block->isSupportableType()) return;
                 }).always(function() {
                     setupProductPage();
                     $('#qty').on('change', setupProductPage);
+                    $(document).trigger('ppc-hints-set');
                 });
 
             // early button display, not active untill hints are received

--- a/view/frontend/templates/button_product_page.phtml
+++ b/view/frontend/templates/button_product_page.phtml
@@ -141,7 +141,6 @@ if (!$block->isSupportableType()) return;
                      * Magento customerData and authenticationPopup objects are
                      * used.
                      */
-
                     // check if login is required
                     if ( !customer().firstname && !isGuestCheckoutAllowed) {
                         // if authentication is required for checkout set a cookie
@@ -149,11 +148,6 @@ if (!$block->isSupportableType()) return;
                         authenticationPopup.showModal();
                         return false;
                     }
-
-                    if (!hints) {
-                        return false;
-                    }
-
                     // wait for validation module init
                     try {
                         $('#product_addtocart_form').validation('isValid');
@@ -164,7 +158,6 @@ if (!$block->isSupportableType()) return;
                     if ( ! $('#product_addtocart_form').validate().form()) {
                         return false;
                     }
-
                     return true;
                 },
 
@@ -181,6 +174,8 @@ if (!$block->isSupportableType()) return;
                 var quantity = Number($('#qty').val());
                 return quantity > 0 ? quantity : 1;
             };
+
+            var hints;
 
             var setupProductPage = function () {
                 var options = {};
@@ -207,32 +202,35 @@ if (!$block->isSupportableType()) return;
                         options: JSON.stringify(options)
                     }]
                 };
+
+                var hintsPromise = new Promise(function (resolve, reject) {
+                    if (hints) {
+                        resolve(hints);
+                        return;
+                    }
+                    $.get(settings.get_hints_url)
+                        .done(function(data) {
+                            hints = data.hints;
+                        })
+                        .fail(function() {
+                            hints = {prefill:{}};
+                        })
+                        .always(function() {
+                            resolve(hints);
+                            // disapatch event when required data is ready
+                            $(document).trigger('ppc-hints-set');
+                            return;
+                        });
+                });
+
                 // if connect.js is not loaded postpone until it is
                 whenDefined(window, 'BoltCheckout', function(){
-                    BoltCheckout.configureProductCheckout(cart, hints, callbacks);
+                    BoltCheckout.configureProductCheckout(cart, hintsPromise, callbacks);
                 });
             };
 
-            var hints;
-
-            // wait for the hints to load
-            // the viable way to assign user to order
-            $.get(settings.get_hints_url)
-                .done(function(data) {
-                    hints = data.hints;
-                }).fail(function() {
-                    hints = {prefill:{}};
-                }).always(function() {
-                    setupProductPage();
-                    $('#qty').on('change', setupProductPage);
-                    $(document).trigger('ppc-hints-set');
-                });
-
-            // early button display, not active untill hints are received
-            // do not run if connect.js is not loaded yet
-            if (window.BoltCheckout) {
-                BoltCheckout.configureProductCheckout({},{}, callbacks);
-            }
+            setupProductPage();
+            $('#qty').on('change', setupProductPage);
 
             <?php if ($block->isConfigurable()): ?>
             $(document).on( 'updatePrice', function (event, data) {


### PR DESCRIPTION
# Description
Show the PPC button disabled and enable it when the required data (hints with encrypted customer id)  is loaded. Prevent dead clicks and errors. Do not hardcode the solution (eg. CSS selectors), make it work via Magento configuration.

Solution: 
1. trigger a custom JS event from the core plugin code when data is loaded (ppc-hints-set)
2. through Magento config add "ppc-disabled" CSS class and JavaScript that listens to the aforementioned event and removes "ppc-disabled" class.

Magento Bolt Pay configuration:

**Additional Checkout Button Class**:
```
ppc-disabled
```
**Global CSS**:
```css
.bolt-product-checkout-button.ppc-disabled {
    opacity: 0.5;
    cursor: default;
    pointer-events: none;
}
```
**Additional Javascript**:
```javascript
$(document).on('ppc-hints-set', function(){
    $('.bolt-product-checkout-button').removeClass('ppc-disabled');
});
```
Fixes: https://app.asana.com/0/941920570700290/1163069420923242/f

(Optional: Add a changelog by writing a comment after "#changelog" on the next line)

#changelog Load hints data via promise, trigger a custom JS event when PPC required data is available, 

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
