### PR TITLE
M2P-82 Update always present checkout button code

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -809,10 +809,7 @@ ob_start();
                     });
 
             if (!wasConfigureCalled) {
-                // temporary disable always present checkout button for refactoring reason
-                // will remove this line in the next PR
-                var config = {};
-                BC = BoltCheckout.configure(cartBarrier.promise, hintBarrier.promise, callbacks, config);
+                BC = BoltCheckout.configure(cartBarrier.promise, hintBarrier.promise, callbacks, boltCheckoutConfig);
                 wasConfigureCalled = true;
             }
         }

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -922,7 +922,7 @@ ob_start();
                         // ie. connect.js not loaded / executed yet,
                         // the button will be processed after connect.js loads.
                         if (window.BoltCheckout) {
-                            BoltCheckout.configure(cart, hints, callbacks);
+                            BoltCheckout.configure(cart, hints, callbacks, boltCheckoutConfig);
                         }
                     });
                     /////////////////////////////////////////////////////
@@ -1000,7 +1000,7 @@ ob_start();
             }
             var new_hints = JSON.stringify(hints);
             if (old_hints !== new_hints) {
-                BoltCheckout.configure(cart, hints, callbacks);
+                BoltCheckout.configure(cart, hints, callbacks, boltCheckoutConfig);
                 old_hints = new_hints;
             }
         };

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -436,7 +436,7 @@ ob_start();
 
         var boltCheckoutConfig = {};
 
-        var addedToCart = false;
+        var newItemAddedToCart = false;
 
         var callbacks = {
 
@@ -781,16 +781,16 @@ ob_start();
                         }
 
                         // When we call configure with promises we don't know if cart is empty or not
-                        // If we set always_present_checkout when we call confogure with promises
-                        // always present button is appear even if cart is epmpty
+                        // If we set always_present_checkout when we call configure with promises
+                        // always present button is appear even if cart is empty
                         if (oldBoltCartValue === "" && !boltConfig.always_present_checkout) {
                             // resolve promises for initial .configure() call
                             cartBarrier.resolve(cart);
                             hintBarrier.resolve(hints);
                         } else {
                             if (boltConfig.always_present_checkout) {
-                                boltCheckoutConfig = (cart.orderToken && cart.orderToken !== "") ? {floatingButtonMode: addedToCart ? "show_cart" : "show_cart_on_hover" } : {};
-                                addedToCart = false;
+                                boltCheckoutConfig = (cart.orderToken && cart.orderToken !== "") ? {floatingButtonMode: newItemAddedToCart ? "show_cart" : "show_cart_on_hover" } : {};
+                                newItemAddedToCart = false;
                             }
                             // reconfigure bolt checkout with new values
                             BC = BoltCheckout.configure(cart, hints, callbacks, boltCheckoutConfig);
@@ -1102,9 +1102,11 @@ ob_start();
         ///////////////////////////////////////////////////////////
 
         // When item added to cart, set flag to animate always present button when we catch cart updating
-        $(document).on("ajax:addToCart", function () {
-            addedToCart = true;
-        });
+        if (boltConfig.always_present_checkout) {
+            $(document).on("ajax:addToCart", function () {
+                newItemAddedToCart = true;
+            });
+        }
 
         // globally register createOrder to be called from all templates
         $(document).on("bolt:createOrder", createOrder);

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -434,6 +434,10 @@ ob_start();
 
         var hints = {prefill:{}};
 
+        var boltCheckoutConfig = {};
+
+        var addedToCart = false;
+
         var callbacks = {
 
             close: function () {
@@ -773,18 +777,23 @@ ob_start();
 
                         hints = deepMergeObjects(hints, data.hints);
                         hints.prefill = prefill;
-                        //////////////////////////
+
                         }
-                        if (oldBoltCartValue === "") {
+
+                        // When we call configure with promises we don't know if cart is empty or not
+                        // If we set always_present_checkout when we call confogure with promises
+                        // always present button is appear even if cart is epmpty
+                        if (oldBoltCartValue === "" && !boltConfig.always_present_checkout) {
                             // resolve promises for initial .configure() call
                             cartBarrier.resolve(cart);
                             hintBarrier.resolve(hints);
                         } else {
-                            // temporary disable always present checkout button for refactoring reason
-                            // will remove this line in the next PR
-                            var config = {};
+                            if (boltConfig.always_present_checkout) {
+                                boltCheckoutConfig = (cart.orderToken && cart.orderToken !== "") ? {floatingButtonMode: addedToCart ? "show_cart" : "show_cart_on_hover" } : {};
+                                addedToCart = false;
+                            }
                             // reconfigure bolt checkout with new values
-                            BC = BoltCheckout.configure(cart, hints, callbacks, config);
+                            BC = BoltCheckout.configure(cart, hints, callbacks, boltCheckoutConfig);
                         }
                         oldBoltCartValue = JSON.stringify(cart);
 
@@ -1092,10 +1101,9 @@ ob_start();
         monitorDataChange(['fieldset.fieldset.rate'], prefetchShipping, false, false);
         ///////////////////////////////////////////////////////////
 
-        // When item added to cart, refresh order and mark data modified so always present button knows new item added
-        // to cart and can animate cart
+        // When item added to cart, set flag to animate always present button when we catch cart updating
         $(document).on("ajax:addToCart", function () {
-            createOrder(null, true);
+            addedToCart = true;
         });
 
         // globally register createOrder to be called from all templates


### PR DESCRIPTION
* When always present button enable we can't resolve promises, because configure expect promises only for the two first arguments. So we should re-call reconfigure.
It can cause dead click and probably should be resolved on server side down the road

* When a user clicks "add to cart" we set a flag and use it a few seconds later - when the updated cart comes from Magento server

Fixes: M2P-82

#changelog M2P-82 Update always present checkout button code

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Refactoring


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
