### PR TITLE
[Debug Endpoint] ENG-216 Add support to retrieve installed modules

### DIFF
--- a/Helper/ModuleRetriever.php
+++ b/Helper/ModuleRetriever.php
@@ -1,10 +1,23 @@
 <?php
-
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2019 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
 
 namespace Bolt\Boltpay\Helper;
 
 use Magento\Framework\App\ResourceConnection;
-use Bolt\Boltpay\Model\Api\Data\PluginVersion;
 use Bolt\Boltpay\Model\Api\Data\PluginVersionFactory;
 
 class ModuleRetriever
@@ -54,7 +67,7 @@ class ModuleRetriever
 			}
 
 			return $installedModules;
-		} catch (\Zend_Db_Statement_Exception $e) {
+		} catch (\Exception $e) {
 			$this->bugsnag->notifyException($e);
 		}
 	}

--- a/Helper/ModuleRetriever.php
+++ b/Helper/ModuleRetriever.php
@@ -1,0 +1,61 @@
+<?php
+
+
+namespace Bolt\Boltpay\Helper;
+
+use Magento\Framework\App\ResourceConnection;
+use Bolt\Boltpay\Model\Api\Data\PluginVersion;
+use Bolt\Boltpay\Model\Api\Data\PluginVersionFactory;
+
+class ModuleRetriever
+{
+	/**
+	 * @var ResourceConnection $resource
+	 */
+	private $resource;
+
+	/**
+	 * @var PluginVersionFactory
+	 */
+	private $pluginVersionFactory;
+
+	/**
+	 * @var Bugsnag
+	 */
+	private $bugsnag;
+
+	/**
+	 *
+	 * @param ResourceConnection $resource
+	 * @param PluginVersionFactory $pluginVersionFactory
+	 * @param Bugsnag $bugsnag
+	 *
+	 */
+	public function __construct(
+		ResourceConnection $resource,
+		PluginVersionFactory $pluginVersionFactory,
+		Bugsnag $bugsnag
+	) {
+		$this->resource = $resource;
+		$this->pluginVersionFactory = $pluginVersionFactory;
+		$this->bugsnag = $bugsnag;
+	}
+
+	public function getInstalledModules()
+	{
+		$connection = $this->resource->getConnection();
+		try {
+			$installedModules = [];
+			$rows = $connection->fetchAll('SELECT module, schema_version FROM setup_module');
+			foreach ($rows AS $row) {
+				$installedModules[] = $this->pluginVersionFactory->create()
+				                                                 ->setName($row['module'])
+				                                                 ->setVersion($row['schema_version']);
+			}
+
+			return $installedModules;
+		} catch (\Zend_Db_Statement_Exception $e) {
+			$this->bugsnag->notifyException($e);
+		}
+	}
+}

--- a/Model/Api/Debug.php
+++ b/Model/Api/Debug.php
@@ -21,9 +21,11 @@ use Bolt\Boltpay\Api\DebugInterface;
 use Bolt\Boltpay\Helper\Config as ConfigHelper;
 use Bolt\Boltpay\Helper\Hook as HookHelper;
 use Bolt\Boltpay\Model\Api\Data\DebugInfoFactory;
-use Bolt\Boltpay\Model\Api\Data\PluginVersionFactory;
 use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Store\Model\StoreManagerInterface;
