### PR TITLE
M2P-49 Fix bug - Unable to complete order with virtual item after applying a discount

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1304,7 +1304,7 @@ class Cart extends AbstractHelper
      * @return array
      * @throws \Exception
      */
-    public function getCartData($paymentOnly, $placeOrderPayload, $immutableQuote = null)
+    public function getCartData($paymentOnly, $placeOrderPayload, $immutableQuote = null, $requireBillingAddress = true)
     {
 
         // If the immutable quote is passed (i.e. discount code validation, bugsnag report generation)
@@ -1368,7 +1368,7 @@ class Cart extends AbstractHelper
         }
         $immutableQuote->collectTotals();
 
-        $cart = $this->buildCartFromQuote($quote, $immutableQuote, $items, $placeOrderPayload, $paymentOnly);
+        $cart = $this->buildCartFromQuote($quote, $immutableQuote, $items, $placeOrderPayload, $paymentOnly, $requireBillingAddress);
         if ($cart == []) {
             // empty cart implies there was an error
             return $cart;

--- a/Test/Unit/Model/Api/DiscountCodeValidationTest.php
+++ b/Test/Unit/Model/Api/DiscountCodeValidationTest.php
@@ -1693,7 +1693,7 @@ class DiscountCodeValidationTest extends TestCase
     public function applyingCouponCode_virtualImmutableQuote()
     {
         $discountAmount = 15;
-        $this->shippingAddressMock->method('getDiscountAmount')->willReturn($discountAmount);
+        $this->billingAddressMock->method('getDiscountAmount')->willReturn($discountAmount);
 
         $expected = [
             'status' => 'success',
@@ -2463,13 +2463,17 @@ class DiscountCodeValidationTest extends TestCase
             ->setMethods(
                 [
                     'addData',
-                    'save'
+                    'save',
+                    'setShouldIgnoreValidation',
+                    'getDiscountAmount'
                 ]
             )
             ->disableOriginalConstructor()
             ->getMock();
     
         $this->billingAddressMock->method('save')->willReturnSelf();
+        $this->billingAddressMock->method('addData')->willReturnSelf();
+        $this->billingAddressMock->method('setShouldIgnoreValidation')->willReturnSelf();
 
         $this->couponMock = $this->getMockBuilder(\Magento\SalesRule\Model\Coupon::class)
             ->setMethods(

--- a/Test/Unit/Model/Api/DiscountCodeValidationTest.php
+++ b/Test/Unit/Model/Api/DiscountCodeValidationTest.php
@@ -1229,6 +1229,7 @@ class DiscountCodeValidationTest extends TestCase
             ->willReturn($giftcardMock);
 
         $this->immutableQuoteMock->expects(self::once())->method('getItemsCount')->willReturn(1);
+        $this->immutableQuoteMock->method('isVirtual')->willReturn(false);
 
         $this->expectErrorResponse(
             BoltErrorResponse::ERR_SERVICE,
@@ -2199,10 +2200,14 @@ class DiscountCodeValidationTest extends TestCase
         $customerId = null,
         $isVirtual = false,
         $quoteId = self::IMMUTABLE_QUOTE_ID,
-        $parentQuoteId = self::PARENT_QUOTE_ID
+        $parentQuoteId = self::PARENT_QUOTE_ID,
+        $billingAddress = null
     ) {
         if (is_null($shippingAddress)) {
             $shippingAddress = $this->shippingAddressMock;
+        }
+        if (is_null($billingAddress)) {
+            $billingAddress = $this->billingAddressMock;
         }
         $quoteItem = $this->getMockBuilder(\Magento\Quote\Model\Quote\Item::class)
             ->setMethods(['getSku', 'getQty', 'getCalculationPrice'])
@@ -2245,7 +2250,7 @@ class DiscountCodeValidationTest extends TestCase
         $quote->method('getAppliedRuleIds')->willReturn('2,3');
         $quote->method('isVirtual')->willReturn($isVirtual);
         $quote->method('getShippingAddress')->willReturn($shippingAddress);
-        $quote->method('getBillingAddress')->willReturn($shippingAddress);
+        $quote->method('getBillingAddress')->willReturn($billingAddress);
         $quote->method('getQuoteCurrencyCode')->willReturn('USD');
         $quote->method('collectTotals')->willReturnSelf();
         $quote->method('getItemsCount')->willReturn(1);
@@ -2453,6 +2458,18 @@ class DiscountCodeValidationTest extends TestCase
         $this->shippingAddressMock->method('setCollectShippingRates')->with(true)->willReturnSelf();
         $this->shippingAddressMock->method('getShippingDiscountAmount')->willReturn(0);
         $this->shippingAddressMock->method('getShippingAmount')->willReturn(5);
+        
+        $this->billingAddressMock = $this->getMockBuilder(\Magento\Quote\Model\Quote\Address::class)
+            ->setMethods(
+                [
+                    'addData',
+                    'save'
+                ]
+            )
+            ->disableOriginalConstructor()
+            ->getMock();
+    
+        $this->billingAddressMock->method('save')->willReturnSelf();
 
         $this->couponMock = $this->getMockBuilder(\Magento\SalesRule\Model\Coupon::class)
             ->setMethods(
@@ -2476,7 +2493,7 @@ class DiscountCodeValidationTest extends TestCase
             ->getMock();
 
         $this->immutableQuoteMock = $this->getMockBuilder(Quote::class)
-            ->setMethods(['getItemsCount', 'getCouponCode'])
+            ->setMethods(['getItemsCount', 'getCouponCode', 'isVirtual'])
             ->disableOriginalConstructor()
             ->getMock();
 


### PR DESCRIPTION
# Description
When trying to apply coupon to virtual qoute on Bolt modal, it would fail, cause the billing address of $immutableQuote is always empty, and the cart data returned from Cart Helper function is empty as a result, this PR is to fix this bug.

Fixes: https://boltpay.atlassian.net/browse/M2P-49

#changelog Fix bug - Unable to complete order with virtual item after applying a discount

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
