### PR TITLE
Reward points need to be displayed in the minicart [EN-188]

### DIFF
--- a/Controller/Cart/CheckoutConfig.php
+++ b/Controller/Cart/CheckoutConfig.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Controller\Cart;
+
+/**
+ * Class CheckoutConfig
+ * Retrieve checkout config consumed by minicart addons {@see \Bolt\Boltpay\ViewModel\MinicartAddons}
+ *
+ * @package Bolt\Boltpay\Controller\Cart
+ */
+class CheckoutConfig extends \Magento\Framework\App\Action\Action
+{
+
+    /**
+     * @var \Magento\Checkout\Model\Session current checkout session
+     */
+    private $checkoutSession;
+
+    /**
+     * @var \Magento\Checkout\Model\CompositeConfigProvider default checkout configuration provider
+     */
+    private $configProvider;
+
+    /**
+     * CheckoutConfig action constructor
+     * @param \Magento\Framework\App\Action\Context           $context default Action context
+     * @param \Magento\Checkout\Model\Session                 $checkoutSession current checkout session
+     * @param \Magento\Checkout\Model\CompositeConfigProvider $configProvider default checkout configuration provider
+     */
+    public function __construct(
+        \Magento\Framework\App\Action\Context $context,
+        \Magento\Checkout\Model\Session $checkoutSession,
+        \Magento\Checkout\Model\CompositeConfigProvider $configProvider
+    ) {
+        parent::__construct($context);
+        $this->checkoutSession = $checkoutSession;
+        $this->configProvider = $configProvider;
+    }
+
+    /**
+     * Generates checkout config that is otherwise present as window.checkoutConfig on checkout and cart pages
+     *
+     * @return \Magento\Framework\Controller\Result\Json response object that will encode data into JSON format string
+     *                                                   and set content type header to application/json
+     */
+    public function execute()
+    {
+        $config = $this->checkoutSession->getQuoteId() ? $this->configProvider->getConfig() : [];
+        return $this->resultFactory->create(\Magento\Framework\Controller\ResultFactory::TYPE_JSON)
+            ->setData($config);
+    }
+}

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -285,6 +285,11 @@ class Config extends AbstractHelper
     const XML_PATH_REWARD_POINTS = 'payment/boltpay/reward_points';
 
     /**
+     * Use Reward Points on Minicart configuration path
+     */
+    const XML_PATH_REWARD_POINTS_MINICART = 'payment/boltpay/reward_points_minicart';
+
+    /**
      * Payment Only Checkout Enabled configuration path
      */
     const XML_PATH_PAYMENT_ONLY_CHECKOUT = 'payment/boltpay/enable_payment_only_checkout';
