### PR TITLE
Add observer on order creation event to injest non-Bolt orders

### DIFF
--- a/Helper/Api.php
+++ b/Helper/Api.php
@@ -64,7 +64,7 @@ class Api extends AbstractHelper
 
 
     /**
-     * Api create order
+     * Api create non-Bolt order
      */
     const API_CREATE_NON_BOLT_ORDER = 'non_bolt_order';
 

--- a/Helper/Api.php
+++ b/Helper/Api.php
@@ -62,6 +62,12 @@ class Api extends AbstractHelper
      */
     const API_CREATE_ORDER = 'merchant/orders';
 
+
+    /**
+     * Api create order
+     */
+    const API_CREATE_NON_BOLT_ORDER = 'non_bolt_order';
+
     /**
      * Api create tracking
      */

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -488,7 +488,7 @@ class Cart extends AbstractHelper
      *
      * @param $quote
      */
-    public function setLastImmutableQuote($quote)
+    protected function setLastImmutableQuote($quote)
     {
         $this->lastImmutableQuote = $quote;
     }

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1355,11 +1355,12 @@ class Cart extends AbstractHelper
      * @param array $items
      * @param bool $paymentOnly             flag that represents the type of checkout
      * @param string $placeOrderPayload     additional data collected from the (one page checkout) page,
+     * @param bool $requireBillingAddress   require that the billing address is set
      *
      * @return array
      * @throws \Exception
      */
