### PR TITLE
Show message in backoffice when key is not set

### DIFF
--- a/Block/Form.php
+++ b/Block/Form.php
@@ -160,4 +160,11 @@ class Form extends PaymentForm
     public function isAdminReorderForLoggedInCustomerFeatureEnabled(){
         return $this->featureSwitch->isAdminReorderForLoggedInCustomerFeatureEnabled();
     }
+
+    /**
+     * @return string
+     */
+    public function getPublishableKeyBackOffice(){
+        return $this->configHelper->getPublishableKeyBackOffice();
+    }
 }

--- a/Test/Unit/Block/FormTest.php
+++ b/Test/Unit/Block/FormTest.php
@@ -177,4 +177,15 @@ class FormTest extends \PHPUnit\Framework\TestCase
         $this->featureSwitch->expects(static::once())->method('isAdminReorderForLoggedInCustomerFeatureEnabled')->willReturn(true);
         $this->assertTrue($this->block->isAdminReorderForLoggedInCustomerFeatureEnabled());
     }
+
+    /**
+     * @test
+     */
+    public function getPublishableKeyBackOfficeShouldReturnConfigValue(){
+        $this->configHelperMock
+            ->method('getPublishableKeyBackOffice')
+            ->willReturn("backoffice-key");
+
+        $this->assertEquals("backoffice-key", $this->block->getPublishableKeyBackOffice());
+    }
 }

--- a/view/adminhtml/templates/boltpay/button.phtml
+++ b/view/adminhtml/templates/boltpay/button.phtml
@@ -3,10 +3,14 @@
  * @var \Bolt\Boltpay\Block\Form $block
  */
 $code = $block->escapeHtml($block->getMethodCode());
+$backofficePublishableKey = $block->getPublishableKeyBackOffice();
 $customerCreditCardInfos = $block->getCustomerCreditCardInfo();
 $isAdminReorderForLoggedInCustomerFeatureEnabled = $block->isAdminReorderForLoggedInCustomerFeatureEnabled();
 ?>
 
+<?php if (!$backofficePublishableKey): ?>
+    In order to use Bolt from admin, please set "Publishable Key - Back Office" in the config.
+<?php else: ?>
 <fieldset class="admin__fieldset payment-method" id="payment_form_<?php /* @noEscape */ echo $code; ?>" style="display:none">
     <?php if ($isAdminReorderForLoggedInCustomerFeatureEnabled && $customerCreditCardInfos): ?>
         <div>
@@ -49,4 +53,6 @@ $isAdminReorderForLoggedInCustomerFeatureEnabled = $block->isAdminReorderForLogg
             });
         });
     </script>
+<?php endif; ?>
+
 <?php endif; ?>

--- a/view/adminhtml/templates/boltpay/button.phtml
+++ b/view/adminhtml/templates/boltpay/button.phtml
@@ -9,7 +9,7 @@ $isAdminReorderForLoggedInCustomerFeatureEnabled = $block->isAdminReorderForLogg
 ?>
 
 <?php if (!$backofficePublishableKey): ?>
-    In order to use Bolt from admin, please set "Publishable Key - Back Office" in the config.
+    In order to use Bolt from admin, please set "Publishable Key - Back Office" in the magento config (Stores > Configuration > Sales > Payment methods > Bolt Pay).
 <?php else: ?>
 <fieldset class="admin__fieldset payment-method" id="payment_form_<?php /* @noEscape */ echo $code; ?>" style="display:none">
     <?php if ($isAdminReorderForLoggedInCustomerFeatureEnabled && $customerCreditCardInfos): ?>


### PR DESCRIPTION
# Description
Currently we always show Bolt dropdown UI in admin order creation page but Bolt is useless unless key is configured. This PR adds message indicating you need to set key.

Before:
![Screen Shot 2020-04-03 at 4 40 37 PM](https://user-images.githubusercontent.com/980077/78417436-daae3800-75e6-11ea-998a-e6542962fec2.png)


After:
![Screen Shot 2020-04-03 at 4 52 00 PM](https://user-images.githubusercontent.com/980077/78417439-dda92880-75e6-11ea-8368-fe47205a3de3.png)


#changelog Show message in backoffice when key is not set



# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
