### PR TITLE
Pass immutableQuote as parameter rather than as attribute

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1503,7 +1503,7 @@ class Cart extends AbstractHelper
 
         // add discount data
         list ($discounts, $totalAmount, $diff) = $this->collectDiscounts (
-            $totalAmount, $diff, $paymentOnly
+            $totalAmount, $diff, $paymentOnly, $immutableQuote
         );
         $cart['discounts'] = $discounts;
         /////////////////////////////////////////////////////////////////////////////////
@@ -1581,9 +1581,9 @@ class Cart extends AbstractHelper
     public function collectDiscounts (
         $totalAmount,
         $diff,
-        $paymentOnly
+        $paymentOnly,
+        $quote
     ) {
-        $quote = $this->getLastImmutableQuote();
         $currencyCode = $quote->getQuoteCurrencyCode();
         $parentQuote = $this->getQuoteById($quote->getBoltParentQuoteId());
         $address = $this->getCalculationAddress($quote);

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -3623,7 +3623,7 @@ ORDER
             $totalAmount,
             $diff,
             $paymentOnly,
-            $quote
+            $this->immutableQuoteMock
         );
 
         static::assertEquals($diffResult, $diff);

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -3442,7 +3442,6 @@ ORDER
 
         $quote->method('getBoltParentQuoteId')->willReturn(999999);
         $quote->method('getTotals')->willReturn([]);
-        $currentMock->expects(static::once())->method('getLastImmutableQuote')->willReturn($quote);
         $currentMock->expects(static::once())->method('getCalculationAddress')->with($quote)
             ->willReturn($shippingAddress);
         $shippingAddress->expects(static::once())->method('getDiscountAmount')->willReturn(0);
@@ -3462,7 +3461,8 @@ ORDER
         list($discounts, $totalAmountResult, $diffResult) = $currentMock->collectDiscounts(
             $totalAmount,
             $diff,
-            $paymentOnly
+            $paymentOnly,
+            $quote
         );
 
         static::assertEquals($diffResult, $diff);
@@ -3486,7 +3486,6 @@ ORDER
         $quote->method('getBoltParentQuoteId')->willReturn(999999);
         $currentMock->expects(static::once())->method('getQuoteById')->willReturn($quote);
         $quote->method('getTotals')->willReturn([]);
-        $currentMock->expects(static::once())->method('getLastImmutableQuote')->willReturn($quote);
         $currentMock->expects(static::once())->method('getCalculationAddress')->with($quote)
             ->willReturn($shippingAddress);
         $shippingAddress->expects(static::any())->method('getCouponCode')->willReturn('123456');
@@ -3507,7 +3506,8 @@ ORDER
         list($discounts, $totalAmountResult, $diffResult) = $currentMock->collectDiscounts(
             $totalAmount,
             $diff,
-            $paymentOnly
+            $paymentOnly,
+            $quote
         );
 
         static::assertEquals($diffResult, $diff);
@@ -3533,7 +3533,6 @@ ORDER
         $quote->method('getTotals')->willReturn([]);
         $quote->method('getBoltParentQuoteId')->willReturn(999999);
         $currentMock->expects(static::once())->method('getQuoteById')->willReturn($quote);
-        $currentMock->expects(static::once())->method('getLastImmutableQuote')->willReturn($quote);
         $currentMock->expects(static::once())->method('getCalculationAddress')->with($quote)
             ->willReturn($shippingAddress);
         $shippingAddress->expects(static::any())->method('getCouponCode')->willReturn(false);
@@ -3554,7 +3553,8 @@ ORDER
         list($discounts, $totalAmountResult, $diffResult) = $currentMock->collectDiscounts(
             $totalAmount,
             $diff,
-            $paymentOnly
+            $paymentOnly,
+            $quote
         );
         static::assertEquals($diffResult, $diff);
         $expectedDiscountAmount = 100 * $appliedDiscount;
@@ -3577,7 +3577,6 @@ ORDER
             [
                 'getWebsiteId',
                 'getQuoteById',
-                'getLastImmutableQuote',
                 'getCalculationAddress'
             ]
         );
@@ -3585,7 +3584,6 @@ ORDER
 
         $currentMock->expects(static::once())->method('getWebsiteId')->willReturn(self::WEBSITE_ID);
         $currentMock->expects(static::once())->method('getQuoteById')->willReturn($this->quoteMock);
