### PR TITLE
Allow the retry pending hook to authorize the order if its status is pending payment

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -1704,7 +1704,8 @@ class Order extends AbstractHelper
         if (
             $transactionState == $prevTransactionState &&
             $reference == $prevTransactionReference &&
-            !$newCapture
+            !$newCapture &&
+            !($hookType == Hook::HT_PENDING && $order->getState() == OrderModel::STATE_PENDING_PAYMENT)
         ) {
             if ($this->isAnAllowedUpdateFromAdminPanel($order, $transactionState)){
                 $payment->setIsTransactionApproved(true);

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -2954,6 +2954,47 @@ class OrderTest extends TestCase
 
     /**
      * @test
+     * @covers ::updateOrderPayment
+     */
+    public function updateOrderPayment_sameState_withPendingHookAndOrderStatusIsPendingPayment()
+    {
+        $transactionState = OrderHelper::TS_AUTHORIZED;
+        $prevTransactionState = OrderHelper::TS_AUTHORIZED;
+        list($transaction, $paymentMock) = $this->updateOrderPaymentSetUp($transactionState);
+        $prevTransactionReference = self::REFERENCE_ID;
+        $this->orderMock->expects(self::any())->method('getState')
+            ->willReturn(OrderModel::STATE_PENDING_PAYMENT);
+
+        $this->currentMock->expects(self::never())->method('isAnAllowedUpdateFromAdminPanel')
+            ->with($this->orderMock, $transactionState)->willReturn(true);
+        $paymentMock->expects(self::never())->method('setIsTransactionApproved')->with(true);
+        $paymentMock->expects(self::atLeastOnce())->method('getAdditionalInformation')
+            ->withConsecutive(
+                ['transaction_state'],
+                ['transaction_reference'],
+                ['real_transaction_id'],
+                ['authorized'],
+                ['captures']
+            )->willReturnOnConsecutiveCalls(
+                $prevTransactionState,
+                $prevTransactionReference,
+                self::TRANSACTION_ID,
+                true,
+                ''
+            );
+
+        $this->transactionBuilder->expects(self::once())->method('setPayment')->with($paymentMock)->willReturnSelf();
+        $this->transactionBuilder->expects(self::once())->method('setOrder')->with($this->orderMock)->willReturnSelf();
+        $this->transactionBuilder->expects(self::once())->method('setTransactionId')->willReturnSelf();
+        $this->transactionBuilder->expects(self::once())->method('setAdditionalInformation')->willReturnSelf();
+        $this->transactionBuilder->expects(self::once())->method('setFailSafe')->with(true)->willReturnSelf();
+        $this->transactionBuilder->expects(self::once())->method('build')->willReturn($paymentMock);
+
+        $this->currentMock->updateOrderPayment($this->orderMock, $transaction, self::REFERENCE_ID, self::HOOK_TYPE_PENDING);
+    }
+
+    /**
+     * @test
      *
      * @covers ::updateOrderPayment
      */


### PR DESCRIPTION
This PR resolves the following case:
1. The customer clicked the Pay button in the Bolt modal and the order was created on both Bolt and Magento.
2. The first pending hook was sent to Magento and the exception “Unprocessable Entity: SQLSTATE[40001]: Serialization failure: 1213 Deadlock found when trying to get lock“ was thrown ( See here: http://prntscr.com/rnr9cp). The deadlock exception is an edge case exception.
3. Since the first pending hook failed, Bolt re-sent the second pending hook to Magento to re-authorize the order. But the odd thing here is that it skipped because of this code http://prntscr.com/sb7lgg

So I create the PR to allow the retry pending hook to authorize the order if it's status is pending payment so the #3 above won’t occur.

Fixes: 
https://coredevelop.atlassian.net/browse/BOLT-1151
https://app.asana.com/0/564264490825835/1174248011660489

#changelog Allow the retry pending hook to authorize the order if its status is pending payment

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [x] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
