### PR TITLE
Remove beta because PPC is GA

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -85,7 +85,7 @@
                     <label>Additional options</label>
                     <attribute type="expanded">1</attribute>
                     <field id="product_page_checkout" translate="label" type="select" sortOrder="80" showInDefault="1" showInWebsite="1" showInStore="0">
-                        <label>(BETA) Product page checkout</label>
+                        <label>Product page checkout</label>
                         <comment>Enable Bolt Checkout on Product Pages</comment>
                         <config_path>payment/boltpay/product_page_checkout</config_path>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>


### PR DESCRIPTION
Remove beta from ppc admin setting label because it's GA

Fixes: (link Asana Task)

#changelog Remove beta because PPC is GA

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [ ] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
