### PR TITLE
Factor out logic to build cart from standard quote

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1242,7 +1242,6 @@ class Cart extends AbstractHelper
      */
     public function getCartData($paymentOnly, $placeOrderPayload, $immutableQuote = null)
     {
-        $cart = [];
 
         // If the immutable quote is passed (i.e. discount code validation, bugsnag report generation)
         // load the parent quote, otherwise load the session quote
@@ -1259,7 +1258,7 @@ class Cart extends AbstractHelper
         // In case #1 the empty cart is returned
         // In case #2 the cart generation continues for the cloned quote
         if (!$immutableQuote && (!$quote || !$quote->getAllVisibleItems())) {
-            return $cart;
+            return [];
         }
 
         ////////////////////////////////////////////////////////
@@ -1273,8 +1272,6 @@ class Cart extends AbstractHelper
             $this->reserveOrderId($immutableQuote, $quote);
         }
 
-        $billingAddress  = $immutableQuote->getBillingAddress();
-        $shippingAddress = $immutableQuote->getShippingAddress();
         ////////////////////////////////////////////////////////
 
         // Get array of all items that can be display directly
@@ -1282,7 +1279,7 @@ class Cart extends AbstractHelper
 
         if (!$items) {
             // This is the case when customer empties the cart.
-            return $cart;
+            return [];
         }
 
         $this->setLastImmutableQuote($immutableQuote);
@@ -1307,10 +1304,26 @@ class Cart extends AbstractHelper
         }
         $immutableQuote->collectTotals();
 
+        $cart = $this->buildCartFromQuote($quote, $immutableQuote, $items, $placeOrderPayload, $paymentOnly);
+
         // Set order_reference to parent quote id.
         // This is the constraint field on Bolt side and this way
-        // duplicate payments / orders are prevented/
+        // duplicate payments / orders are prevented
         $cart['order_reference'] = $immutableQuote->getBoltParentQuoteId();
+
+        $this->sessionHelper->cacheFormKey($immutableQuote);
+
+        // $this->logHelper->addInfoLog(json_encode($cart, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES));
+
+        return $cart;
+    }
+
+    public function buildCartFromQuote($quote, $immutableQuote, $items, $placeOrderPayload, $paymentOnly)
+    {
+        $cart = [];
+
+        $billingAddress  = $immutableQuote->getBillingAddress();
+        $shippingAddress = $immutableQuote->getShippingAddress();
 
         //Use display_id to hold and transmit, all the way back and forth, both reserved order id and immutable quote id
         $cart['display_id'] = $immutableQuote->getReservedOrderId() . ' / ' . $immutableQuote->getId();
@@ -1326,8 +1339,8 @@ class Cart extends AbstractHelper
         // Trying several possible places.
         $email = $billingAddress->getEmail()
             ?: $shippingAddress->getEmail()
-            ?: $this->customerSession->getCustomer()->getEmail()
-            ?: $immutableQuote->getCustomerEmail();
+                ?: $this->customerSession->getCustomer()->getEmail()
+                    ?: $immutableQuote->getCustomerEmail();
 
         // Billing address
         $cartBillingAddress = [
@@ -1494,10 +1507,6 @@ class Cart extends AbstractHelper
             });
             $this->bugsnag->notifyError('Cart Totals Mismatch', "Totals adjusted by $diff.");
         }
-
-        $this->sessionHelper->cacheFormKey($immutableQuote);
-
-        // $this->logHelper->addInfoLog(json_encode($cart, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES));
 
         return $cart;
     }

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1339,8 +1339,8 @@ class Cart extends AbstractHelper
         // Trying several possible places.
         $email = $billingAddress->getEmail()
             ?: $shippingAddress->getEmail()
