### PR TITLE
PPC button missing in IE fix

### DIFF
--- a/view/frontend/templates/button_product_page.phtml
+++ b/view/frontend/templates/button_product_page.phtml
@@ -193,7 +193,7 @@ if (!$block->isSupportableType()) return;
                 var options = {};
                 var compositeAttributes = ['super_attribute', 'options'];
                 formData = new FormData(document.getElementById("product_addtocart_form"));
-                formData.forEach(function(value, key) {
+                $.each( formData, function( key, value ) {
                     var matchResult;
                     for (var index in compositeAttributes) {
                         var compositeAttribute = compositeAttributes[index];


### PR DESCRIPTION
# Description
[M2 v2.6.0 production readiness bug] PPC button is missing in IE

Fixes: https://boltpay.atlassian.net/browse/M2P-47

#changelog PPC button missing in IE fix

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
