### PR TITLE
don't send API request when merchant key is empty

### DIFF
--- a/Block/BlockTrait.php
+++ b/Block/BlockTrait.php
@@ -61,6 +61,86 @@ trait BlockTrait
     }
 
     /**
+     * If we have multi-website, we need current store_id
+     *
+     * @return int
+     */
+    public function getStoreId()
+    {
+        return $this->_storeManager->getStore()->getId();
+    }
+
+    /**
+     * Get Bolt Payment module active state.
+     * @return bool
+     */
+    public function isEnabled()
+    {
+        $storeId = $this->getStoreId();
+        return $this->configHelper->isActive($storeId);
+    }
+
+    /**
+     * Get blacklisted pages, stored in "pageFilters.blacklist" additional configuration
+     * as an array of "Full Action Name" identifiers, [<router_controller_action>]
+     *
+     * @return array
+     */
+    protected function getPageBlacklist()
+    {
+        return $this->configHelper->getPageBlacklist();
+    }
+
+    /**
+     * Check if Bolt checkout is restricted on the current loading page.
+     * Takes into account Minicart support and whitelisted / blacklisted pages configuration
+     * as well as the IP restriction.
+     * "Full Action Name", <router_controller_action>, is used to identify the page.
+     *
+     * @return bool
+     */
+    private function isPageRestricted()
+    {
+        $currentPage = $this->getRequest()->getFullActionName();
+
+        // Check if the page is blacklisted
+        if (in_array($currentPage, $this->getPageBlacklist())) {
+            return true;
+        }
+
+        // If IP whitelist is defined, the Bolt checkout functionality
+        // must be limited to the non cached pages, shopping cart and checkout (internal or 3rd party).
+        if (!$this->configHelper->getIPWhitelistArray()) {
+            return false;
+        }
+        return !in_array($currentPage, $this->getPageWhitelist());
+    }
+
+    /**
+     * Get whitelisted pages, the default, non cached, shopping cart and checkout pages,
+     * and the pages stored in "pageFilters.whitelist" additional configuration,
+     * as an array of "Full Action Name" identifiers, [<router_controller_action>]
+     *
+     * @return array
+     */
+    protected function getPageWhitelist()
+    {
+        $values =  $this->configHelper->getPageWhitelist();
+        return array_unique(array_merge(Config::$defaultPageWhitelist, $values));
+    }
+
+    /**
+     * Check if the client IP is restricted -
+     * there is an IP whitelist and the client IP is not on the list.
+     *
+     * @return bool
+     */
+    protected function isIPRestricted()
+    {
+        return $this->configHelper->isIPRestricted();
+    }
+
+    /**
      * Return true if we need to disable bolt scripts and button
      * Checks whether the module is active,
      * the page is Bolt checkout restricted and if there is an IP restriction.

--- a/Block/BlockTrait.php
+++ b/Block/BlockTrait.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+namespace Bolt\Boltpay\Block;
+
+use Bolt\Boltpay\Helper\Config;
+use Bolt\Boltpay\Helper\FeatureSwitch\Decider;
+
+trait BlockTrait
+{
+    /**
+     * @var Config
+     */
+    protected $configHelper;
+
+
+    /** @var Decider */
+    protected $featureSwitches;
+
+    /**
+     * @return mixed
+     */
+    public function shouldTrackCheckoutFunnel() {
+        return $this->configHelper->shouldTrackCheckoutFunnel();
+    }
+
+    /**
+     * Get checkout key. Any of the defined publishable keys for use with track.js.
+     *
+     * @return  string
+     */
+    public function getCheckoutKey()
+    {
+        if($this->configHelper->isPaymentOnlyCheckoutEnabled() && $this->_request->getFullActionName() == Config::CHECKOUT_PAGE_ACTION){
+            return $this->configHelper->getPublishableKeyPayment();
+        }
+
+        return $this->configHelper->getPublishableKeyCheckout();
+    }
+
+    /**
+     * Return true if publishable key or API key is empty
+     * @return bool
+     */
+    public function isKeyMissing()
+    {
+        return !$this->getCheckoutKey() || !$this->configHelper->getApiKey() || !$this->configHelper->getSigningSecret();
+    }
+
+    /**
+     * Return true if we need to disable bolt scripts and button
+     * Checks whether the module is active,
+     * the page is Bolt checkout restricted and if there is an IP restriction.
+     *
+     * @return bool
+     */
+    public function shouldDisableBoltCheckout()
+    {
+        if (!$this->featureSwitches->isBoltEnabled()) {
+            return true;
+        }
+        return !$this->isEnabled() || $this->isPageRestricted() || $this->isIPRestricted() || $this->isKeyMissing();
+    }
+}

