### PR TITLE
M2P-83 Fix bug - PPC is broken if "MiniCart" setting field is set to "No"

### DIFF
--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -22,6 +22,7 @@
         <referenceBlock name="head.additional">
             <block class="Bolt\Boltpay\Block\Js" name="boltjs"    template="Bolt_Boltpay::js/boltjs.phtml"/>
             <block class="Bolt\Boltpay\Block\Js" name="boltcss"   template="Bolt_Boltpay::css/boltcss.phtml"/>
+            <block class="Bolt\Boltpay\Block\Js" name="boltglobaljs" template="Bolt_Boltpay::js/boltglobaljs.phtml"/>
             <block class="Bolt\Boltpay\Block\Js" name="replacejs" template="Bolt_Boltpay::js/replacejs.phtml"/>
         </referenceBlock>
         <!-- for blank theme-->

--- a/view/frontend/templates/js/boltglobaljs.phtml
+++ b/view/frontend/templates/js/boltglobaljs.phtml
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * Replace js template
+ * Puts / replaces the checkout buttons according to defined selectors.
+ * Maintains Bolt checkout functionality.
+ *
+ * @var $block \Bolt\Boltpay\Block\Js
+ */
+if ($block->shouldDisableBoltCheckout()) return;
+
+//check if we need Bolt on this page
+if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled() && !$block->isBoltProductPage()) return;
+
+$trackCallbackCode = $block->getTrackCallbacks();
+
+function wrapWithCatch($jsCode, $argName='') {
+echo "
+function($argName) {
+    try {
+        $jsCode
+    } catch (error) {
+        console.error(error);
+    }
+}";
+}
+
+ob_start();
+?>
+<script type="text/javascript">
+    // Store the configuration parameters passed from the php block
+    // in the global object. Used in this file and on the payment page
+    // in payment method renderer, vendor/boltpay/bolt-magento2/view/frontend/web/js/view/payment/method-renderer/boltpay.js
+    window.boltConfig = <?php echo $block->getSettings(); ?>;
+
+    window.boltConfig.trackCallbacks = {
+        onCheckoutStart: <?php wrapWithCatch($trackCallbackCode['checkout_start']); ?>,
+        onEmailEnter: <?php wrapWithCatch($trackCallbackCode['email_enter'], 'email'); ?>,
+        onShippingDetailsComplete: <?php wrapWithCatch($trackCallbackCode['shipping_details_complete']); ?>,
+        onShippingOptionsComplete: <?php wrapWithCatch($trackCallbackCode['shipping_options_complete']); ?>,
+        onPaymentSubmit: <?php wrapWithCatch($trackCallbackCode['payment_submit']); ?>,
+        onSuccess: <?php wrapWithCatch( $block->getJavascriptSuccess() . $trackCallbackCode['success'], 'data') ?>,
+        onClose: <?php wrapWithCatch($trackCallbackCode['close']); ?>,
+    };
+    
+    ////////////////////////////////////////////////////////////////////////
+    // Wait for an object to be defined and
+    // execute a callback when it becomes available
+    ////////////////////////////////////////////////////////////////////////
+    window.whenDefined = function(obj, property, callback) {
+        if (obj[property]) {
+            callback();
+        } else {
+            var prop = '_'+property;
+            Object.defineProperty(obj, property, {
+                configurable: true,
+                enumerable: true,
+                writeable: true,
+                get: function() {
+                    return this[prop];
+                },
+                // calls callback when variable is set
+                set: function(value) {
+                    this[prop] = value;
+                    callback();
+                }
+            });
+        }
+    };
+    ////////////////////////////////////////////////////////////////////////
+</script>
+<?php
+$js = ob_get_clean();
+echo $block->minifyJs($js);
+?>

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -29,37 +29,9 @@ if ($block->shouldDisableBoltCheckout()) return;
 //product page checkout has its own JS script
 if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) return;
 
-$trackCallbackCode = $block->getTrackCallbacks();
-
-function wrapWithCatch($jsCode, $argName='') {
-echo "
-function($argName) {
-    try {
-        $jsCode
-    } catch (error) {
-        console.error(error);
-    }
-}";
-}
-
 ob_start();
 ?>
 <script type="text/javascript">
-    // Store the configuration parameters passed from the php block
-    // in the global object. Used in this file and on the payment page
-    // in payment method renderer, vendor/boltpay/bolt-magento2/view/frontend/web/js/view/payment/method-renderer/boltpay.js
-    window.boltConfig = <?php echo $block->getSettings(); ?>;
-
-    window.boltConfig.trackCallbacks = {
-        onCheckoutStart: <?php wrapWithCatch($trackCallbackCode['checkout_start']); ?>,
-        onEmailEnter: <?php wrapWithCatch($trackCallbackCode['email_enter'], 'email'); ?>,
-        onShippingDetailsComplete: <?php wrapWithCatch($trackCallbackCode['shipping_details_complete']); ?>,
-        onShippingOptionsComplete: <?php wrapWithCatch($trackCallbackCode['shipping_options_complete']); ?>,
-        onPaymentSubmit: <?php wrapWithCatch($trackCallbackCode['payment_submit']); ?>,
-        onSuccess: <?php wrapWithCatch( $block->getJavascriptSuccess() . $trackCallbackCode['success'], 'data') ?>,
-        onClose: <?php wrapWithCatch($trackCallbackCode['close']); ?>,
-    };
-
     ///////////////////////
     // String.trim Polyfill
     ///////////////////////
@@ -225,32 +197,6 @@ ob_start();
         });
         return { promise: promise, resolve: function(t){resolveHolder(t)}};
     };
-
-    ////////////////////////////////////////////////////////////////////////
-    // Wait for an object to be defined and
-    // execute a callback when it becomes available
-    ////////////////////////////////////////////////////////////////////////
-    window.whenDefined = function(obj, property, callback) {
-        if (obj[property]) {
-            callback();
-        } else {
-            var prop = '_'+property;
-            Object.defineProperty(obj, property, {
-                configurable: true,
-                enumerable: true,
-                writeable: true,
-                get: function() {
-                    return this[prop];
-                },
-                // calls callback when variable is set
-                set: function(value) {
-                    this[prop] = value;
-                    callback();
-                }
-            });
-        }
-    };
-    ////////////////////////////////////////////////////////////////////////
 
     ////////////////////////////////////////////////////
     // DI: Inserting required Magento objects


### PR DESCRIPTION
# Description
If PPC is enabled while MiniCart is disabled, then PPC does not work in the product page due to the Js errors "Uncaught TypeError: Cannot read property 'trackCallbacks' of undefined" and “whenDefined is not defined“, it is because window.boltConfig.trackCallbacks and window.whenDefined are not initialized.

So we move the window.boltConfig and window.whenDefined to a separate js file for global reference.

Fixes: https://boltpay.atlassian.net/browse/M2P-83

#changelog Fix bug - PPC is broken if "MiniCart" setting field is set to "No"

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
