### PR TITLE
M2P-72 Retrieve bundle product by SKU properly when getting the main product image

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1173,14 +1173,14 @@ class Cart extends AbstractHelper
 
                 // This will override the $_product with the variant product to get the variant image rather than the main product image.
                 try {
-                    $variantProductToGetImage = $this->productRepository->get($item->getSku(), false, $storeId);
+                    $variantProductToGetImage = $this->productRepository->getById($product['reference'], false, $storeId);
                 } catch (\Exception $e) {
                     $this->bugsnag->registerCallback(function ($report) use ($product) {
                         $report->setMetaData([
                             'ITEM' => $product
                         ]);
                     });
-                    $this->bugsnag->notifyError('Could not retrieve product from repository', "SKU: {$product['sku']}");
+                    $this->bugsnag->notifyError('Could not retrieve product from repository', "ProductId: {$product['reference']}, SKU: {$product['sku']}");
                 }
                 try {
                     $productImageUrl = $imageHelper->init($variantProductToGetImage, 'product_small_image')->getUrl();

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1173,7 +1173,12 @@ class Cart extends AbstractHelper
 
                 // This will override the $_product with the variant product to get the variant image rather than the main product image.
                 try {
-                    $variantProductToGetImage = $this->productRepository->getById($product['reference'], false, $storeId);
+                    // If the cart item is type of bundle product, its SKU is a combination with bundle selections,
+                    // so we need to retrieve the sku of bundle product without bundle selections.
+                    $product_sku = 'bundle' == $item->getProductType()
+                                   ? $_product->getData('sku')
+                                   : $product['sku'];
+                    $variantProductToGetImage = $this->productRepository->get($product_sku, false, $storeId);
                 } catch (\Exception $e) {
                     $this->bugsnag->registerCallback(function ($report) use ($product) {
                         $report->setMetaData([

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -4339,7 +4339,7 @@ ORDER
         );
         $this->bugsnag->expects(static::exactly(2))->method('notifyError')->withConsecutive(
             ['Could not retrieve product from repository', 'SKU: ' . self::PRODUCT_SKU],
-            ['Item image missing', 'SKU: ' . self::PRODUCT_SKU]
+            ['Item image missing', 'ProductId: ' .self::PRODUCT_ID. ', SKU: ' . self::PRODUCT_SKU]
         );
         $this->appEmulation->expects(static::once())->method('stopEnvironmentEmulation');
 

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -4338,8 +4338,8 @@ ORDER
             )
         );
         $this->bugsnag->expects(static::exactly(2))->method('notifyError')->withConsecutive(
-            ['Could not retrieve product from repository', 'SKU: ' . self::PRODUCT_SKU],
-            ['Item image missing', 'ProductId: ' .self::PRODUCT_ID. ', SKU: ' . self::PRODUCT_SKU]
+            ['Could not retrieve product from repository', 'ProductId: ' .self::PRODUCT_ID. ', SKU: ' . self::PRODUCT_SKU],
+            ['Item image missing', 'SKU: ' . self::PRODUCT_SKU]
         );
         $this->appEmulation->expects(static::once())->method('stopEnvironmentEmulation');
 


### PR DESCRIPTION
# Description
For bundle product in the cart, its sku is a combination with bundle selections, format as "bundleproductsku-selection1sku-selection2sku-..." , and it cause an exception "Could not retrieve product from repository" when trying to get the main product image (https://github.com/BoltApp/bolt-magento2/pull/485/commits/822d481d4d0e0e2cde1c148d7561cd1b06fa3532)
So we need to get the proper SKU for bundle product.

Fixes: [M2P-72](https://boltpay.atlassian.net/browse/M2P-72)

#changelog Retrieve bundle product by SKU properly when getting the main product image

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
