### PR TITLE
MX-1236 Postpone order->place() hook and do it when pending/processing hook received

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -1710,6 +1710,18 @@ class Order extends AbstractHelper
         // Get the transaction state
         $transactionState = $this->getTransactionState($transaction, $payment, $hookType);
 
+        // Place order now because we postponed it when order was created
+        if (($order->getState()=="bolt_pending") && !in_array($transactionState,
+            [
+                self::TS_PARTIAL_VOIDED,
+                self::TS_CANCELED,
+                self::TS_REJECTED_REVERSIBLE,
+                self::TS_REJECTED_IRREVERSIBLE,
+                self::TS_CREDIT_COMPLETED
+            ])) {
+            $order->place();
+        }
+
         $newCapture = in_array($transactionState, [self::TS_CAPTURED, self::TS_COMPLETED])
             ? $this->getUnprocessedCapture($payment, $transaction)
             : null;

--- a/Plugin/OrderPlugin.php
+++ b/Plugin/OrderPlugin.php
@@ -17,6 +17,7 @@
 namespace Bolt\Boltpay\Plugin;
 
 use Magento\Sales\Model\Order;
+use Bolt\Boltpay\Helper\Order as OrderHelper;
 
 /**
  * Class OrderSenderPlugin
@@ -26,51 +27,24 @@ use Magento\Sales\Model\Order;
 class OrderPlugin
 {
     /**
-     * Override the default "new" order state with the "pending_payment"
-     * unless the special "bolt_new" state is received in which case state "new" is used.
+     * Override Order place method.
+     * Skip execution when we just created order
+     * We call it manually later when bolt transaction it created
      *
      * @param Order $subject
-     * @param string $state
-     * @return array
+     * @param callable $proceed
+     * @return Order
      */
-    public function beforeSetState(Order $subject, $state)
+    public function aroundPlace(Order $subject, callable $proceed)
     {
         if (!$subject->getPayment() || $subject->getPayment()->getMethod() != \Bolt\Boltpay\Model\Payment::METHOD_CODE) {
-            return [$state];
+            return $proceed();
         }
-        if ($state === \Bolt\Boltpay\Helper\Order::BOLT_ORDER_STATE_NEW) {
-            $state = Order::STATE_NEW;
+        if (is_null($subject->getState())) {
+            $subject->setState(OrderHelper::BOLT_ORDER_STATUS_PENDING);
+            $subject->setStatus(OrderHelper::BOLT_ORDER_STATUS_PENDING);
+            return $subject;
         }
-        elseif (!$subject->getState() || $state === Order::STATE_NEW) {
-            $state = Order::STATE_PENDING_PAYMENT;
-        }
-        return [$state];
-    }
-
-    /**
-     * Override the default "pending" order status with the "pending_payment"
-     * unless the special "bolt_pending" status is received in which case status "pending" is used.
-     *
-     * @param Order $subject
-     * @param string $status
-     * @return array
-     */
-    public function beforeSetStatus(Order $subject, $status)
-    {
-        if (!$subject->getPayment() || $subject->getPayment()->getMethod() != \Bolt\Boltpay\Model\Payment::METHOD_CODE) {
-            return [$status];
-        }
-        if ($status === \Bolt\Boltpay\Helper\Order::BOLT_ORDER_STATUS_PENDING) {
-            $status = $subject->getConfig()->getStateDefaultStatus(Order::STATE_NEW);
-        }
-        elseif ((
-            !  $subject->getStatus()
-            || $subject->getStatus() == Order::STATE_PENDING_PAYMENT
-            || $subject->getStatus() == Order::STATE_NEW
-            ) && $status === \Bolt\Boltpay\Helper\Order::MAGENTO_ORDER_STATUS_PENDING
-        ) {
-            $status = $subject->getConfig()->getStateDefaultStatus(Order::STATE_PENDING_PAYMENT);
-        }
-        return [$status];
+        return $proceed();
     }
 }


### PR DESCRIPTION
This PR works around issue around we trigger event sales_order_place_after when order just created and we don't know if transaction will be failed or not.

Event triggers in method order::place()
https://github.com/magento/magento2/blob/9e9703afdacac8c0ad098d7a492f3a9000c80199/app/code/Magento/Sales/Model/Order.php#L1185
Actually "place" means place payment.

So solution is to not call it when we created order. We can call it in pending/processing hook.

We had another protection around failed order: we don't set status "new" to order before hook received. But order status "new" is setting into order::place() so we can remove the appropriate code.

To call order::place() only once we rely to order status "bolt_pending". So we can have problem it 3party plugin decides to update status. But I don't think that it's the real issue.

Fixes: [MX-1236]

#changelog trigger event sales_order_place_after when we have payment

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.


[MX-1236]: https://boltpay.atlassian.net/browse/MX-1236