### PR TITLE
 Add source field to the API request data and add transaction reference to the order status history when recharging the customer

### DIFF
--- a/Model/CustomerCreditCard.php
+++ b/Model/CustomerCreditCard.php
@@ -119,8 +119,9 @@ class CustomerCreditCard extends AbstractModel implements \Magento\Framework\Dat
                     "display_id" =>  $order->getIncrementId()  .'/ '.$order->getQuoteId(),
                     'order_reference' => $order->getQuoteId(),
                     'total_amount' => CurrencyUtils::toMinor($order->getGrandTotal(), $orderCurrency),
-                    'currency' => $orderCurrency
-                ]
+                    'currency' => $orderCurrency,
+                ],
+                'source' => 'direct_payments'
             ]
         );
 


### PR DESCRIPTION
 Add source field to the API request data and add transaction reference to the order status history when recharging the customer

# Description
Add source field to the API request data and add transaction reference to the order status history when recharging the customer

Fixes: https://app.asana.com/0/564264490825835/1167109004841033

#changelog  Add source field to the API request data and add transaction reference to the order status history when recharging the customer

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
