### PR TITLE
Add support for Magento CustomerBalance to boltcart section

### DIFF
--- a/etc/frontend/sections.xml
+++ b/etc/frontend/sections.xml
@@ -32,4 +32,15 @@
         <section name="boltcart"/>
     </action>
     <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!--
+    /**
+     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     * We explicitly configure Magento_CustomerBalance support which is not implicitly done via the "cart" section
+     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     */
+    -->
+    <action name="rest/*/V1/carts/mine/balance/apply">
+        <section name="boltcart"/>
+    </action>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
 </config>


### PR DESCRIPTION
# Description
Applying the Magento store credit (Customer Balance) doesn't automatically trigger a Magento cart section refresh and therefore does not trigger the boltcart section to update.  We explicitly register that action here.

Fixes: https://boltpay.atlassian.net/browse/M2P-112

#changelog Add support for Magento CustomerBalance to boltcart section

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