--- a/Block/Checkout/Success.php
+++ b/Block/Checkout/Success.php
@@ -11,15 +11,18 @@
  *
  * @category   Bolt
  * @package    Bolt_Boltpay
- * @copyright  Copyright (c) 2018 Bolt Financial, Inc (https://www.bolt.com)
+ * @copyright  Copyright (c) 2020 Bolt Financial, Inc (https://www.bolt.com)
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
+
 namespace Bolt\Boltpay\Block\Checkout;
 
 use Bolt\Boltpay\Helper\Config;
 use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Element\Template\Context;
 use Magento\Framework\App\ProductMetadataInterface;
+use Bolt\Boltpay\Block\BlockTrait;
+use Bolt\Boltpay\Helper\FeatureSwitch\Decider;
 
 /**
  * Class Success
@@ -28,34 +31,34 @@ use Magento\Framework\App\ProductMetadataInterface;
  */
 class Success extends Template
 {
+    use BlockTrait;
+
     /**
      * @var ProductMetadataInterface
      */
     private $productMetadata;
 
     /**
-     * @var Config
-     */
-    private $configHelper;
-
-    /**
      * Success constructor.
      *
      * @param ProductMetadataInterface $productMetadata
-     * @param Config          $configHelper
+     * @param Config                   $configHelper
      * @param Context                  $context
+     * @param Decider                  $featureSwitches
      * @param array                    $data
      */
     public function __construct(
         ProductMetadataInterface $productMetadata,
         Config $configHelper,
         Context $context,
+        Decider $featureSwitches,
         array $data = []
     ) {
         parent::__construct($context, $data);
 
         $this->productMetadata = $productMetadata;
         $this->configHelper = $configHelper;
+        $this->featureSwitches = $featureSwitches;
     }
 
     /**
@@ -66,13 +69,6 @@ class Success extends Template
         // Workaround for known magento issue - https://github.com/magento/magento2/issues/12504
         return (bool) (version_compare($this->getMagentoVersion(), '2.2.0', '<'))
             || (bool) (version_compare($this->getMagentoVersion(), '2.3.4', '>='));
-    }
-
-    /**
-     * @return bool
-     */
-    public function shouldTrackCheckoutFunnel() {
-        return $this->configHelper->shouldTrackCheckoutFunnel();
     }
 
     /**

--- a/Block/Customer/CreditCard.php
+++ b/Block/Customer/CreditCard.php
@@ -11,12 +11,15 @@
  *
  * @category   Bolt
  * @package    Bolt_Boltpay
- * @copyright  Copyright (c) 2019 Bolt Financial, Inc (https://www.bolt.com)
+ * @copyright  Copyright (c) 2020 Bolt Financial, Inc (https://www.bolt.com)
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
 namespace Bolt\Boltpay\Block\Customer;
 
+use Bolt\Boltpay\Block\BlockTrait;
+use Bolt\Boltpay\Helper\Config;
+use Bolt\Boltpay\Helper\FeatureSwitch\Decider;
 use Magento\Framework\View\Element\Template;
 use Magento\Theme\Block\Html\Pager;
 use Bolt\Boltpay\Model\ResourceModel\CustomerCreditCard\CollectionFactory;
@@ -29,6 +32,8 @@ use Magento\Framework\Data\Form\FormKey;
  */
 class CreditCard extends Template
 {
+    use BlockTrait;
+
     const CURRENT_PAGE = 1;
     const PAGE_SIZE = 10;
     /**
@@ -54,6 +59,8 @@ class CreditCard extends Template
      * @param CollectionFactory $collectionFactory
      * @param Session $customerSession
      * @param FormKey $formKey
+     * @param Config $configHelper
+     * @param Decider $featureSwitches
      * @param array $data
      */
     public function __construct(
@@ -61,12 +68,16 @@ class CreditCard extends Template
         CollectionFactory $collectionFactory,
         Session $customerSession,
         FormKey $formKey,
+        Config $configHelper,
+        Decider $featureSwitches,
         array $data = []
     )
     {
         $this->formKey = $formKey;
         $this->collectionFactory = $collectionFactory;
         $this->customerSession = $customerSession;
+        $this->configHelper = $configHelper;
+        $this->featureSwitches = $featureSwitches;
         parent::__construct($context, $data);
     }
 

--- a/Block/Js.php
+++ b/Block/Js.php
@@ -202,16 +202,6 @@ class Js extends Template
     }
 
     /**
-     * Get Bolt Payment module active state.
-     * @return bool
-     */
-    public function isEnabled()
-    {
-        $storeId = $this->getStoreId();
-        return $this->configHelper->isActive($storeId);
-    }
-
-    /**
      * Get quote is virtual flag, false if no existing quote
      * @return bool
      */
@@ -324,76 +314,6 @@ class Js extends Template
     {
         $storeId = $this->getStoreId();
         return $this->configHelper->getIsPreAuth($storeId);
-    }
-
-    /**
-     * Get blacklisted pages, stored in "pageFilters.blacklist" additional configuration
-     * as an array of "Full Action Name" identifiers, [<router_controller_action>]
-     *
-     * @return array
-     */
-    protected function getPageBlacklist()
-    {
-        return $this->configHelper->getPageBlacklist();
-    }
-
-    /**
-     * Get whitelisted pages, the default, non cached, shopping cart and checkout pages,
-     * and the pages stored in "pageFilters.whitelist" additional configuration,
-     * as an array of "Full Action Name" identifiers, [<router_controller_action>]
-     *
-     * @return array
-     */
-    protected function getPageWhitelist()
-    {
-        $values =  $this->configHelper->getPageWhitelist();
-        return array_unique(array_merge(Config::$defaultPageWhitelist, $values));
-    }
-
-    /**
-     * Check if Bolt checkout is restricted on the current loading page.
-     * Takes into account Minicart support and whitelisted / blacklisted pages configuration
-     * as well as the IP restriction.
-     * "Full Action Name", <router_controller_action>, is used to identify the page.
-     *
-     * @return bool
-     */
-    private function isPageRestricted()
-    {
-        $currentPage = $this->getRequest()->getFullActionName();
-
-        // Check if the page is blacklisted
-        if (in_array($currentPage, $this->getPageBlacklist())) {
-            return true;
-        }
-
-        // If IP whitelist is defined, the Bolt checkout functionality
-        // must be limited to the non cached pages, shopping cart and checkout (internal or 3rd party).
-        if (!$this->configHelper->getIPWhitelistArray()) {
-            return false;
-        }
-        return !in_array($currentPage, $this->getPageWhitelist());
-    }
-
-    /**
-     * Check if the client IP is restricted -
-     * there is an IP whitelist and the client IP is not on the list.
-     *
-     * @return bool
-     */
-    protected function isIPRestricted()
-    {
-        return $this->configHelper->isIPRestricted();
-    }
-
-    /**
-     * If we have multi-website, we need current store_id
-     *
-     * @return int
-     */
-    public function getStoreId()
-    {
-        return $this->_storeManager->getStore()->getId();
     }
 
     /**

--- a/Block/Js.php
+++ b/Block/Js.php
@@ -33,10 +33,7 @@ use Bolt\Boltpay\Helper\Bugsnag;
  */
 class Js extends Template
 {
-    /**
-     * @var Config
-     */
-    protected $configHelper;
+    use BlockTrait;
 
     /** @var CheckoutSession */
     private $checkoutSession;
@@ -49,17 +46,14 @@ class Js extends Template
      /** @var Bugsnag  Bug logging interface*/
     private $bugsnag;
 
-    /** @var Decider */
-    private $featureSwitches;
-
     /**
      * @param Context         $context
      * @param Config          $configHelper
      * @param CheckoutSession $checkoutSession
      * @param CartHelper      $cartHelper
      * @param Bugsnag         $bugsnag;
-     * @param array           $data
      * @param Decider         $featureSwitches
+     * @param array           $data
      */
     public function __construct(
         Context $context,
@@ -100,20 +94,6 @@ class Js extends Template
         $cdnUrl = $this->configHelper->getCdnUrl();
 
         return $cdnUrl.'/connect.js';
-    }
-
-    /**
-     * Get checkout key. Any of the defined publishable keys for use with track.js.
-     *
-     * @return  string
-     */
-    public function getCheckoutKey()
-    {
-        if($this->configHelper->isPaymentOnlyCheckoutEnabled() && $this->_request->getFullActionName() == Config::CHECKOUT_PAGE_ACTION){
-            return $this->configHelper->getPublishableKeyPayment();
-        }
-
-        return $this->configHelper->getPublishableKeyCheckout();
     }
 
     /**
@@ -407,21 +387,6 @@ class Js extends Template
     }
 
     /**
-     * Return true if we need to disable bolt scripts and button
-     * Checks whether the module is active,
-     * the page is Bolt checkout restricted and if there is an IP restriction.
-     *
-     * @return bool
-     */
-    public function shouldDisableBoltCheckout()
-    {
-        if (!$this->featureSwitches->isBoltEnabled()) {
-            return true;
-        }
-        return !$this->isEnabled() || $this->isPageRestricted() || $this->isIPRestricted();
-    }
-
-    /**
      * If we have multi-website, we need current store_id
      *
      * @return int
@@ -447,10 +412,6 @@ class Js extends Template
     public function getModuleVersion()
     {
         return $this->configHelper->getModuleVersion();
-    }
-
-    public function shouldTrackCheckoutFunnel() {
-        return $this->configHelper->shouldTrackCheckoutFunnel();
     }
 
     /**

--- a/Test/Unit/Block/Checkout/SuccessTest.php
+++ b/Test/Unit/Block/Checkout/SuccessTest.php
@@ -19,6 +19,7 @@ namespace Bolt\Boltpay\Test\Unit\Block\Checkout;
 
 use Bolt\Boltpay\Block\Checkout\Success;
 use Bolt\Boltpay\Helper\Config as HelperConfig;
+use Bolt\Boltpay\Helper\FeatureSwitch\Decider;
 
 /**
  * Class SuccessTest
@@ -59,9 +60,9 @@ class SuccessTest extends \PHPUnit\Framework\TestCase
                 ]
             )
             ->getMock();
-
-        $data = $this->createMock(\Magento\Framework\App\ProductMetadata::class);
-        $this->block = new Success($data, $this->configHelper, $contextMock);
+        $deciderMock = $this->createMock(Decider::class);
+        $productMetadataMock = $this->createMock(\Magento\Framework\App\ProductMetadata::class);
+        $this->block = new Success($productMetadataMock, $this->configHelper, $contextMock, $deciderMock);
     }
 
     /**

--- a/Test/Unit/Block/Customer/CreditCardTest.php
+++ b/Test/Unit/Block/Customer/CreditCardTest.php
@@ -18,12 +18,13 @@
 namespace Bolt\Boltpay\Test\Unit\Block\Customer;
 
 use Bolt\Boltpay\Block\Customer\CreditCard;
+use Bolt\Boltpay\Helper\FeatureSwitch\Decider;
 use Magento\Framework\View\Element\Template\Context;
 use Bolt\Boltpay\Model\ResourceModel\CustomerCreditCard\CollectionFactory;
 use Magento\Framework\App\Request\Http;
 use Magento\Customer\Model\Session;
 use Magento\Framework\Data\Form\FormKey;
-
+use Bolt\Boltpay\Helper\Config;
 
 /**
  * Class CreditCardTest
@@ -65,6 +66,11 @@ class CreditCardTest extends \PHPUnit\Framework\TestCase
     private $formKeyMock;
 
     /**
+     * @var Decider
+     */
+    protected $deciderMock;
+
+    /**
      * @inheritdoc
      */
     protected function setUp()
@@ -93,6 +99,8 @@ class CreditCardTest extends \PHPUnit\Framework\TestCase
             ->getMock();;
         $this->customerSessionMock = $this->createMock(Session::class);
         $this->customerSessionMock->method('getCustomerId')->willReturn(self::CUSTOMER_ID);
+        $this->deciderMock = $this->createMock(Decider::class);
+        $this->configHelperMock = $this->createMock(Config::class);
     }
 
     private function initCurrentMock()
@@ -104,7 +112,9 @@ class CreditCardTest extends \PHPUnit\Framework\TestCase
                     $this->contextMock,
                     $this->collectionFactoryMock,
                     $this->customerSessionMock,
-                    $this->formKeyMock
+                    $this->formKeyMock,
+                    $this->configHelperMock,
+                    $this->deciderMock
                 ]
             )->getMock();
     }

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -33,6 +33,9 @@ class JsTest extends \PHPUnit\Framework\TestCase
     // Number of settings in method getSettings()
     const SETTINGS_NUMBER = 18;
     const STORE_ID = 1;
