### PR TITLE
M2P-96 Not allowing the captures to be saved in the payment info until the invoice is created

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -1855,7 +1855,6 @@ class Order extends AbstractHelper
             'transaction_reference' => $transaction->reference,
             'transaction_state' => $transactionState,
             'authorized' => $paymentAuthorized || in_array($transactionState, [self::TS_AUTHORIZED, self::TS_CAPTURED]),
-            'captures' => implode(',', $processedCaptures),
             'refunds' => implode(',', $processedRefunds),
             'processor' => $transaction->processor
         ];
@@ -1871,7 +1870,7 @@ class Order extends AbstractHelper
         $payment->setParentTransactionId($parentTransactionId);
         $payment->setTransactionId($transactionId);
         $payment->setLastTransId($transactionId);
-        $payment->setAdditionalInformation($paymentData);
+        $payment->setAdditionalInformation(array_merge((array)$payment->getAdditionalInformation(), $paymentData));
         $payment->setIsTransactionClosed($transactionType != Transaction::TYPE_AUTH);
 
         $this->setOrderPaymentInfoData($payment, $transaction);
@@ -1901,6 +1900,9 @@ class Order extends AbstractHelper
             $currencyCode = $order->getOrderCurrencyCode();
             $this->validateCaptureAmount($order, CurrencyUtils::toMajor($amount, $currencyCode));
             $invoice = $this->createOrderInvoice($order, $realTransactionId, CurrencyUtils::toMajor($amount, $currencyCode));
+            $payment->setAdditionalInformation(
+                array_merge((array)$payment->getAdditionalInformation(), ['captures' => implode(',', $processedCaptures)])
+            );
         }
 
         if (!$order->getTotalDue()) {

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -2976,7 +2976,7 @@ class OrderTest extends TestCase
                 ['authorized'],
                 ['captures'],
                 ['refunds'],
-                ['processor']
+                [null]
             )->willReturnOnConsecutiveCalls(
                 $prevTransactionState,
                 $prevTransactionReference,
@@ -2984,7 +2984,7 @@ class OrderTest extends TestCase
                 true,
                 '',
                 0,
-                self::PROCESSOR_VANTIV
+                ''
             );
 
         $this->transactionBuilder->expects(self::once())->method('setPayment')->with($paymentMock)->willReturnSelf();


### PR DESCRIPTION
This PR resolves the following case:
1. Customer placed an order and it was created successfully on both Magento and Bolt
2. The captures are saved into the payment info in http://prntscr.com/synm4g
3. The pending hook was sent to Magento and the exception “Unprocessable Entity: SQLSTATE[40001]: Serialization failure: 1213 Deadlock found when trying to get lock“ was thrown in http://prntscr.com/syo29u. The deadlock exception is an edge case exception. 
4. After that, the re-try pending hook and the payment hook were sent to Magento and they were ignored because of this check http://prntscr.com/sy64s5
5. The order was stuck in Pending Payment status and the invoice wasn’t created

So I create the PR to fix the issue by not allowing the captures to be saved in the payment info until the invoice is created. So #4 won’t be ignored and the retry pending hook and payment hook can update the order and create invoice

Fixes: https://boltpay.atlassian.net/browse/M2P-96
https://boltpay.atlassian.net/browse/EN-68

#changelog Not allowing the captures to be saved in the payment info untill the …

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
