### PR TITLE
Add a cron job to clean webhook logs older than 30 days

### DIFF
--- a/Cron/DeleteOldWebHookLogs.php
+++ b/Cron/DeleteOldWebHookLogs.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Cron;
+
+/**
+ * Class DeleteOldWebHookLogs
+ * @package Bolt\Boltpay\Cron
+ */
+class DeleteOldWebHookLogs
+{
+    /**
+     * @var \Bolt\Boltpay\Model\ResourceModel\WebhookLogFactory
+     */
+    protected $webhookLogFactory;
+
+    /**
+     * DeleteOldWebHookLogs constructor.
+     * @param \Bolt\Boltpay\Model\ResourceModel\WebhookLogFactory $webhookLogFactory
+     */
+    public function __construct(
+        \Bolt\Boltpay\Model\ResourceModel\WebhookLogFactory $webhookLogFactory
+    ) {
+        $this->webhookLogFactory = $webhookLogFactory;
+    }
+
+    /**
+     * Delete attempts older than 30 days
+     * @return $this
+     */
+    public function execute()
+    {
+        $this->webhookLogFactory->create()->deleteOldAttempts();
+        return $this;
+    }
+}

--- a/Model/ResourceModel/WebhookLog.php
+++ b/Model/ResourceModel/WebhookLog.php
@@ -22,11 +22,42 @@ use \Magento\Framework\Model\ResourceModel\Db\AbstractDb;
 class WebhookLog extends AbstractDb
 {
     /**
+     * Core Date
+     *
+     * @var \Magento\Framework\Stdlib\DateTime\DateTime
+     */
+    protected $_coreDate;
+
+    public function __construct(
+        \Magento\Framework\Stdlib\DateTime\DateTime $coreDate,
+        \Magento\Framework\Model\ResourceModel\Db\Context $context,
+        $connectionName = null
+    )
+    {
+        $this->_coreDate = $coreDate;
+        parent::__construct($context, $connectionName);
+    }
+
+    /**
      * WebhookLog Resource initialization
      * @return void
      */
     protected function _construct()
     {
         $this->_init('bolt_webhook_log', 'id');
+    }
+
+    /**
+     * Delete attempts older than 30 days
+     *
+     * @return void
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function deleteOldAttempts()
+    {
+        $this->getConnection()->delete(
+            $this->getMainTable(),
+            ['updated_at < ?' => $this->_coreDate->gmtDate(null, time() - 86400 * 30)]
+        );
     }
 }

--- a/Model/WebhookLog.php
+++ b/Model/WebhookLog.php
@@ -29,6 +29,35 @@ class WebhookLog extends AbstractModel implements \Magento\Framework\DataObject\
 
     protected $_cacheTag = self::CACHE_TAG;
 
+    /**
+     * Core Date
+     *
+     * @var \Magento\Framework\Stdlib\DateTime\DateTime
+     */
+    protected $_coreDate;
+
+    /**
+     * WebhookLog constructor.
+     * @param \Magento\Framework\Stdlib\DateTime\DateTime $coreDate
+     * @param \Magento\Framework\Model\Context $context
+     * @param \Magento\Framework\Registry $registry
+     * @param \Magento\Framework\Model\ResourceModel\AbstractResource|null $resource
+     * @param \Magento\Framework\Data\Collection\AbstractDb|null $resourceCollection
+     * @param array $data
+     */
+    public function __construct(
+        \Magento\Framework\Stdlib\DateTime\DateTime $coreDate,
+        \Magento\Framework\Model\Context $context,
+        \Magento\Framework\Registry $registry,
+        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
+        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
+        array $data = []
+    )
+    {
+        $this->_coreDate = $coreDate;
+        parent::__construct($context, $registry, $resource, $resourceCollection, $data);
+    }
+
     protected function _construct()
     {
         $this->_init('Bolt\Boltpay\Model\ResourceModel\WebhookLog');
@@ -53,6 +82,7 @@ class WebhookLog extends AbstractModel implements \Magento\Framework\DataObject\
         $this->setTransactionId($transactionId)
             ->setHookType($hookType)
             ->setNumberOfMissingQuoteFailedHooks(1)
+            ->setUpdatedAt($this->_coreDate->gmtDate())
             ->save();
 
         return $this;
@@ -63,7 +93,9 @@ class WebhookLog extends AbstractModel implements \Magento\Framework\DataObject\
      */
     public function incrementAttemptCount()
     {
-        $this->setNumberOfMissingQuoteFailedHooks($this->getNumberOfMissingQuoteFailedHooks() + 1)->save();
+        $this->setNumberOfMissingQuoteFailedHooks($this->getNumberOfMissingQuoteFailedHooks() + 1)
+             ->setUpdatedAt($this->_coreDate->gmtDate())
+             ->save();
 
         return $this;
     }

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -79,6 +79,8 @@ class UpgradeSchema implements UpgradeSchemaInterface
 
         $this->setupWebhookLogTable($setup);
 
+        $this->updateWebhookLogTable($setup);
+
         $setup->endSetup();
     }
 
@@ -234,5 +236,24 @@ class UpgradeSchema implements UpgradeSchemaInterface
             )
             ->setComment("Bolt customer credit cards");
         $setup->getConnection()->createTable($table);
