### PR TITLE
Show the error message when estimating shipping and tax in the Bolt popup

### DIFF
--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -260,8 +260,10 @@ class ShippingMethods implements ShippingMethodsInterface
         }
 
         if (!$quoteItems) {
-            throw new LocalizedException(
-                __('The Cart is empty.')
+            throw new BoltException (
+                __('The cart is empty. Please reload the page and checkout again.'),
+                null,
+                6103
             );
         }
 
@@ -283,8 +285,10 @@ class ShippingMethods implements ShippingMethodsInterface
                     ]
                 ]);
             });
-            throw new LocalizedException(
-                __('Cart Items data has changed.')
+            throw new BoltException (
+                __('Something in your cart has changed and needs to be revised. Please reload the page and checkout again.'),
+                null,
+                6103
             );
         }
     }
@@ -341,7 +345,14 @@ class ShippingMethods implements ShippingMethodsInterface
             $this->quote = $this->getQuoteById($quoteId);
 
             if (!$this->quote) {
-                $this->throwUnknownQuoteIdException($quoteId);
+                $exception =  new BoltException(
+                    __('Unknown quote id: %1.', $quoteId)
+                );
+                return $this->catchExceptionAndSendError(
+                    $exception,
+                    __('Something went wrong with your cart. Please reload the page and checkout again.'),
+                    6103
+                );
             }
 
             $this->preprocessHook();


### PR DESCRIPTION

# Description
Some customers don’t know that reloading the page will resolve the issue so this PR to show the error message when estimating shipping and tax in the Bolt popup

Fixes: 
https://app.asana.com/0/564264490825835/1174575430604089
https://app.asana.com/0/1137788479595677/1161674658962066

#changelog Show the error message when estimating shipping and tax in the Bolt popup

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
