### PR TITLE
M2P-140 Listen if 3p modules update quote total

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -2292,14 +2292,14 @@ if (!$block->isSaveCartInSections()) { ?>
         'Magento_Checkout/js/model/quote',
         'domReady!'
         ], function ($, customerData, quote) {
+            // If quote total was changed through a method we didn't create,
+            // we should reload the bolt cart since totals are probably now out of sync.
             quote.totals.subscribe(function (newValue) {
                 if (expectCartRendering) {
                     expectCartRendering = false;
                     return;
                 }
 
-                // If we don't expect cart rendering possible it caused by any third party plugin (for example, 3p coupon is applied)
-                // Bolt cart can be changes, it worth to invalidate
                 expectCartRendering = false;
                 if (waitingForResolvingPromises) {
                     return;

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -1258,6 +1258,9 @@ if (!$block->isSaveCartInSections()) { ?>
         return { promise: promise, resolve: function(t){resolveHolder(t)}};
     };
 
+    var expectCartRendering = true;
+    var waitingForResolvingPromises = false;
+
     ////////////////////////////////////////////////////
     // DI: Inserting required Magento objects
     // the code below is dependant on.
@@ -1698,7 +1701,6 @@ if (!$block->isSaveCartInSections()) { ?>
         /////////////////////////////////////////////////////
         var createRequest = false;
         var allowAutoOpen = true;
-        var waitingForResolvingPromises = false;
         var oldBoltCartValue = "";
         var BC;
         var hintBarrier;
@@ -2246,6 +2248,7 @@ if (!$block->isSaveCartInSections()) { ?>
         // When we know that cart will be updated soon we call configure with promises
         // to make sure bolt checkout with outdated cart isn't available for user
         $(document).on("ajax:addToCart", function () {
+            expectCartRendering = true;
             // If merchant shows popup after add to cart
             // delay 0 allows to render bolt button before we call configure
             setTimeout(callConfigureWithPromises, 0);
@@ -2258,9 +2261,11 @@ if (!$block->isSaveCartInSections()) { ?>
             invalidateBoltCart();
         });
         $(document).on("ajax:updateCartItemQty", function () {
+            expectCartRendering = true;
             callConfigureWithPromises();
         });
         $(document).on("ajax:removeFromCart", function () {
+            expectCartRendering = true;
             callConfigureWithPromises();
         });
 
@@ -2279,6 +2284,30 @@ if (!$block->isSaveCartInSections()) { ?>
         ////////////////////////////////////////////////////
         <?php echo $block->getAdditionalJavascript(); ?>
     });
+
+    if (trim(location.pathname, '/') === 'checkout/cart') {
+        require([
+        'jquery',
+        'Magento_Customer/js/customer-data',
+        'Magento_Checkout/js/model/quote',
+        'domReady!'
+        ], function ($, customerData, quote) {
+            quote.totals.subscribe(function (newValue) {
+                if (expectCartRendering) {
+                    expectCartRendering = false;
+                    return;
+                }
+
+                // If we don't expect cart rendering possible it caused by any third party plugin (for example, 3p coupon is applied)
+                // Bolt cart can be changes, it worth to invalidate
+                expectCartRendering = false;
+                if (waitingForResolvingPromises) {
+                    return;
+                }
+                customerData.reload(['boltcart'], true);
+            });
+       })
+    }
 </script>
 <?php
 }


### PR DESCRIPTION
If a third party plugin doesn't update Magento cart after discount applying we don't update bolt cart as well.
Solution: invalidate bolt cart if quote total was updated and we don't know a reason.
We don't want to invalidate bolt date if quote total updated when page is loaded, or after on of magento event (add to cart, etc)

Fixes: [M2P-140]

#changelog Fix an issue with some third party discounts modules

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
