### PR TITLE
 Fix the save credit card failure by allowing order to be created with the immutable quote even when the parent quote is deleted

### DIFF
--- a/Model/Api/OrderManagement.php
+++ b/Model/Api/OrderManagement.php
@@ -161,7 +161,7 @@ class OrderManagement implements OrderManagementInterface
             $this->hookHelper->preProcessWebhook($storeId);
 
             if ($type === 'pending') {
-                $this->orderHelper->saveCustomerCreditCard($reference,$storeId);
+                $this->orderHelper->saveCustomerCreditCard($display_id, $reference,$storeId);
             }
 
             if ($type == 'cart.create') {

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -3742,7 +3742,7 @@ class OrderTest extends TestCase
         $this->customerCreditCardFactory->expects(static::never())->method('create');
         $this->customerCreditCardFactory->expects(static::never())->method('saveCreditCard');
 
-        $result = $this->currentMock->saveCustomerCreditCard(OrderManagementTest::REFERENCE,OrderManagementTest::STORE_ID);
+        $result = $this->currentMock->saveCustomerCreditCard(self::DISPLAY_ID,OrderManagementTest::REFERENCE,OrderManagementTest::STORE_ID);
         $this->assertFalse($result);
 
     }
@@ -3790,8 +3790,60 @@ class OrderTest extends TestCase
         $this->customerCreditCardFactory->expects(static::once())->method('create')->willReturnSelf();
         $this->customerCreditCardFactory->expects(static::once())->method('saveCreditCard')->willReturnSelf();
 
-        $result = $this->currentMock->saveCustomerCreditCard(OrderManagementTest::REFERENCE,OrderManagementTest::STORE_ID);
+        $result = $this->currentMock->saveCustomerCreditCard(self::DISPLAY_ID,OrderManagementTest::REFERENCE,OrderManagementTest::STORE_ID);
         $this->assertTrue($result);
+    }
+
+    /**
+     * @test
+     */
+    public function testSaveCustomerCreditCard_IfParentQuoteDoesNotExist(){
+        $this->initCurrentMock(['fetchTransactionInfo']);
+        $transaction = new \stdClass();
+        @$transaction->from_consumer->id = 1;
+        @$transaction->from_credit_card->id = 1;
+        @$transaction->order->cart->order_reference = self::QUOTE_ID;
+
+        $this->currentMock->expects(static::once())->method('fetchTransactionInfo')->with(OrderManagementTest::REFERENCE, OrderManagementTest::STORE_ID)
+            ->willReturn($transaction);
+        $this->quoteMock->expects(self::once())->method('getCustomerId')
+            ->willReturn(self::CUSTOMER_ID);
+
+        $this->cartHelper->expects(self::exactly(2))->method('getQuoteById')
+            ->withConsecutive([self::QUOTE_ID], [self::IMMUTABLE_QUOTE_ID])
+            ->willReturnOnConsecutiveCalls(null, $this->quoteMock);
+
+        $this->customerCreditCardCollectionFactory->expects(self::once())->method('create')->willReturnSelf();
+        $this->customerCreditCardCollectionFactory->expects(self::once())->method('doesCardExist')->willReturn(false);
+
+        $this->customerCreditCardFactory->expects(static::once())->method('create')->willReturnSelf();
+        $this->customerCreditCardFactory->expects(static::once())->method('saveCreditCard')->willReturnSelf();
+
+        $result = $this->currentMock->saveCustomerCreditCard(self::DISPLAY_ID,OrderManagementTest::REFERENCE,OrderManagementTest::STORE_ID);
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @test
+     */
+    public function testSaveCustomerCreditCard_IfQuoteDoesNotExist(){
+        $this->initCurrentMock(['fetchTransactionInfo']);
+        $transaction = new \stdClass();
+        @$transaction->from_consumer->id = 1;
+        @$transaction->from_credit_card->id = 1;
+        @$transaction->order->cart->order_reference = self::QUOTE_ID;
+
+        $this->currentMock->expects(static::once())->method('fetchTransactionInfo')->with(OrderManagementTest::REFERENCE, OrderManagementTest::STORE_ID)
+            ->willReturn($transaction);
+
+
+        $this->cartHelper->expects(self::exactly(2))->method('getQuoteById')
+            ->withConsecutive([self::QUOTE_ID], [self::IMMUTABLE_QUOTE_ID])
+            ->willReturnOnConsecutiveCalls(null, null);
+
+
+        $result = $this->currentMock->saveCustomerCreditCard(self::DISPLAY_ID,OrderManagementTest::REFERENCE,OrderManagementTest::STORE_ID);
+        $this->assertFalse($result);
     }
 
     /**
@@ -3817,7 +3869,7 @@ class OrderTest extends TestCase
         $this->customerCreditCardFactory->expects(static::once())->method('create')->willReturnSelf();
         $this->customerCreditCardFactory->expects(static::once())->method('saveCreditCard')->willThrowException(new \Exception());
 
-        $result = $this->currentMock->saveCustomerCreditCard(OrderManagementTest::REFERENCE,OrderManagementTest::STORE_ID);
+        $result = $this->currentMock->saveCustomerCreditCard(self::DISPLAY_ID,OrderManagementTest::REFERENCE,OrderManagementTest::STORE_ID);
         $this->assertFalse($result);
     }
 
@@ -3846,7 +3898,7 @@ class OrderTest extends TestCase
         $this->customerCreditCardFactory->expects(static::never())->method('create');
         $this->customerCreditCardFactory->expects(static::never())->method('saveCreditCard');
 
-        $result = $this->currentMock->saveCustomerCreditCard(OrderManagementTest::REFERENCE, OrderManagementTest::STORE_ID);
+        $result = $this->currentMock->saveCustomerCreditCard(self::DISPLAY_ID,OrderManagementTest::REFERENCE,OrderManagementTest::STORE_ID);
         $this->assertFalse($result);
     }
 

--- a/Test/Unit/Model/Api/OrderManagementTest.php
+++ b/Test/Unit/Model/Api/OrderManagementTest.php
@@ -767,7 +767,7 @@ class OrderManagementTest extends TestCase
     public function testSaveCustomerCreditCardWhenPendingHookIsSentToMagento(){
         $type = "pending";
         $this->orderHelperMock->expects(self::once())->method('saveCustomerCreditCard')
-            ->with(self::REFERENCE,self::STORE_ID)->willReturnSelf();
+            ->with(self::DISPLAY_ID, self::REFERENCE, self::STORE_ID)->willReturnSelf();
 
         $this->currentMock->manage(
             self::ID,


### PR DESCRIPTION
# Description
1. Customer added items to cart, clicked the Bolt button, finished the first and second steps in the Bolt modal
2. During the third step, somehow the parent quote was deleted
3. Customer clicked the 'Pay' button in the Bolt modal and the exception "PHP Fatal error:  Uncaught Error: Call to a member function getCustomerId() on bool in vendor/boltpay/bolt-magento2/Helper/Order.php:867" was thrown so the order wasn't created on Magento

The PR fixes the save credit card failure by allowing order to be created with the immutable quote even when the parent quote has been deleted

Fixes: 
https://app.asana.com/0/1125081140214268/1173245397463499
https://app.asana.com/0/564264490825835/1174039461828337

#changelog  Fix the save credit card failure by allowing order to be created with the immutable quote even when the parent quote is deleted

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
