### PR TITLE
M2P-100 zero subtotal order creation error fix

### DIFF
--- a/Plugin/Magento/TogglePaymentMethodsPlugin.php
+++ b/Plugin/Magento/TogglePaymentMethodsPlugin.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+namespace Bolt\Boltpay\Plugin\Magento;
+
+use Magento\Framework\Event\Observer;
+
+class TogglePaymentMethodsPlugin
+{
+    /**
+     * @param $subject
+     * @param callable $proceed
+     * @param Observer $observer
+     */
+    public function aroundExecute(
+        $subject,
+        callable $proceed,
+        Observer $observer
+    ) {
+        $proceed($observer);
+
+        $paymentMethod = $observer->getEvent()->getMethodInstance()->getCode();
+        if ($paymentMethod != \Bolt\Boltpay\Model\Payment::METHOD_CODE) {
+            return;
+        }
+
+        $result = $observer->getEvent()->getResult();
+        if ($result->getData('is_available')) {
+            return;
+        }
+
+        $quote = $observer->getEvent()->getQuote();
+        if (!$quote) {
+            return;
+        }
+
+        if ($quote->getBaseGrandTotal() == 0) {
+            $result->setData('is_available', true);
+        }
+    }
+}

--- a/Test/Unit/Plugin/Magento/TogglePaymentMethodsPluginTest.php
+++ b/Test/Unit/Plugin/Magento/TogglePaymentMethodsPluginTest.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Test\Unit\Plugin\Magento;
+
+use Bolt\Boltpay\Plugin\Magento\TogglePaymentMethodsPlugin;
+use Magento\Framework\DataObject;
+use Magento\Framework\Event;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Quote\Model\Quote;
+use PHPUnit\Framework\TestCase;
+use Magento\Quote\Api\Data\PaymentMethodInterface;
+
+/**
+ * Class TogglePaymentMethodsPluginTest
+ * @package Bolt\Boltpay\Test\Unit\Plugin\Magento
+ * @coversDefaultClass \Bolt\Boltpay\Plugin\Magento\TogglePaymentMethodsPlugin
+ */
+class TogglePaymentMethodsPluginTest extends TestCase
+{
+    /** @var ObserverInterface|MockObject  */
+    protected $subject;
+
+    /** @var Observer|MockObject  */
+    protected $observer;
+
+    /** @var callable  */
+    protected $proceed;
+
+    /** @var Event|MockObject  */
+    protected $event;
+
+    /** @var PaymentMethodInterface|MockObject  */
+    protected $payment;
+
+    /** @var callable|MockObject  */
+    protected $callback;
+
+    /** @var TogglePaymentMethodsPlugin  */
+    protected $plugin;
+
+    /** @var DataObject|MockObject  */
+    protected $result;
+
+    protected function setUp()
+    {
+        $this->plugin = (new ObjectManager($this))->getObject(TogglePaymentMethodsPlugin::class);
+        $this->subject = $this->createMock(
+            ObserverInterface::class
+        );
+        $this->observer = $observer = $this->createMock(Observer::class);
+        /** @var callable $callback */
+        $this->callback = $callback = $this->getMockBuilder(\stdClass::class)
+            ->setMethods(['__invoke'])->getMock();
+        $this->proceed = function (Observer $obsrvr) use ($observer, $callback) {
+            $this->assertEquals($obsrvr, $observer);
+            return $callback($obsrvr);
+        };
+        $this->payment = $this->createMock(PaymentMethodInterface::class);
+        $this->result = $this->createMock(DataObject::class);
+        $this->event = $this->getMockBuilder(Event::class)
+            ->setMethods(['getMethodInstance', 'getResult', 'getQuote'])->getMock();
+        $this->event->method('getMethodInstance')->willReturn($this->payment);
+        $this->event->method('getResult')->willReturn($this->result);
+        $this->observer->method('getEvent')->willReturn($this->event);
+    }
+
+    /**
+     * @test
+     * @covers ::aroundExecute
+     */
+    public function aroundExecute_ifNonBoltPayment_return()
+    {
+        $this->callback->expects(self::once())->method('__invoke')->with($this->observer);
+        $this->payment->expects(self::once())->method('getCode')->willReturn('other_method');
+        $this->event->expects(self::never())->method('getResult');
+        $this->plugin->aroundExecute($this->subject, $this->proceed, $this->observer);
+    }
+
+    /**
+     * @test
+     * @covers ::aroundExecute
+     */
+    public function aroundExecute_ifBoltPaymentAndResultIsAvailable_return()
+    {
+        $this->callback->expects(self::once())->method('__invoke')->with($this->observer);
+        $this->payment->expects(self::once())->method('getCode')
+            ->willReturn(\Bolt\Boltpay\Model\Payment::METHOD_CODE);
+        $this->event->expects(self::once())->method('getResult');
+        $this->result->expects(self::once())->method('getData')
+            ->with('is_available')->willReturn(true);
+        $this->event->expects(self::never())->method('getQuote');
+        $this->plugin->aroundExecute($this->subject, $this->proceed, $this->observer);
+    }
+
+    /**
+     * @test
+     * @covers ::aroundExecute
+     */
+    public function aroundExecute_ifBoltPaymentAndNotResultIsAvailableAndNoQuote_return()
+    {
+        $this->callback->expects(self::once())->method('__invoke')->with($this->observer);
+        $this->payment->expects(self::once())->method('getCode')
+            ->willReturn(\Bolt\Boltpay\Model\Payment::METHOD_CODE);
+        $this->event->expects(self::once())->method('getResult');
+        $this->result->expects(self::once())->method('getData')
+            ->with('is_available')->willReturn(false);
+        $this->event->expects(self::once())->method('getQuote')->willReturn(null);
+        $this->result->expects(self::never())->method('setData');
+        $this->plugin->aroundExecute($this->subject, $this->proceed, $this->observer);
+    }
+
+    /**
+     * @test
+     * @covers ::aroundExecute
+     */
+    public function aroundExecute_ifBoltPaymentAndNotResultIsAvailableAndQuoteZeroTotal_setIsAvailable()
+    {
+        $this->callback->expects(self::once())->method('__invoke')->with($this->observer);
+        $this->payment->expects(self::once())->method('getCode')
+            ->willReturn(\Bolt\Boltpay\Model\Payment::METHOD_CODE);
+        $this->event->expects(self::once())->method('getResult');
+        $this->result->expects(self::once())->method('getData')
+            ->with('is_available')->willReturn(false);
+        $quote = $this->getMockBuilder(Quote::class)
+            ->disableOriginalConstructor()->setMethods(['getBaseGrandTotal'])->getMock();
+        $quote->expects(self::once())->method('getBaseGrandTotal')->willReturn(0);
+        $this->event->expects(self::once())->method('getQuote')->willReturn($quote);
+        $this->result->expects(self::once())->method('setData')
+            ->with('is_available', true);
+        $this->plugin->aroundExecute($this->subject, $this->proceed, $this->observer);
+    }
+
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -298,4 +298,22 @@
         </arguments>
     </type>
 
+    <type name="Magento\GiftCardAccount\Observer\TogglePaymentMethods">
+        <plugin name="BoltTogglePaymentMethodsPlugin"
+                type="Bolt\Boltpay\Plugin\Magento\TogglePaymentMethodsPlugin"
+                sortOrder="1"/>
+    </type>
+
+    <type name="Magento\CustomerBalance\Observer\TogglePaymentMethodsObserver">
+        <plugin name="BoltTogglePaymentMethodsObserverPlugin"
+                type="Bolt\Boltpay\Plugin\Magento\TogglePaymentMethodsPlugin"
+                sortOrder="1"/>
+    </type>
+
+    <type name="Magento\Reward\Observer\PreparePaymentMethod">
+        <plugin name="BoltPreparePaymentMethodPlugin"
+                type="Bolt\Boltpay\Plugin\Magento\TogglePaymentMethodsPlugin"
+                sortOrder="1"/>
+    </type>
+
 </config>


### PR DESCRIPTION
# Description
When Magento Commerce edition Gift Card, Store Credit or Reward Points amount used covers the whole order price (items, shipping and tax) the order creation fails with Bolt payment. The above modules expect the Payment method to be Zero Subtotal Checkout in such cases. We, on the other hand, need to keep it as Bolt Pay. The solution is to create a plugin that overrides the payment_method_is_active observers defined in these modules to allow Bolt Pay.

Fixes: [M2P-100](https://boltpay.atlassian.net/browse/M2P-100)

#changelog Zero subtotal order creation error fix

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
