### PR TITLE
[Order management] ENP-25 show bolt account button

### DIFF
--- a/Block/Js.php
+++ b/Block/Js.php
@@ -46,6 +46,9 @@ class Js extends Template
      /** @var Bugsnag  Bug logging interface*/
     private $bugsnag;
 
+    /** @var array */
+    static $blockAlreadyShown;
+
     /**
      * @param Context         $context
      * @param Config          $configHelper
@@ -94,6 +97,18 @@ class Js extends Template
         $cdnUrl = $this->configHelper->getCdnUrl();
 
         return $cdnUrl.'/connect.js';
+    }
+
+    /**
+     * Get account js url
+     *
+     * @return  string
+     */
+    public function getAccountJsUrl()
+    {
+        $cdnUrl = $this->configHelper->getCdnUrl();
+
+        return $cdnUrl.'/account.js';
     }
 
     /**
@@ -394,5 +409,29 @@ class Js extends Template
             return "";
         }
         return '--bolt-primary-action-color:' . $buttonColor;
+    }
+
+    /**
+     * Return true if Order Management is enabled
+     * @return bool
+     */
+    public function isOrderManagementEnabled()
+    {
+        return $this->configHelper->isOrderManagementEnabled();
+    }
+
+    /**
+     * Return false if block wasn't shown yet
+     * Need to provide using block only once
+     *
+     * @return bool
+     */
+    public function isBlockAlreadyShown($blockType)
+    {
+        if (isset(static::$blockAlreadyShown[$blockType])) {
+            return true;
+        }
+        static::$blockAlreadyShown[$blockType] = true;
+        return false;
     }
 }

--- a/Block/Js.php
+++ b/Block/Js.php
@@ -417,7 +417,8 @@ class Js extends Template
      */
     public function isOrderManagementEnabled()
     {
-        return $this->configHelper->isOrderManagementEnabled();
+        return $this->configHelper->isOrderManagementEnabled() &&
+            $this->featureSwitches->isOrderManagementEnabled();
     }
 
     /**

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -122,6 +122,11 @@ class Config extends AbstractHelper
      */
     const XML_PATH_PRODUCT_PAGE_CHECKOUT = 'payment/boltpay/product_page_checkout';
 
