### PR TITLE
[Debug Endpoint] ENG-363 Add HMAC check for requests

### DIFF
--- a/Model/Api/Debug.php
+++ b/Model/Api/Debug.php
@@ -18,10 +18,12 @@
 namespace Bolt\Boltpay\Model\Api;
 
 use Bolt\Boltpay\Api\DebugInterface;
-use Magento\Framework\App\ProductMetadataInterface;
-use Bolt\Boltpay\Model\Api\Data\DebugInfoFactory;
+use Bolt\Boltpay\Helper\Hook as HookHelper;
 use Bolt\Boltpay\Model\Api\Data\BoltConfigSettingFactory;
+use Bolt\Boltpay\Model\Api\Data\DebugInfoFactory;
 use Bolt\Boltpay\Model\Api\Data\PluginVersionFactory;
+use Magento\Framework\App\ProductMetadataInterface;
+use Magento\Store\Model\StoreManagerInterface;
 
 class Debug implements DebugInterface
 {
@@ -41,6 +43,16 @@ class Debug implements DebugInterface
 	private $pluginVersionFactory;
 
 	/**
+	 * @var HookHelper
+	 */
+	private $hookHelper;
+
+	/**
+	 * @var StoreManagerInterface
+	 */
+	private $storeManager;
+
+	/**
 	 * @var ProductMetadataInterface
 	 */
 	private $productMetadata;
@@ -49,17 +61,23 @@ class Debug implements DebugInterface
 	 * @param DebugInfoFactory $debugInfoFactory
 	 * @param BoltConfigSettingFactory $boltConfigSettingFactory
 	 * @param PluginVersionFactory $pluginVersionFactory
+	 * @param StoreManagerInterface $storeManager
+	 * @param HookHelper $hookHelper
 	 * @param ProductMetadataInterface $productMetadata
 	 */
 	public function __construct(
 		DebugInfoFactory $debugInfoFactory,
 		BoltConfigSettingFactory $boltConfigSettingFactory,
 		PluginVersionFactory $pluginVersionFactory,
+		StoreManagerInterface $storeManager,
+		HookHelper $hookHelper,
 		ProductMetadataInterface $productMetadata
 	) {
 		$this->debugInfoFactory = $debugInfoFactory;
 		$this->boltConfigSettingFactory = $boltConfigSettingFactory;
 		$this->pluginVersionFactory = $pluginVersionFactory;
+		$this->storeManager = $storeManager;
+		$this->hookHelper = $hookHelper;
 		$this->productMetadata = $productMetadata;
 	}
 
@@ -71,6 +89,9 @@ class Debug implements DebugInterface
 	 */
 	public function debug()
 	{
+		# verify request
+		$this->hookHelper->preProcessWebhook($this->storeManager->getStore()->getId());
+
 		$result = $this->debugInfoFactory->create();
 
 		# populate php version

--- a/Test/Unit/Model/Api/DebugTest.php
+++ b/Test/Unit/Model/Api/DebugTest.php
@@ -110,20 +110,4 @@ class DebugTest extends TestCase
 		$this->assertNotNull($debugInfo->getPhpVersion());
 		$this->assertEquals('2.3.0', $debugInfo->getPlatformVersion());
 	}
-
-
-//	/**
-//	 * @test
-//	 * @covers ::debug
-//	 */
-//	public function debug_invalid_hmac()
-//	{
-//		$this->expectException(InvalidArgumentException::class);
-//
-//		$debugInfo = $this->debug->debug();
-//
-//		$this->assertNotNull($debugInfo);
-//		$this->assertNotNull($debugInfo->getPhpVersion());
-//		$this->assertEquals('2.3.0', $debugInfo->getPlatformVersion());
-//	}
 }


### PR DESCRIPTION
# Description
Add HMAC check for requests to the debug endpoint. It is needed because this endpoint is exposing some sensitive server information (eg: php version, platform verstion, bolt settings etc) of the merchant. 

Tech Spec: https://docs.google.com/document/d/1Q-0NZHQew1ALm4MOyVGl2m0-JUG_mnmhcn9zPcqJo98/edit#heading=h.cunzcjjb9kz

Fixes: [ENG-363]

#changelog [Debug Endpoint] Add HMAC check for requests

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.


[ENG-363]: https://boltpay.atlassian.net/browse/ENG-363