### PR TITLE
always return hints prefill as object

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -856,6 +856,7 @@ class Cart extends AbstractHelper
             $hints['virtual_terminal_mode'] = true;
         }
 
+        $hints['prefill'] = (object)$hints['prefill'];
         return $hints;
     }
 


### PR DESCRIPTION
# Description
Fix for: when hints prefill is empty it is sent as an array instead of an object

Fixes: https://app.asana.com/0/941920570700290/1165294438865863/f

(Optional: Add a changelog by writing a comment after "#changelog" on the next line)

#changelog always return hints prefill as object

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