@@ -1290,6 +1295,22 @@ class Config extends AbstractHelper
     }
 
     /**
+     * Get Use Reward Points on Minicart configuration
+     *
+     * @param int|string|Store $store scope used for retrieving the configuration value
+     *
+     * @return bool Minicart Reward Points configuration flag
+     */
+    public function displayRewardPointsInMinicartConfig($store = null)
+    {
+        return $this->getScopeConfig()->isSetFlag(
+            self::XML_PATH_REWARD_POINTS_MINICART,
+            ScopeInterface::SCOPE_STORE,
+            $store
+        );
+    }
+
+    /**
      * Get Payment Only Checkout Enabled configuration
      *
      * @param int|string|Store $store
@@ -1578,6 +1599,10 @@ class Config extends AbstractHelper
 		$boltSettings[] = $this->boltConfigSettingFactory->create()
 		                                                 ->setName('reward_points')
 		                                                 ->setValue(var_export($this->useRewardPointsConfig(), true));
+		// Reward Points Minicart
+		$boltSettings[] = $this->boltConfigSettingFactory->create()
+		                                                 ->setName('reward_points_minicart')
+		                                                 ->setValue(var_export($this->displayRewardPointsInMinicartConfig(), true));
 		// Enable Payment Only Checkout
 		$boltSettings[] = $this->boltConfigSettingFactory->create()
 		                                                 ->setName('enable_payment_only_checkout')

--- a/Plugin/Magento/Rewards/Controller/Cart/RemoveActionPlugin.php
+++ b/Plugin/Magento/Rewards/Controller/Cart/RemoveActionPlugin.php
@@ -36,7 +36,7 @@ class RemoveActionPlugin
     }
 
     /**
-     * The original behavior, intended for the shopping cart page is to trigger
+     * The original behavior intended for the shopping cart page is to trigger
      * the browser to reload by sending a "Location" header. This is ok
      * from the shopping cart page, but we do not want this from the mini-cart.
      * To improve UX we remove the "Location" header so that the page does not

--- a/Plugin/Magento/Rewards/Controller/Cart/RemoveActionPlugin.php
+++ b/Plugin/Magento/Rewards/Controller/Cart/RemoveActionPlugin.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Plugin\Magento\Rewards\Controller\Cart;
+
+/**
+ * Plugin for {@see \Magento\Reward\Controller\Cart\Remove} used to add AJAX support
+ */
+class RemoveActionPlugin
+{
+    /**
+     * @var \Bolt\Boltpay\Helper\Config Bolt configuration helper instance
+     */
+    private $configHelper;
+
+    /**
+     * @param \Bolt\Boltpay\Helper\Config $configHelper Bolt configuration helper instance
+     */
+    public function __construct(\Bolt\Boltpay\Helper\Config $configHelper)
+    {
+        $this->configHelper = $configHelper;
+    }
+
+    /**
+     * The original behavior, intended for the shopping cart page is to trigger
+     * the browser to reload by sending a "Location" header. This is ok
+     * from the shopping cart page, but we do not want this from the mini-cart.
+     * To improve UX we remove the "Location" header so that the page does not
+     * "randomly" reload the user's page. This is consistent with other native
+     * mini-cart edit behavior.
+     *
+     * @see \Magento\Reward\Controller\Cart\Remove::execute
+     *
+     * @param \Magento\Reward\Controller\Cart\Remove        $subject the frontend controller wrapped by this plugin
+     * @param void|\Magento\Framework\App\ResponseInterface $result original result of the wrapped method
+     *
+     * @return void|\Magento\Framework\App\ResponseInterface original result of the wrapped method
+     */
+    public function afterExecute(\Magento\Reward\Controller\Cart\Remove $subject, $result)
+    {
+        if ($this->configHelper->displayRewardPointsInMinicartConfig() && $subject->getRequest()->isAjax()) {
+            $subject->getResponse()->clearHeader('Location');
+            $subject->getResponse()->setStatusHeader(200);
+        }
+        return $result;
+    }
+}

--- a/Test/Unit/Controller/Cart/CheckoutConfigTest.php
+++ b/Test/Unit/Controller/Cart/CheckoutConfigTest.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Test\Unit\Controller\Cart;
+
+use PHPUnit\Framework\TestCase;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+
+/**
+ * @coversDefaultClass \Bolt\Boltpay\Controller\Cart\CheckoutConfig
+ */
+class CheckoutConfigTest extends TestCase
+{
+    /**
+     * @var \Magento\Framework\App\Action\Context
+     */
+    private $context;
+
+    /**
+     * @var \Magento\Checkout\Model\Session|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $checkoutSession;
+
+    /**
+     * @var \Bolt\Boltpay\Controller\Cart\CheckoutConfig
+     */
+    private $currentMock;
+
+    /**
+     * @var \Magento\Checkout\Model\CompositeConfigProvider|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $configProvider;
+
+    /**
+     * Setup method, called before each test
+     */
+    protected function setUp()
+    {
+        $om = new ObjectManager($this);
+        $this->context = $om->getObject(\Magento\Framework\App\Action\Context::class);
+        $this->checkoutSession = $this->createMock(\Magento\Checkout\Model\Session::class);
+        $this->configProvider = $this->createMock(\Magento\Checkout\Model\CompositeConfigProvider::class);
+        $this->currentMock = $om->getObject(
+            \Bolt\Boltpay\Controller\Cart\CheckoutConfig::class,
+            [
+                'context'         => $this->context,
+                'checkoutSession' => $this->checkoutSession,
+                'configProvider' => $this->configProvider
+            ]
+        );
+    }
+
+    /**
+     * @test
+     * that __construct sets properties to provided values
+     *
+     * @covers ::__construct
+     */
+    public function __construct_always_setsProperties()
+    {
+        $instance = new \Bolt\Boltpay\Controller\Cart\CheckoutConfig(
+            $this->context,
+            $this->checkoutSession,
+            $this->configProvider
+        );
+        static::assertAttributeEquals($this->checkoutSession, 'checkoutSession', $instance);
+        static::assertAttributeEquals($this->configProvider, 'configProvider', $instance);
+    }
+
+    /**
+     * @test
+     * that execute doesn't collect configuration from config provider and returns an empty response
+     * if session quote id is not defined
+     *
+     * @covers ::execute
+     */
+    public function execute_withEmptySessionQuoteId_returnsEmptyResponse()
+    {
+        $this->checkoutSession->expects(static::once())->method('getQuoteId')->willReturn(null);
+        $jsonResultMock = $this->createMock(\Magento\Framework\Controller\Result\Json::class);
+        $resultFactory = static::getObjectAttribute($this->currentMock, 'resultFactory');
+        $resultFactory->expects(static::once())->method('create')
+            ->with(\Magento\Framework\Controller\ResultFactory::TYPE_JSON)
+            ->willReturn($jsonResultMock);
+        $jsonResultMock->expects(static::once())->method('setData')->with([])->willReturnSelf();
+        $this->configProvider->expects(static::never())->method('getConfig');
+        static::assertEquals($jsonResultMock, $this->currentMock->execute());
+    }
+
+    /**
+     * @test
+     * that execute returns checkout config from composite provider if session quote id is set
+     *
+     * @covers ::execute
+     */
+    public function execute_withVariousConfigProviders_returnsConfigJSONResponse()
+    {
+        $this->checkoutSession->expects(static::once())->method('getQuoteId')->willReturn(10001);
+        $jsonResultMock = $this->createMock(\Magento\Framework\Controller\Result\Json::class);
+        $resultFactory = static::getObjectAttribute($this->currentMock, 'resultFactory');
+        $resultFactory->expects(static::once())->method('create')
+            ->with(\Magento\Framework\Controller\ResultFactory::TYPE_JSON)
+            ->willReturn($jsonResultMock);
+        $config = [
+            'authentication' => [
+                'reward' => [
+                    'isAvailable'         => true,
+                    'tooltipLearnMoreUrl' => 'http://m2ee.local/reward-points',
+                    'tooltipMessage'      => 'Sign in now and earn 0 Reward points (<span class="price">$1.00</span>) for this order.'
+                ]
+            ],
+            'review'         => [
+                'reward' => [
+                    'removeUrl' => 'http://m2ee.local/reward/cart/remove/'
+                ]
+            ]
+        ];
+        $this->configProvider->expects(static::once())->method('getConfig')
+            ->willReturn($config);
+        $jsonResultMock->expects(static::once())->method('setData')->with($config)->willReturnSelf();
+
+        static::assertEquals($jsonResultMock, $this->currentMock->execute());
+    }
+}

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -561,6 +561,7 @@ JSON;
             ['useStoreCreditConfig', BoltConfig::XML_PATH_STORE_CREDIT],
             ['useAmastyStoreCreditConfig', BoltConfig::XML_PATH_AMASTY_STORE_CREDIT],
             ['useRewardPointsConfig', BoltConfig::XML_PATH_REWARD_POINTS, false],
