### PR TITLE
Make GetFeatureSwitch call when merchant key is changed

### DIFF
--- a/Plugin/CheckSettingsUpdate.php
+++ b/Plugin/CheckSettingsUpdate.php
@@ -41,7 +41,7 @@ class CheckSettingsUpdate
     private $configHelper;
 
     /*
-     * @var Manager
+     * @var FeatureSwitchManager
      */
     protected $fsManager;
 

--- a/Plugin/CheckSettingsUpdate.php
+++ b/Plugin/CheckSettingsUpdate.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2018 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Plugin;
+
+use Magento\Config\Model\Config as MagentoConfig;
+use Bolt\Boltpay\Helper\Cart as CartHelper;
+use Bolt\Boltpay\Helper\Config as ConfigHelper;
+use Bolt\Boltpay\Helper\FeatureSwitch\Manager as FeatureSwitchManager;
+use Bolt\Boltpay\Helper\Bugsnag;
+
+/**
+ * Class ClearQuote
+ *
+ * @package Bolt\Boltpay\Plugin
+ */
+class CheckSettingsUpdate
+{
+    /**
+     * @var CartHelper
+     */
+    private $cartHelper;
+
+    /**
+     * @var ConfigHelper
+     */
+    private $configHelper;
+
+    /*
+     * @var Manager
+     */
+    protected $fsManager;
+
+    /**
+     * @var Bugsnag
+     */
+    private $bugsnag;
+
+    /**
+     * $string
+     */
+    private $oldApiKey;
+
+    /**
+     * @param CartHelper $cartHelper
+     * @param ConfigHelper $configHelper
+     * @param FeatureSwitchManager $fsManager
+     * @param Bugsnag $bugsnag
+     */
+    public function __construct(
+        CartHelper $cartHelper,
+        ConfigHelper $configHelper,
+        FeatureSwitchManager $fsManager,
+        Bugsnag $bugsnag
+    )
+    {
+        $this->cartHelper = $cartHelper;
+        $this->configHelper = $configHelper;
+        $this->fsManager = $fsManager;
+        $this->bugsnag = $bugsnag;
+    }
+
+    /**
+     * @param CheckoutSession $subject
+     * @return null Return null because method Save have no arguments
+     */
+    public function beforeSave(MagentoConfig $subject)
+    {
+        $this->oldApiKey = $this->configHelper->getApiKey();
+        return null;
+    }
+
+    /**
+     * @param CheckoutSession $subject
+     * @return CheckoutSession
+     */
+    public function afterSave(MagentoConfig $subject, $result)
+    {
+        $apiKey = $this->configHelper->getApiKey();
+        if ($apiKey && $apiKey != $this->oldApiKey) {
+            try {
+                $this->fsManager->updateSwitchesFromBolt();
+            } catch (\Exception $e) {
+                $this->bugsnag->notifyException($e);
+            }
+        }
+        return $result;
+    }
+}
+

