### PR TITLE
M2P-131 Invalidate bolt cart when we redirect user to thank you page

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -1514,6 +1514,8 @@ if (!$block->isSaveCartInSections()) { ?>
                 if (callbacks.success_url) {
                     // redirect on success order save
                     location.href = callbacks.success_url;
+                    // invalidate bolt cart to prevent bolt initialization on thank you page
+                    customerData.reload(['boltcart'], true);
                 } else {
                     // re-create order in case checkout was closed
                     // after order was changed from inside the checkout,


### PR DESCRIPTION
We need to invalidate bolt cart before a user is redirected to thank you page to prevent bolt order initialization on thank you page. It helps us to get rid of API errors and clean the datadog log (see task for details) 

Fixes: [M2P-131]

#changelog M2P-131 Invalidate bolt cart when we redirect user to thank you page

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
