### PR TITLE
M2P-136 Recalculate shipping and tax after selecting a shipping method in the native checkout page

### DIFF
--- a/Section/CustomerData/BoltCart.php
+++ b/Section/CustomerData/BoltCart.php
@@ -14,10 +14,14 @@
  * @copyright  Copyright (c) 2020 Bolt Financial, Inc (https://www.bolt.com)
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
+
 namespace Bolt\Boltpay\Section\CustomerData;
 
 use Magento\Customer\CustomerData\SectionSourceInterface;
 use Bolt\Boltpay\Helper\Cart as CartHelper;
+use Magento\Framework\App\Response\RedirectInterface;
+use Bolt\Boltpay\Helper\Config;
+use Magento\Framework\UrlInterface;
 
 class BoltCart implements SectionSourceInterface
 {
@@ -26,14 +30,57 @@ class BoltCart implements SectionSourceInterface
      */
     private $cartHelper;
 
+    /**
+     * @var RedirectInterface
+     */
+    private $redirect;
+
+    /**
+     * @var Config
+     */
+    private $configHelper;
+
+    /**
+     * @var UrlInterface
+     */
+    private $url;
+
+    /**
+     * BoltCart constructor.
+     * @param CartHelper $cartHelper
+     * @param RedirectInterface $redirect
+     * @param Config $configHelper
+     * @param UrlInterface $url
+     */
     public function __construct(
-        CartHelper $cartHelper
-    ) {
+        CartHelper $cartHelper,
+        RedirectInterface $redirect,
+        Config $configHelper,
+        UrlInterface $url
+    )
+    {
         $this->cartHelper = $cartHelper;
+        $this->redirect = $redirect;
+        $this->configHelper = $configHelper;
+        $this->url = $url;
     }
 
     public function getSectionData()
     {
+        if ($this->isBoltUsedInCheckoutPage()) {
+            return $this->cartHelper->calculateCartAndHints(true);
+        }
+
         return $this->cartHelper->calculateCartAndHints();
+    }
+
+    /**
+     * @return bool
+     */
+    private function isBoltUsedInCheckoutPage()
+    {
+        $checkoutUrl = $this->url->getUrl('checkout');
+        $refererUrl = $this->redirect->getRefererUrl();
+        return (trim($refererUrl, '/') == trim($checkoutUrl, '/') && $this->configHelper->isPaymentOnlyCheckoutEnabled());
     }
 }

--- a/Test/Unit/Section/CustomerData/BoltCartTest.php
+++ b/Test/Unit/Section/CustomerData/BoltCartTest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Test\Unit\Section\CustomerData;
+
+use Bolt\Boltpay\Helper\Cart as CartHelper;
+use Bolt\Boltpay\Helper\Config as ConfigHelper;
+use Bolt\Boltpay\Section\CustomerData\BoltCart;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use PHPUnit\Framework\TestCase;
+use Magento\Framework\App\Response\RedirectInterface;
+use Bolt\Boltpay\Helper\Config;
+use Magento\Framework\UrlInterface;
+
+/**
+ * Class BoltCartTest
+ * @package Bolt\Boltpay\Test\Unit\Section\CustomerData
+ * @coversDefaultClass \Bolt\Boltpay\Section\CustomerData\BoltCart
+ */
+class BoltCartTest extends TestCase
+{
+    /**
+     * @var CartHelper
+     */
+    private $cartHelper;
+
+    /**
+     * @var ConfigHelper
+     */
+    private $configHelper;
+
+    /**
+     * @var BoltCart
+     */
+    private $boltCart;
+
+    /**
+     * @var RedirectInterface
+     */
+    private $redirect;
+
+    /**
+     * @var UrlInterface
+     */
+    private $url;
+
+    /**
+     * @inheritdoc
+     */
+    public function setUp()
+    {
+        $this->cartHelper = $this->createPartialMock(CartHelper::class, ['calculateCartAndHints']);
+        $this->configHelper = $this->createPartialMock(ConfigHelper::class, ['isPaymentOnlyCheckoutEnabled']);
+        $this->redirect = $this->createPartialMock(RedirectInterface::class, [
+            'getRefererUrl', 'getRedirectUrl', 'error',
+            'success', 'updatePathParams', 'redirect'
+        ]);
+        $this->url = $this->createPartialMock(UrlInterface::class,
+            [
+                'getUrl', 'getUseSession', 'getBaseUrl',
+                'getCurrentUrl', 'getRouteUrl', 'addSessionParam', 'addQueryParams',
+                'setQueryParam', 'escape', 'getDirectUrl', 'sessionUrlVar',
+                'isOwnOriginUrl', 'getRedirectUrl', 'setScope'
+            ]
+        );
+
+        $this->boltCart = (new ObjectManager($this))->getObject(
+            BoltCart::class,
+            [
+                'cartHelper' => $this->cartHelper,
+                'redirect' => $this->redirect,
+                'configHelper' => $this->configHelper,
+                'url' => $this->url,
+            ]
+        );
+    }
+
+
+    /**
+     * @test
+     * @covers ::getSectionData
+     * @covers ::isBoltUsedInCheckoutPage
+     */
+    public function getSectionData_withBoltIsUsedInCheckoutPage()
+    {
+        $this->url->expects(self::once())->method('getUrl')->willReturn('https://test/checkout');
+        $this->redirect->expects(self::once())->method('getRefererUrl')->willReturn('https://test/checkout');
+        $this->configHelper->expects(self::once())->method('isPaymentOnlyCheckoutEnabled')->willReturn(true);
+        $this->cartHelper->expects(self::once())->method('calculateCartAndHints')->with(true);
+        $this->boltCart->getSectionData();
+    }
+
+    /**
+     * @test
+     * @covers ::getSectionData
+     * @covers ::isBoltUsedInCheckoutPage
+     */
+    public function getSectionData_withBoltIsNotUsedInCheckoutPage()
+    {
+        $this->url->expects(self::once())->method('getUrl')->willReturn('https://test/checkout');
+        $this->redirect->expects(self::once())->method('getRefererUrl')->willReturn('https://test/checkout22');
+        $this->cartHelper->expects(self::once())->method('calculateCartAndHints')->with(false);
+        $this->boltCart->getSectionData();
+    }
+}

--- a/etc/frontend/sections.xml
+++ b/etc/frontend/sections.xml
@@ -50,4 +50,12 @@
         <section name="boltcart"/>
     </action>
 
+    <action name="rest/*/V1/guest-carts/*/shipping-information">
+        <section name="boltcart"/>
+    </action>
+
+    <action name="rest/*/V1/carts/mine/shipping-information">
+        <section name="boltcart"/>
+    </action>
+
 </config>


### PR DESCRIPTION
# Description
Currently, there is a bug that after selecting a shipping method, the shipping and tax amount isn’t applied to the Bolt modal on the native checkout page.

This PR fixes the issue by recalculating the shipping and tax after the customer selects a shipping method and click on Next button.

Below are the test videos:
Before fix: https://drive.google.com/file/d/11Dgm4hAHiIvjJjMftXw7x2s3rz5QtKoE/view
After fix: https://drive.google.com/file/d/1w4aGXYb2E9EOf5Z2s7b44VV3tHKAZ04r/view

Fixes: https://boltpay.atlassian.net/browse/M2P-136

#changelog Recalculate shipping and tax after selecting a shipping method in the native checkout page

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
