### PR TITLE
Add configuration check before sending invoice email

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -38,11 +38,13 @@ use Magento\Quote\Model\QuoteManagement;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\OrderRepositoryInterface as OrderRepository;
 use Magento\Sales\Model\Order as OrderModel;
+use Magento\Sales\Model\Order\Email\Container\InvoiceIdentity as InvoiceEmailIdentity;
 use Magento\Sales\Model\Order\Email\Sender\InvoiceSender;
 use Magento\Sales\Model\Order\Email\Sender\OrderSender;
 use Magento\Sales\Model\Order\Payment\Transaction;
 use Magento\Sales\Model\Order\Payment\Transaction\Builder as TransactionBuilder;
 use Bolt\Boltpay\Model\Service\InvoiceService;
+use Magento\Store\Model\ScopeInterface;
 use Zend_Http_Client_Exception;
 use Magento\Sales\Model\Order\Invoice;
 use Magento\Framework\DataObjectFactory;
@@ -1969,7 +1971,11 @@ class Order extends AbstractHelper
 
         $order->addRelatedObject($invoice);
 
-        if (!$invoice->getEmailSent()) {
+        if ($this->scopeConfig->isSetFlag(
+                InvoiceEmailIdentity::XML_PATH_EMAIL_ENABLED,
+                ScopeInterface::SCOPE_STORE,
+                $order->getStoreId()
+            ) && !$invoice->getEmailSent()) {
             try {
                 $this->invoiceSender->send($invoice);
             } catch (\Exception $e) {


### PR DESCRIPTION
# Description
While some versions of Magento have been tested and have been updated to check email configurations before sending out invoice emails, (where I tested 2.2.7 and 2.3.3), other versions do not.  This adds a check from our end just in case.

Fixes: https://boltpay.atlassian.net/browse/M2P-13

#changelog Add configuration check before sending invoice email

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
