### PR TITLE
M2P-102 Magento Commerce duplicate gift card creation on invoice save fix

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -1969,7 +1969,6 @@ class Order extends AbstractHelper
         $invoice->setBaseGrandTotal($amount);
         $invoice->setGrandTotal($amount);
         $invoice->register();
-        $invoice->save();
 
         $order->addRelatedObject($invoice);
 

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -3217,7 +3217,6 @@ class OrderTest extends TestCase
                 'setBaseGrandTotal',
                 'setGrandTotal',
                 'register',
-                'save',
             ]
         );
         $this->orderMock->expects(static::once())->method('getTotalInvoiced')->willReturn($totalInvoiced);
@@ -3297,7 +3296,6 @@ class OrderTest extends TestCase
                 'setBaseGrandTotal',
                 'setGrandTotal',
                 'register',
-                'save',
             ]
         );
         $message = 'Expected exception message';
@@ -3338,7 +3336,6 @@ class OrderTest extends TestCase
                 'setBaseGrandTotal',
                 'setGrandTotal',
                 'register',
-                'save',
             ]
         );
         $message = 'Expected exception message';


### PR DESCRIPTION
# Description
When the Gift Card is purchased two gc instances get created in the Magento system.
They are created upon invoice save and it appears that we are calling it twice, once directly and another time as the order related object. 
Proposed solution: remove one of the calls.

Fixes: [M2P-102](https://boltpay.atlassian.net/browse/M2P-102)
#changelog Magento Commerce duplicate gift card creation on invoice save fix

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
