### PR TITLE
Fix Bug - undefined store id result in the failure of  backoffice order creation 

### DIFF
--- a/view/adminhtml/templates/boltpay/js/replacejs.phtml
+++ b/view/adminhtml/templates/boltpay/js/replacejs.phtml
@@ -307,8 +307,18 @@ require([
         }
     };
 
+    var boltConfigHandler = {
+        get: function(target, property) {
+            return target['boltConfig'][property];
+        },
+        set: function(target, property, value, receiver) {
+            target['boltConfig'][property] = value;
+            return true;
+        },
+    };
+
     // The configuration parameters passed from the php block
-    var settings = window.boltConfig,
+    var settings = new Proxy(window, boltConfigHandler),
     // TODO: make `with-cards` option backend configurable
         bolt_button_css_class    = 'bolt-checkout-button with-cards',
         bolt_button_selector     = '.bolt-checkout-button',

--- a/view/adminhtml/templates/boltpay/js/replacejs.phtml
+++ b/view/adminhtml/templates/boltpay/js/replacejs.phtml
@@ -307,6 +307,9 @@ require([
         }
     };
 
+    // The window object may be reset during backoffice creation for some reasons,
+    // as a result, the variable settings fail to keep in sync with window.boltConfig,
+    // so we use Proxy object to make sure settings always point to the updated window.boltConfig.
     var boltConfigHandler = {
         get: function(target, property) {
             return target['boltConfig'][property];

--- a/view/adminhtml/templates/boltpay/js/replacejs.phtml
+++ b/view/adminhtml/templates/boltpay/js/replacejs.phtml
@@ -307,21 +307,12 @@ require([
         }
     };
 
+    // The configuration parameters passed from the php block.
     // The window object may be reset during backoffice creation for some reasons,
     // as a result, the variable settings fail to keep in sync with window.boltConfig,
-    // so we use Proxy object to make sure settings always point to the updated window.boltConfig.
-    var boltConfigHandler = {
-        get: function(target, property) {
-            return target['boltConfig'][property];
-        },
-        set: function(target, property, value, receiver) {
-            target['boltConfig'][property] = value;
-            return true;
-        },
-    };
-
-    // The configuration parameters passed from the php block
-    var settings = new Proxy(window, boltConfigHandler),
+    // so we should treat it as a internal copy of window.boltConfig, the updates have to
+    // be applied on this variable instead of window.boltConfig.
+    var settings = window.boltConfig,
     // TODO: make `with-cards` option backend configurable
         bolt_button_css_class    = 'bolt-checkout-button with-cards',
         bolt_button_selector     = '.bolt-checkout-button',
@@ -456,8 +447,8 @@ require([
             hints = deepMergeObjects(hints, data.hints);
             hints.prefill = prefill;
 
-            window.boltConfig.storeId = data.storeId;
-            window.boltConfig.is_pre_auth = data.isPreAuth;
+            settings.storeId = data.storeId;
+            settings.is_pre_auth = data.isPreAuth;
 
             insertConnectScript(data.publishableKey);
         };


### PR DESCRIPTION
# Description
The window object may be reset during backoffice creation for some reasons, as a result, the variable settings fail to keep in sync with window.boltConfig, so we use Proxy object to make sure settings always point to the updated window.boltConfig.

Fixes: https://app.asana.com/0/941920570700290/1167452929959226/f

#changelog Fix Bug - undefined store id result in the failure of  backoffice order creation 

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Asana task link and provided a changelog message if applicable.
