### PR TITLE
Always Present Checkout button.

### DIFF
--- a/Block/Js.php
+++ b/Block/Js.php
@@ -226,6 +226,7 @@ class Js extends Template
             'is_pre_auth'              => $this->getIsPreAuth(),
             'default_error_message'    => $this->getBoltPopupErrorMessage(),
             'button_css_styles'        => $this->getButtonCssStyles(),
+            'always_present_checkout' => $this->featureSwitches->isAlwaysPresentCheckoutEnabled(),
         ]);
     }
 

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -1714,15 +1714,15 @@ class Config extends AbstractHelper
 
     /**
      * Get config value for whether or not always present checkout is enabled
-     * @param int|string|Store $store
+     * @param int|string|Store $storeId
      * @return boolean
      */
-    public function isAlwaysPresentCheckoutEnabled($store = null)
+    public function isAlwaysPresentCheckoutEnabled($storeId = null)
     {
         return $this->getScopeConfig()->isSetFlag(
             self::XML_PATH_ALWAYS_PRESENT_CHECKOUT,
             ScopeInterface::SCOPE_STORE,
-            $store
+            $storeId
         );
     }
 

--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -212,4 +212,8 @@ class Decider extends AbstractHelper {
     public function isMerchantMetricsEnabled() {
         return $this->isSwitchEnabled(Definitions::M2_MERCHANT_METRICS);
     }
+
+    public function isAlwaysPresentCheckoutEnabled() {
+        return $this->isSwitchEnabled(Definitions::M2_ALWAYS_PRESENT_CHECKOUT);
+    }
 }

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -91,6 +91,8 @@ class Definitions {
      */
     const M2_MERCHANT_METRICS = "M2_MERCHANT_METRICS";
 
+    const M2_ALWAYS_PRESENT_CHECKOUT = "M2_ALWAYS_PRESENT_CHECKOUT";
+
     const DEFAULT_SWITCH_VALUES = array(
         self::M2_SAMPLE_SWITCH_NAME =>  array(
           self::NAME_KEY            => self::M2_SAMPLE_SWITCH_NAME,
@@ -157,6 +159,12 @@ class Definitions {
             self::VAL_KEY             => true,
             self::DEFAULT_VAL_KEY     => false,
             self::ROLLOUT_KEY         => 100
+        ),
+        self::M2_ALWAYS_PRESENT_CHECKOUT => array(
+            self::NAME_KEY => self::M2_ALWAYS_PRESENT_CHECKOUT,
+            self::VAL_KEY => true,
+            self::DEFAULT_VAL_KEY => false,
+            self::ROLLOUT_KEY => 0,
         )
     );
 }

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -33,7 +33,7 @@ use Magento\Framework\App\Request\Http;
 class JsTest extends \PHPUnit\Framework\TestCase
 {
     // Number of settings in method getSettings()
-    const SETTINGS_NUMBER = 20;
+    const SETTINGS_NUMBER = 21;
     const STORE_ID = 1;
     const CONFIG_API_KEY = 'test_api_key';
     const CONFIG_SIGNING_SECRET = 'test_signing_secret';

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -340,6 +340,7 @@ class JsTest extends \PHPUnit\Framework\TestCase
     public function getSettings()
     {
         $this->deciderMock->method('isPayByLinkEnabled')->willReturn(true);
+        $this->deciderMock->method('isAlwaysPresentCheckoutEnabled')->willReturn(true);
         $result = $this->block->getSettings();
 
         $this->assertJson($result, 'The Settings config do not have a proper JSON format.');
@@ -366,6 +367,7 @@ class JsTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey('toggle_checkout', $array, $message . 'toggle_checkout');
         $this->assertArrayHasKey('default_error_message', $array, $message . 'default_error_message');
         $this->assertArrayHasKey('button_css_styles', $array, $message . 'button_css_styles');
+        $this->assertArrayHasKey('always_present_checkout', $array, $message . 'always_present_checkout');
     }
 
     /**

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -567,7 +567,7 @@ JSON;
             ['shouldMinifyJavascript', BoltConfig::XML_PATH_SHOULD_MINIFY_JAVASCRIPT, false],
             ['shouldCaptureMetrics', BoltConfig::XML_PATH_CAPTURE_MERCHANT_METRICS],
             ['isOrderManagementEnabled', BoltConfig::XML_PATH_PRODUCT_ORDER_MANAGEMENT],
-            ['isAlwaysPresentCheckoutButtonEnabled', BoltConfig::XML_PATH_ALWAYS_PRESENT_CHECKOUT, false],
+            ['isAlwaysPresentCheckoutEnabled', BoltConfig::XML_PATH_ALWAYS_PRESENT_CHECKOUT, false],
         ];
     }
 

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -95,6 +95,11 @@
                         <config_path>payment/boltpay/order_management</config_path>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     </field>
+                    <field id="always_present_checkout" translate="label" type="select" sortOrder="83" showInDefault="0" showInWebsite="0" showInStore="0">
+                        <label>(BETA) Enable Always Present Checkout Button</label>
+                        <config_path>payment/boltpay/always_present_checkout</config_path>
+                        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    </field>
                     <field id="button_color" translate="label" type="text" sortOrder="87" showInDefault="1" showInWebsite="1" showInStore="0">
                         <label>Primary Color</label>
                         <config_path>payment/boltpay/button_color</config_path>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -95,7 +95,7 @@
                         <config_path>payment/boltpay/order_management</config_path>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     </field>
-                    <field id="always_present_checkout" translate="label" type="select" sortOrder="83" showInDefault="0" showInWebsite="0" showInStore="0">
+                    <field id="always_present_checkout" translate="label" type="select" sortOrder="83" showInDefault="1" showInWebsite="1" showInStore="0">
                         <label>(BETA) Enable Always Present Checkout Button</label>
                         <config_path>payment/boltpay/always_present_checkout</config_path>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -45,7 +45,6 @@ function($argName) {
 ob_start();
 ?>
 <script type="text/javascript">
-
     // Store the configuration parameters passed from the php block
     // in the global object. Used in this file and on the payment page
     // in payment method renderer, vendor/boltpay/bolt-magento2/view/frontend/web/js/view/payment/method-renderer/boltpay.js
@@ -681,7 +680,7 @@ ob_start();
         /////////////////////////////////////////////////////
         var createRequest = false;
         var allowAutoOpen = true;
-        var createOrder = function () {
+        var createOrder = function (el, dataChanged) {
             // Check if BoltCheckout is defined (connect.js executed).
             // If not, postpone processing until it is
             if (!window.BoltCheckout) {
@@ -806,8 +805,12 @@ ob_start();
                         createRequest = false;
                     })
             });
+            // Get number of items in cart from counter element
+            var numItems = $(".counter-number").text();
 
-            var BC = BoltCheckout.configure(cart, hintBarrier.promise, callbacks);
+            // Call config with floatingButtonMode if always present checkout enabled and items were or were not just added to cart (dataChanged)
+            var config = boltConfig.always_present_checkout && (numItems && numItems !=="0" || dataChanged)? {floatingButtonMode: dataChanged ? "show_cart" : "show_cart_on_hover" } : {};
+            var BC = BoltCheckout.configure(cart, hintBarrier.promise, callbacks, config);
         };
         /////////////////////////////////////////////////////
 
@@ -859,6 +862,9 @@ ob_start();
             checkout_buttons = true;
             processButtons();
         });
+        if (boltConfig.always_present_checkout) {
+            processButtons();
+        }
         ////////////////////////////////////////////////
 
         //////////////////////////////////////////////////////////
@@ -941,8 +947,10 @@ ob_start();
                         onDataChange(selector, function(element) {
                             if (visible_only && element.offsetParent === null) return;
                             if (element.textContent !== value) {
+                                var originalValue = value;
                                 value = element.textContent;
                                 if (non_empty && !value) return;
+                                if (originalValue !== "" && parseInt(originalValue) > -1) return;
                                 fn(element);
                             }
                         });
@@ -984,10 +992,10 @@ ob_start();
         // Monitor DOM element showing grand total / cart item number
         // and trigger Bolt order creation on totals change. This event
         // happens when discounts are added / removed from the page and
-        // totals updated or items added via ajax call.
+        // totals updated or items added via ajax call. Don't ignore empty values (non-empty = false).
         // TODO: add this option to plugin configuration admin page
         ///////////////////////////////////////////////////////////////
-        monitorDataChange(settings.totals_change_selectors, createOrder, true, false);
+        monitorDataChange(settings.totals_change_selectors, createOrder, false, false);
         ///////////////////////////////////////////////////////////////
 
         ///////////////////////////////////////////////////////////
@@ -1103,6 +1111,12 @@ ob_start();
         ///////////////////////////////////////////////////////////
         monitorDataChange(['fieldset.fieldset.rate'], prefetchShipping, false, false);
         ///////////////////////////////////////////////////////////
+
+        // When item added to cart, refresh order and mark data modified so always present button knows new item added
+        // to cart and can animate cart
+        $(document).on("ajax:addToCart", function () {
+            createOrder(null, true);
+        });
 
         ////////////////////////////////////////////////////
         // Initially configures BoltCheckout.

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -1015,8 +1015,6 @@ ob_start();
                 // Get number of items in cart from counter element
                 var numItems = $(".counter-number").text();
 
-                // Call config with floatingButtonMode if always present checkout enabled and items were or were not just added to cart (dataChanged)
-                var config = boltConfig.always_present_checkout && (numItems && numItems !=="0") ? {floatingButtonMode: "show_cart_on_hover" } : {};
                 BoltCheckout.configure(cart, hints, callbacks);
                 old_hints = new_hints;
             }

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -806,8 +806,12 @@ ob_start();
                         createRequest = false;
                     })
             });
+            // Get number of items in cart from counter element
+            var numItems = $(".counter-number").text();
 
-            var BC = BoltCheckout.configure(cart, hintBarrier.promise, callbacks);
+            // Call config with floatingButtonMode if always present checkout enabled and items were or were not just added to cart (dataChanged)
+            var config = boltConfig.always_present_checkout && (numItems && numItems !=="0" || dataChanged)? {floatingButtonMode: dataChanged ? "show_cart" : "show_cart_on_hover" } : {};
+            var BC = BoltCheckout.configure(cart, hintBarrier.promise, callbacks, config);
         };
         /////////////////////////////////////////////////////
 

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -863,6 +863,9 @@ ob_start();
             checkout_buttons = true;
             processButtons();
         });
+        if (boltConfig.always_present_checkout) {
+            processButtons();
+        }
         ////////////////////////////////////////////////
 
         //////////////////////////////////////////////////////////

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -806,12 +806,8 @@ ob_start();
                         createRequest = false;
                     })
             });
-            // Get number of items in cart from counter element
-            var numItems = $(".counter-number").text();
 
-            // Call config with floatingButtonMode if always present checkout enabled and items were or were not just added to cart (dataChanged)
-            var config = boltConfig.always_present_checkout && (numItems && numItems !=="0" || dataChanged)? {floatingButtonMode: dataChanged ? "show_cart" : "show_cart_on_hover" } : {};
-            var BC = BoltCheckout.configure(cart, hintBarrier.promise, callbacks, config);
+            var BC = BoltCheckout.configure(cart, hintBarrier.promise, callbacks);
         };
         /////////////////////////////////////////////////////
 
@@ -913,12 +909,7 @@ ob_start();
                         // ie. connect.js not loaded / executed yet,
                         // the button will be processed after connect.js loads.
                         if (window.BoltCheckout) {
-                            // Get number of items in cart from counter element
-                            var numItems = $(".counter-number").text();
-
-                            // Call config with floatingButtonMode if always present checkout enabled and items were or were not just added to cart (dataChanged)
-                            var config = boltConfig.always_present_checkout && (numItems && numItems !=="0") ? {floatingButtonMode: "show_cart_on_hover" } : {};
-                            BoltCheckout.configure(cart, hints, callbacks, config);
+                            BoltCheckout.configure(cart, hints, callbacks);
                         }
                     });
                     /////////////////////////////////////////////////////
@@ -1026,7 +1017,7 @@ ob_start();
 
                 // Call config with floatingButtonMode if always present checkout enabled and items were or were not just added to cart (dataChanged)
                 var config = boltConfig.always_present_checkout && (numItems && numItems !=="0") ? {floatingButtonMode: "show_cart_on_hover" } : {};
-                BoltCheckout.configure(cart, hints, callbacks, config);
+                BoltCheckout.configure(cart, hints, callbacks);
                 old_hints = new_hints;
             }
         };

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -1016,9 +1016,6 @@ ob_start();
             }
             var new_hints = JSON.stringify(hints);
             if (old_hints !== new_hints) {
-                // Get number of items in cart from counter element
-                var numItems = $(".counter-number").text();
-
                 BoltCheckout.configure(cart, hints, callbacks);
                 old_hints = new_hints;
             }

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -863,9 +863,6 @@ ob_start();
             checkout_buttons = true;
             processButtons();
         });
-        if (boltConfig.always_present_checkout) {
-            processButtons();
-        }
         ////////////////////////////////////////////////
 
         //////////////////////////////////////////////////////////
@@ -916,7 +913,12 @@ ob_start();
                         // ie. connect.js not loaded / executed yet,
                         // the button will be processed after connect.js loads.
                         if (window.BoltCheckout) {
-                            BoltCheckout.configure(cart, hints, callbacks);
+                            // Get number of items in cart from counter element
+                            var numItems = $(".counter-number").text();
+
+                            // Call config with floatingButtonMode if always present checkout enabled and items were or were not just added to cart (dataChanged)
+                            var config = boltConfig.always_present_checkout && (numItems && numItems !=="0") ? {floatingButtonMode: "show_cart_on_hover" } : {};
+                            BoltCheckout.configure(cart, hints, callbacks, config);
                         }
                     });
                     /////////////////////////////////////////////////////
@@ -1019,7 +1021,12 @@ ob_start();
             }
             var new_hints = JSON.stringify(hints);
             if (old_hints !== new_hints) {
-                BoltCheckout.configure(cart, hints, callbacks);
+                // Get number of items in cart from counter element
+                var numItems = $(".counter-number").text();
+
+                // Call config with floatingButtonMode if always present checkout enabled and items were or were not just added to cart (dataChanged)
+                var config = boltConfig.always_present_checkout && (numItems && numItems !=="0") ? {floatingButtonMode: "show_cart_on_hover" } : {};
+                BoltCheckout.configure(cart, hints, callbacks, config);
                 old_hints = new_hints;
             }
         };


### PR DESCRIPTION
# Description
Introducing the always present checkout button into the M2 code base. The button appears and enables initiation of checkout from any white listed when there are one or more items in the cart. The feature exists behind a feature switch. We respect the Bolt Everywhere flag for minicart and appears on whitelisted pages (the same as minicart). We likely will disable minicart for merchants who use this button but the code should still support minicart and always present checkout button on the same page.

![image](https://user-images.githubusercontent.com/3989200/82951957-5da79b00-9f65-11ea-9252-c17b168724e3.png)

The button is:

Hidden when no items in cart.
When an item is added to cart the Buy Now button appears. Minicart animates.
When navigating to another product or category page the Buy Now button appears.
To setup the button call BoltCheckout.configure with {floatingButtonOption: "show_cart"} or {floatingButtonOption: "show_cart_on_hover"} as the last argument depending on whether an item was just added or has been there.

To call when an item is added to cart, I set a listener on "ajax:addToCart". I call createOrder with dataChanged set to true which triggers configure with {floatingButtonOption: "show_cart"}`.

The tricky part is determining whether an item was just added to cart, has been there, or if there are no items in the cart. I check to see if there are now items in the cart by modifying monitorDataChange to watch for cart counter going from empty to a number. When this occurs we call createOrder call which triggers BoltCheckout.configure(cart, hints, callbacks, {floatingButtonOption: "show_cart_on_hover"}).

Another tricky part is not calling configure from monitorDataChange when we already called from the "ajax:addToCart" listener. We do this by checking what changed in monitorDataChange to only capture the cart being updated on page load (transitioning from empty string to a number).

See Product Spec here: https://docs.google.com/document/d/1EoTBhNeRPAj-RupFczAaLHakYgqonYMJvAjMFIm-EFk/edit#heading=h.dfj49q9kev35

See Technical Spec here: 
https://docs.google.com/document/d/1wP962zqqvyBPWQx7F3yXA48a8BtX1lN1C5Ni0hVqncY/edit

Fulfills:
https://app.asana.com/0/1146941972725303/1165704788287983/f
https://app.asana.com/0/1146941972725303/1176822385483791/f
https://app.asana.com/0/1146941972725303/1176822385483793/f

#changelog Always Present Checkout button.
Adds support for Always Present Checkout button. Adds feature switch for button.

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [X] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [X] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
	- Added unit tests for feature switch. JS changes not super unit testable.
- [X] I have added my Jira ticket link and provided a changelog message.
