### PR TITLE
Handle case when we render one more bolt button

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -1699,7 +1699,6 @@ if (!$block->isSaveCartInSections()) { ?>
         var createRequest = false;
         var allowAutoOpen = true;
         var waitingForResolvingPromises = false;
-        var reconfigureBoltWhenResolvePromises = false;
         var oldBoltCartValue = "";
         var BC;
         var hintBarrier;
@@ -1759,7 +1758,11 @@ if (!$block->isSaveCartInSections()) { ?>
             // Bolt button is added into DOM so we need to call Configure() again
             // we rely on current bolt cart
             if (waitingForResolvingPromises) {
-                reconfigureBoltWhenResolvePromises = true;
+                // if bolt checkout is opened we can't show new button now and will show it only if user close bolt checkout
+                if (popUpOpen) {
+                    return;
+                }
+                BC = BoltCheckout.configure(cartBarrier.promise, hintBarrier.promise, callbacks);
                 return;
             }
             if (!cart) {
@@ -1933,11 +1936,6 @@ if (!$block->isSaveCartInSections()) { ?>
                         if (waitingForResolvingPromises && !boltConfig.always_present_checkout) {
                             cartBarrier.resolve(cart);
                             hintBarrier.resolve(hints);
-                            if (reconfigureBoltWhenResolvePromises) {
-                                // new bolt button was added to DOM after last configure call
-                                // so we need to reconfigure
-                                BC = BoltCheckout.configure(cart, hints, callbacks, boltCheckoutConfig);
-                            }
                         } else {
                             if (boltConfig.always_present_checkout) {
                                 boltCheckoutConfig = (cart.orderToken && cart.orderToken !== "") ? {floatingButtonMode: newItemAddedToCart ? "show_cart" : "show_cart_on_hover" } : {};
@@ -1947,7 +1945,6 @@ if (!$block->isSaveCartInSections()) { ?>
                             BC = BoltCheckout.configure(cart, hints, callbacks, boltCheckoutConfig);
                         }
                         waitingForResolvingPromises = false;
-                        reconfigureBoltWhenResolvePromises = false;
                         oldBoltCartValue = JSON.stringify(cart);
 
                         // open the checkout if auto-open flag is set

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -1426,6 +1426,9 @@ if (!$block->isSaveCartInSections()) { ?>
             if (getCheckoutKey() !== '') {
                 setCheckoutTypeStyle();
                 insertConnectScript();
+                if (getCheckoutType() !== 'payment') {
+                    callConfigureAfterAddingNewButton();
+                }
             }
         };
 
@@ -1696,6 +1699,7 @@ if (!$block->isSaveCartInSections()) { ?>
         var createRequest = false;
         var allowAutoOpen = true;
         var waitingForResolvingPromises = false;
+        var reconfigureBoltWhenResolvePromises = false;
         var oldBoltCartValue = "";
         var BC;
         var hintBarrier;
@@ -1749,6 +1753,19 @@ if (!$block->isSaveCartInSections()) { ?>
                     invalidateBoltCart();
                 }
             }
+        }
+
+        var callConfigureAfterAddingNewButton = function() {
+            // Bolt button is added into DOM so we need to call Configure() again
+            // we rely on current bolt cart
+            if (waitingForResolvingPromises) {
+                reconfigureBoltWhenResolvePromises = true;
+                return;
+            }
+            if (!cart) {
+                return;
+            }
+            BC = BoltCheckout.configure(cart, hints, callbacks, boltCheckoutConfig);
         }
 
         if (getCheckoutType() !== 'payment') {
@@ -1916,6 +1933,11 @@ if (!$block->isSaveCartInSections()) { ?>
                         if (waitingForResolvingPromises && !boltConfig.always_present_checkout) {
                             cartBarrier.resolve(cart);
                             hintBarrier.resolve(hints);
+                            if (reconfigureBoltWhenResolvePromises) {
+                                // new bolt button was added to DOM after last configure call
+                                // so we need to reconfigure
+                                BC = BoltCheckout.configure(cart, hints, callbacks, boltCheckoutConfig);
+                            }
                         } else {
                             if (boltConfig.always_present_checkout) {
                                 boltCheckoutConfig = (cart.orderToken && cart.orderToken !== "") ? {floatingButtonMode: newItemAddedToCart ? "show_cart" : "show_cart_on_hover" } : {};
@@ -1925,6 +1947,7 @@ if (!$block->isSaveCartInSections()) { ?>
                             BC = BoltCheckout.configure(cart, hints, callbacks, boltCheckoutConfig);
                         }
                         waitingForResolvingPromises = false;
+                        reconfigureBoltWhenResolvePromises = false;
                         oldBoltCartValue = JSON.stringify(cart);
 
                         // open the checkout if auto-open flag is set
@@ -2226,7 +2249,9 @@ if (!$block->isSaveCartInSections()) { ?>
         // When we know that cart will be updated soon we call configure with promises
         // to make sure bolt checkout with outdated cart isn't available for user
         $(document).on("ajax:addToCart", function () {
-            callConfigureWithPromises();
+            // If merchant shows popup after add to cart
+            // delay 0 allows to render bolt button before we call configure
+            setTimeout(callConfigureWithPromises, 0);
             // set flag to animate always present button when we catch cart updating
             if (boltConfig.always_present_checkout) {
                 newItemAddedToCart = true;


### PR DESCRIPTION
After the refactoring bolt button on add-on-cart popup was broken, the fix handles it as well as other cases when we add a new bolt button in the DOM.

The **first commit** is the same as in https://github.com/BoltApp/bolt-magento2/pull/769. I reverted it yesterday becuase it affected on integration tests.
The **second commit** fixes an issue that happens when user clicks the first bolt button before we render the second one.
Although eventually, we want to fix this is the storm [EN-340], we are pretty good with this interim solution. See also [M2P-124](https://boltpay.atlassian.net/browse/M2P-124), [M2P-129](https://boltpay.atlassian.net/browse/M2P-124)

Fixes: (link Jira ticket)

#changelog Handle case when we render the one more bolt button

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.


[EN-340]: https://boltpay.atlassian.net/browse/EN-340