### PR TITLE
M2P-82 Read bolt cart from sections instead of AJAX call

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -627,7 +627,7 @@ ob_start();
         /////////////////////////////////////////////////////
         var createRequest = false;
         var allowAutoOpen = true;
-        var isFirstCall = true;
+        var hasConfigureCalled = false;
         var oldBoltCartValue = "";
         var createOrder = function (el, dataChanged) {
             // Check if BoltCheckout is defined (connect.js executed).
@@ -785,8 +785,10 @@ ob_start();
                             cartBarrier.resolve(cart);
                             hintBarrier.resolve(hints);
                         } else {
-                            // reconfigure bolt checkout with new values
+                            // temporary disable always present checkout button for refactoring reason
+                            // will remove this line in the next PR
                             config = {};
+                            // reconfigure bolt checkout with new values
                             BoltCheckout.configure(cart, hints, callbacks, config);
                         }
                         oldBoltCartValue = JSON.stringify(cart);
@@ -799,9 +801,9 @@ ob_start();
                         }
                     });
 
-            if (isFirstCall) {
+            if (!hasConfigureCalled) {
                 var BC = BoltCheckout.configure(cartBarrier.promise, hintBarrier.promise, callbacks, boltCheckoutConfig);
-                isFirstCall = false;
+                hasConfigureCalled = true;
             }
         }
         }

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -627,8 +627,9 @@ ob_start();
         /////////////////////////////////////////////////////
         var createRequest = false;
         var allowAutoOpen = true;
-        var hasConfigureCalled = false;
+        var wasConfigureCalled = false;
         var oldBoltCartValue = "";
+        var BC;
         var createOrder = function (el, dataChanged) {
             // Check if BoltCheckout is defined (connect.js executed).
             // If not, postpone processing until it is
@@ -752,7 +753,7 @@ ob_start();
                         .always(function() {
                             createRequest = false;
                         })
-                        var BC = BoltCheckout.configure(cart, hintBarrier.promise, callbacks);
+                        BC = BoltCheckout.configure(cart, hintBarrier.promise, callbacks);
                 });
             } else {
             var hintBarrier = boltBarrier();
@@ -787,9 +788,9 @@ ob_start();
                         } else {
                             // temporary disable always present checkout button for refactoring reason
                             // will remove this line in the next PR
-                            config = {};
+                            var config = {};
                             // reconfigure bolt checkout with new values
-                            BoltCheckout.configure(cart, hints, callbacks, config);
+                            BC = BoltCheckout.configure(cart, hints, callbacks, config);
                         }
                         oldBoltCartValue = JSON.stringify(cart);
 
@@ -801,9 +802,12 @@ ob_start();
                         }
                     });
 
-            if (!hasConfigureCalled) {
-                var BC = BoltCheckout.configure(cartBarrier.promise, hintBarrier.promise, callbacks, boltCheckoutConfig);
-                hasConfigureCalled = true;
+            if (!wasConfigureCalled) {
+                // temporary disable always present checkout button for refactoring reason
+                // will remove this line in the next PR
+                var config = {};
+                BC = BoltCheckout.configure(cartBarrier.promise, hintBarrier.promise, callbacks, config);
+                wasConfigureCalled = true;
             }
         }
         }

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -627,6 +627,8 @@ ob_start();
         /////////////////////////////////////////////////////
         var createRequest = false;
         var allowAutoOpen = true;
