### PR TITLE
Unknown RevertGiftCardAccountBalance fix

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -99,7 +99,7 @@ class Order extends AbstractHelper
     const TT_APM_REFUND = 'apm_refund';
 
     const VALID_HOOKS_FOR_ORDER_CREATION = [Hook::HT_PENDING, Hook::HT_PAYMENT];
-    
+
     // Payment method was used for Bolt transaction
     const TP_VANTIV = 'vantiv';
     const TP_PAYPAL = 'paypal';
@@ -1169,8 +1169,15 @@ class Order extends AbstractHelper
         }
 
         $parentQuoteId = $order->getQuoteId();
-        $this->deleteOrder($order);
         $parentQuote = $this->cartHelper->getQuoteById($parentQuoteId);
+        $this->_eventManager->dispatch(
+            'sales_model_service_quote_submit_failure',
+            [
+                'order' => $order,
+                'quote' => $parentQuote
+            ]
+        );
+        $this->deleteOrder($order);
         // reactivate session quote - the condiotion excludes PPC quotes
         if ($parentQuoteId != $immutableQuoteId) {
             $this->cartHelper->quoteResourceSave($parentQuote->setIsActive(true));

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -1820,9 +1820,17 @@ class OrderTest extends TestCase
         $state = Order::STATE_PENDING_PAYMENT;
         $this->orderMock->expects(static::once())->method('getState')->willReturn($state);
         $this->orderMock->expects(static::once())->method('getQuoteId')->willReturn(self::QUOTE_ID);
-        $this->currentMock->expects(static::once())->method('deleteOrder')->with($this->orderMock);
         $this->cartHelper->expects(static::once())->method('getQuoteById')->with(self::QUOTE_ID)
             ->willReturn($this->quoteMock);
+        $this->eventManager->expects(self::once())->method('dispatch')
+            ->with(
+                'sales_model_service_quote_submit_failure',
+                [
+                    'order' => $this->orderMock,
+                    'quote' => $this->quoteMock
+                ]
+            );
+        $this->currentMock->expects(static::once())->method('deleteOrder')->with($this->orderMock);
         $this->quoteMock->expects(static::once())->method('setIsActive')->with(true)->willReturnSelf();
         $this->cartHelper->expects(static::once())->method('quoteResourceSave')->with($this->quoteMock);
         $this->currentMock->deleteOrderByIncrementId(self::DISPLAY_ID);

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -6,7 +6,4 @@
     <event name="sales_order_place_after">
         <observer name="nonBoltOrderObserver" instance="Bolt\Boltpay\Observer\NonBoltOrderObserver" />
     </event>
-    <event name="sales_order_delete_before">
-        <observer name="magento_giftcardaccount" instance="Magento\GiftCardAccount\Observer\RevertGiftCardAccountBalance"/>
-    </event>
 </config>


### PR DESCRIPTION
# Description
The Commerce Edition module observer, Magento\GiftCardAccount\Observer\RevertGiftCardAccountBalance,  is configured in events.xml but the class is not present in Community Edition.

The exception is thrown in failed_payment hook processing. Order gets cancelled but not deleted.
In such cases it blocks further checkouts for registered customers so this is a high severity bug.

The solution is to dispatch `sales_model_service_quote_submit_failure`, that the aforementioned observer listens to, if present.

This event is also observed by (some) other gift card / store credit / reward points modules for balance reverting so it is a universal solution.

Fixes: https://boltpay.atlassian.net/browse/M2P-91

#changelog Unknown RevertGiftCardAccountBalance fix

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
