### PR TITLE
Fix issue when user close bolt modal and open again

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -1851,7 +1851,7 @@ if (!$block->isSaveCartInSections()) { ?>
             } else {
             customerData.get('boltcart').subscribe(function(data) {
                 cart = data.cart !== undefined ? data.cart : {};
-                if (JSON.stringify(cart) === oldBoltCartValue) {
+                if ((JSON.stringify(cart) === oldBoltCartValue) && !waitingForResolvingPromises) {
                     return;
                 }
 


### PR DESCRIPTION
# Description
When a user closes bolt modal we call configure() with promises to make sure user can't open checkout with the old cart.
But if cart wasn't changed we do nothing and don't resolve promises.

Solution: resolve promises even if bolt cart wasn't change.

Fixes: (link Jira ticket)

#changelog Fix issue when user close bolt modal and open again

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
