### PR TITLE
Removal of Backoffice Orders Triggering Minimum Amount Validation

### DIFF
--- a/Model/Api/CreateOrder.php
+++ b/Model/Api/CreateOrder.php
@@ -434,7 +434,7 @@ class CreateOrder implements CreateOrderInterface
      */
     public function validateMinimumAmount($quote)
     {
-        if (!$quote->validateMinimumAmount()) {
+        if ($quote->getBoltCheckoutType() != CartHelper::BOLT_CHECKOUT_TYPE_BACKOFFICE && !$quote->validateMinimumAmount()) {
             $minAmount = $this->configHelper->getMinimumOrderAmount($quote->getStoreId());
             $this->bugsnag->registerCallback(function ($report) use ($quote, $minAmount) {
                 $report->setMetaData([

--- a/Plugin/QuotePlugin.php
+++ b/Plugin/QuotePlugin.php
@@ -61,4 +61,22 @@ class QuotePlugin
         }
         return $result;
     }
+
+    /**
+     * Change result of the validateMinimumAmount method for Bolt backoffice quotes to always return true
+     * @see \Magento\Quote\Model\Quote::validateMinimumAmount
+     *
+     * @param \Magento\Quote\Model\Quote $subject
+     * @param bool                       $result of the parent method call
+     *
+     * @return bool true if Bolt backoffice quote, otherwise parent method result
+     */
+    public function afterValidateMinimumAmount(\Magento\Quote\Model\Quote $subject, $result)
+    {
+        if ($subject->getBoltCheckoutType() == \Bolt\Boltpay\Helper\Cart::BOLT_CHECKOUT_TYPE_BACKOFFICE
+            && $subject->getPayment()->getMethod() == \Bolt\Boltpay\Model\Payment::METHOD_CODE) {
+            return true;
+        }
+        return $result;
+    }
 }

--- a/Test/Unit/Model/Api/CreateOrderTest.php
+++ b/Test/Unit/Model/Api/CreateOrderTest.php
@@ -320,6 +320,22 @@ class CreateOrderTest extends TestCase
 
     /**
      * @test
+     * that validateMinimumAmount skips validation if quote checkout type is backoffice
+     *
+     * @covers ::validateMinimumAmount
+     *
+     * @throws BoltException from tested method
+     */
+    public function validateMinimumAmount_withBackofficeCheckoutType_skipsValidation()
+    {
+        $this->quoteMock->expects(static::once())->method('getBoltCheckoutType')
+            ->willReturn(CartHelper::BOLT_CHECKOUT_TYPE_BACKOFFICE);
+        $this->quoteMock->expects(static::never())->method('validateMinimumAmount');
+        $this->currentMock->validateMinimumAmount($this->quoteMock);
+    }
+
+    /**
+     * @test
      */
     public function validateTotalAmount_valid()
     {


### PR DESCRIPTION
# Description
This PR disables both Bolt internal and Magento built-in minimum order amount validation for Bolt backoffice orders.

Fixes: https://boltpay.atlassian.net/browse/M2P-84

#changelog Removal of Backoffice Orders Triggering Minimum Amount Validation

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