+    const CONFIG_API_KEY = 'test_api_key';
+    const CONFIG_SIGNING_SECRET = 'test_signing_secret';
+    const CONFIG_PUBLISHABLE_KEY = 'test_publishable_key';
 
     /**
      * @var HelperConfig
@@ -77,7 +80,7 @@ class JsTest extends \PHPUnit\Framework\TestCase
     /**
      * @var Decider
      */
-    private $decider;
+    protected $deciderMock;
 
     /**
      * @inheritdoc
@@ -103,7 +106,7 @@ class JsTest extends \PHPUnit\Framework\TestCase
             'getReplaceSelectors', 'getGlobalCSS', 'getPrefetchShipping', 'getQuoteIsVirtual',
             'getTotalsChangeSelectors', 'getAdditionalCheckoutButtonClass', 'getAdditionalConfigString', 'getIsPreAuth',
             'shouldTrackCheckoutFunnel','isPaymentOnlyCheckoutEnabled', 'isIPRestricted', 'getPageBlacklist',
-            'getMinicartSupport', 'getIPWhitelistArray'
+            'getMinicartSupport', 'getIPWhitelistArray', 'getApiKey', 'getSigningSecret'
         ];
 
         $this->configHelper = $this->getMockBuilder(HelperConfig::class)
@@ -121,7 +124,7 @@ class JsTest extends \PHPUnit\Framework\TestCase
 
         $this->cartHelperMock = $this->createMock(CartHelper::class);
         $this->bugsnagHelperMock = $this->createMock(Bugsnag::class);
-        $this->decider = $this->createMock(Decider::class);
+        $this->deciderMock = $this->createMock(Decider::class);
 
         $this->requestMock = $this->getMockBuilder(Http::class)
             ->disableOriginalConstructor()
@@ -136,7 +139,7 @@ class JsTest extends \PHPUnit\Framework\TestCase
         $this->contextMock->method('getStoreManager')->willReturn($storeManager);
 
         $this->block = $this->getMockBuilder(BlockJs::class)
-            ->setMethods(['configHelper', 'getUrl', 'getBoltPopupErrorMessage'])
+            ->setMethods(['getUrl', 'getBoltPopupErrorMessage'])
             ->setConstructorArgs(
                 [
                     $this->contextMock,
@@ -144,7 +147,7 @@ class JsTest extends \PHPUnit\Framework\TestCase
                     $this->checkoutSessionMock,
                     $this->cartHelperMock,
                     $this->bugsnagHelperMock,
-                    $this->decider
+                    $this->deciderMock
                 ]
             )
             ->getMock();
@@ -422,7 +425,7 @@ class JsTest extends \PHPUnit\Framework\TestCase
      */
     public function shouldDisableBoltCheckout_featureSwitchOff()
     {
-        $this->decider->method('isBoltEnabled')->willReturn(false);
+        $this->deciderMock->method('isBoltEnabled')->willReturn(false);
         $this->assertTrue($this->block->shouldDisableBoltCheckout(), 'feature switch for disabling bolt not working properly');
     }
 