+    /**
+     * Enable Bolt order management
+     */
+    const XML_PATH_PRODUCT_ORDER_MANAGEMENT = 'payment/boltpay/order_management';
+
 
     /**
      * Prefetch shipping
@@ -670,6 +675,22 @@ class Config extends AbstractHelper
     {
         return $this->getScopeConfig()->isSetFlag(
             self::XML_PATH_PRODUCT_PAGE_CHECKOUT,
+            ScopeInterface::SCOPE_STORE,
+            $store
+        );
+    }
+
+    /**
+     * Get Order management flag from config
+     *
+     * @param int|string|Store $store
+     *
+     * @return  boolean
+     */
+    public function isOrderManagementEnabled($store = null)
+    {
+        return $this->getScopeConfig()->isSetFlag(
+            self::XML_PATH_PRODUCT_ORDER_MANAGEMENT,
             ScopeInterface::SCOPE_STORE,
             $store
         );

--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -192,4 +192,8 @@ class Decider extends AbstractHelper {
     {
         return $this->isSwitchEnabled(Definitions::M2_TRACK_SHIPMENT);
     }
+
+    public function isOrderManagementEnabled() {
+        return $this->isSwitchEnabled(Definitions::M2_ORDER_MANAGEMENT);
+    }
 }

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -66,6 +66,11 @@ class Definitions {
      */
     const M2_TRACK_SHIPMENT = "M2_TRACK_SHIPMENT";
 
+    /**
+     * Enable Order Management (account button)
+     */
+    const M2_ORDER_MANAGEMENT = "M2_ORDER_MANAGEMENT";
+
     const DEFAULT_SWITCH_VALUES = array(
         self::M2_SAMPLE_SWITCH_NAME =>  array(
           self::NAME_KEY            => self::M2_SAMPLE_SWITCH_NAME,
@@ -99,6 +104,12 @@ class Definitions {
         ),
         self::M2_TRACK_SHIPMENT => array(
             self::NAME_KEY            => self::M2_TRACK_SHIPMENT,
+            self::VAL_KEY             => true,
+            self::DEFAULT_VAL_KEY     => false,
+            self::ROLLOUT_KEY         => 100
+        ),
+        self::M2_ORDER_MANAGEMENT =>  array(
+            self::NAME_KEY            => self::M2_ORDER_MANAGEMENT,
             self::VAL_KEY             => true,
             self::DEFAULT_VAL_KEY     => false,
             self::ROLLOUT_KEY         => 100

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -515,6 +515,7 @@ JSON;
             ['isSessionEmulationEnabled', BoltConfig::XML_PATH_API_EMULATE_SESSION],
             ['shouldMinifyJavascript', BoltConfig::XML_PATH_SHOULD_MINIFY_JAVASCRIPT, false],
             ['shouldCaptureMetrics', BoltConfig::XML_PATH_CAPTURE_MERCHANT_METRICS],
+            ['isOrderManagementEnabled', BoltConfig::XML_PATH_PRODUCT_ORDER_MANAGEMENT],
         ];
     }
 

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -62,6 +62,10 @@
                     <label>(BETA) Enable product page checkout</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
+                <field id="order_management" translate="label" type="select" sortOrder="82" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <label>(BETA) Enable Bolt order management</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
                 <field id="geolocation_api_key" translate="label" type="obscure" sortOrder="85" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Geolocation API Key</label>
                     <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -31,6 +31,7 @@
                 <custom_cdn></custom_cdn>
                 <debug>0</debug>
                 <product_page_checkout>0</product_page_checkout>
+                <order_management>0</order_management>
                 <allowspecific>0</allowspecific>
                 <order_status>new</order_status>
                 <currency>USD</currency>

--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -24,6 +24,14 @@
             <block class="Bolt\Boltpay\Block\Js" name="boltcss"   template="Bolt_Boltpay::css/boltcss.phtml"/>
             <block class="Bolt\Boltpay\Block\Js" name="replacejs" template="Bolt_Boltpay::js/replacejs.phtml"/>
         </referenceBlock>
+        <!-- for blank theme-->
+        <referenceBlock name="top.links">
+            <block class="Bolt\Boltpay\Block\Js" name="boltaccount_blank" template="Bolt_Boltpay::boltaccount.phtml" before="-"/>
+        </referenceBlock>
+        <!-- for luna theme-->
+        <referenceBlock name="header.links">
+            <block class="Bolt\Boltpay\Block\Js" name="boltaccount_luna" template="Bolt_Boltpay::boltaccount.phtml" before="-"/>
+        </referenceBlock>
         <referenceBlock name="after.body.start">
             <block class="Bolt\Boltpay\Block\Js" name="bolt_popup" template="Bolt_Boltpay::popup.phtml" />
         </referenceBlock>

--- a/view/frontend/templates/boltaccount.phtml
+++ b/view/frontend/templates/boltaccount.phtml
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2018 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * Bolt Account button
+ *
+ * @var $block \Bolt\Boltpay\Block\Js
+ */
+if ($block->shouldDisableBoltCheckout()) return;
+if (!$block->isOrderManagementEnabled()) return;
+if ($block->isBlockAlreadyShown('account')) return;
+$accountJsUrl   = $block->getAccountJsUrl();
+$checkoutKey  = $block->getCheckoutKey();
+?>
+<div class="bolt-account-login"></div>
+<script
+        id="bolt-account"
+        type="text/javascript"
+        src="<?php echo $accountJsUrl; ?>"
+        data-shopping-cart-id="magento2"
+        async
+        data-publishable-key="<?php echo $checkoutKey; ?>">
+</script>
+<style>
+.bolt-account-login{
+    display: inline-block;
+    margin-left: 15px;
+}
+.header.panel>.header.links{
+    height: 50px;
+    line-height: 50px;
+}
+.header.panel>.header.links>li.welcome,.header.panel>.header.links>li>a {
+    line-height: 50px!important;
+}
+.header.panel>.header.links>li.customer-welcome>span>button {
+    margin-top: 14px;
+}
+.header.panel {
+    padding-top: 0px!important;
+    padding-bottom: 0px!important;
+}
+</style>

--- a/view/frontend/templates/boltaccount.phtml
+++ b/view/frontend/templates/boltaccount.phtml
@@ -69,28 +69,3 @@ $checkoutKey = $block->getCheckoutKey();
 
     });
 </script>
-
-<style>
-    .bolt-account-login {
-        display: inline-block;
-        margin-left: 15px;
-    }
-
-    .header.panel > .header.links {
-        height: 50px;
-        line-height: 50px;
-    }
-
-    .header.panel > .header.links > li.welcome, .header.panel > .header.links > li > a {
-        line-height: 50px !important;
-    }
-
-    .header.panel > .header.links > li.customer-welcome > span > button {
-        margin-top: 14px;
-    }
-
-    .header.panel {
-        padding-top: 0px !important;
-        padding-bottom: 0px !important;
-    }
-</style>

--- a/view/frontend/templates/boltaccount.phtml
+++ b/view/frontend/templates/boltaccount.phtml
@@ -23,35 +23,74 @@
 if ($block->shouldDisableBoltCheckout()) return;
 if (!$block->isOrderManagementEnabled()) return;
 if ($block->isBlockAlreadyShown('account')) return;
-$accountJsUrl   = $block->getAccountJsUrl();
-$checkoutKey  = $block->getCheckoutKey();
+$accountJsUrl = $block->getAccountJsUrl();
+$checkoutKey = $block->getCheckoutKey();
 ?>
 <div class="bolt-account-login"></div>
-<script
-        id="bolt-account"
-        type="text/javascript"
-        src="<?php echo $accountJsUrl; ?>"
-        data-shopping-cart-id="magento2"
-        async
-        data-publishable-key="<?php echo $checkoutKey; ?>">
+<script>
+    require([
+        'jquery',
+        'matchMedia',
+    ], function ($, mediaCheck) {
+        var insertAccountScript = function () {
+            var scriptTag = document.getElementById('bolt-account');
+            if (scriptTag) {
+                return;
+            }
+            scriptTag = document.createElement('script');
+            scriptTag.setAttribute('type', 'text/javascript');
+            scriptTag.setAttribute('async', '');
+            scriptTag.setAttribute('src', '<?php echo $accountJsUrl; ?>');
+            scriptTag.setAttribute('id', 'bolt-account');
+            scriptTag.setAttribute('data-publishable-key', '<?php echo $checkoutKey; ?>');
+            document.head.appendChild(scriptTag);
+        }
+        mediaCheck({
+            media: '(max-width: 768px)',
+            entry: function () {
+                // When magento constructs mobile menu it copies elements instead of moving
+                // We need to wait for this coping, remove first bolt-account-login div
+                // And only ofter that insert account.js script
+                let timerId = setTimeout(function boltAccountLookup() {
+                    var $account_div = $("div.bolt-account-login");
+                    if ($account_div.length==2) {
+                        $account_div.eq(0).remove();
+                        insertAccountScript();
+                    } else {
+                        timerId = setTimeout(boltAccountLookup, 1000)
+                    }
+                }, 1000);
+            },
+            exit: function () {
+                // For desktop we are ready to insert script
+                insertAccountScript();
+            }
+        });
+
+    });
 </script>
+
 <style>
-.bolt-account-login{
-    display: inline-block;
-    margin-left: 15px;
-}
-.header.panel>.header.links{
-    height: 50px;
-    line-height: 50px;
-}
-.header.panel>.header.links>li.welcome,.header.panel>.header.links>li>a {
-    line-height: 50px!important;
-}
-.header.panel>.header.links>li.customer-welcome>span>button {
-    margin-top: 14px;
-}
-.header.panel {
-    padding-top: 0px!important;
-    padding-bottom: 0px!important;
-}
+    .bolt-account-login {
+        display: inline-block;
+        margin-left: 15px;
+    }
+
+    .header.panel > .header.links {
+        height: 50px;
+        line-height: 50px;
+    }
+
+    .header.panel > .header.links > li.welcome, .header.panel > .header.links > li > a {
+        line-height: 50px !important;
+    }
+
+    .header.panel > .header.links > li.customer-welcome > span > button {
+        margin-top: 14px;
+    }
+
+    .header.panel {
+        padding-top: 0px !important;
+        padding-bottom: 0px !important;
+    }
 </style>


### PR DESCRIPTION
add <div class="bolt-track-order"></div> and include core script account.js to show bolt account button

Fixes: [ENP-25]

#changelog Show bolt account button (order management)

Project summary:
Frontend changes:
add &lt;div class="bolt-track-order"&gt;&lt;/div&gt;
include core script account.js
As a result "account" button is shown
2. When a user clicks on the "account" button, they see iFrame with a prompt to enter an email.
3. Bolt server calls the new plugin endpoint to know if there is magento2 user with this email.
If yes, a user is redirected to M2 login page
If no, a user fills in the phone number, enters SMS code, and sees a page with all orders from this store.
4. When merchant staff add track number into order plugin, send it to bolt so that a user can see it in account iFrame
See https://boltpay.atlassian.net/wiki/spaces/EN/pages/735019129/Shopper+Dashboard+-+Order+Management

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.


[ENP-25]: https://boltpay.atlassian.net/browse/ENP-25