### PR TITLE
Ignore Bolt hooks for the invoice creation and credit memo creation with default switch is off

### DIFF
--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -200,4 +200,12 @@ class Decider extends AbstractHelper {
     public function isPayByLinkEnabled() {
         return $this->isSwitchEnabled(Definitions::M2_PAY_BY_LINK);
     }
+
+    public function isIgnoreHookForCreditMemoCreationEnabled() {
+        return $this->isSwitchEnabled(Definitions::M2_IGNORE_HOOK_FOR_CREDIT_MEMO_CREATION);
+    }
+
+    public function isIgnoreHookForInvoiceCreationEnabled() {
+        return $this->isSwitchEnabled(Definitions::M2_IGNORE_HOOK_FOR_INVOICE_CREATION);
+    }
 }

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -76,6 +76,16 @@ class Definitions {
      */
     const M2_PAY_BY_LINK = "M2_PAY_BY_LINK";
 
+    /**
+     * Enable ignore hook for invoice creation feature
+     */
+    const M2_IGNORE_HOOK_FOR_INVOICE_CREATION = "M2_IGNORE_HOOK_FOR_INVOICE_CREATION";
+
+    /**
+     * Enable ignore hook for credit memo creation feature
+     */
+    const M2_IGNORE_HOOK_FOR_CREDIT_MEMO_CREATION = "M2_IGNORE_HOOK_FOR_CREDIT_MEMO_CREATION";
+
     const DEFAULT_SWITCH_VALUES = array(
         self::M2_SAMPLE_SWITCH_NAME =>  array(
           self::NAME_KEY            => self::M2_SAMPLE_SWITCH_NAME,
@@ -124,6 +134,18 @@ class Definitions {
             self::VAL_KEY             => true,
             self::DEFAULT_VAL_KEY     => false,
             self::ROLLOUT_KEY         => 0
-        )
+        ),
+        self::M2_IGNORE_HOOK_FOR_CREDIT_MEMO_CREATION =>  array(
+            self::NAME_KEY            => self::M2_IGNORE_HOOK_FOR_CREDIT_MEMO_CREATION,
+            self::VAL_KEY             => true,
+            self::DEFAULT_VAL_KEY     => false,
+            self::ROLLOUT_KEY         => 0
+        ),
+        self::M2_IGNORE_HOOK_FOR_INVOICE_CREATION =>  array(
+            self::NAME_KEY            => self::M2_IGNORE_HOOK_FOR_INVOICE_CREATION,
+            self::VAL_KEY             => true,
+            self::DEFAULT_VAL_KEY     => false,
+            self::ROLLOUT_KEY         => 0
+        ),
     );
 }


### PR DESCRIPTION
# Description
In some cases, we need to ignore Bolt hooks for the invoice creation and credit memo creation in order to support the merchant's ERP flow.


Fixes: 
https://app.asana.com/0/1142111051828235/1165846798496323
https://app.asana.com/0/564264490825835/1172269575436441

#changelog Ignore Bolt hooks for the invoice creation and credit memo creation with default switch is off

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
