### PR TITLE
M2P-75 prevent additional credit memo creation attempt

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -1816,10 +1816,9 @@ class Order extends AbstractHelper
                 $transactionType = Transaction::TYPE_REFUND;
                 $transactionId = $transaction->id . '-refund';
 
-                if ($this->featureSwitches->isCreatingCreditMemoFromWebHookEnabled()){
+                if (Hook::$fromBolt && $this->featureSwitches->isCreatingCreditMemoFromWebHookEnabled()){
                     $this->createCreditMemoForHookRequest($order, $transaction);
                 }
-
                 break;
 
             default:

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -3015,6 +3015,7 @@ class OrderTest extends TestCase
      */
     public function updateOrderPayment_variousTxStates($transactionState, $transactionType, $transactionId)
     {
+        Hook::$fromBolt = true;
         /**
          * @var MockObject|OrderPayment $paymentMock
          */


### PR DESCRIPTION
# Description
M2P-75 When refund (Credit Memo) is triggered from the store, the plugin should not explicitly create it because it is implicitly created by Magento.

Fixes: https://boltpay.atlassian.net/browse/M2P-75

#changelog M2P-75 prevent additional credit memo creation attempt

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