-        $currentMock->expects(static::once())->method('getLastImmutableQuote')->willReturn($this->immutableQuoteMock);
         $currentMock->expects(static::once())->method('getCalculationAddress')->with($this->immutableQuoteMock)
             ->willReturn($shippingAddress);
         $shippingAddress->expects(static::any())->method('getCouponCode')->willReturn(false);
@@ -3624,7 +3622,8 @@ ORDER
         list($discounts, $totalAmountResult, $diffResult) = $currentMock->collectDiscounts(
             $totalAmount,
             $diff,
-            $paymentOnly
+            $paymentOnly,
+            $quote
         );
 
         static::assertEquals($diffResult, $diff);
@@ -3652,7 +3651,6 @@ ORDER
             [
                 'getWebsiteId',
                 'getQuoteById',
-                'getLastImmutableQuote',
                 'getCalculationAddress'
             ]
         );
@@ -3660,7 +3658,6 @@ ORDER
 
         $currentMock->expects(static::once())->method('getWebsiteId')->willReturn(self::WEBSITE_ID);
         $currentMock->expects(static::once())->method('getQuoteById')->willReturn($this->quoteMock);
-        $currentMock->expects(static::once())->method('getLastImmutableQuote')->willReturn($this->immutableQuoteMock);
         $currentMock->expects(static::once())->method('getCalculationAddress')->with($this->immutableQuoteMock)
             ->willReturn($shippingAddress);
         $shippingAddress->expects(static::any())->method('getCouponCode')->willReturn(false);
@@ -3694,7 +3691,8 @@ ORDER
         list($discounts, $totalAmountResult, $diffResult) = $currentMock->collectDiscounts(
             $totalAmount,
             $diff,
-            $paymentOnly
+            $paymentOnly,
+            $this->immutableQuoteMock
         );
 
         static::assertEquals($diffResult, $diff);
@@ -3724,14 +3722,12 @@ ORDER
             [
                 'getWebsiteId',
                 'getQuoteById',
-                'getLastImmutableQuote',
                 'getCalculationAddress'
             ]
         );
         $shippingAddress = $this->getAddressMock();
 
         $currentMock->expects(static::once())->method('getQuoteById')->willReturn($this->quoteMock);
-        $currentMock->expects(static::once())->method('getLastImmutableQuote')->willReturn($this->immutableQuoteMock);
         $currentMock->expects(static::once())->method('getCalculationAddress')->with($this->immutableQuoteMock)
             ->willReturn($shippingAddress);
         $shippingAddress->expects(static::any())->method('getCouponCode')->willReturn(false);
@@ -3760,7 +3756,8 @@ ORDER
         list($discounts, $totalAmountResult, $diffResult) = $currentMock->collectDiscounts(
             $totalAmount,
             $diff,
-            $paymentOnly
+            $paymentOnly,
+            $this->immutableQuoteMock
         );
 
         static::assertEquals($diffResult, $diff);
@@ -3791,7 +3788,6 @@ ORDER
         $quote->method('getBoltParentQuoteId')->willReturn(999999);
         $mock->expects(static::once())->method('getQuoteById')->willReturn($quote);
         $quote->method('getTotals')->willReturn([]);
-        $mock->expects(static::once())->method('getLastImmutableQuote')->willReturn($quote);
         $mock->expects(static::once())->method('getCalculationAddress')->with($quote)->willReturn($shippingAddress);
         $shippingAddress->expects(static::any())->method('getCouponCode')->willReturn(false);
         $shippingAddress->expects(static::any())->method('getDiscountAmount')->willReturn(false);
@@ -3809,7 +3805,7 @@ ORDER
         $appliedDiscount = 10; // $
         $this->discountHelper->expects(static::once())->method('getMirasvitStoreCreditAmount')
             ->with($quote, $paymentOnly)->willReturn($appliedDiscount);
-        list($discounts, $totalAmountResult, $diffResult) = $mock->collectDiscounts($totalAmount, $diff, $paymentOnly);
+        list($discounts, $totalAmountResult, $diffResult) = $mock->collectDiscounts($totalAmount, $diff, $paymentOnly, $quote);
         static::assertEquals($diffResult, $diff);
         $expectedDiscountAmount = 100 * $appliedDiscount;
         $expectedTotalAmount = $totalAmount - $expectedDiscountAmount;
@@ -3833,7 +3829,6 @@ ORDER
         $quote->method('getBoltParentQuoteId')->willReturn(999999);
         $currentMock->expects(static::once())->method('getQuoteById')->willReturn($quote);
         $quote->method('getTotals')->willReturn([]);