+    }
+
+    private function updateWebhookLogTable($setup){
+        $tableCreated = $setup->getConnection()->isTableExists('bolt_webhook_log');
+
+        if (!$tableCreated) {
+            return;
+        }
+
+        $connection = $setup->getConnection();
+
+        $connection->addColumn(
+            $setup->getTable('bolt_webhook_log'),
+            'updated_at', [
+                'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TIMESTAMP,
+                'comment' => 'Updated At'
+            ]
+        );
+
     }
 }

--- a/Test/Unit/Cron/DeleteOldWebHookLogsTest.php
+++ b/Test/Unit/Cron/DeleteOldWebHookLogsTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Test\Unit\Helper;
+
+use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Model\ResourceModel\WebhookLogFactory;
+use Bolt\Boltpay\Cron\DeleteOldWebHookLogs;
+
+/**
+ * Class DeleteOldWebHookLogsTest
+ * @package Bolt\Boltpay\Test\Unit\Helper
+ */
+class DeleteOldWebHookLogsTest extends TestCase
+{
+
+    /**
+     * @var DeleteOldWebHookLogs
+     */
+    private $currentMock;
+
+    /**
+     * @var WebhookLogFactory
+     */
+    private $webhookLogFactory;
+
+    public function setUp()
+    {
+        $this->webhookLogFactory = $this->createPartialMock(
+            WebhookLogFactory::class,
+            ['create', 'deleteOldAttempts']
+        );
+
+        $this->currentMock = $this->getMockBuilder(DeleteOldWebHookLogs::class)
+            ->setConstructorArgs([
+               $this->webhookLogFactory
+            ])
+            ->enableProxyingToOriginalMethods()
+            ->getMock();
+    }
+
+    /**
+     * @test
+     */
+    public function execute()
+    {
+        $this->webhookLogFactory->expects(self::once())->method('create')->willReturnSelf();
+        $this->webhookLogFactory->expects(self::once())->method('deleteOldAttempts')->willReturnSelf();;
+        $this->currentMock->execute();
+    }
+}

--- a/Test/Unit/Model/WebhookLogTest.php
+++ b/Test/Unit/Model/WebhookLogTest.php
@@ -20,6 +20,11 @@ namespace Bolt\Boltpay\Test\Unit\Model;
 use Bolt\Boltpay\Model\WebhookLog;
 use PHPUnit\Framework\TestCase;
 use Bolt\Boltpay\Test\Unit\TestHelper;
