### PR TITLE
Success order redirect does not work for back-office orders

### DIFF
--- a/Controller/Adminhtml/Cart/Data.php
+++ b/Controller/Adminhtml/Cart/Data.php
@@ -60,7 +60,7 @@ class Data extends Action
      * @var MetricsClient
      */
     private $metricsClient;
-    
+
     /**
      * @var DataObjectFactory
      */
@@ -116,7 +116,8 @@ class Data extends Action
             }
 
             $storeId = $this->cartHelper->getSessionQuoteStoreId();
-            $publishableKey = $this->configHelper->getPublishableKeyBackOffice($storeId);
+            $backOfficeKey = $this->configHelper->getPublishableKeyBackOffice($storeId);
+            $paymentOnlyKey = $this->configHelper->getPublishableKeyPayment($storeId);
             $isPreAuth = $this->configHelper->getIsPreAuth($storeId);
 
             // format and send the response
@@ -129,7 +130,8 @@ class Data extends Action
             $result = $this->dataObjectFactory->create();
             $result->setData('cart', $cart);
             $result->setData('hints', $hints);
-            $result->setData('publishableKey', $publishableKey);
+            $result->setData('backOfficeKey', $backOfficeKey);
+            $result->setData('paymentOnlyKey', $paymentOnlyKey);
             $result->setData('storeId', $storeId);
             $result->setData('isPreAuth', $isPreAuth);
 

--- a/Controller/Adminhtml/Order/ReceivedUrl.php
+++ b/Controller/Adminhtml/Order/ReceivedUrl.php
@@ -99,4 +99,14 @@ class ReceivedUrl extends Action
 
         return $this->_backendUrl->getUrl('sales/order/view', $params);
     }
+
+    /**
+     * Here we don't validate URL form/secret keys because administrator is redirected here from frontend
+     * This poses no security risk as this endpoint requires payload signed by Bolt to work
+     * Potentially move signature validation here
+     */
+    public function _processUrlKeys()
+    {
+        return true;
+    }
 }

--- a/Test/Unit/Controller/Adminhtml/Order/ReceivedUrlTest.php
+++ b/Test/Unit/Controller/Adminhtml/Order/ReceivedUrlTest.php
@@ -31,7 +31,11 @@ use Magento\Sales\Model\Order;
 use Bolt\Boltpay\Helper\Order as OrderHelper;
 use Magento\Backend\Model\UrlInterface;
 use Bolt\Boltpay\Test\Unit\TestHelper;
+use PHPUnit_Framework_MockObject_MockObject;
 
+/**
+ * @coversDefaultClass \Bolt\Boltpay\Controller\Adminhtml\Order\ReceivedUrl
+ */
 class ReceivedUrlTest extends TestCase
 {
     const ORDER_ID = '1234';
@@ -134,6 +138,19 @@ class ReceivedUrlTest extends TestCase
         $this->order->expects(self::once())->method('getStoreId')->willReturn(self::STORE_ID);
 
         TestHelper::invokeMethod($this->currentMock, 'getRedirectUrl',[$this->order]);
+    }
 
+    /**
+     * @test
+     * that _processUrlKeys always returns true
+     *
+     * @covers ::_processUrlKeys
+     */
+    public function _processUrlKeys_always_returnsTrue()
+    {
+        /** @var PHPUnit_Framework_MockObject_MockObject|ReceivedUrl $currentMock */
+        $currentMock = $this->getMockBuilder(ReceivedUrl::class)
+            ->disableOriginalConstructor()->setMethods(null)->getMock();
+        static::assertTrue($currentMock->_processUrlKeys());
     }
 }

--- a/view/adminhtml/templates/boltpay/js/replacejs.phtml
+++ b/view/adminhtml/templates/boltpay/js/replacejs.phtml
@@ -217,19 +217,6 @@ require([
     };
 
     /**
-     * Get the checkout key for backoffice processing.
-     *
-     * return string
-     */
-    var getBackofficeKey = function () {
-        return settings['publishable_key_back_office'];
-    };
-
-    var getPaymentOnlyKey = function() {
-        return settings['publishable_key_payment'];
-    }
-
-    /**
      * Inject connect.js
      * return void
      */
@@ -250,15 +237,6 @@ require([
         scriptTag.setAttribute('data-publishable-key', publishableKey);
         scriptTag.onload = function() {BoltCheckout.configure(cart, hints, callbacks);}
         document.head.appendChild(scriptTag);
-    };
-
-    /**
-     * return void
-     */
-    var processButtons = function () {
-        if (getBackofficeKey() || getPaymentOnlyKey()) {
-            createOrder();
-        }
     };
 
     // The configuration parameters passed from the php block.
@@ -397,16 +375,16 @@ require([
             settings.storeId = data.storeId;
             settings.is_pre_auth = data.isPreAuth;
 
-            if (getBackofficeKey()) {
-                insertConnectScript(data.publishableKey);
+            if (data.backOfficeKey) {
+                insertConnectScript(data.backOfficeKey);
             }
-            if (getPaymentOnlyKey() && settings.pay_by_link_url) {
+            if (data.paymentOnlyKey && settings.pay_by_link_url) {
                 $(".bolt-checkout-pay-by-link").html("Send <a href='"
-                    + settings.pay_by_link_url + "?publishable_key=" + getPaymentOnlyKey()
+                    + settings.pay_by_link_url + "?publishable_key=" + data.paymentOnlyKey
                     + "&token=" + data.cart.orderToken
                     + "'>this link</a> to consumer to receive payment");
             }
-            if (getBackofficeKey() && getPaymentOnlyKey() && settings.pay_by_link_url) {
+            if (data.backOfficeKey && data.paymentOnlyKey && settings.pay_by_link_url) {
                 $(".bolt-checkout-options-separator").show();
             }
         };
@@ -421,19 +399,15 @@ require([
     };
     /////////////////////////////////////////////////////
 
-    /////////////////////////////////////////////////////
-    // Flag that is true if checkout buttons exists on the page
-    var checkout_buttons = false;
     ////////////////////////////////////////////////
     // process the button when available on the page
     ////////////////////////////////////////////////
     onElementReady(bolt_button_selector, function(element) {
-        checkout_buttons = true;
-        processButtons();
+        createOrder();
     });
     ////////////////////////////////////////////////
     onElementReady(".bolt-checkout-pay-by-link", function(element) {
-        processButtons();
+        createOrder();
     });
     ////////////////////////////////////////////////
 


### PR DESCRIPTION
# Description
Switch to using raw header value for referrer, as the method used previously doesn't work for different (sub)domains. Don't use secret key when generating admin create order url to compare referrer against as they won't always match. Disable secret key validation for admin received url endpoint as there is no good way to generate it from frontend.

Fixes: https://boltpay.atlassian.net/browse/M2P-66

#changelog Success order redirect does not work for back-office orders

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
