### PR TITLE
M2P-134 Correct the shipping method code

### DIFF
--- a/Model/Api/Tax.php
+++ b/Model/Api/Tax.php
@@ -105,7 +105,7 @@ class Tax extends ShippingTax implements TaxInterface
         }
 
         $selectedOption = $shipping_option['reference'];
-        list($carrierCode, $methodCode) = explode('_', $selectedOption);
+        list($carrierCode, $methodCode) = explode('_', $selectedOption, 2);
 
         $this->addressInformation->setShippingCarrierCode($carrierCode);
         $this->addressInformation->setShippingMethodCode($methodCode);

--- a/Test/Unit/Model/Api/TaxTest.php
+++ b/Test/Unit/Model/Api/TaxTest.php
@@ -159,9 +159,14 @@ class TaxTest extends TestCase
      * @test
      * that setAddressInformation would return set shipping method code and set shipping carrier code
      *
+     * @dataProvider provider_setAddressInformation_happyPath
      * @covers ::setAddressInformation
+     * @param $shippingReference
+     * @param $carrierCode
+     * @param $methodCode
+     *
      */
-    public function setAddressInformation_happyPath()
+    public function setAddressInformation_happyPath($shippingReference, $carrierCode, $methodCode)
     {
         $addressData = [
             'region' => 'California',
@@ -174,7 +179,7 @@ class TaxTest extends TestCase
         ];
 
         $shipping_option = [
-            'reference' => 'carrierCode_methodCode'
+            'reference' => $shippingReference
         ];
 
         $this->initCurrentMock(['populateAddress']);
@@ -187,10 +192,17 @@ class TaxTest extends TestCase
             ->with($address);
 
         $this->addressInformation->expects(self::once())->method('setShippingCarrierCode')
-            ->with('carrierCode');
-        $this->addressInformation->expects(self::once())->method('setShippingMethodCode')->with('methodCode');
+            ->with($carrierCode);
+        $this->addressInformation->expects(self::once())->method('setShippingMethodCode')->with($methodCode);
 
         $this->assertNull($this->currentMock->setAddressInformation($addressData, $shipping_option));
+    }
+
+    public function provider_setAddressInformation_happyPath(){
+        return [
+          ['carrierCode_methodCode','carrierCode', 'methodCode'],
+          ['shqshared_GROUND_HOME_DELIVERY', 'shqshared', 'GROUND_HOME_DELIVERY']
+        ];
     }
 
     /**


### PR DESCRIPTION
# Description
Currently, if the shipping reference is shqshared_GROUND_HOME_DELIVERY
together with this logic - https://github.com/BoltApp/bolt-magento2/blob/master/Model/Api/Tax.php#L108 , the shipping carrier code will be **shqshared**, the shipping method code will be **GROUND** and this isn’t expected.

This PR fixes the issue by getting the first string until the first underscore is the shipping carrier code (in this case, it’s **shqshared**) and the rest of the string after the first underscore is the method code regardless if it contains other underscore characters (in this case, it’s **GROUND_HOME_DELIVERY**). 

Fixes: 
https://boltpay.atlassian.net/browse/ON-88
https://boltpay.atlassian.net/browse/M2P-134

#changelog Correct the shipping method code

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
