### PR TITLE
Bugfix: Call configure after we render new bolt button

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -1426,6 +1426,9 @@ if (!$block->isSaveCartInSections()) { ?>
             if (getCheckoutKey() !== '') {
                 setCheckoutTypeStyle();
                 insertConnectScript();
+                if (getCheckoutType() !== 'payment') {
+                    callConfigureAfterAddingNewButton();
+                }
             }
         };
 
@@ -1696,6 +1699,7 @@ if (!$block->isSaveCartInSections()) { ?>
         var createRequest = false;
         var allowAutoOpen = true;
         var waitingForResolvingPromises = false;
+        var reconfigureBoltWhenResolvePromises = false;
         var oldBoltCartValue = "";
         var BC;
         var hintBarrier;
@@ -1749,6 +1753,19 @@ if (!$block->isSaveCartInSections()) { ?>
                     invalidateBoltCart();
                 }
             }
+        }
+
+        var callConfigureAfterAddingNewButton = function() {
+            // Bolt button is added into DOM so we need to call Configure() again
+            // we rely on current bolt cart
+            if (waitingForResolvingPromises) {
+                reconfigureBoltWhenResolvePromises = true;
+                return;
+            }
+            if (!cart) {
+                return;
+            }
+            BC = BoltCheckout.configure(cart, hints, callbacks, boltCheckoutConfig);
         }
 
         if (getCheckoutType() !== 'payment') {
@@ -1916,6 +1933,11 @@ if (!$block->isSaveCartInSections()) { ?>
                         if (waitingForResolvingPromises && !boltConfig.always_present_checkout) {
                             cartBarrier.resolve(cart);
                             hintBarrier.resolve(hints);
+                            if (reconfigureBoltWhenResolvePromises) {
+                                // new bolt button was added to DOM after last configure call
+                                // so we need to reconfigure
+                                BC = BoltCheckout.configure(cart, hints, callbacks, boltCheckoutConfig);
+                            }
                         } else {
                             if (boltConfig.always_present_checkout) {
                                 boltCheckoutConfig = (cart.orderToken && cart.orderToken !== "") ? {floatingButtonMode: newItemAddedToCart ? "show_cart" : "show_cart_on_hover" } : {};
@@ -1925,6 +1947,7 @@ if (!$block->isSaveCartInSections()) { ?>
                             BC = BoltCheckout.configure(cart, hints, callbacks, boltCheckoutConfig);
                         }
                         waitingForResolvingPromises = false;
+                        reconfigureBoltWhenResolvePromises = false;
                         oldBoltCartValue = JSON.stringify(cart);
 
                         // open the checkout if auto-open flag is set
@@ -2226,7 +2249,9 @@ if (!$block->isSaveCartInSections()) { ?>
         // When we know that cart will be updated soon we call configure with promises
         // to make sure bolt checkout with outdated cart isn't available for user
         $(document).on("ajax:addToCart", function () {
-            callConfigureWithPromises();
+            // If merchant shows popup after add to cart
+            // delay 0 allows to render bolt button before we call configure
+            setTimeout(callConfigureWithPromises, 0);
             // set flag to animate always present button when we catch cart updating
             if (boltConfig.always_present_checkout) {
                 newItemAddedToCart = true;


### PR DESCRIPTION
When we render bolt button on popup after user clicks "add to cart" we don't call BoltCheckout.configure() so bolt button isn't showed.

Proposal:
1. fix it and call BoltCheckout.configure(). We no need to update bolt cart in those cases.
2. if we render bolt button after we call configure with promises, postpone new configure call. Otherwise, we can have dead click on others checkout buttons
3. Add delay 0 to call configure after magento triggers add to cart events. If we do this, new bolt button is rendered meanwhile and shows right after we make postponed call.

Actually (3) is enough to fix the known issue for PolyWood but step (1) and (2) add some reliability for other cases (when new bolt button is rendered in any moment different from add to cart).

Fixes: (link Jira ticket)

#changelog Bugfix: Call configure after we render new bolt button

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