--- a/Test/Unit/Plugin/CheckSettingsUpdateTest.php
+++ b/Test/Unit/Plugin/CheckSettingsUpdateTest.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2018 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Test\Unit\Helper;
+
+use PHPUnit\Framework\TestCase;
+use Magento\Config\Model\Config as MagentoConfig;
+use Bolt\Boltpay\Helper\Cart as CartHelper;
+use Bolt\Boltpay\Helper\Config as ConfigHelper;
+use Bolt\Boltpay\Helper\FeatureSwitch\Manager as FeatureSwitchManager;
+use Bolt\Boltpay\Helper\Bugsnag;
+use Bolt\Boltpay\Plugin\CheckSettingsUpdate;
+
+/**
+ * @coversDefaultClass \Bolt\Boltpay\Plugin\CheckSettingsUpdate
+ */
+class CheckSettingsUpdateTest extends TestCase
+{
+    const OLD_KEY = 'old_key';
+    const NEW_KEY = 'new_key';
+
+    /**
+     * @var CheckSettingsUpdate
+     */
+    private $currentMock;
+
+    /**
+     * @var MagentoConfig
+     */
+
+    private $magentoConfig;
+
+    /**
+     * @var CartHelper
+     */
+    private $cartHelper;
+
+    /**
+     * @var ConfigHelper
+     */
+    private $configHelper;
+
+    /*
+     * @var Manager
+     */
+    protected $fsManager;
+
+    /**
+     * @var Bugsnag
+     */
+    private $bugsnag;
+
+    public function setUp()
+    {
+        /*
+        $this->context = $this->getMockBuilder(Context::class)
+            ->disableOriginalConstructor()
+            ->getMock();*/
+
+        $this->cartHelper = $this->createMock(CartHelper::class);
+        $this->configHelper = $this->createMock(ConfigHelper::class);
+        $this->fsManager = $this->createMock(FeatureSwitchManager::class);
+        $this->bugsnag = $this->createMock(Bugsnag::class);
+        $this->magentoConfig = $this->createMock(magentoConfig::class);
+
+        $this->initCurrentMock([]);
+    }
+
+    /**
+     * @param array $methods
+     * @param bool $enableOriginalConstructor
+     * @param bool $enableProxyingToOriginalMethods
+     */
+    private function initCurrentMock($methods = [])
+    {
+        $builder = $this->getMockBuilder(CheckSettingsUpdate::class)
+            ->enableOriginalConstructor()
+            ->setConstructorArgs(
+                [
+                    $this->cartHelper,
+                    $this->configHelper,
+                    $this->fsManager,
+                    $this->bugsnag,
+                ]
+            )
+            ->setMethods($methods)
+            ->enableProxyingToOriginalMethods();
+
+        $this->currentMock = $builder->getMock();
+    }
+
+    private function callBeforeSaveAndAfterSave()
+    {
+        $beforeSaveResult = $this->currentMock->beforeSave($this->magentoConfig);
+        $afterSaveResult = $this->currentMock->afterSave($this->magentoConfig, $this->magentoConfig);
+        $this->assertNull($beforeSaveResult);
+        $this->assertSame($this->magentoConfig, $afterSaveResult);
+    }
+
+    /**
+     * @test
+     */
+    public function callBeforeSaveAndAfterSave_whenKeyNotChanged_doNothing()
+    {
+        $this->configHelper->expects($this->exactly(2))
+            ->method('getApiKey')->willReturn(self::OLD_KEY);
+        $this->fsManager->expects($this->never())
+            ->method('updateSwitchesFromBolt');
+        $this->callBeforeSaveAndAfterSave();
+    }
+
+    /**
+     * @test
+     */
+    public function callBeforeSaveAndAfterSave_whenKeyChanged_updateSwitches()
+    {
+        $this->configHelper->expects($this->at(0))
+            ->method('getApiKey')->willReturn(self::OLD_KEY);
+        $this->configHelper->expects($this->at(1))
+            ->method('getApiKey')->willReturn(self::NEW_KEY);
+        $this->fsManager->expects($this->once())
+            ->method('updateSwitchesFromBolt');
+        $this->callBeforeSaveAndAfterSave();
+    }
+
+    /**
+     * @test
+     */
+    public function callBeforeSaveAndAfterSave_whenKeyChangedToEmpty_doNothing()
+    {
+        $this->configHelper->expects($this->at(0))
+            ->method('getApiKey')->willReturn(self::OLD_KEY);
+        $this->configHelper->expects($this->at(1))
+            ->method('getApiKey')->willReturn('');
+        $this->fsManager->expects($this->never())
+            ->method('updateSwitchesFromBolt');
+        $this->callBeforeSaveAndAfterSave();
+    }
+
+    /**
+     * @test
+     */
+    public function callBeforeSaveAndAfterSave_whenKeyChangedAnfUpdateSwitchesThrowException_callBugsnag()
+    {
+        $this->configHelper->expects($this->at(0))
+            ->method('getApiKey')->willReturn(self::OLD_KEY);
+        $this->configHelper->expects($this->at(1))
+            ->method('getApiKey')->willReturn(self::NEW_KEY);
+        $e = new \Exception('test exception');
+        $this->fsManager->expects($this->once())
+            ->method('updateSwitchesFromBolt')->willThrowException($e);
+        $this->bugsnag->expects($this->once())
+            ->method('notifyException')->with($e);
+        $this->callBeforeSaveAndAfterSave();
+    }
+
+}

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Config\Model\Config">
+        <plugin name="Bolt_BoltPay_Check_Settings_Update" type="Bolt\Boltpay\Plugin\CheckSettingsUpdate" />
+    </type>
+
     <type name="Bolt\Boltpay\Helper\Cart">
         <arguments>
             <argument name="checkoutSession" xsi:type="object">Magento\Backend\Model\Session\Quote</argument>


### PR DESCRIPTION
We should make GetFeatureSwitch call each time when plugin is installed / updated, but now we don't do it when plugin is installed: at this moment merchant key is empty and API call fails.
**Solution:**
Call GetFeatureSwitch  each time when merchant key is changed

Fixes: https://app.asana.com/0/941920570700290/1162717349359250/f

#changelog Make GetFeatureSwitch call when merchant key is changed

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Asana task link and provided a changelog message if applicable.