-                ?: $this->customerSession->getCustomer()->getEmail()
-                    ?: $immutableQuote->getCustomerEmail();
+            ?: $this->customerSession->getCustomer()->getEmail()
+            ?: $immutableQuote->getCustomerEmail();
 
         // Billing address
         $cartBillingAddress = [

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1305,6 +1305,10 @@ class Cart extends AbstractHelper
         $immutableQuote->collectTotals();
 
         $cart = $this->buildCartFromQuote($quote, $immutableQuote, $items, $placeOrderPayload, $paymentOnly);
+        if ($cart == []) {
+            // empty cart implies there was an error
+            return $cart;
+        }
 
         // Set order_reference to parent quote id.
         // This is the constraint field on Bolt side and this way

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -3011,6 +3011,8 @@ ORDER
         $getCartItemsResult = [[$testItem], 12345, 123];
         $collectDiscountsResult = [[], 12345, 123];
         $currentMock = $this->getCartDataSetUp($getCartItemsResult, $collectDiscountsResult);
+        $this->immutableQuoteMock->expects(static::atLeastOnce())->method('getBoltParentQuoteId')
+            ->willReturn(self::PARENT_QUOTE_ID);
 
         $this->quoteShippingAddress->expects(static::once())->method('setCollectShippingRates')->with(true);
         $this->quoteShippingAddress->expects(static::any())->method('getShippingMethod')
@@ -3112,6 +3114,8 @@ ORDER
         $testDiscount = ['description' => 'Test discount', 'amount' => 22345];
         $collectDiscountsResult = [[$testDiscount], -10000, 0];
         $currentMock = $this->getCartDataSetUp($getCartItemsResult, $collectDiscountsResult);
+        $this->immutableQuoteMock->expects(static::atLeastOnce())->method('getBoltParentQuoteId')
+            ->willReturn(self::PARENT_QUOTE_ID);
 
         $this->quoteShippingAddress->expects(static::once())->method('setCollectShippingRates')->with(true);
         $this->quoteShippingAddress->expects(static::any())->method('getShippingMethod')

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -2589,7 +2589,7 @@ ORDER
             ->willReturn($this->getAddressMock());
         $this->immutableQuoteMock->expects(static::any())->method('getShippingAddress')
             ->willReturn($this->getAddressMock());
-        $this->immutableQuoteMock->expects(static::atLeastOnce())->method('getBoltParentQuoteId')
+        $this->immutableQuoteMock->expects(static::never())->method('getBoltParentQuoteId')
             ->willReturn(self::PARENT_QUOTE_ID);
         $this->immutableQuoteMock->expects(static::atLeastOnce())->method('getReservedOrderId')
             ->willReturn(self::ORDER_INCREMENT_ID);
@@ -2979,8 +2979,6 @@ ORDER
             ->willReturn($this->getAddressMock());
         $this->immutableQuoteMock->expects(static::any())->method('getShippingAddress')
             ->willReturn($this->getAddressMock());
-        $this->immutableQuoteMock->expects(static::atLeastOnce())->method('getBoltParentQuoteId')
-            ->willReturn(self::PARENT_QUOTE_ID);
         $this->immutableQuoteMock->expects(static::atLeastOnce())->method('getReservedOrderId')
             ->willReturn(self::ORDER_INCREMENT_ID);
         $this->immutableQuoteMock->expects(static::atLeastOnce())->method('getId')
@@ -3279,7 +3277,7 @@ ORDER
             ->willReturn($this->getAddressMock());
         $this->immutableQuoteMock->expects(static::any())->method('getShippingAddress')
             ->willReturn($this->getAddressMock());
-        $this->immutableQuoteMock->expects(static::atLeastOnce())->method('getBoltParentQuoteId')
+        $this->immutableQuoteMock->expects(static::never())->method('getBoltParentQuoteId')
             ->willReturn(self::PARENT_QUOTE_ID);
         $this->immutableQuoteMock->expects(static::atLeastOnce())->method('getReservedOrderId')
             ->willReturn(self::ORDER_INCREMENT_ID);


### PR DESCRIPTION
This will let us use the same method when creating carts for non-Bolt orders. Was not sure how to test locally, so will be looking into that next-- although this is just a simple refactor so is low risk.

#changelog Refactor methods to expose them for new use cases