### PR TITLE
Ignore $0.00 refund

### DIFF
--- a/Model/Payment.php
+++ b/Model/Payment.php
@@ -458,8 +458,13 @@ class Payment extends AbstractMethod
         try {
             $startTime = $this->metricsClient->getCurrentTime();
 
-            if ($amount < 0) {
-                throw new LocalizedException(__('Invalid amount for refund.'));
+            if ($amount < 0.01) {
+                ////////////////////////////////////////////////////////////////////////////////
+                // In certain circumstances, an amount's value of zero can be sent.
+                // This will then result in an exception by the Bolt API.
+                // In these instances, there is no need to call the Bolt API, so we simply return
+                ////////////////////////////////////////////////////////////////////////////////
+                return $this;
             }
 
             $order = $payment->getOrder();

--- a/Test/Unit/Model/PaymentTest.php
+++ b/Test/Unit/Model/PaymentTest.php
@@ -525,17 +525,6 @@ class PaymentTest extends TestCase
 
     /**
      * @test
-     */
-    public function refundPayment_invalidAmount()
-    {
-        $this->orderMock->method( 'getOrderCurrencyCode' )->willReturn( 'USD' );
-        $this->expectException(LocalizedException::class);
-        $this->expectExceptionMessage('Invalid amount for refund.');
-        $this->currentMock->refund($this->paymentMock, -1);
-    }
-
-    /**
-     * @test
      * that refund avoids calling Bolt refund API for amounts lower than 1 cent
      *
      * @covers ::refund
@@ -548,17 +537,9 @@ class PaymentTest extends TestCase
      */
     public function refund_withAmountsLessThanOneCent_refundsWithoutCallingTheBoltApi($amount)
     {
-        $this->orderMock->expects($this->once())->method('getOrderCurrencyCode')->willReturn('USD');
-        $this->apiHelper->expects($this->never())->method('buildRequest');
-        $this->apiHelper->expects($this->never())->method('sendRequest');
-        $paymentMock = $this->getMockBuilder(InfoInterface::class)
-            ->setMethods(['getOrder', 'getCreditMemo' ])
-            ->getMockForAbstractClass();
-        $paymentMock->expects($this->once())->method('getOrder')->willReturn($this->orderMock);
-        $creditMemoMock = $this->createMock(Order\Creditmemo::class);
-        $paymentMock->expects($this->once())->method('getCreditMemo')->willReturn($creditMemoMock);
-        $creditMemoMock->expects($this->once())->method('getGrandTotal')->willReturn($amount);
-        $this->currentMock->refund($paymentMock, $amount);
+        $this->orderMock->expects(self::never())->method( 'getOrderCurrencyCode' )->willReturn( 'USD' );
+
+        $this->currentMock->refund($this->paymentMock, $amount);
     }
 
     /**


### PR DESCRIPTION
# Description
In certain circumstances, an amount's value of zero can be sent. This will then result in an exception by the Bolt API. In these instances, there is no need to call the Bolt API, so we simply return

This PR applied the same logic as M1 https://github.com/BoltApp/bolt-magento1/blob/master/app/code/community/Bolt/Boltpay/Model/Payment.php#L354

‌
Fixes: https://app.asana.com/0/1142111051828235/1176054279832409

#changelog Ignore $0.00 refund

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