+            ['displayRewardPointsInMinicartConfig', BoltConfig::XML_PATH_REWARD_POINTS_MINICART, false],
             ['isPaymentOnlyCheckoutEnabled', BoltConfig::XML_PATH_PAYMENT_ONLY_CHECKOUT],
             ['isBoltOrderCachingEnabled', BoltConfig::XML_PATH_BOLT_ORDER_CACHING, false],
             ['isSessionEmulationEnabled', BoltConfig::XML_PATH_API_EMULATE_SESSION],
@@ -927,6 +928,7 @@ JSON;
 			'getIPWhitelistArray',
 			'useStoreCreditConfig',
 			'useRewardPointsConfig',
+			'displayRewardPointsInMinicartConfig',
 			'isPaymentOnlyCheckoutEnabled',
 			'isBoltOrderCachingEnabled',
 			'isSessionEmulationEnabled',
@@ -968,6 +970,7 @@ JSON;
 		$this->currentMock->method('getIPWhitelistArray')->willReturn(['127.0.0.1', '0.0.0.0']);
 		$this->currentMock->method('useStoreCreditConfig')->willReturn(false);
 		$this->currentMock->method('useRewardPointsConfig')->willReturn(false);
+		$this->currentMock->method('displayRewardPointsInMinicartConfig')->willReturn(false);
 		$this->currentMock->method('isPaymentOnlyCheckoutEnabled')->willReturn(false);
 		$this->currentMock->method('isBoltOrderCachingEnabled')->willReturn(true);
 		$this->currentMock->method('isSessionEmulationEnabled')->willReturn(true);
@@ -1011,6 +1014,7 @@ JSON;
 			['ip_whitelist', '127.0.0.1, 0.0.0.0'],
 			['store_credit', 'false'],
 			['reward_points', 'false'],
+			['reward_points_minicart', 'false'],
 			['enable_payment_only_checkout', 'false'],
 			['bolt_order_caching', 'true'],
 			['api_emulate_session', 'true'],
@@ -1019,7 +1023,7 @@ JSON;
 			['track_checkout_funnel', 'false'],
 		];
 		$actual = $this->currentMock->getAllConfigSettings();
