### PR TITLE
[M2P-77] Fix bug - Parameter is missing when calling parent method

### DIFF
--- a/Model/Payment.php
+++ b/Model/Payment.php
@@ -555,7 +555,7 @@ class Payment extends AbstractMethod
         if ($this->cartHelper->hasProductRestrictions($quote)) {
             return false;
         }
-        return parent::isAvailable();
+        return parent::isAvailable($quote);
     }
 
     public function getTitle()

--- a/Test/Unit/Model/PaymentTest.php
+++ b/Test/Unit/Model/PaymentTest.php
@@ -50,7 +50,7 @@ use \Magento\Sales\Model\Order\Payment\Transaction\Repository as TransactionRepo
 use \Magento\Sales\Model\Order\Payment\Transaction;
 use Magento\Sales\Model\Order\Invoice;
 use Magento\Sales\Model\ResourceModel\Order\Collection;
-
+use Magento\Framework\Event\Manager;
 
 /**
  * Class PaymentTest
@@ -168,6 +168,9 @@ class PaymentTest extends TestCase
      * @var Order\Creditmemo|\PHPUnit\Framework\MockObject\MockObject
      */
     private $creditMemoMock;
+    
+    /** @var MockObject|Manager */
+    private $eventManager;
 
     protected function setUp()
     {
@@ -834,8 +837,10 @@ class PaymentTest extends TestCase
     private function initRequiredMocks()
     {
         $mockAppState = $this->createMock(State::class);
+        $this->eventManager = $this->createMock(Manager::class);
         $this->context = $this->createMock(Context::class);
         $this->context->method('getAppState')->willReturn($mockAppState);
+        $this->context->method('getEventManager')->willReturn($this->eventManager);
 
         $this->registry = $this->createMock(Registry::class);
         $this->extensionFactory = $this->createMock(ExtensionAttributesFactory::class);

--- a/Test/Unit/Model/PaymentTest.php
+++ b/Test/Unit/Model/PaymentTest.php
@@ -840,7 +840,7 @@ class PaymentTest extends TestCase
         $this->eventManager = $this->createMock(Manager::class);
         $this->context = $this->createMock(Context::class);
         $this->context->method('getAppState')->willReturn($mockAppState);
-        $this->context->method('getEventManager')->willReturn($this->eventManager);
+        $this->context->method('getEventDispatcher')->willReturn($this->eventManager);
 
         $this->registry = $this->createMock(Registry::class);
         $this->extensionFactory = $this->createMock(ExtensionAttributesFactory::class);
@@ -905,7 +905,7 @@ class PaymentTest extends TestCase
                                     $this->apiHelper,
                                     $this->orderHelper,
                                     $this->bugsnag,
-                                      $this->metricsClient,
+                                    $this->metricsClient,
                                     $this->dataObjectFactory,
                                     $this->cartHelper,
                                     $this->transactionRepository,


### PR DESCRIPTION
# Description
https://github.com/BoltApp/bolt-magento2/blob/master/Model/Payment.php#L558
The parameter $quote is missing when calling its parent method isAvailable

Fixes: https://boltpay.atlassian.net/browse/M2P-77

#changelog Fix bug - Parameter is missing when calling parent method

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
