### PR TITLE
M2P-88 Fix bug - Bolt PPC is broken if the product name contains single quote

### DIFF
--- a/view/frontend/templates/button_product_page.phtml
+++ b/view/frontend/templates/button_product_page.phtml
@@ -226,7 +226,7 @@ if (!$block->isSupportableType()) return;
                     items: [{
                         reference: '<?= $block->getProduct()->getId(); ?>',
                         price: itemPrice,
-                        name: '<?= $block->getProduct()->getName(); ?>',
+                        name: '<?= addcslashes( $block->getProduct()->getName(), "'" ); ?>',
                         quantity: getQty(),
                         options: JSON.stringify(options)
                     }]


### PR DESCRIPTION
# Description
If the product name contains any single quote, then the frontend js script of Bolt PPC would run into an error `Uncaught SyntaxError: Unexpected identifier`.

So we need to escape the product name that they pass otherwise this will cause things to break on the product page anytime a single quote is used in the product name. 

Fixes: https://boltpay.atlassian.net/browse/M2P-88

#changelog Fix bug - Bolt PPC is broken if the product name contains single quote

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