-    public function buildCartFromQuote($quote, $immutableQuote, $items, $placeOrderPayload, $paymentOnly)
+    public function buildCartFromQuote($quote, $immutableQuote, $items, $placeOrderPayload, $paymentOnly, $requireBillingAddress = true)
     {
         $cart = [];
 
@@ -1435,7 +1436,7 @@ class Cart extends AbstractHelper
                 if (@$cart['billing_address']){
                     $this->totalsCollector->collectAddressTotals($immutableQuote, $address);
                     $address->save();
-                } else {
+                } else if ($requireBillingAddress) {
                     $this->logAddressData($cartBillingAddress);
                     $this->bugsnag->notifyError(
                         'Order create error',

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -488,7 +488,7 @@ class Cart extends AbstractHelper
      *
      * @param $quote
      */
-    protected function setLastImmutableQuote($quote)
+    public function setLastImmutableQuote($quote)
     {
         $this->lastImmutableQuote = $quote;
     }

--- a/Observer/NonBoltOrderObserver.php
+++ b/Observer/NonBoltOrderObserver.php
@@ -221,6 +221,9 @@ class NonBoltOrderObserver implements ObserverInterface
             if (count($names) > 1) {
                 $address->setFirstName($names[0]);
                 $address->setLastName($names[1]);
+            } else if (count($names) > 2) {
+                $address->setFirstName(array_shift($names));
+                $address->setLastName(join(" ", $names));
             } else {
                 $address->setLastName($name);
             }

--- a/Observer/NonBoltOrderObserver.php
+++ b/Observer/NonBoltOrderObserver.php
@@ -10,6 +10,7 @@ use Bolt\Boltpay\Helper\Log as LogHelper;
 use Bolt\Boltpay\Helper\MetricsClient;
 use Bolt\Boltpay\Model\Payment;
 use Bolt\Boltpay\Model\Response;
+use Error;
 use Exception;
 use Magento\Customer\Api\Data\CustomerInterface;
 use Magento\Framework\DataObjectFactory;
@@ -133,6 +134,11 @@ class NonBoltOrderObserver implements ObserverInterface
         } catch (Exception $exception) {
             $this->metricsClient->processCountMetric("non_bolt_order_creation.failure", 1);
             $this->bugsnag->notifyException($exception);
+            return;
+        } catch (Error $error) {
+            // catch errors so failures here don't prevent orders from being created
+            $this->metricsClient->processCountMetric("non_bolt_order_creation.failure", 1);
+            $this->bugsnag->notifyException($error);
             return;
         }
 

--- a/Observer/NonBoltOrderObserver.php
+++ b/Observer/NonBoltOrderObserver.php
@@ -218,10 +218,7 @@ class NonBoltOrderObserver implements ObserverInterface
         if ($address->getLastName() == null) {
             $name = $address->getFirstName();
             $names = preg_split("/[\s]+/", $name);
-            if (count($names) > 1) {
-                $address->setFirstName($names[0]);
-                $address->setLastName($names[1]);
-            } else if (count($names) > 2) {
+           if (count($names) > 1) {
                 $address->setFirstName(array_shift($names));
                 $address->setLastName(join(" ", $names));
             } else {

--- a/Observer/NonBoltOrderObserver.php
+++ b/Observer/NonBoltOrderObserver.php
@@ -110,6 +110,7 @@ class NonBoltOrderObserver implements ObserverInterface
 
             $payment = $order->getPayment();
             if ($payment && $payment->getMethod() == Payment::METHOD_CODE) {
+                // ignore Bolt orders
                 return;
             }
 
@@ -127,7 +128,7 @@ class NonBoltOrderObserver implements ObserverInterface
 
             $this->handleMissingName($quote);
 
-            $cart = $this->cartHelper->buildCartFromQuote($quote, $quote, $items, null, true,false);
+            $cart = $this->cartHelper->buildCartFromQuote($quote, $quote, $items, null, true, false);
             $customer = $quote->getCustomer();
             $storeId = $order->getStoreId();
             $result = $this->createNonBoltOrder($cart, $customer, $storeId);

--- a/Observer/NonBoltOrderObserver.php
+++ b/Observer/NonBoltOrderObserver.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace Bolt\Boltpay\Observer;
+
+use Bolt\Boltpay\Helper\Api as ApiHelper;
+use Bolt\Boltpay\Helper\Bugsnag;
+use Bolt\Boltpay\Helper\Config as ConfigHelper;
+use Bolt\Boltpay\Helper\Cart as CartHelper;
+use Bolt\Boltpay\Helper\Log as LogHelper;
+use Bolt\Boltpay\Helper\MetricsClient;
+use Bolt\Boltpay\Model\Payment;
+use Bolt\Boltpay\Model\Response;
+use Exception;
+use Magento\Customer\Api\Data\CustomerInterface;
+use Magento\Framework\DataObjectFactory;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Exception\LocalizedException;
+use Zend_Http_Client_Exception;
+
+/**
+ * Class NonBoltOrderObserver
+ *
+ * @package Bolt\Boltpay\Observer
+ */
+class NonBoltOrderObserver implements ObserverInterface
+{
+    /**
+     * @var ApiHelper
+     */
+    private $apiHelper;
+
+    /**
+     * @var Bugsnag
+     */
+    private $bugsnag;
+
+    /**
+     * @var CartHelper
+     */
+    private $cartHelper;
+
+    /**
+     * @var DataObjectFactory
+     */
+    private $dataObjectFactory;
+
+    /**
+     * @var ConfigHelper
+     */
+    private $configHelper;
+
+    /**
+     * @var LogHelper
+     */
+    private $logHelper;
+
+    /**
+     * @var MetricsClient
+     */
+    private $metricsClient;
+
+    /**
+     * @param ApiHelper $apiHelper
+     * @param Bugsnag $bugsnag
+     * @param CartHelper $cartHelper
+     * @param ConfigHelper $configHelper
+     * @param DataObjectFactory $dataObjectFactory
+     * @param LogHelper $logHelper
+     * @param MetricsClient $metricsClient
+     */
+    public function __construct(
+        ApiHelper $apiHelper,
+        Bugsnag $bugsnag,
+        CartHelper $cartHelper,
+        ConfigHelper $configHelper,
+        DataObjectFactory $dataObjectFactory,
+        LogHelper $logHelper,
+        MetricsClient $metricsClient
+    ) {
+        $this->apiHelper = $apiHelper;
+        $this->bugsnag = $bugsnag;
+        $this->cartHelper = $cartHelper;
+        $this->configHelper = $configHelper;
+        $this->dataObjectFactory = $dataObjectFactory;
+        $this->logHelper = $logHelper;
+        $this->metricsClient = $metricsClient;
+    }
+
+    /**
+     * @param Observer $observer
+     */
+    public function execute(Observer $observer)
+    {
+        try {
+            $order = $observer->getEvent()->getOrder();
+            if (!$order) {
+                // for multi-address orders, the event will have a list of orders instead
+                $orders = $observer->getEvent()->getOrders();
+                if (!$orders || count($orders) < 1) {
+                    $this->metricsClient->processCountMetric("non_bolt_order_creation.no_order", 1);
+                    return;
+                }
+
+                $order = $orders[0];
+            }
+
+            $payment = $order->getPayment();
+            if ($payment && $payment->getMethod() == Payment::METHOD_CODE) {
+                return;
+            }
+
+            $quote = $observer->getEvent()->getQuote();
+            if (!$quote) {
+                $this->metricsClient->processCountMetric("non_bolt_order_creation.no_quote", 1);
+                return;
+            }
+
+            $items = $quote->getAllVisibleItems();
+            if (!$items) {
+                $this->metricsClient->processCountMetric("non_bolt_order_creation.no_items", 1);
+                return;
+            }
+
+            $cart = $this->cartHelper->buildCartFromQuote($quote, $quote, $items, null, true);
+            $customer = $quote->getCustomer();
+            $storeId = $order->getStoreId();
+            $result = $this->createNonBoltOrder($cart, $customer, $storeId);
+            if ($result != 200) {
+                $this->metricsClient->processCountMetric("non_bolt_order_creation.failure", 1);
+                return;
+            }
+        } catch (Exception $exception) {
+            $this->metricsClient->processCountMetric("non_bolt_order_creation.failure", 1);
+            $this->bugsnag->notifyException($exception);
+            return;
+        }
+
+        $this->metricsClient->processCountMetric("non_bolt_order_creation.success", 1);
+    }
+
+    /**
+     * Call Bolt Create Non-Bolt Order API
+     *
+     * @param array $cart
+     * @param CustomerInterface $customer
+     * @param int $storeId
+     * @return Response|int
+     * @throws LocalizedException
+     * @throws Zend_Http_Client_Exception
+     */
+    protected function createNonBoltOrder($cart, $customer, $storeId)
+    {
+        $apiKey = $this->configHelper->getApiKey($storeId);
+
+        $phone = $this->getPhone($cart);
+        $requestData = $this->dataObjectFactory->create();
+        $requestData->setApiData([
+            'cart' => $cart,
+            'user_identifier' => [
+                'email' => $customer->getEmail(),
+                'phone' => $phone,
+            ],
+            'user_identity' => [
+                'first_name' => $customer->getFirstname(),
+                'last_name' => $customer->getLastname(),
+            ],
+        ]);
+        $requestData->setDynamicApiUrl(ApiHelper::API_CREATE_NON_BOLT_ORDER);
+        $requestData->setApiKey($apiKey);
+        $requestData->setStatusOnly(true);
+
+        $request = $this->apiHelper->buildRequest($requestData);
+        return $this->apiHelper->sendRequest($request);
+    }
+
+    /**
+     * Get phone number from the cart if it exists
+     *
+     * @param array $cart
+     * @return string
+     */
+    protected function getPhone($cart)
+    {
+        if (count($cart['shipments']) < 1) {
+            return null;
+        }
+
+        if ($cart['shipments'][0]['shipping_address'] == null) {
+            return null;
+        }
+
+        return $cart['shipments'][0]['shipping_address']['phone'];
+    }
+}

--- a/Observer/NonBoltOrderObserver.php
+++ b/Observer/NonBoltOrderObserver.php
@@ -104,10 +104,10 @@ class NonBoltOrderObserver implements ObserverInterface
     {
         try {
             $order = $observer->getEvent()->getOrder();
-            if (!$order) {
+            if ($order == null) {
                 // for multi-address orders, the event will have a list of orders instead
                 $orders = $observer->getEvent()->getOrders();
-                if (!$orders || count($orders) < 1) {
+                if ($orders == null || count($orders) < 1) {
                     $this->metricsClient->processCountMetric("non_bolt_order_creation.no_order", 1);
                     return;
                 }

--- a/Observer/NonBoltOrderObserver.php
+++ b/Observer/NonBoltOrderObserver.php
@@ -105,14 +105,7 @@ class NonBoltOrderObserver implements ObserverInterface
         try {
             $order = $observer->getEvent()->getOrder();
             if ($order == null) {
-                // for multi-address orders, the event will have a list of orders instead
-                $orders = $observer->getEvent()->getOrders();
-                if ($orders == null || count($orders) < 1) {
-                    $this->metricsClient->processCountMetric("non_bolt_order_creation.no_order", 1);
-                    return;
-                }
-
-                $order = $orders[0];
+                return;
             }
 
             $payment = $order->getPayment();

--- a/Test/Unit/Observer/NonBoltOrderObserverTest.php
+++ b/Test/Unit/Observer/NonBoltOrderObserverTest.php
@@ -23,6 +23,7 @@ use Bolt\Boltpay\Helper\Cart as CartHelper;
 use Bolt\Boltpay\Helper\Log as LogHelper;
 use Bolt\Boltpay\Helper\MetricsClient;
 use Bolt\Boltpay\Model\Payment;
+use Exception;
 use Magento\Customer\Api\Data\CustomerInterface;
 use Magento\Framework\DataObject;
 use Bolt\Boltpay\Helper\Config as ConfigHelper;
@@ -128,7 +129,6 @@ class NonBoltOrderObserverTest extends TestCase
             ->setMethods(['buildCartFromQuote'])
             ->disableOriginalConstructor()
             ->getMock();
-        $this->cartHelper->method('buildCartFromQuote')->willReturn(self::CART);
         $this->configHelper = $this->createMock(ConfigHelper::class);
         $this->dataObject = $this->getMockBuilder(DataObject::class)
             ->setMethods(['setApiData'])
@@ -181,6 +181,7 @@ class NonBoltOrderObserverTest extends TestCase
             ->method('getEvent')
             ->willReturn($event);
 
+        $this->cartHelper->method('buildCartFromQuote')->willReturn(self::CART);
         $expectedOrderData = [
             'cart' => self::CART,
             'user_identifier' => [
@@ -284,5 +285,91 @@ class NonBoltOrderObserverTest extends TestCase
             ->willReturn($event);
         $this->apiHelper->expects($this->never())->method('sendRequest');
         $this->observer->execute($eventObserver);
+    }
+
+    /**
+     * @test
+     */
+    public function testExecuteBuildCartError()
+    {
+        $order = $this->createMock(Order::class);
+        $item = $this->createMock(Item::class);
+        $customer = $this->createMock(CustomerInterface::class);
+        $customer->method('getEmail')->willReturn(self::EMAIL);
+        $customer->method('getFirstname')->willReturn(self::FIRST_NAME);
+        $customer->method('getLastname')->willReturn(self::LAST_NAME);
+        $quote = $this->createMock(Quote::class);
+        $quote->method('getAllVisibleItems')->willReturn([$item]);
+        $quote->method('getCustomer')->willReturn($customer);
+
+        $event = $this->getMockBuilder(Event::class)
+            ->setMethods(['getOrder', 'getQuote'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $event->expects($this->once())
+            ->method('getOrder')
+            ->willReturn($order);
+        $event->expects($this->once())
+            ->method('getQuote')
+            ->willReturn($quote);
+        $eventObserver = $this->getMockBuilder(Event\Observer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $eventObserver->expects($this->exactly(2))
+            ->method('getEvent')
+            ->willReturn($event);
+
+        $this->cartHelper->method('buildCartFromQuote')->willReturnCallback(function() {
+            trigger_error("Error", E_ERROR);
+        });
+        $this->dataObject->expects($this->never())->method("setApiData");
+        $this->apiHelper->expects($this->never())->method('buildRequest')->willReturn(new Request());
+        $this->apiHelper->expects($this->never())->method('sendRequest')->willReturn(200);
+        $this->observer->execute($eventObserver);
+
+        // assert that an error was not thrown by the observer
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @test
+     */
+    public function testExecuteBuildCartException()
+    {
+        $order = $this->createMock(Order::class);
+        $item = $this->createMock(Item::class);
+        $customer = $this->createMock(CustomerInterface::class);
+        $customer->method('getEmail')->willReturn(self::EMAIL);
+        $customer->method('getFirstname')->willReturn(self::FIRST_NAME);
+        $customer->method('getLastname')->willReturn(self::LAST_NAME);
+        $quote = $this->createMock(Quote::class);
+        $quote->method('getAllVisibleItems')->willReturn([$item]);
+        $quote->method('getCustomer')->willReturn($customer);
+
+        $event = $this->getMockBuilder(Event::class)
+            ->setMethods(['getOrder', 'getQuote'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $event->expects($this->once())
+            ->method('getOrder')
+            ->willReturn($order);
+        $event->expects($this->once())
+            ->method('getQuote')
+            ->willReturn($quote);
+        $eventObserver = $this->getMockBuilder(Event\Observer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $eventObserver->expects($this->exactly(2))
+            ->method('getEvent')
+            ->willReturn($event);
+
+        $this->cartHelper->method('buildCartFromQuote')->willThrowException(new Exception());
+        $this->dataObject->expects($this->never())->method("setApiData");
+        $this->apiHelper->expects($this->never())->method('buildRequest')->willReturn(new Request());
+        $this->apiHelper->expects($this->never())->method('sendRequest')->willReturn(200);
+        $this->observer->execute($eventObserver);
+
+        // assert that an error was not thrown by the observer
+        $this->assertTrue(true);
     }
 }

--- a/Test/Unit/Observer/NonBoltOrderObserverTest.php
+++ b/Test/Unit/Observer/NonBoltOrderObserverTest.php
@@ -1,0 +1,288 @@
+<?php
+
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2018 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Test\Unit\Observer;
+
+use Bolt\Boltpay\Helper\Api as ApiHelper;
+use Bolt\Boltpay\Helper\Cart as CartHelper;
+use Bolt\Boltpay\Helper\Log as LogHelper;
+use Bolt\Boltpay\Helper\MetricsClient;
+use Bolt\Boltpay\Model\Payment;
+use Magento\Customer\Api\Data\CustomerInterface;
+use Magento\Framework\DataObject;
+use Bolt\Boltpay\Helper\Config as ConfigHelper;
+use Magento\Framework\DataObjectFactory;
+use Bolt\Boltpay\Helper\Bugsnag;
+use Magento\Framework\Event;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\Quote\Item;
+use Magento\Sales\Api\Data\OrderPaymentInterface;
+use Magento\Sales\Model\Order;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use Bolt\Boltpay\Observer\NonBoltOrderObserver as Observer;
+use \PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Model\Request;
+
+/**
+ * Class TrackingSaveObserverTest
+ * @coversDefaultClass \Bolt\Boltpay\Observer\TrackingSaveObserver
+ */
+class NonBoltOrderObserverTest extends TestCase
+{
+    const IMMUTABLE_QUOTE_ID = 1001;
+    const RESERVED_ORDER_ID = '100010001';
+    const FIRST_NAME = 'IntegrationBolt';
+    const LAST_NAME = 'BoltTest';
+    const EMAIL = 'integration@bolt.com';
+    const PHONE = '132 231 1234';
+    const EXPECTED_SHIPMENT = [
+        'cost'             => 0,
+        'tax_amount'       => 0,
+        'shipping_address' => [
+            'first_name'      => self::FIRST_NAME,
+            'last_name'       => self::LAST_NAME,
+            'phone'           => self::PHONE,
+            'email'           => self::EMAIL,
+        ],
+        'service'          => null,
+        'reference'        => null,
+    ];
+    const CART = [
+        'order_reference' => self::IMMUTABLE_QUOTE_ID,
+        'display_id'      => self::RESERVED_ORDER_ID . ' / ' . self::IMMUTABLE_QUOTE_ID,
+        'shipments'       => [self::EXPECTED_SHIPMENT],
+        'total_amount'    => 100,
+        'tax_amount'      => 0,
+    ];
+
+    /**
+     * @var ApiHelper|MockObject
+     */
+    private $apiHelper;
+
+    /**
+     * @var Bugsnag|MockObject
+     */
+    private $bugsnag;
+
+    /**
+     * @var CartHelper|MockObject
+     */
+    private $cartHelper;
+
+    /**
+     * @var ConfigHelper
+     */
+    private $configHelper;
+
+    /**
+     * @var DataObjectFactory
+     */
+    private $dataObjectFactory;
+
+    /**
+     * @var DataObject|MockObject
+     */
+    private $dataObject;
+
+    /**
+     * @var LogHelper|MockObject
+     */
+    private $logHelper;
+
+    /**
+     * @var MetricsClient
+     */
+    private $metricsClient;
+
+    /**
+     * @var Observer
+     */
+    protected $observer;
+
+    protected function setUp()
+    {
+        $this->initRequiredMocks();
+    }
+
+    private function initRequiredMocks()
+    {
+        $this->apiHelper = $this->createMock(ApiHelper::class);
+        $this->bugsnag = $this->createMock(Bugsnag::class);
+        $this->cartHelper = $this->getMockBuilder(CartHelper::class)
+            ->setMethods(['buildCartFromQuote'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->cartHelper->method('buildCartFromQuote')->willReturn(self::CART);
+        $this->configHelper = $this->createMock(ConfigHelper::class);
+        $this->dataObject = $this->getMockBuilder(DataObject::class)
+            ->setMethods(['setApiData'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->dataObjectFactory = $this->createMock(DataObjectFactory::class);
+        $this->dataObjectFactory->method('create')->willReturn($this->dataObject);
+        $this->logHelper = $this->createMock(LogHelper::class);
+        $this->metricsClient = $this->createMock(MetricsClient::class);
+        $this->observer = new Observer(
+            $this->apiHelper,
+            $this->bugsnag,
+            $this->cartHelper,
+            $this->configHelper,
+            $this->dataObjectFactory,
+            $this->logHelper,
+            $this->metricsClient
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function testExecute()
+    {
+        $order = $this->createMock(Order::class);
+        $item = $this->createMock(Item::class);
+        $customer = $this->createMock(CustomerInterface::class);
+        $customer->method('getEmail')->willReturn(self::EMAIL);
+        $customer->method('getFirstname')->willReturn(self::FIRST_NAME);
+        $customer->method('getLastname')->willReturn(self::LAST_NAME);
+        $quote = $this->createMock(Quote::class);
+        $quote->method('getAllVisibleItems')->willReturn([$item]);
+        $quote->method('getCustomer')->willReturn($customer);
+
+        $event = $this->getMockBuilder(Event::class)
+            ->setMethods(['getOrder', 'getQuote'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $event->expects($this->once())
+            ->method('getOrder')
+            ->willReturn($order);
+        $event->expects($this->once())
+            ->method('getQuote')
+            ->willReturn($quote);
+        $eventObserver = $this->getMockBuilder(Event\Observer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $eventObserver->expects($this->exactly(2))
+            ->method('getEvent')
+            ->willReturn($event);
+
+        $expectedOrderData = [
+            'cart' => self::CART,
+            'user_identifier' => [
+                'email' => self::EMAIL,
+                'phone' => self::PHONE,
+            ],
+            'user_identity' => [
+                'first_name' => self::FIRST_NAME,
+                'last_name' => self::LAST_NAME,
+            ],
+        ];
+
+        $this->dataObject->expects($this->once())
+            ->method("setApiData")
+            ->with($expectedOrderData);
+
+        $this->apiHelper->expects($this->once())->method('buildRequest')->willReturn(new Request());
+        $this->apiHelper->expects($this->once())->method('sendRequest')->willReturn(200);
+        $this->observer->execute($eventObserver);
+    }
+
+    /**
+     * @test
+     */
+    public function testExecuteNoOrder()
+    {
+        $event = $this->getMockBuilder(Event::class)
+            ->setMethods(['getOrder', 'getOrders'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $event->expects($this->once())
+            ->method('getOrder')
+            ->willReturn(null);
+        $event->expects($this->once())
+            ->method('getOrders')
+            ->willReturn(null);
+        $eventObserver = $this->getMockBuilder(Event\Observer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $eventObserver->expects($this->exactly(2))
+            ->method('getEvent')
+            ->willReturn($event);
+        $this->apiHelper->expects($this->never())->method('sendRequest');
+        $this->observer->execute($eventObserver);
+    }
+
+    /**
+     * @test
+     */
+    public function testExecuteNoQuote()
+    {
+        $order = $this->createMock(Order::class);
+        $event = $this->getMockBuilder(Event::class)
+            ->setMethods(['getOrder', 'getQuote'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $event->expects($this->once())
+            ->method('getOrder')
+            ->willReturn($order);
+        $event->expects($this->once())
+            ->method('getQuote')
+            ->willReturn(null);
+        $eventObserver = $this->getMockBuilder(Event\Observer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $eventObserver->expects($this->exactly(2))
+            ->method('getEvent')
+            ->willReturn($event);
+        $this->apiHelper->expects($this->never())->method('sendRequest');
+        $this->observer->execute($eventObserver);
+    }
+
+    /**
+     * @test
+     */
+    public function testExecuteBoltOrder()
+    {
+        $payment = $this->getMockForAbstractClass(OrderPaymentInterface::class);
+        $payment->expects($this->once())
+            ->method('getMethod')
+            ->willReturn(Payment::METHOD_CODE);
+        $order = $this->getMockBuilder(Order::class)
+            ->setMethods(['getPayment'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $order->expects($this->once())
+            ->method('getPayment')
+            ->willReturn($payment);
+        $event = $this->getMockBuilder(Event::class)
+            ->setMethods(['getOrder'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $event->expects($this->once())
+            ->method('getOrder')
+            ->willReturn($order);
+        $eventObserver = $this->getMockBuilder(Event\Observer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $eventObserver->expects($this->exactly(1))
+            ->method('getEvent')
+            ->willReturn($event);
+        $this->apiHelper->expects($this->never())->method('sendRequest');
+        $this->observer->execute($eventObserver);
+    }
+}

--- a/Test/Unit/Observer/NonBoltOrderObserverTest.php
+++ b/Test/Unit/Observer/NonBoltOrderObserverTest.php
@@ -198,19 +198,16 @@ class NonBoltOrderObserverTest extends TestCase
     public function testExecuteNoOrder()
     {
         $event = $this->getMockBuilder(Event::class)
-            ->setMethods(['getOrder', 'getOrders'])
+            ->setMethods(['getOrder'])
             ->disableOriginalConstructor()
             ->getMock();
         $event->expects($this->once())
             ->method('getOrder')
             ->willReturn(null);
-        $event->expects($this->once())
-            ->method('getOrders')
-            ->willReturn(null);
         $eventObserver = $this->getMockBuilder(Event\Observer::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $eventObserver->expects($this->exactly(2))
+        $eventObserver->expects($this->once())
             ->method('getEvent')
             ->willReturn($event);
         $this->apiHelper->expects($this->never())->method('sendRequest');

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -3,7 +3,7 @@
     <event name="sales_order_shipment_track_save_after">
         <observer name="boltTrackSaveObserver" instance="Bolt\Boltpay\Observer\TrackingSaveObserver" />
     </event>
-    <event name="checkout_submit_all_after">
+    <event name="sales_order_place_after">
         <observer name="nonBoltOrderObserver" instance="Bolt\Boltpay\Observer\NonBoltOrderObserver" />
     </event>
     <event name="sales_order_delete_before">

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -3,6 +3,9 @@
     <event name="sales_order_shipment_track_save_after">
         <observer name="boltTrackSaveObserver" instance="Bolt\Boltpay\Observer\TrackingSaveObserver" />
     </event>
+    <event name="checkout_submit_all_after">
+        <observer name="nonBoltOrderObserver" instance="Bolt\Boltpay\Observer\NonBoltOrderObserver" />
+    </event>
     <event name="sales_order_delete_before">
         <observer name="magento_giftcardaccount" instance="Magento\GiftCardAccount\Observer\RevertGiftCardAccountBalance"/>
     </event>


### PR DESCRIPTION
# Description
This observer will trigger on all completed orders, and conditionally send non-Bolt order information to the Bolt backend. This is part of the non-Bolt order management project, which will let shoppers see all of the purchases in the Bolt shopper dashboard regardless of how they paid.

Tested locally with my Magento 2 devbox-- Bolt orders were ignored and non-Bolt order information was successfully sent to the Hail backend and stored in the DB.

#changelog Add observer on order creation event to injest non-Bolt orders
Add observer for all completed orders to ingest non-Bolt order information.