@@ -431,13 +434,16 @@ class JsTest extends \PHPUnit\Framework\TestCase
      */
     public function shouldDisableBoltCheckout_featureSwitchOn()
     {
-        $this->decider->method('isBoltEnabled')->willReturn(true);
+        $this->deciderMock->method('isBoltEnabled')->willReturn(true);
         $this->configHelper->method('isActive')->willReturn(true);
         $this->configHelper->method('isIPRestricted')->willReturn(false);
         $this->requestMock->method('getFullActionName')->willReturn('unrestrictedPage');
         $this->configHelper->method('getPageBlacklist')->willReturn(array('anotherPage', 'restrictedPage'));
         $this->configHelper->method('getMinicartSupport')->willReturn(true);
         $this->configHelper->method('getIPWhitelistArray')->willReturn(array());
+        $this->configHelper->method('getApiKey')->willReturn(self::CONFIG_API_KEY);
+        $this->configHelper->method('getSigningSecret')->willReturn(self::CONFIG_SIGNING_SECRET);
+        $this->configHelper->method('getPublishableKeyCheckout')->willReturn(self::CONFIG_PUBLISHABLE_KEY);
         $this->assertFalse($this->block->shouldDisableBoltCheckout(), 'feature switch for disabling bolt not working properly');
     }
 

