### PR TITLE
Reward Points minicart compatibility with replace.js refactor

### DIFF
--- a/Test/Unit/ViewModel/MinicartAddonsTest.php
+++ b/Test/Unit/ViewModel/MinicartAddonsTest.php
@@ -218,43 +218,4 @@ class MinicartAddonsTest extends TestCase
             ],
         ];
     }
-
-    /**
-     * @test
-     * that getOrderCreationTriggers returns expected selector(s) based on configuration state
-     *
-     * @dataProvider getOrderCreationTriggers_withVariousConfigurationsProvider
-     *
-     * @covers ::getOrderCreationTriggers
-     *
-     * @param bool   $displayRewardPointsInMinicartConfig value flag
-     * @param string $expectedResult of the method call
-     */
-    public function getOrderCreationTriggers_withVariousConfigurations_returnsElementSelector(
-        $displayRewardPointsInMinicartConfig,
-        $expectedResult
-    ) {
-        $this->configHelper->expects(static::once())->method('displayRewardPointsInMinicartConfig')
-            ->willReturn($displayRewardPointsInMinicartConfig);
-        static::assertEquals($expectedResult, $this->currentMock->getOrderCreationTriggers());
-    }
-
-    /**
-     * Data provider for {@see getOrderCreationTriggers_withVariousConfigurations}
-     *
-     * @return array[] containing configuration value for minicart reward points and expected result of the method call
-     */
-    public function getOrderCreationTriggers_withVariousConfigurationsProvider()
-    {
-        return [
-            [
-                'displayRewardPointsInMinicartConfig' => true,
-                'expectedResult'                      => '.totals.rewardpoints'
-            ],
-            [
-                'displayRewardPointsInMinicartConfig' => false,
-                'expectedResult'                      => ''
-            ],
-        ];
-    }
 }

--- a/ViewModel/MinicartAddons.php
+++ b/ViewModel/MinicartAddons.php
@@ -113,18 +113,4 @@ class MinicartAddons implements \Magento\Framework\View\Element\Block\ArgumentIn
         return $this->configHelper->getMinicartSupport() && !empty($this->getLayout());
     }
 
-    /**
-     * Gets element selector to be used in DOM observer. Appearance of these elements signifies a change to
-     * the Magento cart data and, therefore, requires an ajax call to create a new Bolt order.
-     *
-     * @return string element selector
-     */
-    public function getOrderCreationTriggers()
-    {
-        $selectors = [];
-        if ($this->configHelper->displayRewardPointsInMinicartConfig()) {
-            $selectors[] = '.totals.rewardpoints';
-        }
-        return implode(',', $selectors);
-    }
 }

--- a/etc/frontend/sections.xml
+++ b/etc/frontend/sections.xml
@@ -21,4 +21,15 @@
     <action name="checkout/onepage/saveOrder">
         <section name="bolthints"/>
     </action>
+    <!--
+    /**
+     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     * We explictly configure Magento_Reward minicart support which is not implicitly done via the "cart" section
+     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     */
+    -->
+    <action name="rest/*/V1/reward/mine/use-reward">
+        <section name="boltcart"/>
+    </action>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
 </config>

--- a/view/frontend/templates/checkout/minicart_addons.phtml
+++ b/view/frontend/templates/checkout/minicart_addons.phtml
@@ -23,8 +23,8 @@ if (!$miniCartView->shouldShow()) { return;
 ?>
 <script>
     require([
-        'jquery', 'Magento_Customer/js/model/customer',
-    ], function ($, customer) {
+        'jquery', 'Magento_Customer/js/model/customer', 'Magento_Customer/js/customer-data'
+    ], function ($, customer, customerData) {
         function append_minicart_addons () {
             require(['uiLayout'], function (layout) {
                 layout(<?php echo $miniCartView->getLayoutJSON(); ?>);
@@ -39,13 +39,10 @@ if (!$miniCartView->shouldShow()) { return;
                         dataType:   'json',
                         showLoader: true,
                         success:    function (response) {
-                            $(document).trigger('bolt:createOrder');
-                            require(
-                                [
-                                    'Magento_Checkout/js/action/get-payment-information',
-                                    'Magento_Customer/js/customer-data'
-                                ],
-                                function (getPaymentInformationAction, customerData) {
+                            customerData.reload(['boltcart'], true);
+                            require([
+                                    'Magento_Checkout/js/action/get-payment-information'
+                                ], function (getPaymentInformationAction) {
                                     getPaymentInformationAction().always(function () {
                                         customerData.reload(['messages'], true);
                                     });
@@ -73,11 +70,5 @@ if (!$miniCartView->shouldShow()) { return;
         } else {
             append_minicart_addons();
         }
-        require(['Magento_Ui/js/lib/view/utils/dom-observer'], function (domObserver) {
-            domObserver.get(
-                '<?php echo $miniCartView->getOrderCreationTriggers(); ?>',
-                function () {$(document).trigger('bolt:createOrder');}
-            );
-        });
     });
 </script>

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -805,7 +805,6 @@ ob_start();
                             BC.open();
                             allowAutoOpen = false;
                         }
-                    });
 
                         // prefetch Shipping and Tax for multi-step checkout
                         prefetchShipping();

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -805,6 +805,7 @@ ob_start();
                             BC.open();
                             allowAutoOpen = false;
                         }
+                    });
 
                         // prefetch Shipping and Tax for multi-step checkout
                         prefetchShipping();
@@ -1107,8 +1108,8 @@ ob_start();
             });
         }
 
-        // globally register createOrder to be called from all templates
-        $(document).on("bolt:createOrder", createOrder);
+        // globally register createOrder to be called from all templates, which is triggered by invalidating the customer section
+        $(document).on('bolt:createOrder', function () {customerData.reload(['boltcart'], true);});
 
         ////////////////////////////////////////////////////
         // Initially configures BoltCheckout.


### PR DESCRIPTION
# Description
This PR adds compatibility for Reward Points minicart feature when using new `boltcart` customer section. Minicart rewards functionality depends on `createOrder` function always creating an order with the latest data. It is expected to be called after both [adding](https://github.com/BoltApp/bolt-magento2/blob/011d6dafbef37de5c604df7f90e833f4f70b6d55/view/frontend/templates/checkout/minicart_addons.phtml#L78) and [removing](https://github.com/BoltApp/bolt-magento2/blob/011d6dafbef37de5c604df7f90e833f4f70b6d55/view/frontend/templates/checkout/minicart_addons.phtml#L41) reward points by triggering `bolt:createOrder` event which is tied to `createOrder` [here](https://github.com/BoltApp/bolt-magento2/blob/03f38eed8dc0c88f7ee9630a375420d0f3aca851/view/frontend/templates/js/replacejs.phtml#L1076)
Adding is resolved by adding `rest/*/V1/reward/mine/use-reward` to `sections.xml` with `boltcart` section. When removing rewards, `boltcart` section is now reloaded directly (using `customerData.reload(['boltcart'], true)`), because remove action only accepts `GET` requests. This refactor makes DOM observing redundant and is now removed. For compatibility and possible future use `bolt:createOrder` event now triggers Bolt order creation by reloading `boltcart` customer section.

Fixes: https://boltpay.atlassian.net/browse/M2P-82

#changelog Reward Points minicart compatibility with replace.js refactor

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.