-		$this->assertEquals(40, count($actual));
+		$this->assertEquals(41, count($actual));
 		for ($i = 0; $i < 2; $i ++) {
 			$this->assertEquals($expected[$i][0], $actual[$i]->getName());
 			$this->assertEquals($expected[$i][1], $actual[$i]->getValue(), 'actual value for ' . $expected[$i][0] . ' is not equals to expected');

--- a/Test/Unit/Plugin/Magento/Rewards/Controller/Cart/RemoveActionPluginTest.php
+++ b/Test/Unit/Plugin/Magento/Rewards/Controller/Cart/RemoveActionPluginTest.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Test\Unit\Plugin\Magento\Rewards\Controller\Cart;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Bolt\Boltpay\Plugin\Magento\Rewards\Controller\Cart\RemoveActionPlugin
+ */
+class RemoveActionPluginTest extends TestCase
+{
+    /**
+     * @var \Bolt\Boltpay\Helper\Config|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $configHelper;
+
+    /**
+     * @var \Magento\Reward\Controller\Cart\Remove|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $subject;
+
+    /**
+     * @var \Bolt\Boltpay\Plugin\Magento\Rewards\Controller\Cart\RemoveActionPlugin
+     */
+    private $currentMock;
+
+    /**
+     * @var \Magento\Framework\App\Request\Http|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $requestMock;
+
+    /**
+     * @var \Magento\Framework\HTTP\PhpEnvironment\Response|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $responseMock;
+
+    /**
+     * Setup method, called before each test
+     */
+    protected function setUp()
+    {
+        $this->configHelper = $this->createMock(\Bolt\Boltpay\Helper\Config::class);
+        $this->subject = $this->getMockBuilder('\Magento\Reward\Controller\Cart\Remove')
+            ->setMethods(['getRequest', 'getResponse'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->currentMock = new \Bolt\Boltpay\Plugin\Magento\Rewards\Controller\Cart\RemoveActionPlugin(
+            $this->configHelper
+        );
+        $this->requestMock = $this->createMock(\Magento\Framework\App\Request\Http::class);
+        $this->responseMock = $this->createMock(\Magento\Framework\HTTP\PhpEnvironment\Response::class);
+        $this->subject->method('getRequest')->willReturn($this->requestMock);
+        $this->subject->method('getResponse')->willReturn($this->responseMock);
+    }
+
+    /**
+     * @test
+     * that afterExecute will remove redirect from response
+     * only if request is AJAX and reward points on minicart is enabled
+     *
+     * @dataProvider afterExecute_withVariousStatesProvider
+     *
+     * @covers ::afterExecute
+     *
+     * @param bool $displayRewardPointsInMinicartConfig flag value
+     * @param bool $isAjax current request flag
+     * @param bool $expectRemoveRedirect whether or not to expect response alteration
+     */
+    public function afterExecute_withVariousStates_removesRedirectIfFeatureEnabledAndRequestIsAjax(
+        $displayRewardPointsInMinicartConfig,
+        $isAjax,
+        $expectRemoveRedirect
+    ) {
+        $this->configHelper->expects(static::once())->method('displayRewardPointsInMinicartConfig')
+            ->willReturn($displayRewardPointsInMinicartConfig);
+        $this->requestMock->expects($displayRewardPointsInMinicartConfig ? static::once() : static::never())
+            ->method('isAjax')->willReturn($isAjax);
+        $this->responseMock->expects($expectRemoveRedirect ? static::once() : static::never())
+            ->method('clearHeader')->with('Location');
+        $this->responseMock->expects($expectRemoveRedirect ? static::once() : static::never())
+            ->method('setStatusHeader')->with(200);
+        static::assertEquals(
+            $this->responseMock,
+            $this->currentMock->afterExecute($this->subject, $this->responseMock)
+        );
+    }
+
+    /**
+     * Data provider for {@see afterExecute_withVariousStates_removesRedirectIfFeatureEnabledAndRequestIsAjax}
+     */
+    public function afterExecute_withVariousStatesProvider()
+    {
+        return [
+            ['displayRewardPointsInMinicartConfig' => true, 'isAjax' => true, 'expectRemoveRedirect' => true],
+            ['displayRewardPointsInMinicartConfig' => true, 'isAjax' => false, 'expectRemoveRedirect' => false],
+            ['displayRewardPointsInMinicartConfig' => false, 'isAjax' => true, 'expectRemoveRedirect' => false],
+            ['displayRewardPointsInMinicartConfig' => false, 'isAjax' => false, 'expectRemoveRedirect' => false],
+        ];
+    }
+
+    /**
+     * @test
+     * that __construct sets properties to provided values
+     *
+     * @covers ::__construct
+     */
+    public function __construct_always_setsProperty()
+    {
+        $instance = new \Bolt\Boltpay\Plugin\Magento\Rewards\Controller\Cart\RemoveActionPlugin($this->configHelper);
+        static::assertAttributeEquals($this->configHelper, 'configHelper', $instance);
+    }
+}

--- a/Test/Unit/ViewModel/MinicartAddonsTest.php
+++ b/Test/Unit/ViewModel/MinicartAddonsTest.php
@@ -1,0 +1,260 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Test\Unit\ViewModel;
+
+use PHPUnit\Framework\TestCase;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+
+/**
+ * @coversDefaultClass \Bolt\Boltpay\ViewModel\MinicartAddons
+ */
+class MinicartAddonsTest extends TestCase
+{
+    const DEFAULT_LAYOUT = [
+        [
+            'parent'    => 'minicart_content.extra_info',
+            'name'      => 'minicart_content.extra_info.rewards',
+            'component' => 'Magento_Reward/js/view/payment/reward',
+            'config'    => [],
+        ],
+        [
+            'parent'    => 'minicart_content.extra_info',
+            'name'      => 'minicart_content.extra_info.rewards_total',
+            'component' => 'Magento_Reward/js/view/cart/reward',
+            'config'    => [
+                'template' => 'Magento_Reward/cart/reward',
+                'title'    => 'Reward Points',
+            ],
+        ]
+    ];
+
+    /**
+     * @var \Bolt\Boltpay\Helper\Config|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $configHelper;
+
+    /**
+     * @var \Magento\Framework\Serialize\SerializerInterface
+     */
+    private $serializer;
+
+    /**
+     * @var \Magento\Framework\App\Http\Context|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $httpContext;
+    private $currentMock;
+
+    /**
+     * Setup test dependencies, called before each test
+     */
+    public function setUp()
+    {
+        $this->configHelper = $this->createMock(\Bolt\Boltpay\Helper\Config::class);
+        $this->serializer = (new ObjectManager($this))
+            ->getObject(\Magento\Framework\Serialize\Serializer\Json::class);
+        $this->httpContext = $this->createMock(\Magento\Framework\App\Http\Context::class);
+        $this->currentMock = new \Bolt\Boltpay\ViewModel\MinicartAddons(
+            $this->serializer,
+            $this->httpContext,
+            $this->configHelper
+        );
+    }
+
+    /**
+     * @test
+     * that __construct always sets internal properties appropriately
+     *
+     * @covers ::__construct
+     */
+    public function __construct_always_setsInternalProperties()
+    {
+        $instance = new \Bolt\Boltpay\ViewModel\MinicartAddons(
+            $this->serializer,
+            $this->httpContext,
+            $this->configHelper
+        );
+        static::assertAttributeEquals($this->serializer, 'serializer', $instance);
+        static::assertAttributeEquals($this->configHelper, 'configHelper', $instance);
+        static::assertAttributeEquals($this->httpContext, 'httpContext', $instance);
+    }
+
+    /**
+     * @test
+     * that getLayout returns layout updates based on configuration and context state
+     *
+     * @covers ::getLayout
+     *
+     * @dataProvider getLayout_withVariousStatesProvider
+     *
+     * @param bool  $customerLoggedIn HTTP context flag
+     * @param bool  $displayRewardPointsInMinicartConfig flag value
+     * @param array $expectedResult of the method call
+     *
+     * @throws \ReflectionException if getLayout method is not defined
+     */
+    public function getLayout_withVariousStates_returnsLayout(
+        $customerLoggedIn,
+        $displayRewardPointsInMinicartConfig,
+        $expectedResult
+    ) {
+        $this->httpContext->expects(static::once())->method('getValue')
+            ->with(\Magento\Customer\Model\Context::CONTEXT_AUTH)
+            ->willReturn($customerLoggedIn);
+        $this->configHelper->expects($customerLoggedIn ? static::once() : static::never())
+            ->method('displayRewardPointsInMinicartConfig')
+            ->willReturn($displayRewardPointsInMinicartConfig);
+        static::assertEquals(
+            $expectedResult,
+            \Bolt\Boltpay\Test\Unit\TestHelper::invokeMethod($this->currentMock, 'getLayout')
+        );
+    }
+
+    /**
+     * Data provider for {@see getLayout_withVariousStates_returnsLayout}
+     *
+     * @return array[] containing customer logged in flag, use reward points on minicart config and expected result of the method call
+     */
+    public function getLayout_withVariousStatesProvider()
+    {
+        return [
+            'Happy path - customer logged in and rewards on minicart enabled' => [
+                'customerLoggedIn'                    => true,
+                'displayRewardPointsInMinicartConfig' => true,
+                'expectedResult'                      => self::DEFAULT_LAYOUT
+            ],
+            [
+                'customerLoggedIn'                    => false,
+                'displayRewardPointsInMinicartConfig' => true,
+                'expectedResult'                      => []
+            ],
+            [
+                'customerLoggedIn'                    => true,
+                'displayRewardPointsInMinicartConfig' => false,
+                'expectedResult'                      => []
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * that getLayoutJSON returns the result of the getLayout method in JSON format
+     *
+     * @covers ::getLayoutJSON
+     */
+    public function getLayoutJSON()
+    {
+        $currentMock = $this->createPartialMock(\Bolt\Boltpay\ViewModel\MinicartAddons::class, ['getLayout']);
+        \Bolt\Boltpay\Test\Unit\TestHelper::setProperty($currentMock, 'serializer', $this->serializer);
+        $currentMock->expects(static::once())->method('getLayout')->willReturn(self::DEFAULT_LAYOUT);
+        $result = $currentMock->getLayoutJSON();
+        static::assertJson($result);
+        static::assertEquals(self::DEFAULT_LAYOUT, $this->serializer->unserialize($result));
+    }
+
+    /**
+     * @test
+     * that shouldShow returns true only if Bolt on minicart is enabled and at least one minicart addon is enabled
+     *
+     * @dataProvider shouldShow_withVariousStatesProvider
+     *
+     * @covers ::shouldShow
+     *
+     * @param bool  $minicartSupport configuration value
+     * @param array $layout stubbed result of the getLayout method call
+     * @param bool  $expectedResult of the method call
+     *
+     * @throws \ReflectionException if configHelper property is undefined
+     */
+    public function shouldShow_withVariousStates_determinesIfAddonsShouldBeRendered(
+        $minicartSupport,
+        $layout,
+        $expectedResult
+    ) {
+        $currentMock = $this->createPartialMock(\Bolt\Boltpay\ViewModel\MinicartAddons::class, ['getLayout']);
+        \Bolt\Boltpay\Test\Unit\TestHelper::setProperty($currentMock, 'configHelper', $this->configHelper);
+        $this->configHelper->expects(static::once())->method('getMinicartSupport')->willReturn($minicartSupport);
+        $currentMock->expects($minicartSupport ? static::once() : static::never())->method('getLayout')
+            ->willReturn($layout);
+        static::assertEquals($expectedResult, $currentMock->shouldShow());
+    }
+
+    /**
+     * Data provider for {@see shouldShow_withVariousStates_determinesIfAddonsShouldBeRendered}
+     *
+     * @return array[] containing minicart support config value, subbed result of getLayout and expected result
+     */
+    public function shouldShow_withVariousStatesProvider()
+    {
+        return [
+            [
+                'minicartSupport' => true,
+                'layout'          => self::DEFAULT_LAYOUT,
+                'expectedResult'  => true,
+            ],
+            [
+                'minicartSupport' => true,
+                'layout'          => [],
+                'expectedResult'  => false,
+            ],
+            [
+                'minicartSupport' => false,
+                'layout'          => self::DEFAULT_LAYOUT,
+                'expectedResult'  => false,
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * that getOrderCreationTriggers returns expected selector(s) based on configuration state
+     *
+     * @dataProvider getOrderCreationTriggers_withVariousConfigurationsProvider
+     *
+     * @covers ::getOrderCreationTriggers
+     *
+     * @param bool   $displayRewardPointsInMinicartConfig value flag
+     * @param string $expectedResult of the method call
+     */
+    public function getOrderCreationTriggers_withVariousConfigurations_returnsElementSelector(
+        $displayRewardPointsInMinicartConfig,
+        $expectedResult
+    ) {
+        $this->configHelper->expects(static::once())->method('displayRewardPointsInMinicartConfig')
+            ->willReturn($displayRewardPointsInMinicartConfig);
+        static::assertEquals($expectedResult, $this->currentMock->getOrderCreationTriggers());
+    }
+
+    /**
+     * Data provider for {@see getOrderCreationTriggers_withVariousConfigurations}
+     *
+     * @return array[] containing configuration value for minicart reward points and expected result of the method call
+     */
+    public function getOrderCreationTriggers_withVariousConfigurationsProvider()
+    {
+        return [
+            [
+                'displayRewardPointsInMinicartConfig' => true,
+                'expectedResult'                      => '.totals.rewardpoints'
+            ],
+            [
+                'displayRewardPointsInMinicartConfig' => false,
+                'expectedResult'                      => ''
+            ],
+        ];
+    }
+}

--- a/ViewModel/MinicartAddons.php
+++ b/ViewModel/MinicartAddons.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\ViewModel;
+
+/**
+ * MinicartAddons view model
+ *
+ * @package Bolt\Boltpay\ViewModel
+ */
+class MinicartAddons implements \Magento\Framework\View\Element\Block\ArgumentInterface
+{
+    /**
+     * @var \Bolt\Boltpay\Helper\Config instance of the Bolt configuration helper
+     */
+    public $configHelper;
+
+    /**
+     * @var \Magento\Framework\Serialize\SerializerInterface JSON serializer instance
+     */
+    private $serializer;
+
+    /**
+     * @var \Magento\Framework\App\Http\Context request context data
+     */
+    private $httpContext;
+
+    /**
+     * @var array layout updates that need to be applied to minicart Ui component layout
+     */
+    private $_layout;
+
+    /**
+     * MinicartAddons constructor.
+     *
+     * @param \Magento\Framework\Serialize\SerializerInterface $serializer JSON serializer instance
+     * @param \Magento\Framework\App\Http\Context              $httpContext request context data
+     * @param \Bolt\Boltpay\Helper\Config                      $config instance of the Bolt configuration helper
+     */
+    public function __construct(
+        \Magento\Framework\Serialize\SerializerInterface $serializer,
+        \Magento\Framework\App\Http\Context $httpContext,
+        \Bolt\Boltpay\Helper\Config $config
+    ) {
+        $this->configHelper = $config;
+        $this->serializer = $serializer;
+        $this->httpContext = $httpContext;
+    }
+
+    /**
+     * Gets layout updates that need to be applied to minicart Ui component layout
+     *
+     * @return array minicart layout updates
+     */
+    protected function getLayout()
+    {
+        if ($this->_layout === null) {
+            $this->_layout = [];
+            if ($this->httpContext->getValue(\Magento\Customer\Model\Context::CONTEXT_AUTH)
+                && $this->configHelper->displayRewardPointsInMinicartConfig()) {
+                $this->_layout[] = [
+                    'parent'    => 'minicart_content.extra_info',
+                    'name'      => 'minicart_content.extra_info.rewards',
+                    'component' => 'Magento_Reward/js/view/payment/reward',
+                    'config'    => [],
+                ];
+                $this->_layout[] = [
+                    'parent'    => 'minicart_content.extra_info',
+                    'name'      => 'minicart_content.extra_info.rewards_total',
+                    'component' => 'Magento_Reward/js/view/cart/reward',
+                    'config'    => [
+                        'template' => 'Magento_Reward/cart/reward',
+                        'title'    => 'Reward Points',
+                    ],
+                ];
+            }
+        }
+        return $this->_layout;
+    }
+
+    /**
+     * Gets layout updates that need to be applied to minicart Ui component layout in JSON
+     *
+     * @return string JSON minicart layout updates
+     */
+    public function getLayoutJSON()
+    {
+        return $this->serializer->serialize($this->getLayout());
+    }
+
+    /**
+     * Return true if Bolt on minicart is enabled and at least one minicart addon is enabled
+     * (currently only reward points)
+     *
+     * @return bool whether or not to apply addons
+     */
+    public function shouldShow()
+    {
+        return $this->configHelper->getMinicartSupport() && !empty($this->getLayout());
+    }
+
+    /**
+     * Gets element selector to be used in DOM observer. Appearance of these elements signifies a change to
+     * the Magento cart data and, therefore, requires an ajax call to create a new Bolt order.
+     *
+     * @return string element selector
+     */
+    public function getOrderCreationTriggers()
+    {
+        $selectors = [];
+        if ($this->configHelper->displayRewardPointsInMinicartConfig()) {
+            $selectors[] = '.totals.rewardpoints';
+        }
+        return implode(',', $selectors);
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -232,6 +232,12 @@
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <if_module_enabled>Magento_Reward</if_module_enabled>
                     </field>
+                    <field id="reward_points_minicart" translate="label" type="select" sortOrder="246" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Use Magento Commerce Reward Points on Minicart</label>
+                        <config_path>payment/boltpay/reward_points_minicart</config_path>
+                        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                        <if_module_enabled>Magento_Reward</if_module_enabled>
+                    </field>
                     <field id="amasty_store_credit" translate="label" type="select" sortOrder="250" showInDefault="1" showInWebsite="1" showInStore="1">
                         <label>Use Amasty Store Credit on Shopping Cart</label>
                         <config_path>payment/boltpay/amasty_store_credit</config_path>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -60,6 +60,7 @@ tr.shipping.totals td.amount span.price,
                 <store_credit>0</store_credit>
                 <amasty_store_credit>0</amasty_store_credit>
                 <reward_points>0</reward_points>
+                <reward_points_minicart>0</reward_points_minicart>
                 <enable_payment_only_checkout>0</enable_payment_only_checkout>
                 <bolt_order_caching>1</bolt_order_caching>
                 <api_emulate_session>1</api_emulate_session>

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -77,4 +77,9 @@
             </argument>
         </arguments>
     </type>
+
+    <type name="Magento\Reward\Controller\Cart\Remove">
+        <plugin sortOrder="1" name="boltBoltpayRemove"
+                type="Bolt\Boltpay\Plugin\Magento\Rewards\Controller\Cart\RemoveActionPlugin"/>
+    </type>
 </config>

--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -36,5 +36,13 @@
         <referenceBlock name="after.body.start">
             <block class="Bolt\Boltpay\Block\Js" name="bolt_popup" template="Bolt_Boltpay::popup.phtml" />
         </referenceBlock>
+        <referenceContainer name="header-wrapper">
+            <block name="bolt_minicart_additions" as="bolt_minicart_additions"
+                   before="minicart" template="Bolt_Boltpay::checkout/minicart_addons.phtml">
+                <arguments>
+                    <argument name="view_model" xsi:type="object">Bolt\Boltpay\ViewModel\MinicartAddons</argument>
+                </arguments>
+            </block>
+        </referenceContainer>
     </body>
 </page>

--- a/view/frontend/templates/checkout/minicart_addons.phtml
+++ b/view/frontend/templates/checkout/minicart_addons.phtml
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/** @var \Magento\Framework\View\Element\Template $block */
+/** @var \Bolt\Boltpay\ViewModel\MinicartAddons $miniCartView */
+$miniCartView = $block->getViewModel();
+if (!$miniCartView->shouldShow()) return;
+?>
+<script>
+    require([
+        'jquery', 'Magento_Customer/js/model/customer',
+    ], function ($, customer) {
+        function append_minicart_addons () {
+            require(['uiLayout'], function (layout) {
+                layout(<?php echo $miniCartView->getLayoutJSON(); ?>);
+
+                <?php if($miniCartView->configHelper->displayRewardPointsInMinicartConfig()):?>
+                $('#minicart-content-wrapper').on('click', '.totals.rewardpoints .action.delete', function (e) {
+                    e.preventDefault();
+                    $.ajax({
+                        url:        window.checkoutConfig.review.reward.removeUrl,
+                        type:       'GET',
+                        cache:      false,
+                        dataType:   'json',
+                        showLoader: true,
+                        success:    function (response) {
+                            $(document).trigger('bolt:createOrder');
+                            require(
+                                [
+                                    'Magento_Checkout/js/action/get-payment-information',
+                                    'Magento_Customer/js/customer-data'
+                                ],
+                                function (getPaymentInformationAction, customerData) {
+                                    getPaymentInformationAction().always(function () {
+                                        customerData.reload(['messages'], true);
+                                    });
+                                }
+                            );
+                        }
+                    });
+                });
+                <?php endif; ?>
+            });
+        }
+
+        if (typeof window.checkoutConfig == 'undefined') {
+            $.ajax({
+                url: '<?php echo $block->getUrl('boltpay/cart/checkoutconfig'); ?>',
+                success:
+                    function (result) {
+                        window.checkoutConfig = result;
+                        customer.setIsLoggedIn(result.isCustomerLoggedIn);
+                        append_minicart_addons();
+                    }
+                ,
+                cache: false
+            });
+        } else {
+            append_minicart_addons();
+        }
+        require(['Magento_Ui/js/lib/view/utils/dom-observer'], function (domObserver) {
+            domObserver.get(
+                '<?php echo $miniCartView->getOrderCreationTriggers(); ?>',
+                function () {$(document).trigger('bolt:createOrder');}
+            );
+        });
+    });
+</script>

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -1072,6 +1072,9 @@ ob_start();
             createOrder(null, true);
         });
 
+        // globally register createOrder to be called from all templates
+        $(document).on("bolt:createOrder", createOrder);
+
         ////////////////////////////////////////////////////
         // Initially configures BoltCheckout.
         // Required for setting check callback which either


### PR DESCRIPTION
# Description
This PR adds support for Magento EE Reward Points to minicart.

Fixes: https://boltpay.atlassian.net/browse/EN-188

#changelog Reward points need to be displayed in the minicart [EN-188]

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
