### PR TITLE
Prevent Bolt order creation if the order already exists

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -668,7 +668,8 @@ class Cart extends AbstractHelper
     {
         //Get cart data
         $cart = $this->getCartData($paymentOnly, $placeOrderPayload);
-        if (!$cart) {
+
+        if (!$cart || $this->doesOrderExist($cart)) {
             return;
         }
 
@@ -715,6 +716,18 @@ class Cart extends AbstractHelper
         }
 
         return $boltOrder;
+    }
+
+    /**
+     * @param $cart
+     * @return false|OrderInterface
+     */
+    public function doesOrderExist($cart)
+    {
+        list($incrementId,) = isset($cart['display_id']) ? explode(' / ', $cart['display_id']) : [null, null];
+        $order = $this->getOrderByIncrementId($incrementId);
+
+        return $order;
     }
 
     /**

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -468,7 +468,8 @@ class CartTest extends TestCase
             'clearExternalData',
             'convertCustomAddressFieldsToCacheIdentifier',
             'getCustomAddressFieldsPascalCaseArray',
-            'getCalculationAddress'
+            'getCalculationAddress',
+            'doesOrderExist'
         ];
 
         $mock = $this->createPartialMock(BoltHelperCart::class, $methods);
@@ -671,6 +672,36 @@ ORDER;
         $result = $mock->getBoltpayOrder(false, '');
 
         $this->assertEquals($result, $boltOrder);
+    }
+
+    /**
+     * @test
+     */
+    public function getBoltpayOrder_IfOrderExists()
+    {
+        $mock = $this->getHelperCartMock();
+
+        $cart = $this->getCart();
+        $mock->expects(self::once())
+            ->method('getCartData')
+            ->with(false, '')
+            ->willReturn($cart);
+
+        $mock->expects(self::once())
+            ->method('doesOrderExist')
+            ->with($cart)
+            ->willReturn(true);
+
+        $mock->expects(self::never())
+            ->method('getSessionQuoteStoreId')
+            ->willReturn(self::STORE_ID);
+
+        $mock->expects(self::never())
+            ->method('isBoltOrderCachingEnabled')
+            ->with(self::STORE_ID)
+            ->willReturn(false);
+
+         $mock->getBoltpayOrder(false, '');
     }
 
     /**


### PR DESCRIPTION
# Description
Prevent Bolt order creation if the order already exists

Fixes: https://app.asana.com/0/564264490825835/1170646880319281

#changelog Prevent Bolt order creation if the order already exists

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