-        $currentMock->expects(static::once())->method('getLastImmutableQuote')->willReturn($quote);
         $currentMock->expects(static::once())->method('getCalculationAddress')->with($quote)
             ->willReturn($shippingAddress);
         $shippingAddress->expects(static::any())->method('getCouponCode')->willReturn(false);
@@ -3853,7 +3848,8 @@ ORDER
         list($discounts, $totalAmountResult, $diffResult) = $currentMock->collectDiscounts(
             $totalAmount,
             $diff,
-            $paymentOnly
+            $paymentOnly,
+            $quote
         );
         static::assertEquals($diffResult, $diff);
         $expectedDiscountAmount = 100 * $appliedDiscount;
@@ -3879,7 +3875,6 @@ ORDER
         $quote = $this->getQuoteMock($this->getAddressMock(), $shippingAddress);
         $quote->method('getBoltParentQuoteId')->willReturn(999999);
         $currentMock->expects(static::once())->method('getQuoteById')->willReturn($quote);
-        $currentMock->expects(static::once())->method('getLastImmutableQuote')->willReturn($quote);
         $currentMock->expects(static::once())->method('getCalculationAddress')->with($quote)
             ->willReturn($shippingAddress);
         $shippingAddress->expects(static::any())->method('getCouponCode')->willReturn(false);
@@ -3903,7 +3898,8 @@ ORDER
         list($discounts, $totalAmountResult, $diffResult) = $currentMock->collectDiscounts(
             $totalAmount,
             $diff,
-            $paymentOnly
+            $paymentOnly,
+            $quote
         );
         static::assertEquals($diffResult, $diff);
         $expectedDiscountAmount = 100 * $appliedDiscount;
@@ -3929,7 +3925,6 @@ ORDER
         $quote = $this->getQuoteMock($this->getAddressMock(), $shippingAddress);
         $quote->method('getBoltParentQuoteId')->willReturn(999999);
         $currentMock->expects(static::once())->method('getQuoteById')->willReturn($quote);
-        $currentMock->expects(static::once())->method('getLastImmutableQuote')->willReturn($quote);
         $currentMock->expects(static::once())->method('getCalculationAddress')->with($quote)
             ->willReturn($shippingAddress);
         $shippingAddress->expects(static::any())->method('getCouponCode')->willReturn(false);
@@ -3952,7 +3947,8 @@ ORDER
         list($discounts, $totalAmountResult, $diffResult) = $currentMock->collectDiscounts(
             $totalAmount,
             $diff,
-            $paymentOnly
+            $paymentOnly,
+            $quote
         );
         static::assertEquals($diffResult, $diff);
         $expectedDiscountAmount = 100 * $appliedDiscount;
@@ -3977,7 +3973,6 @@ ORDER
         $quote = $this->getQuoteMock($this->getAddressMock(), $shippingAddress);
         $quote->method('getBoltParentQuoteId')->willReturn(999999);
         $currentMock->expects(static::once())->method('getQuoteById')->willReturn($quote);
-        $currentMock->expects(static::once())->method('getLastImmutableQuote')->willReturn($quote);
         $currentMock->expects(static::once())->method('getCalculationAddress')->with($quote)
             ->willReturn($shippingAddress);
         $shippingAddress->expects(static::any())->method('getCouponCode')->willReturn(false);
@@ -4007,7 +4002,8 @@ ORDER
         list($discounts, $totalAmountResult, $diffResult) = $currentMock->collectDiscounts(
             $totalAmount,
             $diff,
-            $paymentOnly
+            $paymentOnly,
+            $quote
         );
         static::assertEquals($diffResult, $diff);
         $expectedDiscountAmount = 100 * $appliedDiscount;
@@ -4033,7 +4029,6 @@ ORDER
 
         $quote->method('getBoltParentQuoteId')->willReturn(999999);
         $currentMock->expects(static::once())->method('getQuoteById')->willReturn($quote);
-        $currentMock->expects(static::once())->method('getLastImmutableQuote')->willReturn($quote);
         $currentMock->expects(static::once())->method('getCalculationAddress')->with($quote)
             ->willReturn($shippingAddress);
 
