### PR TITLE
M2P-133 Add custom product attributes to bolt cart

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -335,6 +335,8 @@ class Config extends AbstractHelper
 
     const XML_PATH_PICKUP_SHIPPING_METHOD_CODE = 'payment/boltpay/pickup_shipping_method_code';
 
+    const XML_PATH_PRODUCT_ATTRIBUTES_LIST = 'payment/boltpay/product_attributes_list';
+
     /**
      * Default whitelisted shopping cart and checkout pages "Full Action Name" identifiers, <router_controller_action>
      * Pages allowed to load Bolt javascript / show checkout button
@@ -1821,5 +1823,22 @@ class Config extends AbstractHelper
     public function isTestEnvSet()
     {
         return isset($_SERVER['TEST_ENV']);
+    }
+
+    /**
+     * @param null $storeId
+     * @return array
+     */
+    public function getProductAttributesList($storeId = null)
+    {
+        $commaSeparateList =  $this->getScopeConfig()->getValue(
+            self::XML_PATH_PRODUCT_ATTRIBUTES_LIST,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+        if (!$commaSeparateList) {
+            return [];
+        }
+        return explode(",", $commaSeparateList);
     }
 }

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -1236,4 +1236,32 @@ Room 4000',
 
         ];
     }
+
+    /**
+     * @param $commaSeparatedList
+     * @param $expected
+     * @test
+     * @covers ::getProductAttributesList
+     * @dataProvider providerGetProductAttributesList
+     */
+    public function getProductAttributesList($commaSeparatedList, $expected)
+    {
+        $this->scopeConfig
+            ->expects(self::any())
+            ->method('getValue')
+            ->with(BoltConfig::XML_PATH_PRODUCT_ATTRIBUTES_LIST, \Magento\Store\Model\ScopeInterface::SCOPE_STORE, null)
+            ->willReturn($commaSeparatedList);
+
+        $result = $this->currentMock->getProductAttributesList();
+        $this->assertEquals($expected, $result);
+    }
+
+    public function providerGetProductAttributesList()
+    {
+        return [
+            ['', []],
+            ['value', ['value']],
+            ['value1,value2', ['value1','value2']],
+        ];
+    }
 }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -343,6 +343,11 @@
                         <depends><field id="enable_store_pickup_feature">1</field></depends>
                         <validate>validate-no-empty</validate>
                     </field>
+                    <field id="product_attributes_list" translate="label" type="text" sortOrder="320" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Product attributes</label>
+                        <config_path>payment/boltpay/product_attributes_list</config_path>
+                        <comment>Comma separated list of product attributes that we send to bolt server. Leave empty for include only standard attributes.</comment>
+                    </field>
                 </group>
             </group>
         </section>


### PR DESCRIPTION
# Description
Adds magento product attributes into bolt cart.
We need this for using attrubutes in custom rules.
Merchant can select which attributes will be added into cart.
Fixes: [M2P-133]
Tech discussion and following steps https://docs.google.com/document/d/1KGH7Ov9VgC5F6cOcHchBriZxduTS02rNPSk15rCuAs4/edit#heading=h.vv6izgxam70a

#changelog M2P-133 Add custom product attributes to bolt cart

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
