### PR TITLE
Add bolt checkout type to quote

### DIFF
--- a/Controller/Order/ReceivedUrl.php
+++ b/Controller/Order/ReceivedUrl.php
@@ -100,7 +100,7 @@ class ReceivedUrl extends Action
      */
     protected function redirectToAdminIfNeeded($quote)
     {
-        if (!$quote->getBoltIsBackendOrder()) {
+        if ($quote->getBoltCheckoutType() != CartHelper::BOLT_CHECKOUT_TYPE_BACKOFFICE) {
             return false;
         }
 

--- a/Model/Api/CreateOrder.php
+++ b/Model/Api/CreateOrder.php
@@ -376,7 +376,7 @@ class CreateOrder implements CreateOrderInterface
      */
     public function isBackOfficeOrder($quote)
     {
-        return (bool)$quote->getBoltIsBackendOrder();
+        return $quote->getBoltCheckoutType() == CartHelper::BOLT_CHECKOUT_TYPE_BACKOFFICE;
     }
 
     /**

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -67,6 +67,7 @@ class UpgradeSchema implements UpgradeSchemaInterface
             [
                 'type' => \Magento\Framework\DB\Ddl\Table::TYPE_SMALLINT,
                 'unsigned' => true,
+                'nullable' => false,
                 'default' => '1',
                 'comment' => '1 - multi-step, 2 - PPC, 3 - back office'
             ]

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -56,14 +56,19 @@ class UpgradeSchema implements UpgradeSchemaInterface
             ]
         );
 
+        $setup->getConnection()->dropColumn(
+            $setup->getTable('quote'),
+            'bolt_is_backend_order'
+        );
+
         $setup->getConnection()->addColumn(
             $setup->getTable('quote'),
-            'bolt_is_backend_order',
+            'bolt_checkout_type',
             [
                 'type' => \Magento\Framework\DB\Ddl\Table::TYPE_SMALLINT,
                 'unsigned' => true,
-                'default' => '0',
-                'comment' => '0 - frontend order, 1 - backend order'
+                'default' => '1',
+                'comment' => '1 - multi-step, 2 - PPC, 3 - back office'
             ]
         );
 

--- a/Test/Unit/Controller/Order/ReceivedUrlTest.php
+++ b/Test/Unit/Controller/Order/ReceivedUrlTest.php
@@ -229,17 +229,17 @@ class ReceivedUrlTest extends TestCase
         $request = $this->initRequest($this->defaultRequestMap);
 
         $order = $this->createOrderMock(Order::STATE_PENDING_PAYMENT);
-        $quote = $this->createPartialMock(Quote::class, [ 'getId', 'getStoreId', 'getBoltIsBackendOrder' ]);
+        $quote = $this->createPartialMock(Quote::class, [ 'getId', 'getStoreId', 'getBoltCheckoutType' ]);
         $quote->method('getId')
               ->willReturn(self::QUOTE_ID);
-        $quote->expects(self::once())->method('getBoltIsBackendOrder')->willReturn(true);
+        $quote->expects(self::once())->method('getBoltCheckoutType')
+              ->willReturn(CartHelper::BOLT_CHECKOUT_TYPE_BACKOFFICE);
 
         $cartHelper = $this->createMock(CartHelper::class);
         $cartHelper->expects($this->once())
                    ->method('getQuoteById')
                    ->with(self::QUOTE_ID)
                    ->willReturn($quote);
-
 
         $checkoutSession = $this->createMock(CheckoutSession::class);
 

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -481,7 +481,8 @@ class CartTest extends TestCase
             'getCustomAddressFieldsPascalCaseArray',
             'getCalculationAddress',
             'doesOrderExist',
-            'deactivateSessionQuote'
+            'deactivateSessionQuote',
+            'saveQuote'
         ];
 
         $mock = $this->createPartialMock(BoltHelperCart::class, $methods);
@@ -2268,11 +2269,6 @@ ORDER;
         $quote->expects($this->onceOrAny($isSuccessfulCase))
             ->method('setIsActive')
             ->with(false);
-        $quote->expects($this->onceOrAny($isSuccessfulCase))
-            ->method('collectTotals')
-            ->willReturnSelf();
-        $quote->expects($this->onceOrAny($isSuccessfulCase))
-            ->method('save');
 
         $this->quoteFactory = $this->getMockBuilder(QuoteFactory::class)
             ->setMethods(['create','load'])
@@ -2305,11 +2301,15 @@ ORDER;
 
         $expectedCartData = $this->createCartByRequest_GetExpectedCartData();
 
-        $cartMock = $this->getCurrentMock(['getCartData']);
+        $cartMock = $this->getCurrentMock(['getCartData', 'saveQuote']);
         $cartMock->expects($this->once())
             ->method('getCartData')
             ->with(false,'',$quote)
             ->willReturn($expectedCartData);
+
+        $cartMock->expects($this->once())
+            ->method('saveQuote')
+            ->with($quote);
 
         $this->assertEquals($expectedCartData, $cartMock->createCartByRequest($request));
     }

--- a/Test/Unit/Model/Api/CreateOrderTest.php
+++ b/Test/Unit/Model/Api/CreateOrderTest.php
@@ -182,8 +182,8 @@ class CreateOrderTest extends TestCase
                 'getAllVisibleItems',
                 'isVirtual',
                 'getShippingAddress',
-                'getBoltIsBackendOrder',
-                'getQuoteCurrencyCode'
+                'getQuoteCurrencyCode',
+                'getBoltCheckoutType'
             ]);
         $this->quoteMock->method('getStoreId')->willReturn(self::STORE_ID);
         $this->quoteMock->method('getQuoteCurrencyCode')->willReturn("USD");
@@ -672,7 +672,9 @@ class CreateOrderTest extends TestCase
      */
     public function isBackOfficeOrder_true()
     {
-        $this->quoteMock->expects(self::once())->method('getBoltIsBackendOrder')->willReturn(true);
+        $this->quoteMock->expects(self::once())
+                        ->method('getBoltCheckoutType')
+                        ->willReturn(CartHelper::BOLT_CHECKOUT_TYPE_BACKOFFICE);
         self::assertTrue($this->currentMock->isBackOfficeOrder($this->quoteMock));
     }
 
@@ -682,7 +684,9 @@ class CreateOrderTest extends TestCase
      */
     public function isBackOfficeOrder_false()
     {
-        $this->quoteMock->expects(self::once())->method('getBoltIsBackendOrder')->willReturn(false);
+        $this->quoteMock->expects(self::once())
+            ->method('getBoltCheckoutType')
+            ->willReturn(CartHelper::BOLT_CHECKOUT_TYPE_MULTISTEP);
         self::assertFalse($this->currentMock->isBackOfficeOrder($this->quoteMock));
     }
 

--- a/Test/Unit/Model/Service/InvoiceServiceTest.php
+++ b/Test/Unit/Model/Service/InvoiceServiceTest.php
@@ -17,6 +17,7 @@
 
 namespace Bolt\Boltpay\Test\Unit\Model;
 
+use Magento\Framework\Serialize\Serializer\Json as JsonSerializer;
 use PHPUnit\Framework\TestCase;
 use Magento\Sales\Api\InvoiceRepositoryInterface;
 use Magento\Sales\Api\InvoiceCommentRepositoryInterface;
@@ -126,6 +127,8 @@ class InvoiceServiceTest extends TestCase
             ['addItem']
         );
 
+        $this->serializer = $this->createMock(JsonSerializer::class);
+
         $this->currentMock = $this->getMockBuilder(InvoiceService::class)
             ->setConstructorArgs([
                 $this->repository,
@@ -134,7 +137,8 @@ class InvoiceServiceTest extends TestCase
                 $this->filterBuilder,
                 $this->invoiceNotifier,
                 $this->orderRepository,
-                $this->orderConverter
+                $this->orderConverter,
+                $this->serializer
             ])
             ->enableProxyingToOriginalMethods()
             ->getMock();


### PR DESCRIPTION
# Description
Replace **bolt_is_backend_order** quote table column with **bolt_checkout_type**
so we can use it to cover more cases, PPC being one of them.
Needed for shipping and tax split to work.

Fixes: https://app.asana.com/0/941920570700290/1172688451409921/f

#changelog Add bolt checkout type to quote

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
