### PR TITLE
Remove unnecessary code in adminhtml/replacejs

### DIFF
--- a/view/adminhtml/templates/boltpay/js/replacejs.phtml
+++ b/view/adminhtml/templates/boltpay/js/replacejs.phtml
@@ -207,6 +207,16 @@ require([
     ////////////////////////////////
 
     /**
+     * Get the current page checkout type.
+     * This function should be extended for Magento checkout extensions.
+     *
+     * return string
+     */
+    var getCheckoutType = function() {
+        return 'payment';
+    };
+
+    /**
      * Get the checkout key according to the checkout type.
      *
      * return string

--- a/view/adminhtml/templates/boltpay/js/replacejs.phtml
+++ b/view/adminhtml/templates/boltpay/js/replacejs.phtml
@@ -207,16 +207,6 @@ require([
     ////////////////////////////////
 
     /**
-     * Get the current page checkout type.
-     * This function should be extended for Magento checkout extensions.
-     *
-     * return string
-     */
-    var getCheckoutType = function() {
-        return 'payment';
-    };
-
-    /**
      * Get the checkout key according to the checkout type.
      *
      * return string
@@ -225,52 +215,6 @@ require([
         var key = 'publishable_key_back_office';
 
         return settings[key];
-    };
-
-    /**
-     * Apply function to every element with the specified selector.
-     *
-     * param selector   elements CSS selector
-     * param fn         function to apply
-     *
-     * return void
-     */
-    var selectorApply = function(selector, fn){
-        var elements = document.querySelectorAll(selector);
-        for (var i = 0, length = elements.length; i < length; i++) {
-            var element = elements[i];
-            fn.call(element, element)
-        }
-    };
-
-    /**
-     * Apply function to every bolt checkout button.
-     *
-     * param fn         function to apply
-     *
-     * return void
-     */
-    var checkoutButtonApply = function(fn) {
-        var elm = document.getElementById('payment_form_boltpay');
-        if (elm.style.visibility = 'visible') {
-            selectorApply(bolt_button_selector, fn);
-        }
-    };
-
-    /**
-     * Toggle checkout button multi-step class, `bolt-multi-step-checkout`, according to the checkout type.
-     *
-     * return void
-     */
-    var setCheckoutTypeStyle = function() {
-        var checkout_type = getCheckoutType();
-        checkoutButtonApply(function(button) {
-            if (checkout_type === 'payment') {
-                button.classList.remove(multi_step_css_class);
-            } else {
-                button.classList.add(multi_step_css_class);
-            }
-        });
     };
 
     /**
@@ -297,12 +241,11 @@ require([
     };
 
     /**
-     * Set checkout button CSS and load connect.js
+     * Set load connect.js
      * return void
      */
     var processButtons = function () {
         if (getCheckoutKey() !== '') {
-            setCheckoutTypeStyle();
             createOrder();
         }
     };
@@ -313,12 +256,7 @@ require([
     // so we should treat it as a internal copy of window.boltConfig, the updates have to
     // be applied on this variable instead of window.boltConfig.
     var settings = window.boltConfig,
-    // TODO: make `with-cards` option backend configurable
-        bolt_button_css_class    = 'bolt-checkout-button with-cards',
-        bolt_button_selector     = '.bolt-checkout-button',
-        multi_step_css_class     = 'bolt-multi-step-checkout',
-        billing_address_selector = '#bolt-billing-address',
-        place_order_payload_id   = 'bolt-place-order-payload';
+        bolt_button_selector     = '.bolt-checkout-button';
 
     // On multiple checkout open/close actions the success event remains registered
     // resulting in making the success call multiple times. This variable stores
@@ -414,8 +352,6 @@ require([
             }
 
             return true;
-            // if orderToken is set the checkout window will open
-            // return !!cart.orderToken;
         }
     };
 
@@ -474,42 +410,6 @@ require([
         processButtons();
     });
     ////////////////////////////////////////////////
-
-    //////////////////////////////////////////////////////////
-    // loop through selectors array and set up the replacement
-    //////////////////////////////////////////////////////////
-    for (var i = 0, length = settings.selectors.length; i < length; i++) {
-        var selector = settings.selectors[i];
-        ! function(selector) {
-            var parts = selector.split('|'),
-                // the CSS selector
-                identifier = parts[0].trim(),
-                // button placement regarding the selector element, prepend, append
-                position =  parts[1];
-            /////////////////////////////////////////////////////
-            // replace the selectors with bolt button identifiers
-            // if / when selectors are in the DOM
-            /////////////////////////////////////////////////////
-            onElementReady(identifier, function(element) {
-                if (getCheckoutKey() === '') return;
-                var bolt_button = document.createElement("div");
-
-                bolt_button.setAttribute("class", bolt_button_css_class);
-                // place the button before or after selector element
-                if (position && position.trim().toLowerCase() === 'append') {
-                    element.parentNode.insertBefore(bolt_button, element.nextSibling);
-                } else {
-                    element.parentNode.insertBefore(bolt_button, element);
-                }
-                // if no position is specified remove the selector element
-                if (!position) {
-                    element.parentNode.removeChild(element);
-                }
-            });
-            /////////////////////////////////////////////////////
-        }(selector);
-    }
-    //////////////////////////////////////////////////////////
 
     ///////////////////////////////////////////////////////////
     // Reconfigure BoltCheckout with page collected hints data
@@ -613,39 +513,6 @@ require([
         } (prefix);
     }
     /////////////////////////////////////////////////////////////////////
-
-    ///////////////////////////////////////////////////////////
-    // Monitor Country DOM element change and update hints
-    ///////////////////////////////////////////////////////////
-    var country_selectors = ['select[name="order[billing_address][country_id]"]'];
-    monitorAttributesChange(country_selectors, function(element) {
-        if (!element.value) {
-            delete hints.prefill.country;
-        }
-        else {
-            hints.prefill.country = element.value;
-        }
-        delete hints.prefill.state;
-
-        configureHints();
-    }, true);
-    ///////////////////////////////////////////////////////////
-
-    ///////////////////////////////////////////////////////////
-    // Monitor State DOM element change and update hints
-    ///////////////////////////////////////////////////////////
-    var state_selectors = ['select[name="order[billing_address][region_id]"]'];
-    monitorAttributesChange(state_selectors, function(element) {
-        if (!element.value) {
-            delete hints.prefill.state;
-        }
-        else {
-            hints.prefill.state = element.options[element.selectedIndex].text;
-        }
-
-        configureHints();
-    });
-    ///////////////////////////////////////////////////////////
 
     /////////////////////////////////////////////////////
     // Call Bolt order creation Magento endpoint on


### PR DESCRIPTION
# Description
Deleting unused code. I believe these code was copied from `frontend/templates/js/replacejs.html` without much thought. These are completely unnecessary (details below).

 - setCheckoutTypeStyle: not needed, we only have one checkout type.
 - selectorApply, checkoutButtonApply: no longer used after deleting setCheckoutTypeStyle
 - billing_address_selector, place_order_payload_id: unused
 - multi_step_css_class, bolt_button_selector: no longer used after deleting setCheckoutTypeStyle
 - "loop through selectors array and set up the replacement": not needed, in admin we embed bolt button in phtml, no need to dynamically replace
 - "Monitor Country DOM element change and update hints": no need, since admin order is paymentonly these hints are not used at all


#changelog Remove unnecessary code in adminhtml/replacejs

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
