### PR TITLE
Rounding the amount before calling the refund API

### DIFF
--- a/Model/Payment.php
+++ b/Model/Payment.php
@@ -467,7 +467,7 @@ class Payment extends AbstractMethod
             $orderCurrency = $order->getOrderCurrencyCode();
             // $amount argument of refund method is in store currency,
             // we need to get amount from credit memo to get the value in order's currency.
-            $refundAmount = CurrencyUtils::toMinorWithoutRounding(
+            $refundAmount = CurrencyUtils::toMinor(
                 $payment->getCreditMemo()->getGrandTotal(),
                 $orderCurrency
             );


### PR DESCRIPTION
# Description
Currently, some merchants have this bug http://prntscr.com/sxj29a when creating online credit memos in the back-office.

This PR resolves it by rounding the amount before calling the refund API

Fixes: https://boltpay.atlassian.net/browse/M2P-93

#changelog Rounding the amount before calling the refund API

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
