### PR TITLE
M2P-141 Set order status to closed if total refunded is equal to total paid and grand total

### DIFF
--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -2817,12 +2817,18 @@ class OrderTest extends TestCase
      * @param string $orderState
      * @param bool   $isHookFromBolt
      * @param bool   $isCreatingCreditMemoFromWebHookEnabled
+     * @param int $orderTotalRefunded
+     * @param int $orderGrandTotal
+     * @param int $orderTotalPaid
      */
-    public function transactionToOrderState($transactionState, $orderState, $isHookFromBolt = false, $isCreatingCreditMemoFromWebHookEnabled = false)
+    public function transactionToOrderState($transactionState, $orderState, $isHookFromBolt = false, $isCreatingCreditMemoFromWebHookEnabled = false, $orderTotalRefunded = 0, $orderGrandTotal = 10 , $orderTotalPaid = 10)
     {
         Hook::$fromBolt = $isHookFromBolt;
         $this->featureSwitches->method('isCreatingCreditMemoFromWebHookEnabled')->willReturn($isCreatingCreditMemoFromWebHookEnabled);
-        static::assertEquals($orderState, $this->currentMock->transactionToOrderState($transactionState));
+        $this->orderMock->method('getTotalRefunded')->willReturn($orderTotalRefunded);
+        $this->orderMock->method('getGrandTotal')->willReturn($orderGrandTotal);
+        $this->orderMock->method('getTotalPaid')->willReturn($orderTotalPaid);
+        static::assertEquals($orderState, $this->currentMock->transactionToOrderState($transactionState, $this->orderMock));
     }
 
     /**
@@ -2839,8 +2845,10 @@ class OrderTest extends TestCase
             [OrderHelper::TS_CANCELED, OrderModel::STATE_CANCELED],
             [OrderHelper::TS_REJECTED_REVERSIBLE, OrderModel::STATE_PAYMENT_REVIEW],
             [OrderHelper::TS_REJECTED_IRREVERSIBLE, OrderModel::STATE_CANCELED],
-            [OrderHelper::TS_CREDIT_COMPLETED, OrderModel::STATE_PROCESSING, true, true],
+            [OrderHelper::TS_CREDIT_COMPLETED, OrderModel::STATE_CLOSED, true, true, 10, 10 ,10],
+            [OrderHelper::TS_CREDIT_COMPLETED, OrderModel::STATE_PROCESSING, true, true, 8, 10 ,10],
             [OrderHelper::TS_CREDIT_COMPLETED, OrderModel::STATE_PROCESSING, false, true],
+            [OrderHelper::TS_CREDIT_COMPLETED, OrderModel::STATE_HOLDED, true, false],
             [OrderHelper::TS_CREDIT_COMPLETED, OrderModel::STATE_HOLDED, true, false],
         ];
     }


### PR DESCRIPTION
# Description
Currently, after creating credit memos by credit hooks, if the total refunded is equal to the grand total and the total paid, the order status is Processing. This isn’t expected. The order status should be Closed.

This PR solves that issue by setting the order status to Closed.

Here are the test screenshots:
- Before fix:  https://prnt.sc/tfh6e9
- After fix: https://prnt.sc/tfhnz2

Fixes: https://boltpay.atlassian.net/browse/M2P-141

#changelog M2P-141 Set order status to closed if total refunded is equal to total paid and grand total

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
