### PR TITLE
ENG-288 - Don't logged failed order token when cart is empty

### DIFF
--- a/Controller/Adminhtml/Cart/Data.php
+++ b/Controller/Adminhtml/Cart/Data.php
@@ -109,11 +109,10 @@ class Data extends Action
             // call the Bolt API
             $boltpayOrder = $this->cartHelper->getBoltpayOrder(true, $place_order_payload);
 
+            // If empty cart - order_token not fetched because doesn't exist. Not a failure.
             if ($boltpayOrder) {
                 $responseData = json_decode(json_encode($boltpayOrder->getResponse()), true);
                 $this->metricsClient->processMetric("back_office_order_token.success", 1, "back_office_order_token.latency", $startTime);
-            } else {
-                $this->metricsClient->processMetric("back_office_order_token.failure", 1, "back_office_order_token.latency", $startTime);
             }
 
             $storeId = $this->cartHelper->getSessionQuoteStoreId();

--- a/Controller/Cart/Data.php
+++ b/Controller/Cart/Data.php
@@ -124,8 +124,8 @@ class Data extends Action
                 $responseData = json_decode(json_encode($response), true);
                 $this->metricsClient->processMetric("order_token.success", 1, "order_token.latency", $startTime);
             } else {
+                // Empty cart - order_token not fetched because doesn't exist. Not a failure.
                 $responseData['cart'] = [];
-                $this->metricsClient->processMetric("order_token.failure", 1,"order_token.latency", $startTime);
             }
 
             // get immutable quote id stored with cart data


### PR DESCRIPTION
# Description
Don't log a failed order token metric when `$boltpayOrder->getResponse()` isn't even called.

Fixes: [ENG-288]

(Optional: Add a changelog by writing a comment after "#changelog" on the next line)

#changelog Don't log a failed order token metric on empty carts

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.


[ENG-288]: https://boltpay.atlassian.net/browse/ENG-288