--- a/view/frontend/templates/button.phtml
+++ b/view/frontend/templates/button.phtml
@@ -11,7 +11,7 @@
  *
  * @category   Bolt
  * @package    Bolt_Boltpay
- * @copyright  Copyright (c) 2018 Bolt Financial, Inc (https://www.bolt.com)
+ * @copyright  Copyright (c) 2020 Bolt Financial, Inc (https://www.bolt.com)
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/view/frontend/templates/button_product_page.phtml
+++ b/view/frontend/templates/button_product_page.phtml
@@ -11,7 +11,7 @@
  *
  * @category   Bolt
  * @package    Bolt_Boltpay
- * @copyright  Copyright (c) 2018 Bolt Financial, Inc (https://www.bolt.com)
+ * @copyright  Copyright (c) 2020 Bolt Financial, Inc (https://www.bolt.com)
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
@@ -184,7 +184,7 @@ if (!$block->isSupportableType()) return;
                         resolve({prefill:{}});
                     })
                     .always(function() {
-                        // disapatch event when required data is ready
+                        // dispatch event when required data is ready
                         $(document).trigger('ppc-hints-set');
                     });
             });

--- a/view/frontend/templates/checkout/success.phtml
+++ b/view/frontend/templates/checkout/success.phtml
@@ -1,4 +1,23 @@
-<?php /* @var $block Bolt\Boltpay\Block\Checkout\Success */ ?>
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/* @var $block Bolt\Boltpay\Block\Checkout\Success */
+if ($block->shouldDisableBoltCheckout()) return;
+?>
 
 <?php if ($block->isAllowInvalidateQuote()): ?>
 <script>

