### PR TITLE
 PPC: retrieve hints from server only once

### DIFF
--- a/view/frontend/templates/button_product_page.phtml
+++ b/view/frontend/templates/button_product_page.phtml
@@ -175,7 +175,19 @@ if (!$block->isSupportableType()) return;
                 return quantity > 0 ? quantity : 1;
             };
 
-            var hints;
+            var hints = new Promise(function (resolve, reject) {
+                $.get(settings.get_hints_url)
+                    .done(function(data) {
+                        resolve(data.hints);
+                    })
+                    .fail(function() {
+                        resolve({prefill:{}});
+                    })
+                    .always(function() {
+                        // disapatch event when required data is ready
+                        $(document).trigger('ppc-hints-set');
+                    });
+            });
 
             var setupProductPage = function () {
                 var options = {};
@@ -203,29 +215,9 @@ if (!$block->isSupportableType()) return;
                     }]
                 };
 
-                var hintsPromise = new Promise(function (resolve, reject) {
-                    if (hints) {
-                        resolve(hints);
-                        return;
-                    }
-                    $.get(settings.get_hints_url)
-                        .done(function(data) {
-                            hints = data.hints;
-                        })
-                        .fail(function() {
-                            hints = {prefill:{}};
-                        })
-                        .always(function() {
-                            resolve(hints);
-                            // disapatch event when required data is ready
-                            $(document).trigger('ppc-hints-set');
-                            return;
-                        });
-                });
-
                 // if connect.js is not loaded postpone until it is
                 whenDefined(window, 'BoltCheckout', function(){
-                    BoltCheckout.configureProductCheckout(cart, hintsPromise, callbacks);
+                    BoltCheckout.configureProductCheckout(cart, hints, callbacks);
                 });
             };
 


### PR DESCRIPTION
# Description
For now, under some fairly rare conditions we can ask hints from server few times:
- AJAX hints call works long time
- User change cart (quantity or product attribute) before AJAX call is finished.

Fixes: https://app.asana.com/0/941920570700290/1165280808501785/f

(Optional: Add a changelog by writing a comment after "#changelog" on the next line)

#changelog  PPC: retrieve hints from server only once

# Type of change

- [x] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
