### PR TITLE
M2P-147 Implement a feature switch to toggle the logic to pre-fill address from Bolt for the logged-in customer

### DIFF
--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -246,4 +246,8 @@ class Decider extends AbstractHelper
     public function isSaveCartInSections() {
         return $this->isSwitchEnabled(Definitions::M2_SAVE_CART_IN_SECTIONS);
     }
+
+    public function ifShouldDisablePrefillAddressForLoggedInCustomer() {
+        return $this->isSwitchEnabled(Definitions::M2_IF_SHOULD_DISABLE_PREFILL_ADDRESS_FROM_BOLT_FOR_LOGGED_IN_CUSTOMER);
+    }
 }

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -112,6 +112,11 @@ class Definitions
      */
     const M2_SAVE_CART_IN_SECTIONS = "M2_SAVE_CART_IN_SECTIONS";
 
+    /**
+     * Disable pre-fill address from Bolt for the logged-in customer
+     */
+    const M2_IF_SHOULD_DISABLE_PREFILL_ADDRESS_FROM_BOLT_FOR_LOGGED_IN_CUSTOMER = "M2_IF_SHOULD_DISABLE_PREFILL_ADDRESS_FROM_BOLT_FOR_LOGGED_IN_CUSTOMER";
+
     const DEFAULT_SWITCH_VALUES = [
         self::M2_SAMPLE_SWITCH_NAME =>  [
           self::NAME_KEY            => self::M2_SAMPLE_SWITCH_NAME,
@@ -209,5 +214,11 @@ class Definitions
             self::DEFAULT_VAL_KEY     => false,
             self::ROLLOUT_KEY         => 100
         ],
+        self::M2_IF_SHOULD_DISABLE_PREFILL_ADDRESS_FROM_BOLT_FOR_LOGGED_IN_CUSTOMER =>  [
+            self::NAME_KEY            => self::M2_IF_SHOULD_DISABLE_PREFILL_ADDRESS_FROM_BOLT_FOR_LOGGED_IN_CUSTOMER,
+            self::VAL_KEY             => true,
+            self::DEFAULT_VAL_KEY     => false,
+            self::ROLLOUT_KEY         => 0
+        ]
     ];
 }


### PR DESCRIPTION
# Description
There is a merchant that doesn’t want to use the logic pre-fill address from Bolt for the logged-in customer. 
So I created this PR to implement a feature switch to toggle that logic

Fixes: 
https://boltpay.atlassian.net/browse/M2P-147
https://boltpay.atlassian.net/browse/EN-395

#changelog M2P-147 Implement a feature switch to toggle the logic to pre-fill address from Bolt for the logged-in customer

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
