### PR TITLE
Added gift cards recovery after failed payment transaction

### DIFF
--- a/etc/events.xml
+++ b/etc/events.xml
@@ -3,4 +3,7 @@
     <event name="sales_order_shipment_track_save_after">
         <observer name="boltTrackSaveObserver" instance="Bolt\Boltpay\Observer\TrackingSaveObserver" />
     </event>
+    <event name="sales_order_delete_before">
+        <observer name="magento_giftcardaccount" instance="Magento\GiftCardAccount\Observer\RevertGiftCardAccountBalance"/>
+    </event>
 </config>


### PR DESCRIPTION
# Description
If the order was created through pre-auth process and then deleted on magento side due to failed payment transaction, which was declined by Vantiv, we should restore a gift card afterword.

Fixes https://boltpay.atlassian.net/browse/SUP-132

#changelog Added recovery of gist cards after a failed payment transaction

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
