### PR TITLE
In-Store Pickup feature in the backoffice

### DIFF
--- a/Plugin/Magento/Sales/Model/AdminOrder/CreatePlugin.php
+++ b/Plugin/Magento/Sales/Model/AdminOrder/CreatePlugin.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Plugin\Magento\Sales\Model\AdminOrder;
+
+use Magento\Sales\Model\AdminOrder\Create;
+use Magento\Backend\Model\Session\Quote as AdminCheckoutSession;
+use Bolt\Boltpay\Helper\Config as ConfigHelper;
+
+class CreatePlugin
+{
+    /**
+     * @var \Bolt\Boltpay\Helper\Config
+     */
+    private $configHelper;
+
+    /** @var AdminCheckoutSession */
+    private $adminCheckoutSession;
+
+    /**
+     * CreatePlugin constructor.
+     * @param ConfigHelper $configHelper
+     * @param AdminCheckoutSession $adminCheckoutSession
+     */
+    public function __construct(
+        ConfigHelper $configHelper,
+        AdminCheckoutSession $adminCheckoutSession
+    )
+    {
+        $this->adminCheckoutSession = $adminCheckoutSession;
+        $this->configHelper = $configHelper;
+    }
+
+    /**
+     * @param Create $subject
+     * @param $data
+     * @return array
+     */
+    public function beforeImportPostData(Create $subject, $data)
+    {
+        if ($this->configHelper->isStorePickupFeatureEnabled() && isset($data['shipping_method'])) {
+            if ($this->configHelper->isPickupInStoreShippingMethodCode($data['shipping_method'])) {
+                $this->adminCheckoutSession->setData('old_shipping_address', $subject->getShippingAddress()->getData());
+                $subject->getShippingAddress()->addData($this->configHelper->getPickupAddressData());
+            } else {
+                if ($oldShippingAddress = $this->adminCheckoutSession->getData('old_shipping_address')) {
+                    $subject->getShippingAddress()->addData($oldShippingAddress);
+                    $this->adminCheckoutSession->unsetData('old_shipping_address');
+                }
+            }
+        }
+
+        return [$data];
+    }
+}

