### PR TITLE
Notify Bugsnag when BoltException is caught

### DIFF
--- a/Controller/Cart/Data.php
+++ b/Controller/Cart/Data.php
@@ -150,6 +150,7 @@ class Data extends Action
                 'backUrl' => '',
             ]);
         } catch (BoltException $e) {
+            $this->bugsnag->notifyException($e);
             $result->setData([
                 'status' => 'success',
                 'restrict' => true,

--- a/Test/Unit/Controller/Cart/DataTest.php
+++ b/Test/Unit/Controller/Cart/DataTest.php
@@ -225,6 +225,7 @@ class DataTest extends TestCase
         //replace default set in init
         $cartHelper = $this->createMock(Cart::class);
         $cartHelper->method('hasProductRestrictions')->willReturn(true);
+        $this->bugsnag->expects($this->once())->method('notifyException');
 
         $expected = array(
             'status' => 'success',
@@ -254,6 +255,7 @@ class DataTest extends TestCase
         //replace default set in init
         $cartHelper = $this->createMock(Cart::class);
         $cartHelper->method('isCheckoutAllowed')->willReturn(false);
+        $this->bugsnag->expects($this->once())->method('notifyException');
 
         $expected = array(
             'status' => 'success',


### PR DESCRIPTION
# Description

[MX-859](https://boltpay.atlassian.net/browse/MX-859)

Merchant_order_token.failure metric is captured more often than success. Failure is only captured by a few merchants, possible they are not on the latest update. Bugsnag is not notified when a failed metric is captured for these merchants. A fix for now is to notify Bugsnag whenever order_token.failure is processed in the plugin code. We can push merchants to update their plugin to continue further with this issue. 

#changelog Notify Bugsnag when BoltException is caught

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