+use Magento\Framework\Stdlib\DateTime\DateTime;
+use Magento\Framework\Model\Context;
+use Magento\Framework\Registry;
+use Magento\Framework\Model\ResourceModel\AbstractResource;
+use Magento\Framework\Data\Collection\AbstractDb;
 
 class WebhookLogTest extends TestCase
 {
@@ -27,18 +32,62 @@ class WebhookLogTest extends TestCase
     const HOOK_TYPE = 'pending';
 
     /**
-     * @var \Bolt\Boltpay\Model\WebhookLog
+     * @var WebhookLog
      */
     private $webhookLogMock;
 
     /**
-     * Setup for CustomerCreditCardTest Class
+     * @var DateTime
      */
+    private $coreDate;
+
+    /**
+     * @var Context
+     */
+    private $context;
+
+    /**
+     * @var Registry
+     */
+    private $registry;
+
+    /**
+     * @var AbstractResource
+     */
+    private $resource;
+
+    /**
+     * @var AbstractDb
+     */
+    private $resourceCollection;
+
     public function setUp()
     {
+        $this->coreDate = $this->createPartialMock(DateTime::class, ['gmtDate']);
+        $this->context = $this->createMock(Context::class);
+        $this->registry = $this->createMock(Registry::class);
+        $this->resource =  $this->createMock(AbstractResource::class);
+        $this->resourceCollection =  $this->createMock(AbstractDb::class);
+
         $this->webhookLogMock = $this->getMockBuilder(WebhookLog::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['_init', 'setTransactionId', 'setHookType', 'getNumberOfMissingQuoteFailedHooks', 'setNumberOfMissingQuoteFailedHooks', 'save', 'load'])
+            ->setConstructorArgs([
+                $this->coreDate,
+                $this->context,
+                $this->registry,
+                $this->resource,
+                $this->resourceCollection,
+                []
+            ])
+            ->setMethods([
+                '_init',
+                'setTransactionId',
+                'setHookType',
+                'getNumberOfMissingQuoteFailedHooks',
+                'setNumberOfMissingQuoteFailedHooks',
+                'save',
+                'load',
+                'setUpdatedAt'
+            ])
             ->getMock();
     }
 
@@ -60,9 +109,11 @@ class WebhookLogTest extends TestCase
      */
     public function recordAttempt()
     {
+        $this->coreDate->expects($this->once())->method('gmtDate')->willReturnSelf();
         $this->webhookLogMock->expects($this->once())->method('setTransactionId')->with(self::TRANSACTION_ID)->willReturnSelf();
         $this->webhookLogMock->expects($this->once())->method('setHookType')->with(self::HOOK_TYPE)->willReturnSelf();
         $this->webhookLogMock->expects($this->once())->method('setNumberOfMissingQuoteFailedHooks')->with(1)->willReturnSelf();
+        $this->webhookLogMock->expects($this->once())->method('setUpdatedAt')->willReturnSelf();
         $this->webhookLogMock->expects($this->once())->method('save')->willReturnSelf();
         $this->webhookLogMock->recordAttempt(self::TRANSACTION_ID, self::HOOK_TYPE);
     }
@@ -72,8 +123,10 @@ class WebhookLogTest extends TestCase
      */
     public function incrementAttemptCount()
     {
+        $this->coreDate->expects($this->once())->method('gmtDate')->willReturnSelf();
         $this->webhookLogMock->expects($this->once())->method('getNumberOfMissingQuoteFailedHooks')->willReturn(1);
         $this->webhookLogMock->expects($this->once())->method('setNumberOfMissingQuoteFailedHooks')->with(2)->willReturnSelf();
+        $this->webhookLogMock->expects($this->once())->method('setUpdatedAt')->willReturnSelf();
         $this->webhookLogMock->expects($this->once())->method('save')->willReturnSelf();
         $this->webhookLogMock->incrementAttemptCount();
     }

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -5,5 +5,8 @@
         <job name="deactivate_quote" instance="Bolt\Boltpay\Cron\DeactivateQuote" method="execute">
             <schedule>0 * * * *</schedule>
         </job>
+        <job name="delete_old_web_hook_logs" instance="Bolt\Boltpay\Cron\DeleteOldWebHookLogs" method="execute">
+            <schedule>0 1 * * *</schedule>
+        </job>
     </group>
 </config>


### PR DESCRIPTION
# Description
Add a cron job to clean webhook logs older than 30 days

Fixes: https://app.asana.com/0/564264490825835/1167004891081257

#changelog Add a cron job to clean webhook logs older than 30 days

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Asana task link and provided a changelog message if applicable.
