### PR TITLE
Send payment method in Bolt request and set transaction reference

### DIFF
--- a/Observer/NonBoltOrderObserver.php
+++ b/Observer/NonBoltOrderObserver.php
@@ -139,7 +139,7 @@ class NonBoltOrderObserver implements ObserverInterface
                 return;
             }
 
-            $payment->setAdditionalInformation("bolt_transaction_reference", $response->reference);
+            $payment->setAdditionalInformation("transaction_reference", $response->reference);
             $payment->save();
         } catch (Exception $exception) {
             $this->metricsClient->processCountMetric("non_bolt_order_creation.failure", 1);
@@ -206,15 +206,11 @@ class NonBoltOrderObserver implements ObserverInterface
             return null;
         }
 
-        if (count($cart['shipments']) < 1) {
-            return null;
+        if (isset($cart['shipments'][0]['shipping_address'])) {
+            return $cart['shipments'][0]['shipping_address']['phone'];
         }
 
-        if (!@$cart['shipments'][0]['shipping_address']) {
-            return null;
-        }
-
-        return $cart['shipments'][0]['shipping_address']['phone'];
+        return null;
     }
 
     /**
@@ -228,19 +224,11 @@ class NonBoltOrderObserver implements ObserverInterface
             return $customer->getEmail();
         }
 
-        if (!@$cart['shipments']) {
-            return null;
+        if (isset($cart['shipments'][0]['shipping_address'])) {
+            return $cart['shipments'][0]['shipping_address']['email'];
         }
 
-        if (count($cart['shipments']) < 1) {
-            return null;
-        }
-
-        if (!@$cart['shipments'][0]['shipping_address']) {
-            return null;
-        }
-
-        return $cart['shipments'][0]['shipping_address']['email'];
+        return null;
     }
 
     /**
@@ -254,19 +242,11 @@ class NonBoltOrderObserver implements ObserverInterface
             return $customer->getFirstname();
         }
 
-        if (!@$cart['shipments']) {
-            return null;
+        if (isset($cart['shipments'][0]['shipping_address'])) {
+            return $cart['shipments'][0]['shipping_address']['first_name'];
         }
 
-        if (count($cart['shipments']) < 1) {
-            return null;
-        }
-
-        if (!@$cart['shipments'][0]['shipping_address']) {
-            return null;
-        }
-
-        return $cart['shipments'][0]['shipping_address']['first_name'];
+        return null;
     }
 
     /**
@@ -280,19 +260,11 @@ class NonBoltOrderObserver implements ObserverInterface
             return $customer->getLastname();
         }
 
-        if (!@$cart['shipments']) {
-            return null;
+        if (isset($cart['shipments'][0]['shipping_address'])) {
+            return $cart['shipments'][0]['shipping_address']['last_name'];
         }
 
-        if (count($cart['shipments']) < 1) {
-            return null;
-        }
-
-        if (!@$cart['shipments'][0]['shipping_address']) {
-            return null;
-        }
-
-        return $cart['shipments'][0]['shipping_address']['last_name'];
+        return null;
     }
 
     /**

--- a/Observer/NonBoltOrderObserver.php
+++ b/Observer/NonBoltOrderObserver.php
@@ -202,10 +202,6 @@ class NonBoltOrderObserver implements ObserverInterface
      */
     protected function getPhone($cart)
     {
-        if (!@$cart['shipments']) {
-            return null;
-        }
-
         if (isset($cart['shipments'][0]['shipping_address'])) {
             return $cart['shipments'][0]['shipping_address']['phone'];
         }

--- a/Observer/NonBoltOrderObserver.php
+++ b/Observer/NonBoltOrderObserver.php
@@ -139,7 +139,7 @@ class NonBoltOrderObserver implements ObserverInterface
                 return;
             }
 
-            $payment->setAdditionalInformation("transaction_reference", $response->reference);
+            $payment->setAdditionalInformation("bolt_transaction_reference", $response->reference);
             $payment->save();
         } catch (Exception $exception) {
             $this->metricsClient->processCountMetric("non_bolt_order_creation.failure", 1);

--- a/Test/Unit/Observer/NonBoltOrderObserverTest.php
+++ b/Test/Unit/Observer/NonBoltOrderObserverTest.php
@@ -53,6 +53,7 @@ class NonBoltOrderObserverTest extends TestCase
     const LAST_NAME = 'BoltTest';
     const EMAIL = 'integration@bolt.com';
     const PHONE = '132 231 1234';
+    const PAYMENT_METHOD = 'paypal_express';
     const EXPECTED_SHIPMENT = [
         'cost'             => 0,
         'tax_amount'       => 0,
@@ -139,6 +140,7 @@ class NonBoltOrderObserverTest extends TestCase
     public function testExecute()
     {
         $order = $this->createMock(Order::class);
+        $payment = $this->createMock(OrderPaymentInterface::class);
         $item = $this->createMock(Item::class);
         $quote = $this->createMock(Quote::class);
         $quote->method('getAllVisibleItems')->willReturn([$item]);
@@ -155,7 +157,12 @@ class NonBoltOrderObserverTest extends TestCase
         $this->quoteRepository->expects($this->once())
             ->method('get')
             ->willReturn($quote);
-
+        $order->expects($this->once())
+            ->method('getPayment')
+            ->willReturn($payment);
+        $payment->expects($this->once())
+            ->method('getMethod')
+            ->willReturn(SELF::PAYMENT_METHOD);
         $event = $this->getMockBuilder(Event::class)
             ->setMethods(['getOrder'])
             ->disableOriginalConstructor()
@@ -181,6 +188,7 @@ class NonBoltOrderObserverTest extends TestCase
                 'first_name' => self::FIRST_NAME,
                 'last_name' => self::LAST_NAME,
             ],
+            'payment_method' => self::PAYMENT_METHOD,
         ];
 
         $this->dataObject->expects($this->once())
@@ -370,6 +378,7 @@ class NonBoltOrderObserverTest extends TestCase
     public function testExecuteShipmentsNotSet()
     {
         $order = $this->createMock(Order::class);
+        $payment = $this->createMock(OrderPaymentInterface::class);
         $item = $this->createMock(Item::class);
         $quote = $this->createMock(Quote::class);
         $quote->method('getAllVisibleItems')->willReturn([$item]);
@@ -386,7 +395,12 @@ class NonBoltOrderObserverTest extends TestCase
         $this->quoteRepository->expects($this->once())
             ->method('get')
             ->willReturn($quote);
-
+        $order->expects($this->once())
+            ->method('getPayment')
+            ->willReturn($payment);
+        $payment->expects($this->once())
+            ->method('getMethod')
+            ->willReturn(SELF::PAYMENT_METHOD);
         $event = $this->getMockBuilder(Event::class)
             ->setMethods(['getOrder'])
             ->disableOriginalConstructor()
@@ -414,6 +428,7 @@ class NonBoltOrderObserverTest extends TestCase
                 'first_name' => self::FIRST_NAME,
                 'last_name' => self::LAST_NAME,
             ],
+            'payment_method' => self::PAYMENT_METHOD,
         ];
 
         $this->dataObject->expects($this->once())


### PR DESCRIPTION
Also add more robust methods to pull email, first name, and last name
from the Cart/Customer objects.

#changelog Send payment method in Bolt request and set transaction reference
Set payment method in request