--- a/Test/Unit/Plugin/Magento/Sales/Model/AdminOrder/CreatePluginTest.php
+++ b/Test/Unit/Plugin/Magento/Sales/Model/AdminOrder/CreatePluginTest.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Test\Unit\Plugin\Magento\Model\AdminOrder;
+
+use PHPUnit\Framework\TestCase;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Bolt\Boltpay\Plugin\Magento\Sales\Model\AdminOrder\CreatePlugin;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use Bolt\Boltpay\Helper\Config as ConfigHelper;
+use Magento\Backend\Model\Session\Quote as AdminCheckoutSession;
+use Magento\Sales\Model\AdminOrder\Create;
+
+/**
+ * Class CreatePlugin
+ * @package Bolt\Boltpay\Test\Unit\Plugin\Magento\Model\AdminOrder;
+ * @coversDefaultClass \Bolt\Boltpay\Plugin\Magento\Sales\Model\AdminOrder\CreatePlugin
+ */
+class CreatePluginTest extends TestCase
+{
+    const STORE_PICKUP_ADDRESS_DATA = [
+        'city' => 'Knoxville',
+        'country_id' => 'US',
+        'postcode' => '37921',
+        'region_code' => 'TN',
+        'region_id' => '56',
+        'street' => '4535 ANNALEE Way
+Room 4000',
+    ];
+
+    const NORMAL_ADDRESS = [
+        'city' => 'Knoxville',
+        'country_id' => 'US',
+        'postcode' => '37921',
+        'region_code' => 'TN',
+        'region_id' => '78',
+        'street' => '4611 ANNALEE Way
+Room 1111',
+    ];
+
+    /**
+     * @var ConfigHelper
+     */
+    protected $configHelper;
+
+    /**
+     * @var AdminCheckoutSession
+     */
+    protected $adminCheckoutSession;
+
+    /**
+     * @var Create
+     */
+    protected $createModel;
+
+    /** @var CreatePlugin */
+    protected $plugin;
+
+    protected function setUp()
+    {
+        $this->configHelper = $this->createPartialMock(ConfigHelper::class, ['isStorePickupFeatureEnabled', 'isPickupInStoreShippingMethodCode', 'getPickupAddressData']);
+        $this->adminCheckoutSession = $this->createPartialMock(AdminCheckoutSession::class, ['setData', 'getData', 'unsetData']);
+        $this->createModel = $this->createPartialMock(Create::class, [
+            'getShippingAddress',
+            'getData',
+            'addData'
+        ]);
+        // initialize test object
+        $objectManager = new ObjectManager($this);
+        $this->plugin = $objectManager->getObject(
+            CreatePlugin::class,
+            [
+                'configHelper' => $this->configHelper,
+                'adminCheckoutSession' => $this->adminCheckoutSession
+            ]
+        );
+    }
+
+    /**
+     * @test
+     * @covers ::beforeImportPostData
+     */
+    public function beforeImportPostData_ifStorePickupFeatureIsDisabled()
+    {
+        $this->configHelper->expects(self::once())->method('isStorePickupFeatureEnabled')->willReturn(false);
+        $this->configHelper->expects(self::never())->method('isPickupInStoreShippingMethodCode')->willReturnSelf();
+        $this->adminCheckoutSession->expects(self::never())->method('getData')->with('old_shipping_address')->willReturnSelf();
+        $this->plugin->beforeImportPostData($this->createModel, ['shipping_method' => 'instorepickup_instorepickup_']);
+    }
+
+    /**
+     * @test
+     * @covers ::beforeImportPostData
+     */
+    public function beforeImportPostData_ifCustomerChooseStorePickUpMethod()
+    {
+        $this->configHelper->expects(self::once())->method('isStorePickupFeatureEnabled')->willReturn(true);
+        $this->configHelper->expects(self::once())->method('isPickupInStoreShippingMethodCode')->with('instorepickup_instorepickup_')->willReturn(true);
+
+        $this->createModel->expects(self::exactly(2))->method('getShippingAddress')->willReturnSelf();
+        $this->createModel->expects(self::once())->method('getData')->willReturn(self::NORMAL_ADDRESS);
+        $this->adminCheckoutSession->expects(self::once())->method('setData')->with('old_shipping_address', self::NORMAL_ADDRESS)->willReturnSelf();
+
+        $this->configHelper->expects(self::once())->method('getPickupAddressData')->willReturn(self::STORE_PICKUP_ADDRESS_DATA);
+        $this->createModel->expects(self::once())->method('addData')->with(self::STORE_PICKUP_ADDRESS_DATA)->willReturnSelf();
+
+        $this->plugin->beforeImportPostData($this->createModel, ['shipping_method' => 'instorepickup_instorepickup_']);
+    }
+
+    /**
+     * @test
+     * @covers ::beforeImportPostData
+     */
+    public function beforeImportPostData_ifCustomerChooseShippingMethodIsStorePickup()
+    {
+        $this->configHelper->expects(self::once())->method('isStorePickupFeatureEnabled')->willReturn(true);
+        $this->configHelper->expects(self::once())->method('isPickupInStoreShippingMethodCode')->with('is_not_instorepickup_instorepickup_')->willReturn(false);
+
+        $this->adminCheckoutSession->expects(self::once())->method('getData')->with('old_shipping_address')->willReturn(false);
+        $this->createModel->expects(self::never())->method('getShippingAddress')->willReturnSelf();
+
+        $this->plugin->beforeImportPostData($this->createModel, ['shipping_method' => 'is_not_instorepickup_instorepickup_']);
+    }
+
+    /**
+     * @test
+     * @covers ::beforeImportPostData
+     */
+    public function beforeImportPostData_ifCustomerChooseStorePickupMethodThenChooseAnotherMethod()
+    {
+        $this->configHelper->expects(self::once())->method('isStorePickupFeatureEnabled')->willReturn(true);
+        $this->configHelper->expects(self::once())->method('isPickupInStoreShippingMethodCode')->with('is_not_instorepickup_instorepickup_')->willReturn(false);
+
+        $this->adminCheckoutSession->expects(self::once())->method('getData')->with('old_shipping_address')->willReturn(self::NORMAL_ADDRESS);
+        $this->adminCheckoutSession->expects(self::once())->method('unsetData')->with('old_shipping_address')->willReturnSelf();
+
+        $this->createModel->expects(self::once())->method('getShippingAddress')->willReturnSelf();
+        $this->createModel->expects(self::once())->method('addData')->with(self::NORMAL_ADDRESS)->willReturnSelf();
+
+        $this->plugin->beforeImportPostData($this->createModel, ['shipping_method' => 'is_not_instorepickup_instorepickup_']);
+    }
+}

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -25,4 +25,8 @@
     <type name="Mirasvit\Credit\Observer\QuotePaymentImportDataBefore">
         <plugin name="Bolt_Boltpay_Mirasvit_Credit_QuotePaymentImportDataBefore_Plugin" type="Bolt\Boltpay\Plugin\MirasvitCreditQuotePaymentImportDataBeforePlugin" sortOrder="1" />
     </type>
+
+    <type name="Magento\Sales\Model\AdminOrder\Create">
+        <plugin name="BoltBoltpayCreatePlugin" type="Bolt\Boltpay\Plugin\Magento\Sales\Model\AdminOrder\CreatePlugin" sortOrder="1"/>
+    </type>
 </config>


### PR DESCRIPTION
# Description
This PR supports the following case in the backoffice:
When the In-Store Pickup Feature is enabled and the customer chose the shipping method which has the same code as the In-Store Pickup Shipping Method Code, it automatically uses the In-Store Pickup Address as the shipping address to calculate the tax and create the order
Here are some of the screenshots:
http://prntscr.com/rqxymm
http://prntscr.com/rqxq2a
http://prntscr.com/rqxxto

Fixes: https://app.asana.com/0/564264490825835/1169894609956309
https://app.asana.com/0/1142111051828235/1143602415454165

#changelog In-Store Pickup feature in the backoffice

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