--- a/view/frontend/templates/css/boltcss.phtml
+++ b/view/frontend/templates/css/boltcss.phtml
@@ -11,7 +11,7 @@
  *
  * @category   Bolt
  * @package    Bolt_Boltpay
- * @copyright  Copyright (c) 2018 Bolt Financial, Inc (https://www.bolt.com)
+ * @copyright  Copyright (c) 2020 Bolt Financial, Inc (https://www.bolt.com)
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/view/frontend/templates/customer/creditcard.phtml
+++ b/view/frontend/templates/customer/creditcard.phtml
@@ -1,6 +1,23 @@
-<?php /** @var  $block \Bolt\Boltpay\Block\Customer\CreditCard */?>
-
 <?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/** @var  $block \Bolt\Boltpay\Block\Customer\CreditCard */
+
+if ($block->shouldDisableBoltCheckout()) return;
 $creditCards = $block->getCreditCardCollection();
 ?>
 <div class="block">

--- a/view/frontend/templates/js/boltjs.phtml
+++ b/view/frontend/templates/js/boltjs.phtml
@@ -11,7 +11,7 @@
  *
  * @category   Bolt
  * @package    Bolt_Boltpay
- * @copyright  Copyright (c) 2018 Bolt Financial, Inc (https://www.bolt.com)
+ * @copyright  Copyright (c) 2020 Bolt Financial, Inc (https://www.bolt.com)
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/view/frontend/templates/js/checkout_funnel.js.phtml
+++ b/view/frontend/templates/js/checkout_funnel.js.phtml
@@ -1,4 +1,24 @@
 <?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * @var $block \Bolt\Boltpay\Block\Js
+ */
+if ($block->shouldDisableBoltCheckout()) return;
 if (!$block->shouldTrackCheckoutFunnel()) return;
 ?>
 

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -11,7 +11,7 @@
  *
  * @category   Bolt
  * @package    Bolt_Boltpay
- * @copyright  Copyright (c) 2018 Bolt Financial, Inc (https://www.bolt.com)
+ * @copyright  Copyright (c) 2020 Bolt Financial, Inc (https://www.bolt.com)
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/view/frontend/templates/popup.phtml
+++ b/view/frontend/templates/popup.phtml
@@ -11,7 +11,7 @@
  *
  * @category   Bolt
  * @package    Bolt_Boltpay
- * @copyright  Copyright (c) 2018 Bolt Financial, Inc (https://www.bolt.com)
+ * @copyright  Copyright (c) 2020 Bolt Financial, Inc (https://www.bolt.com)
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 


### PR DESCRIPTION
# Description
Plugin is publicly available via composer. Anybody can install it. Prevent communication with Bolt if the keys are not set.
- move common methods, shouldDisableBoltCheckout and methods called within, to BlockTrait and use the trait in blocks
- add isKeyMissing check to shouldDisableBoltCheckout
- call shouldDisableBoltCheckout at the begining of templates

Fixes: https://app.asana.com/0/941920570700290/1164917024563610/f

(Optional: Add a changelog by writing a comment after "#changelog" on the next line)

#changelog don't send API request when merchant key is empty

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
