### PR TITLE
Fix void issue

### DIFF
--- a/Model/Payment.php
+++ b/Model/Payment.php
@@ -310,7 +310,7 @@ class Payment extends AbstractMethod
                 );
             }
 
-            if (@$response->status != 'cancelled') {
+            if (!in_array(@$response->status,['cancelled','completed'])) {
                 throw new LocalizedException(__('Payment void error.'));
             }
 

--- a/Test/Unit/Model/PaymentTest.php
+++ b/Test/Unit/Model/PaymentTest.php
@@ -208,16 +208,27 @@ class PaymentTest extends TestCase
 
     /**
      * @test
+     * @dataProvider provider_voidPayment_success
+     *
+     * @param $responseStatus
+     * @throws \Exception
      */
-    public function voidPayment_success()
+    public function voidPayment_success($responseStatus)
     {
         $this->mockApiResponse(
             "merchant/transactions/void",
-            '{"status": "cancelled", "reference": "ABCD-1234-XXXX"}'
+            '{"status": "'.$responseStatus.'", "reference": "ABCD-1234-XXXX"}'
         );
         $this->orderHelper->expects($this->once())->method('updateOrderPayment');
 
         $this->currentMock->void($this->paymentMock);
+    }
+
+    public function provider_voidPayment_success(){
+        return [
+            ['cancelled'],
+            ['completed']
+        ];
     }
 
     /**


### PR DESCRIPTION
# Description
This PR resolves the following case:
1. Order amounting to $100 is created on Magento and Bolt
2. The merchant does a partial capture of $1 on Bolt => the Bolt transaction status changes to Completed
3. The merchant goes to Magento admin and clicks on the Void button
4. The remaining authorization amount ($99) is voided on Bolt but on Magento, the exception “Payment void error“ is thrown since the Bolt transaction status is not canceled
The expected behavior for step #4 is that there shouldn't be any exception thrown and the Magento payment is voided



The expected behavior for step #4 is that there isn’t be any exception thrown and the Magento payment is voided

Fixes: https://app.asana.com/0/564264490825835/1172249160918697

#changelog Fix void issue

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