+        var isFirstCall = true;
+        var oldBoltCartValue = "";
         var createOrder = function (el, dataChanged) {
             // Check if BoltCheckout is defined (connect.js executed).
             // If not, postpone processing until it is
@@ -753,20 +755,14 @@ ob_start();
                         var BC = BoltCheckout.configure(cart, hintBarrier.promise, callbacks);
                 });
             } else {
-            // define the params sent with the request variable
-            var params = [];
-            params.push('form_key=' + $('[name="form_key"]').val());
-            params = params.join('&');
-
             var hintBarrier = boltBarrier();
+            var cartBarrier = boltBarrier();
 
-            cart = new Promise(function (resolve, reject) {
-
-                createRequest = true;
-
-                // send create order request
-                $.get(settings.create_order_url, params)
-                    .done(function (data) {
+            customerData.get('boltcart').subscribe(function(data) {
+                cart = data.cart !== undefined ? data.cart : {};
+                if (JSON.stringify(cart) === oldBoltCartValue) {
+                    return;
+                }
 
                         var boltRestricted = !!data.restrict;
 
@@ -774,37 +770,26 @@ ob_start();
 
                         // Stop if Bolt checkout is restricted
                         if (boltRestricted) {
-                            if (popUpOpen) reject(new Error(data.message));
-                            hintBarrier.resolve(hints);
-                            return;
-                        }
-
-                        if (data.status !== 'success') {
-                            reject(new Error(data.message || 'Network request failed'));
-                            hintBarrier.resolve(hints);
-                            return;
-                        }
-
-                        if (!data.cart) {
-                            reject(new Error('The cart info is missing.'));
-                            hintBarrier.resolve(hints);
-                            return;
-                        }
-
-                        if (!data.cart.orderToken) {
-                            reject(new Error('The cart is empty.'));
-                            hintBarrier.resolve(hints);
-                            return;
-                        }
+                            cart = {};
+                            hints = {};
+                        } else {
 
                         var prefill = isObject(data.hints.prefill) ? deepMergeObjects(hints.prefill, data.hints.prefill) : hints.prefill;
 
                         hints = deepMergeObjects(hints, data.hints);
                         hints.prefill = prefill;
                         //////////////////////////
-
-                        resolve(data.cart);
-                        hintBarrier.resolve(hints);
+                        }
+                        if (oldBoltCartValue === "") {
+                            // resolve promises for initial .configure() call
+                            cartBarrier.resolve(cart);
+                            hintBarrier.resolve(hints);
+                        } else {
+                            // reconfigure bolt checkout with new values
+                            config = {};
+                            BoltCheckout.configure(cart, hints, callbacks, config);
+                        }
+                        oldBoltCartValue = JSON.stringify(cart);
 
                         // open the checkout if auto-open flag is set
                         // one time only on page load
@@ -812,26 +797,14 @@ ob_start();
                             BC.open();
                             allowAutoOpen = false;
                         }
+                    });
 
-                        // prefetch Shipping and Tax for multi-step checkout
-                        if (getCheckoutType() === 'checkout') prefetchShipping();
-                    })
-                    .fail(function(jqXHR, textStatus, errorThrown) {
-                        reject(new Error(errorThrown || jqXHR.statusText || 'Network request failed'));
-                    })
-                    .always(function() {
-                        createRequest = false;
-                    })
-            });
-            // Get number of items in cart from counter element
-            var numItems = $(".counter-number").text();
-
-            // Call config with floatingButtonMode if always present checkout enabled and items were or were not just added to cart (dataChanged)
-            var config = boltConfig.always_present_checkout && (numItems && numItems !=="0" || dataChanged)? {floatingButtonMode: dataChanged ? "show_cart" : "show_cart_on_hover" } : {};
-            var BC = BoltCheckout.configure(cart, hintBarrier.promise, callbacks, config);
+            if (isFirstCall) {
+                var BC = BoltCheckout.configure(cartBarrier.promise, hintBarrier.promise, callbacks, boltCheckoutConfig);
+                isFirstCall = false;
             }
-        };
-
+        }
+        }
         /////////////////////////////////////////////////////
 
         /////////////////////////////////////////////////////


### PR DESCRIPTION
- Call configure with promises if createOrder calls first time
- Add listener for magento section with bolt cart and hints
- In listener:
-- If cart isn't changed do nothing
-- If cart changed and we didn't have cart before - resolve promises we passed to configure
-- If cart changed and we do have old cart - call configure again

Fixes: [M2P-82]

#changelog Plugin refactoring

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Refactoring
# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [x] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
