### PR TITLE
M2P-106 Reload bolt cart when user closes bolt checkout

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -1511,7 +1511,7 @@ if (!$block->isSaveCartInSections()) { ?>
                     // re-create order in case checkout was closed
                     // after order was changed from inside the checkout,
                     // i.e. the discount was applied
-                    createOrder();
+                    customerData.reload(['boltcart'], true);
                 }
             },
 


### PR DESCRIPTION
When user closes bolt checkout we should reload magento section to have updated bolt cart (for example if user applied a discount on bolt modal)

Fixes: [M2P-106]

#changelog M2P-106 Reload bolt cart when user closes bolt checkout

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
