### PR TITLE
Instant Checkout Fix to return Bool instead of string.

### DIFF
--- a/Block/Js.php
+++ b/Block/Js.php
@@ -206,7 +206,7 @@ class Js extends Template
      */
     public function getIsInstantCheckoutButton()
     {
-        return $this->featureSwitches->isInstantCheckoutButton();
+        return (bool)$this->featureSwitches->isInstantCheckoutButton();
     }
 
     /**


### PR DESCRIPTION
# Description
Fix bug with instant checkout for cart casting to boolean.
Fixes: [MX-888 Roll out checkout button v2 to M2](https://github.com/BoltApp/bolt-magento2/pull/695)

#changelog return boolean

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