+use Magento\Framework\Module\FullModuleList;
+use Bolt\Boltpay\Helper\ModuleRetriever;
+
 
 class Debug implements DebugInterface
 {
@@ -58,27 +60,32 @@ class Debug implements DebugInterface
 	private $configHelper;
 
 	/**
+	 * @var ModuleRetriever
+	 */
+	private $moduleRetriever;
+
+	/**
 	 * @param DebugInfoFactory $debugInfoFactory
-	 * @param PluginVersionFactory $pluginVersionFactory
 	 * @param StoreManagerInterface $storeManager
 	 * @param HookHelper $hookHelper
 	 * @param ProductMetadataInterface $productMetadata
 	 * @param ConfigHelper $configHelper
+	 * @param ModuleRetriever $moduleRetriever
 	 */
 	public function __construct(
 		DebugInfoFactory $debugInfoFactory,
-		PluginVersionFactory $pluginVersionFactory,
 		StoreManagerInterface $storeManager,
 		HookHelper $hookHelper,
 		ProductMetadataInterface $productMetadata,
-		ConfigHelper $configHelper
+		ConfigHelper $configHelper,
+		ModuleRetriever $moduleRetriever
 	) {
 		$this->debugInfoFactory = $debugInfoFactory;
-		$this->pluginVersionFactory = $pluginVersionFactory;
 		$this->storeManager = $storeManager;
 		$this->hookHelper = $hookHelper;
 		$this->productMetadata = $productMetadata;
 		$this->configHelper = $configHelper;
+		$this->moduleRetriever = $moduleRetriever;
 	}
 
 	/**
@@ -103,9 +110,11 @@ class Debug implements DebugInterface
 		# populate bolt config settings
 		$result->setBoltConfigSettings($this->configHelper->getAllConfigSettings());
 
-		$otherPluginVersions = [];
-		$otherPluginVersions[] = $this->pluginVersionFactory->create();
-		$result->setOtherPluginVersions($otherPluginVersions);
+		# populate bolt config settings
+		$result->setBoltConfigSettings($this->configHelper->getAllConfigSettings());
+
+		# populate other plugin info
+		$result->setOtherPluginVersions($this->moduleRetriever->getInstalledModules());
 
 		return $result;
 	}

--- a/Model/Api/Debug.php
+++ b/Model/Api/Debug.php
@@ -35,11 +35,6 @@ class Debug implements DebugInterface
 	private $debugInfoFactory;
 
 	/**
-	 * @var PluginVersionFactory
-	 */
-	private $pluginVersionFactory;
-
-	/**
 	 * @var HookHelper
 	 */
 	private $hookHelper;

--- a/Test/Unit/Helper/ModuleRetrieverTest.php
+++ b/Test/Unit/Helper/ModuleRetrieverTest.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2019 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Test\Unit\Helper;
+
+use Bolt\Boltpay\Helper\Bugsnag;
+use Bolt\Boltpay\Helper\ModuleRetriever;
+use Bolt\Boltpay\Model\Api\Data\PluginVersionFactory;
+use Bolt\Boltpay\Model\Api\Data\PluginVersion;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use PHPUnit\Framework\TestCase;
+
+class ModuleRetrieverTest extends TestCase
+{
+	/**
+	 * @var ModuleRetriever
+	 */
+	private $moduleRetriever;
+
+	/**
+	 * @var ResourceConnection
+	 */
+	private $resource;
+
+	/**
+	 * @var AdapterInterface
+	 */
+	private $dbConnection;
+
+	/**
+	 * @var PluginVersionFactory
+	 */
+	private $pluginVersionFactory;
+
+	/**
+	 * @var Bugsnag
+	 */
+	private $bugsnag;
+
+	/**
+	 * @var array
+	 */
+	private $dbResult;
+
+
+	/**
+	 * @inheritdoc
+	 */
+	public function setUp()
+	{
+		$this->dbResult = [
+			[
+				'module' => 'bolt',
+				'schema_version' => '2.3.0'
+			],
+			[
+				'module' => 'amazon',
+				'schema_version' => '1.3.0'
+			]
+		];
+
+		// prepare resource and dbConnection
+		$this->dbConnection = $this->createMock(AdapterInterface::class);
+		$this->resource = $this->createMock(ResourceConnection::class);
+		$this->resource->method('getConnection')->willReturn($this->dbConnection);
+		$this->dbConnection->method('fetchAll')->willReturn($this->dbResult);
+
+		// prepare plugin version factory
+		$this->pluginVersionFactory = $this->createMock(PluginVersionFactory::class);
+		$this->pluginVersionFactory->method('create')->willReturnCallback(function () {
+			return new PluginVersion();
+		});
+
+		// prepare bugsnag
+		$this->bugsnag = $this->createMock(Bugsnag::class);
+
+		// initialize test object
+		$objectManager = new ObjectManager($this);
+		$this->moduleRetriever = $objectManager->getObject(
+			ModuleRetriever::class,
+			[
+				'resource' => $this->resource,
+				'pluginVersionFactory' => $this->pluginVersionFactory,
+				'bugsnag' => $this->bugsnag
+			]
+		);
+	}
+
+	/**
+	 * @test
+	 */
+	public function getInstalledModules_success()
+	{
+		$actual = $this->moduleRetriever->getInstalledModules();
+		$this->assertEquals(count($this->dbResult), count($actual));
+		for ($i = 0; $i < count($this->dbResult); $i++) {
+			$this->assertEquals($this->dbResult[$i]['module'], $actual[$i]->getName());
+			$this->assertEquals($this->dbResult[$i]['schema_version'], $actual[$i]->getVersion());
+		}
+	}
+
+	/**
+	 * @test
+	 */
+	public function getInstalledModules_fail()
+	{
+		$this->dbConnection->method('fetchAll')->willThrowException(new \Exception());
+		$this->bugsnag->expects($this->once())->method('notifyException');
+		$this->moduleRetriever->getInstalledModules();
+	}
+}


### PR DESCRIPTION
# Description
Add support to retrieve installed modules from the database. It does not leverage \Magento\Framework\Module\FullModuleList because that would retrieve modules from Magento core which we are not interested in. (eg: things like Magento_Directory, Magento_Theme would be returned from FullModuleList)

Fixes: [ENG-216]

#changelog [Debug Endpoint] Add support to retrieve installed modules

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.


[ENG-216]: https://boltpay.atlassian.net/browse/ENG-216