### PR TITLE
Add catalog price rule support for backend orders

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -18,6 +18,7 @@
 namespace Bolt\Boltpay\Helper;
 
 use Bolt\Boltpay\Model\Response;
+use Magento\Framework\Registry;
 use Magento\Framework\Session\SessionManagerInterface as CheckoutSession;
 use Magento\Catalog\Model\ProductRepository;
 use Bolt\Boltpay\Helper\Api as ApiHelper;
@@ -228,6 +229,11 @@ class Cart extends AbstractHelper
     private $quoteManagement;
 
     /**
+     * @var Registry
+     */
+    private $coreRegistry;
+
+    /**
      * @param Context           $context
      * @param CheckoutSession   $checkoutSession
      * @param ProductRepository $productRepository
@@ -253,6 +259,7 @@ class Cart extends AbstractHelper
      * @param CartManagementInterface $quoteManagement
      * @param HookHelper $hookHelper
      * @param CustomerRepository $customerRepository
+     * @param Registry $coreRegistry
      *
      * @codeCoverageIgnore
      */
@@ -281,7 +288,8 @@ class Cart extends AbstractHelper
         ResourceConnection $resourceConnection,
         CartManagementInterface $quoteManagement,
         HookHelper $hookHelper,
-        CustomerRepository $customerRepository
+        CustomerRepository $customerRepository,
+        Registry $coreRegistry
     ) {
         parent::__construct($context);
         $this->checkoutSession = $checkoutSession;
@@ -308,6 +316,7 @@ class Cart extends AbstractHelper
         $this->quoteManagement = $quoteManagement;
         $this->hookHelper = $hookHelper;
         $this->customerRepository = $customerRepository;
+        $this->coreRegistry = $coreRegistry;
     }
 
     /**
@@ -1246,6 +1255,25 @@ class Cart extends AbstractHelper
         }
 
         $this->setLastImmutableQuote($immutableQuote);
+        if ($this->isBackendSession()) {
+            /**
+             * initialize rule data for backend orders, consumed by
+             * @see \Magento\CatalogRule\Observer\ProcessAdminFinalPriceObserver::execute
+             */
+            $this->coreRegistry->unregister('rule_data');
+            $this->coreRegistry->register(
+                'rule_data',
+                new \Magento\Framework\DataObject(
+                    [
+                        'store_id'          => $this->checkoutSession->getStore()->getId(),
+                        'website_id'        => $this->checkoutSession->getStore()->getWebsiteId(),
+                        'customer_group_id' => $immutableQuote->getCustomerGroupId()
+                            ? $immutableQuote->getCustomerGroupId()
+                            : $this->checkoutSession->getCustomerGroupId()
+                    ]
+                )
+            );
+        }
         $immutableQuote->collectTotals();
 
         // Set order_reference to parent quote id.

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -23,6 +23,7 @@ use Bolt\Boltpay\Helper\Log;
 use Magento\Catalog\Model\Product;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 use Magento\Customer\Model\Address;
+use Magento\Framework\Registry;
 use Magento\Quote\Model\Quote;
 use Magento\Framework\Exception\NoSuchEntityException;
 use \PHPUnit\Framework\TestCase;
@@ -114,6 +115,11 @@ class CartTest extends TestCase
     private $quoteMock;
 
     /**
+     * @var CustomerRepository|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $coreRegistry;
+
+    /**
      * @inheritdoc
      */
     public function setUp()
@@ -173,6 +179,7 @@ class CartTest extends TestCase
         $this->quoteManagement = $this->createMock(CartManagementInterface::class);
         $this->hookHelper = $this->createMock(HookHelper::class);
         $this->customerRepository = $this->createMock(CustomerRepository::class);
+        $this->coreRegistry = $this->createMock(Registry::class);
     }
 
     /**
@@ -247,7 +254,8 @@ class CartTest extends TestCase
             $this->resourceConnection,
             $this->quoteManagement,
             $this->hookHelper,
-            $this->customerRepository
+            $this->customerRepository,
+            $this->coreRegistry
         );
 
         $paymentOnly = false;
@@ -948,7 +956,8 @@ ORDER;
                 $this->resourceConnection,
                 $this->quoteManagement,
                 $this->hookHelper,
-                $this->customerRepository
+                $this->customerRepository,
+                $this->coreRegistry
             ])->getMock();
     }
 
@@ -2765,5 +2774,40 @@ ORDER;
         $quoteMock->expects(static::once())->method('getShippingAddress')->willReturn($shippingAddress);
         $hints = $this->getCurrentMock()->getHints();
         static::assertEquals((object)[], $hints['prefill']);
+    }
+    /**
+     * @test
+     * that getCartData populates registry rule_data when executed from backend
+     *
+     * @covers ::getCartData
+     */
+    public function getCartData_fromBackend_initializesRuleData()
+    {
+        $billingAddress = $this->getBillingAddress();
+        $shippingAddress = $this->getShippingAddress();
+        $immutableQuote = $this->getQuoteMock($billingAddress, $shippingAddress);
+        $this->checkoutSession = $this->createMock(\Magento\Backend\Model\Session\Quote::class);
+        $currentMock = $this->getCurrentMock(['isBackendSession', 'getCartItems', 'collectDiscounts']);
+        $immutableQuote->method('getAllVisibleItems')->willReturn(true);
+        $currentMock->expects($this->once())->method('getCartItems')->willReturn([[['total_amount' => 0]], 0, 0]);
+
+        $storeMock = $this->createMock(\Magento\Store\Model\Store::class);
+        $storeMock->method('getId')->willReturn(self::STORE_ID);
+        $storeMock->method('getWebsiteId')->willReturn(1);
+
+        $this->checkoutSession->method('getStore')->willReturn($storeMock);
+        $this->coreRegistry->expects($this->once())->method('unregister')->with('rule_data');
+        $this->coreRegistry->expects($this->once())->method('register')->with(
+            'rule_data',
+            new DataObject(
+                [
+                    'store_id'          => self::STORE_ID,
+                    'website_id'        => 1,
+                    'customer_group_id' => \Magento\Customer\Api\Data\GroupInterface::NOT_LOGGED_IN_ID
+                ]
+            )
+        );
+        $immutableQuote->expects($this->once())->method('collectTotals');
+        $currentMock->getCartData(false, '', $immutableQuote);
     }
 }


### PR DESCRIPTION
# Description
Items which have special prices set are not picked up by Bolt in the Admin checkout

Fixes: https://boltpay.atlassian.net/browse/M2P-44

#changelog Add catalog price rule support for backend orders

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
