### PR TITLE
[Debug Endpoint] Add support to retrieve php version and platform version ENG-301 ENG-304

### DIFF
--- a/Model/Api/Debug.php
+++ b/Model/Api/Debug.php
@@ -18,6 +18,7 @@
 namespace Bolt\Boltpay\Model\Api;
 
 use Bolt\Boltpay\Api\DebugInterface;
+use Magento\Framework\App\ProductMetadataInterface;
 use Bolt\Boltpay\Model\Api\Data\DebugInfoFactory;
 use Bolt\Boltpay\Model\Api\Data\BoltConfigSettingFactory;
 use Bolt\Boltpay\Model\Api\Data\PluginVersionFactory;
@@ -40,37 +41,43 @@ class Debug implements DebugInterface
 	private $pluginVersionFactory;
 
 	/**
+	 * @var ProductMetadataInterface
+	 */
+	private $productMetadata;
+
+	/**
 	 * @param DebugInfoFactory $debugInfoFactory
 	 * @param BoltConfigSettingFactory $boltConfigSettingFactory
 	 * @param PluginVersionFactory $pluginVersionFactory
+	 * @param ProductMetadataInterface $productMetadata
 	 */
 	public function __construct(
 		DebugInfoFactory $debugInfoFactory,
 		BoltConfigSettingFactory $boltConfigSettingFactory,
-		PluginVersionFactory $pluginVersionFactory
+		PluginVersionFactory $pluginVersionFactory,
+		ProductMetadataInterface $productMetadata
 	) {
-		$this->debugInfoFactory         = $debugInfoFactory;
+		$this->debugInfoFactory = $debugInfoFactory;
 		$this->boltConfigSettingFactory = $boltConfigSettingFactory;
-		$this->pluginVersionFactory     = $pluginVersionFactory;
+		$this->pluginVersionFactory = $pluginVersionFactory;
+		$this->productMetadata = $productMetadata;
 	}
 
 	/**
 	 * This request handler will return relevant information for Bolt for debugging purpose.
 	 *
-	 * @api
 	 * @return DebugInfo
+	 * @api
 	 */
-	public function debug() {
+	public function debug()
+	{
 		$result = $this->debugInfoFactory->create();
 
 		# populate php version
 		$result->setPhpVersion(phpversion());
 
 		# populate platform version
-		$objectManager = \Magento\Framework\App\ObjectManager::getInstance();
-		$productMetadata = $objectManager->get('Magento\Framework\App\ProductMetadataInterface');
-		$magentoVersion = $productMetadata->getVersion();
-		$result->setPlatformVersion($magentoVersion);
+		$result->setPlatformVersion($this->productMetadata->getVersion());
 
 		$boltSettings = [];
 		$boltSettings[] = $this->boltConfigSettingFactory->create();

--- a/Model/Api/Debug.php
+++ b/Model/Api/Debug.php
@@ -62,8 +62,15 @@ class Debug implements DebugInterface
 	 */
 	public function debug() {
 		$result = $this->debugInfoFactory->create();
-		$result->setPhpVersion("todo");
-		$result->setPlatformVersion("todo");
+
+		# populate php version
+		$result->setPhpVersion(phpversion());
+
+		# populate platform version
+		$objectManager = \Magento\Framework\App\ObjectManager::getInstance();
+		$productMetadata = $objectManager->get('Magento\Framework\App\ProductMetadataInterface');
+		$magentoVersion = $productMetadata->getVersion();
+		$result->setPlatformVersion($magentoVersion);
 
 		$boltSettings = [];
 		$boltSettings[] = $this->boltConfigSettingFactory->create();

--- a/Model/Api/Debug.php
+++ b/Model/Api/Debug.php
@@ -74,7 +74,7 @@ class Debug implements DebugInterface
 		$result = $this->debugInfoFactory->create();
 
 		# populate php version
-		$result->setPhpVersion(phpversion());
+		$result->setPhpVersion(PHP_VERSION);
 
 		# populate platform version
 		$result->setPlatformVersion($this->productMetadata->getVersion());

--- a/Test/Unit/Model/Api/DebugTest.php
+++ b/Test/Unit/Model/Api/DebugTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2019 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Test\Unit\Model\Api;
+
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Bolt\Boltpay\Model\Api\Data\DebugInfo;
+use Bolt\Boltpay\Model\Api\Debug;
+use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Model\Api\Data\DebugInfoFactory;
+use Magento\Framework\App\ProductMetadataInterface;
+
+/**
+ * Class CreateOrderTest
+ *
+ * @package Bolt\Boltpay\Test\Unit\Model\Api
+ * @coversDefaultClass \Bolt\Boltpay\Model\Api\Debug
+ */
+class DebugTest extends TestCase
+{
+	/**
+	 * @var Debug
+	 */
+	private $debug;
+
+	/**
+	 * @var DebugInfoFactory
+	 */
+	private $debugInfoFactory;
+
+	/**
+	 * @var ProductMetadataInterface
+	 */
+	private $productMetadataInterfaceMock;
+
+	/**
+	 * @inheritdoc
+	 */
+	public function setUp()
+	{
+		$this->productMetadataInterfaceMock = $this->createMock(ProductMetadataInterface::class);
+		$this->productMetadataInterfaceMock->method('getVersion')->willReturn('2.3.0');
+
+		$this->debugInfoFactory = $this->createMock(DebugInfoFactory::class);
+		$this->debugInfoFactory->method('create')->willReturn(new DebugInfo());
+
+		$objectManager = new ObjectManager($this);
+		$this->debug = $objectManager->getObject(
+			Debug::class,
+			[
+				'debugInfoFactory' => $this->debugInfoFactory,
+				'productMetadata' => $this->productMetadataInterfaceMock
+			]
+		);
+	}
+
+	/**
+	 * @test
+	 * @covers ::debug
+	 */
+	public function debug_successful()
+	{
+		$debugInfo = $this->debug->debug();
+		$this->assertNotNull($debugInfo);
+		$this->assertNotNull($debugInfo->getPhpVersion());
+		$this->assertEquals('2.3.0', $debugInfo->getPlatformVersion());
+	}
+}


### PR DESCRIPTION
# Description
This PR adds support to retrieve PHP version and platform version in debug endpoint.

Fixes: [ENG-301] [ENG-304]

(Optional: Add a changelog by writing a comment after "#changelog" on the next line)

#changelog Debug Endpoint: add support to retrieve php version and platform version

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.


[ENG-301]: https://boltpay.atlassian.net/browse/ENG-301

[ENG-304]: https://boltpay.atlassian.net/browse/ENG-304