### PR TITLE
PPC support for products with two or more customizable options

### DIFF
--- a/view/frontend/templates/button_product_page.phtml
+++ b/view/frontend/templates/button_product_page.phtml
@@ -229,16 +229,37 @@ if (!$block->isSupportableType()) return;
             setupProductPage();
             $('#qty').on('change', setupProductPage);
 
+            // Object holding the base item price
+            // and price deltas for every custom option selected.
+            // The properties are added / updated on custom
+            // options change in updatePrice event listened below.
+            // The final item price is the sum of all prices stored here.
+            var itemPrices = {
+                basePrice: <?= $block->getProduct()->getFinalPrice(); ?>
+            };
+
+            /**
+             * Sum the values of all (numeric) object properties
+             * @param obj
+             * @returns {number}
+             */
+            var sum = function (obj) {
+                return Object.keys(obj).reduce(
+                    function(sum,key) {
+                        return sum+(parseFloat(obj[key])||0);
+                    }, 0
+                );
+            };
+
             $(document).on( 'updatePrice', function (event, data) {
                 // the name of the property that holds the price data
                 // varies depending on the product type, eg. prices, options
                 var key = Object.keys(data)[0];
                 if (key) {
                     var finalPrice = data[key].finalPrice;
-                    if (finalPrice && typeof finalPrice === 'object') {
-                        var priceDelta = finalPrice.amount ? finalPrice.amount : 0;
-                        itemPrice = <?= $block->getProduct()->getFinalPrice(); ?> + priceDelta;
-                    }
+                    itemPrices[key] =
+                        finalPrice && typeof finalPrice === 'object' && finalPrice.amount ? finalPrice.amount : 0;
+                    itemPrice = sum(itemPrices);
                 }
                 setupProductPage();
             });


### PR DESCRIPTION
# Description
Preconditions:
Product with two or more customizable options is created
Product Page Checkout is enabled
User is on the product page

Steps to reproduce:
1. Select the fist customizable option
2. Select the second customizable option
3. Open bolt modal

Actual result:
Price from the first option is counted up. Price from the both options is counted up in a few seconds.

Expected result:
Price from the both options is counted up immediately.

Fixes: https://app.asana.com/0/941920570700290/1168880447444715/f

#changelog PPC support for products with two or more customizable options

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
