### PR TITLE
[MX-1413] Push auto-rebase result to ci branches instead of overwriting the branch history

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -1,6 +1,10 @@
 # Overview of Custom Circle CI Setup
 
 ## Customization branch auto rebase
+The circle ci workflow _auto-rebase_ will be triggered on every PR merge to master and try to auto-rebase the branches listed in _.circlci/scripts/auto-rebase-branches.txt_ against master one by one. 
+The results of rebasing will be pushed to ci/<branch-name> 
 
-* TODO Add some notes on how to see results, how to resolve etc.
-* Could be some links to documentation else where if needed.
+When a rebase process fails (eg: there is a conflict that needs to resolve manually) for a specified branch, it would try to recover and continue rebasing the other listed branches.
+In the end of the job, it prints out a summary about which branches failed to auto-rebase.
+
+To make your branch auto-rebase on master, simply append the branch name to _.circlci/scripts/auto-rebase-branches.txt_ in the newline separated format.

--- a/.circleci/scripts/auto-rebase.sh
+++ b/.circleci/scripts/auto-rebase.sh
@@ -32,8 +32,8 @@ auto-rebase () {
     git rebase --abort
     return 1
   fi
-  if ! (git push --force-with-lease origin "$branchName"); then
-    echo "Failed to push $branchName"
+  if ! (git push --force-with-lease origin "$branchName":ci/"$branchName"); then
+    echo "Failed to push the auto-rebase result to ci/$branchName"
     git reset --hard HEAD
     return 1
   fi


### PR DESCRIPTION
# Description
The auto-rebase result for branch <auto-rebase-branch> result will be pushed to ci/<auto-rebase-branch> instead directly to  <auto-rebase-branch> because many merchant branches are directly referenced in merchant's composer file and we don't want to upgrade them without notifying merchants for testing

Fixes: [MX-1413] 

#changelog Push auto-rebase result to ci branches instead of overwriting the branch history

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.


[MX-1413]: https://boltpay.atlassian.net/browse/MX-1413