### PR TITLE
Change to be tagging Pavel for tag notifications

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ commands:
     steps:
       - slack/notify:
           color: '#58a359'
-          mentions: 'oleksii,Pavel,'
+          mentions: 'Pavel,oleksii,'
           message: ":white_check_mark: A new RC << parameters.tag >> has been tagged for Magento 2!"
           webhook: $SLACK_MAGENTO2_WEBHOOK
           include_job_number_field: false


### PR DESCRIPTION
# Description
For whatever reason there's a disconnect between the message composed by the circleci notify orb and slack, causing only the first of the tags to be an actual tag. We're changing this here so Pavel gets the real tag, but leaving Oleksii in just in case something changes on circle or slack that causes it to work properly in the future.
Fixes: (link Jira ticket)

#changelog Change to be tagging Pavel for tag notifications

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