@@ -4059,7 +4054,8 @@ ORDER
         list($discounts, $totalAmountResult, $diffResult) = $currentMock->collectDiscounts(
             $totalAmount,
             $diff,
-            $paymentOnly
+            $paymentOnly,
+            $quote
         );
         static::assertEquals(
             ['description' => 'Store Credit', 'amount' => $appliedDiscount * 100, 'type' => 'fixed_amount'],
@@ -4090,7 +4086,6 @@ ORDER
         $quote = $this->getQuoteMock($this->getAddressMock(), $shippingAddress);
         $quote->method('getBoltParentQuoteId')->willReturn(999999);
         $mock->expects(static::once())->method('getQuoteById')->willReturn($quote);
-        $mock->expects(static::once())->method('getLastImmutableQuote')->willReturn($quote);
         $mock->expects(static::once())->method('getCalculationAddress')->with($quote)->willReturn($shippingAddress);
         $shippingAddress->expects(static::any())->method('getCouponCode')->willReturn(false);
         $shippingAddress->expects(static::any())->method('getDiscountAmount')->willReturn(false);
@@ -4115,7 +4110,8 @@ ORDER
         list($discounts, $totalAmountResult, $diffResult) = $mock->collectDiscounts(
             $totalAmount,
             $diff,
-            $paymentOnly
+            $paymentOnly,
+            $quote
         );
         static::assertEquals($diffResult, $diff);
         $expectedDiscountAmount = 100 * $appliedDiscount;
@@ -4139,7 +4135,6 @@ ORDER
         $quote = $this->getQuoteMock($this->getAddressMock(), $shippingAddress);
         $quote->method('getBoltParentQuoteId')->willReturn(999999);
         $mock->expects(static::once())->method('getQuoteById')->willReturn($quote);
-        $mock->expects(static::once())->method('getLastImmutableQuote')->willReturn($quote);
         $mock->expects(static::once())->method('getCalculationAddress')->with($quote)->willReturn($shippingAddress);
         $shippingAddress->expects(static::any())->method('getCouponCode')->willReturn(false);
         $shippingAddress->expects(static::any())->method('getDiscountAmount')->willReturn(false);
@@ -4162,7 +4157,8 @@ ORDER
         list($discounts, $totalAmountResult, $diffResult) = $mock->collectDiscounts(
             $totalAmount,
             $diff,
-            $paymentOnly
+            $paymentOnly,
+            $quote
         );
         static::assertEquals($diffResult, $diff);
         $expectedDiscountAmount = 100 * $appliedDiscount;
@@ -4186,7 +4182,6 @@ ORDER
         $quote = $this->getQuoteMock($this->getAddressMock(), $shippingAddress);
         $quote->method('getBoltParentQuoteId')->willReturn(999999);
         $mock->expects(static::once())->method('getQuoteById')->willReturn($quote);
-        $mock->expects(static::once())->method('getLastImmutableQuote')->willReturn($quote);
         $mock->expects(static::once())->method('getCalculationAddress')->with($quote)->willReturn($shippingAddress);
         $quote->expects(static::once())->method('getUseCustomerBalance')->willReturn(false);
         $this->discountHelper->expects(static::once())->method('isMirasvitStoreCreditAllowed')->with($quote)
@@ -4209,7 +4204,8 @@ ORDER
         list($discounts, $totalAmountResult, $diffResult) = $mock->collectDiscounts(
             $totalAmount,
             $diff,
-            $paymentOnly
+            $paymentOnly,
+            $quote
         );
         static::assertEquals($diffResult, $diff);
         $expectedGiftVoucherAmount = 100 * $giftVoucherDiscount;
@@ -4236,7 +4232,6 @@ ORDER
         $quote = $this->getQuoteMock($this->getAddressMock(), $shippingAddress);
         $quote->method('getBoltParentQuoteId')->willReturn(999999);
         $currentMock->expects(static::once())->method('getQuoteById')->willReturn($quote);
-        $currentMock->expects(static::once())->method('getLastImmutableQuote')->willReturn($quote);
         $currentMock->expects(static::once())->method('getCalculationAddress')->with($quote)
             ->willReturn($shippingAddress);
         $quote->expects(static::once())->method('getUseCustomerBalance')->willReturn(false);
@@ -4258,7 +4253,8 @@ ORDER
         list($discounts, $totalAmountResult, $diffResult) = $currentMock->collectDiscounts(
             $totalAmount,
             $diff,
-            $paymentOnly
+            $paymentOnly,
+            $quote
         );
         static::assertEquals($diffResult, $diff);
 


### PR DESCRIPTION
This makes the method more generic as it doesn't rely on an attribute of the CartHelper being set.

#changelog Pass immutableQuote as parameter rather than as attribute
Refactor collectDiscounts to enable a $quote to be passed rather than pulled from the CartHelper
