### PR TITLE
Cache result of transaction/<reference> API call

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -217,6 +217,11 @@ class Order extends AbstractHelper
     protected $customerCreditCardCollectionFactory;
 
     /**
+     * @var array transaction info cache
+     */
+    private $transactionInfo;
+
+    /**
      * @param Context $context
      * @param ApiHelper $apiHelper
      * @param Config $configHelper
@@ -312,6 +317,9 @@ class Order extends AbstractHelper
      */
     public function fetchTransactionInfo($reference, $storeId = null)
     {
+        if (isset($this->transactionInfo[$reference][$storeId])) {
+            return $this->transactionInfo[$reference][$storeId];
+        }
         //Request Data
         $requestData = $this->dataObjectFactory->create();
         $requestData->setDynamicApiUrl(ApiHelper::API_FETCH_TRANSACTION . "/" . $reference);
@@ -322,6 +330,7 @@ class Order extends AbstractHelper
 
         $result = $this->apiHelper->sendRequest($request);
         $response = $result->getResponse();
+        $this->transactionInfo[$reference][$storeId] = $response;
 
         return $response;
     }

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -317,8 +317,8 @@ class Order extends AbstractHelper
      */
     public function fetchTransactionInfo($reference, $storeId = null)
     {
-        if (isset($this->transactionInfo[$reference][$storeId])) {
-            return $this->transactionInfo[$reference][$storeId];
+        if (isset($this->transactionInfo[$reference])) {
+            return $this->transactionInfo[$reference];
         }
         //Request Data
         $requestData = $this->dataObjectFactory->create();
@@ -330,7 +330,7 @@ class Order extends AbstractHelper
 
         $result = $this->apiHelper->sendRequest($request);
         $response = $result->getResponse();
-        $this->transactionInfo[$reference][$storeId] = $response;
+        $this->transactionInfo[$reference] = $response;
 
         return $response;
     }

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -478,6 +478,12 @@ class OrderTest extends TestCase
             $response,
             $this->currentMock->fetchTransactionInfo(static::REFERENCE_ID, static::STORE_ID)
         );
+
+        // When we call method second time result should be returned from cache
+        static::assertEquals(
+            $response,
+            $this->currentMock->fetchTransactionInfo(static::REFERENCE_ID, static::STORE_ID)
+        );
     }
 
     /**


### PR DESCRIPTION
We do few API calls transaction/<reference> when we handle pending hook.
By this PR we add caching in function OrderHelper::fetchTransactionInfo, like we already do caching in CartHelper::getQuoteById

Fixes: https://app.asana.com/0/941920570700290/1163893469797548/f

#changelog Cache result of transaction/<reference> API call

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
