### PR TITLE
M2P-122 Ignore invoice creation when the payment hook is sent to Magento

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -1915,7 +1915,7 @@ class Order extends AbstractHelper
         }
 
         // We will create an invoice if we have zero amount or new capture.
-        if ($this->isCaptureHookRequest($newCapture) || $this->isZeroAmountHook($transactionState)) {
+        if (!$this->featureSwitches->isIgnoreHookForInvoiceCreationEnabled() && ($this->isCaptureHookRequest($newCapture) || $this->isZeroAmountHook($transactionState))) {
             $currencyCode = $order->getOrderCurrencyCode();
             $this->validateCaptureAmount($order, CurrencyUtils::toMajor($amount, $currencyCode));
             $invoice = $this->createOrderInvoice($order, $realTransactionId, CurrencyUtils::toMajor($amount, $currencyCode));

--- a/Model/Api/OrderManagement.php
+++ b/Model/Api/OrderManagement.php
@@ -240,7 +240,7 @@ class OrderManagement implements OrderManagementInterface
         }
 
         if ($type === HookHelper::HT_CAPTURE && $this->decider->isIgnoreHookForInvoiceCreationEnabled()) {
-            $this->setSuccessResponse('Ignore the credit hook for the invoice creation');
+            $this->setSuccessResponse('Ignore the capture hook for the invoice creation');
             return;
         }
 

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -460,7 +460,7 @@ class OrderTest extends TestCase
 
         $this->context->method('getEventManager')->willReturn($this->eventManager);
         $this->resourceConnection->method('getConnection')->willReturn($this->connection);
-        $this->featureSwitches = $this->createPartialMock(Decider::class, ['isLogMissingQuoteFailedHooksEnabled','isCreatingCreditMemoFromWebHookEnabled']);
+        $this->featureSwitches = $this->createPartialMock(Decider::class, ['isLogMissingQuoteFailedHooksEnabled','isCreatingCreditMemoFromWebHookEnabled','isIgnoreHookForInvoiceCreationEnabled']);
         $this->creditmemoFactory = $this->createPartialMock(CreditmemoFactory::class, ['createByOrder']);
         $this->creditmemoManagement = $this->createMock(CreditmemoManagementInterface::class, ['refund']);
     }
@@ -3221,6 +3221,34 @@ class OrderTest extends TestCase
         $this->transactionBuilder->expects(self::once())->method('setFailSafe')->with(true)->willReturnSelf();
         $this->transactionBuilder->expects(self::once())->method('build')->willReturn($paymentMock);
 
+        $this->currentMock->updateOrderPayment($this->orderMock, null, self::REFERENCE_ID);
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::updateOrderPayment
+     */
+    public function updateOrderPayment_withIgnoreInvoiceCreationEnabled_DoesNotCreateInvoice()
+    {
+        /**
+         * @var MockObject|OrderPayment $paymentMock
+         */
+        list($transaction, $paymentMock) = $this->updateOrderPaymentSetUp(OrderHelper::TS_ZERO_AMOUNT);
+        $this->featureSwitches->method('isIgnoreHookForInvoiceCreationEnabled')->willReturn(true);
+        $invoiceMock = $this->createMock(Invoice::class);
+        $paymentMock->expects(self::atLeastOnce())->method('getAdditionalInformation')
+            ->willReturnMap([['authorized', true]]);
+        $this->currentMock->expects(self::once())->method('fetchTransactionInfo')->willReturn($transaction);
+
+        $this->currentMock->expects(self::never())->method('createOrderInvoice')->willReturn($invoiceMock);
+
+        $this->transactionBuilder->expects(self::once())->method('setPayment')->with($paymentMock)->willReturnSelf();
+        $this->transactionBuilder->expects(self::once())->method('setOrder')->with($this->orderMock)->willReturnSelf();
+        $this->transactionBuilder->expects(self::once())->method('setTransactionId')->willReturnSelf();
+        $this->transactionBuilder->expects(self::once())->method('setAdditionalInformation')->willReturnSelf();
+        $this->transactionBuilder->expects(self::once())->method('setFailSafe')->with(true)->willReturnSelf();
+        $this->transactionBuilder->expects(self::once())->method('build')->willReturn($paymentMock);
         $this->currentMock->updateOrderPayment($this->orderMock, null, self::REFERENCE_ID);
     }
 

--- a/Test/Unit/Model/Api/OrderManagementTest.php
+++ b/Test/Unit/Model/Api/OrderManagementTest.php
@@ -793,7 +793,7 @@ class OrderManagementTest extends TestCase
         $this->response->expects(self::once())->method('setHttpResponseCode')->with(200);
         $this->response->expects(self::once())->method('setBody')->with(json_encode([
             'status' => 'success',
-            'message' => 'Ignore the credit hook for the invoice creation',
+            'message' => 'Ignore the capture hook for the invoice creation',
         ]));
 
 


### PR DESCRIPTION
Some merchants are using ERP. Here are two cases that are needed to be fixed:
Case 1:
1. The auto-capture setting is disabled on Bolt
2. The $0 order is created on both Bolt and Magento
3. Bolt sends a payment hook request to Magento to authorize the order and create an invoice automatically
4. The ERP system sends a request to Magento to create an invoice and it causes an error because the invoice was already created on #3

Case 2:
1. The auto-capture setting is enabled on Bolt
2. The order is created on both Bolt and Magento
3. Bolt sends a payment hook request to Magento to authorize the order and create an invoice automatically
4. The ERP system sends a request to Magento to create an invoice and it causes an error because the invoice was already created on #3

This PR resolves the above cases by ignoring the invoice creation when the payment hook is sent to Magento if the isIgnoreHookForInvoiceCreationEnabled is enabled.

Fixes: https://boltpay.atlassian.net/browse/M2P-122

#changelog Ignore invoice creation when the payment hook is sent to Magento

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
