### PR TITLE
M2P-149 Log composer version for debugging

### DIFF
--- a/Helper/Bugsnag.php
+++ b/Helper/Bugsnag.php
@@ -156,7 +156,8 @@ class Bugsnag extends AbstractHelper
                 'META DATA' => [
                     'store_url' => $this->storeManager->getStore()->getBaseUrl(
                         \Magento\Framework\UrlInterface::URL_TYPE_WEB
-                    )
+                    ),
+                    'composer_version' => $this->configHelper->getComposerVersion()
                 ]
             ]);
         });

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -26,6 +26,7 @@ use Magento\Framework\Module\ResourceInterface;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\Store;
 use Magento\Directory\Model\RegionFactory;
+use Magento\Framework\Composer\ComposerFactory;
 
 /**
  * Boltpay Configuration helper
@@ -36,6 +37,7 @@ use Magento\Directory\Model\RegionFactory;
 class Config extends AbstractHelper
 {
     const BOLT_TRACE_ID_HEADER = 'X-bolt-trace-id';
+    const BOLT_COMPOSER_NAME = 'boltpay/bolt-magento2';
 
     /**
      * @var BoltConfigSettingFactory
@@ -372,12 +374,18 @@ class Config extends AbstractHelper
     private $regionFactory;
 
     /**
-     * @param Context                  $context
-     * @param EncryptorInterface       $encryptor
-     * @param ResourceInterface        $moduleResource
+     * @var ComposerFactory
+     */
+    private $composerFactory;
+
+    /**
+     * @param Context $context
+     * @param EncryptorInterface $encryptor
+     * @param ResourceInterface $moduleResource
      * @param ProductMetadataInterface $productMetadata
      * @param BoltConfigSettingFactory $boltConfigSettingFactory
-     * @param RegionFactory            $regionFactory
+     * @param RegionFactory $regionFactory
+     * @param ComposerFactory $composerFactory
      *
      * @codeCoverageIgnore
      */
@@ -387,7 +395,8 @@ class Config extends AbstractHelper
         ResourceInterface $moduleResource,
         ProductMetadataInterface $productMetadata,
         BoltConfigSettingFactory $boltConfigSettingFactory,
-        RegionFactory $regionFactory
+        RegionFactory $regionFactory,
+        ComposerFactory $composerFactory
     ) {
         parent::__construct($context);
         $this->encryptor = $encryptor;
@@ -395,6 +404,7 @@ class Config extends AbstractHelper
         $this->productMetadata = $productMetadata;
         $this->boltConfigSettingFactory = $boltConfigSettingFactory;
         $this->regionFactory = $regionFactory;
+        $this->composerFactory = $composerFactory;
     }
 
     /**
@@ -455,6 +465,25 @@ class Config extends AbstractHelper
     public function getModuleVersion()
     {
         return $this->moduleResource->getDataVersion('Bolt_Boltpay');
+    }
+
+    /**
+     * @return string
+     * @throws \Exception
+     */
+    public function getComposerVersion()
+    {
+        try {
+            $boltComposerVersion = $this->composerFactory->create()
+                ->getLocker()
+                ->getLockedRepository()
+                ->findPackage(self::BOLT_COMPOSER_NAME, '*')
+                ->getVersion();
+        }catch (\Exception $exception) {
+            return null;
+        }
+
+        return $boltComposerVersion;
     }
 
     /**
@@ -1127,7 +1156,7 @@ class Config extends AbstractHelper
     /**
      * Get filter specified by name from "pageFilters" additional configuration
      *
-     * @param string $filterName   'whitelist'|'blacklist'
+     * @param string $filterName 'whitelist'|'blacklist'
      * @param int|string $storeId
      * @return array
      */

--- a/Model/Api/Data/DebugInfo.php
+++ b/Model/Api/Data/DebugInfo.php
@@ -27,6 +27,11 @@ class DebugInfo implements \JsonSerializable
     /**
      * @var string
      */
+    private $composerVersion;
+
+    /**
+     * @var string
+     */
     private $platformVersion;
 
     /**
@@ -60,6 +65,24 @@ class DebugInfo implements \JsonSerializable
     {
         $this->phpVersion = $phpVersion;
         return $this;
+    }
+
+    /**
+     * @param string $composerVersion
+     * @return $this
+     */
+    public function setComposerVersion($composerVersion)
+    {
+        $this->composerVersion = $composerVersion;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getComposerVersion()
+    {
+        return $this->composerVersion;
     }
 
     /**
@@ -142,6 +165,7 @@ class DebugInfo implements \JsonSerializable
     {
         return [
             'php_version' => $this->phpVersion,
+            'composer_version' => $this->composerVersion,
             'platform_version' => $this->platformVersion,
             'bolt_config_settings' => $this->boltConfigSettings,
             'other_plugin_versions' => $this->otherPluginVersions,

--- a/Model/Api/Debug.php
+++ b/Model/Api/Debug.php
@@ -119,11 +119,11 @@ class Debug implements DebugInterface
         # populate php version
         $result->setPhpVersion(PHP_VERSION);
 
+        # populate bolt config settings
+        $result->setComposerVersion($this->configHelper->getComposerVersion());
+
         # populate platform version
         $result->setPlatformVersion($this->productMetadata->getVersion());
-
-        # populate bolt config settings
-        $result->setBoltConfigSettings($this->configHelper->getAllConfigSettings());
 
         # populate bolt config settings
         $result->setBoltConfigSettings($this->configHelper->getAllConfigSettings());

--- a/Test/Unit/Block/Checkout/Cart/ComponentSwitcherProcessorTest.php
+++ b/Test/Unit/Block/Checkout/Cart/ComponentSwitcherProcessorTest.php
@@ -13,6 +13,7 @@ use Magento\Framework\Module\ResourceInterface;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject;
 use Magento\Directory\Model\RegionFactory;
+use Magento\Framework\Composer\ComposerFactory;
 
 /**
  * @coversDefaultClass \Bolt\Boltpay\Block\Checkout\Cart\ComponentSwitcherProcessor
@@ -57,7 +58,8 @@ class ComponentSwitcherProcessorTest extends TestCase
                     $this->createMock(ResourceInterface::class),
                     $this->createMock(ProductMetadataInterface::class),
                     $this->createMock(BoltConfigSettingFactory::class),
-                    $this->createMock(RegionFactory::class)
+                    $this->createMock(RegionFactory::class),
+                    $this->createMock(ComposerFactory::class)
                 ]
             )
             ->getMock();

--- a/Test/Unit/Block/Checkout/SuccessTest.php
+++ b/Test/Unit/Block/Checkout/SuccessTest.php
@@ -58,7 +58,8 @@ class SuccessTest extends \PHPUnit\Framework\TestCase
                     $this->createMock(\Magento\Framework\Module\ResourceInterface::class),
                     $this->createMock(\Magento\Framework\App\ProductMetadataInterface::class),
                     $this->createMock(BoltConfigSettingFactory::class),
-                    $this->createMock(\Magento\Directory\Model\RegionFactory::class)
+                    $this->createMock(\Magento\Directory\Model\RegionFactory::class),
+                    $this->createMock(\Magento\Framework\Composer\ComposerFactory::class)
                 ]
             )
             ->getMock();

--- a/Test/Unit/Block/JsProductPageTest.php
+++ b/Test/Unit/Block/JsProductPageTest.php
@@ -123,7 +123,8 @@ class JsProductPageTest extends \PHPUnit\Framework\TestCase
                     $this->createMock(\Magento\Framework\Module\ResourceInterface::class),
                     $this->createMock(\Magento\Framework\App\ProductMetadataInterface::class),
                     $this->createMock(BoltConfigSettingFactory::class),
-                    $this->createMock(\Magento\Directory\Model\RegionFactory::class)
+                    $this->createMock(\Magento\Directory\Model\RegionFactory::class),
+                    $this->createMock(\Magento\Framework\Composer\ComposerFactory::class)
                 ]
             )
             ->getMock();

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -24,6 +24,7 @@ use Bolt\Boltpay\Helper\Config as HelperConfig;
 use Bolt\Boltpay\Helper\FeatureSwitch\Decider;
 use Bolt\Boltpay\Model\Api\Data\BoltConfigSettingFactory;
 use Magento\Framework\App\Request\Http;
+use Magento\Framework\Composer\ComposerFactory;
 
 /**
  * Class JsTest
@@ -120,7 +121,8 @@ class JsTest extends \PHPUnit\Framework\TestCase
                     $this->createMock(\Magento\Framework\Module\ResourceInterface::class),
                     $this->createMock(\Magento\Framework\App\ProductMetadataInterface::class),
                     $this->createMock(BoltConfigSettingFactory::class),
-                    $this->createMock(\Magento\Directory\Model\RegionFactory::class)
+                    $this->createMock(\Magento\Directory\Model\RegionFactory::class),
+                    $this->createMock(ComposerFactory::class),
                 ]
             )
             ->getMock();

--- a/Test/Unit/Helper/BugsnagTest.php
+++ b/Test/Unit/Helper/BugsnagTest.php
@@ -39,6 +39,7 @@ class BugsnagTest extends TestCase
 {
     /** @var string Dummy store url */
     const STORE_URL = 'http://store.local/';
+    const COMPOSER_VERSION = 'composer_version';
 
     /** @var MockObject|Bugsnag mocked instance of the class tested */
     private $currentMock;
@@ -66,7 +67,7 @@ class BugsnagTest extends TestCase
     protected function setUp()
     {
         $this->contextMock = $this->createMock(Context::class);
-        $this->configHelperMock = $this->createMock(Config::class);
+        $this->configHelperMock = $this->createPartialMock(Config::class, ['getComposerVersion','isSandboxModeSet','isTestEnvSet','getModuleVersion']);
         $this->directoryListMock = $this->createMock(DirectoryList::class);
         $this->storeManagerMock = $this->createPartialMock(StoreManager::class, ['getStore', 'getBaseUrl']);
         $this->bugsnagMock = $this->createMock(BugsnagClient::class);
@@ -77,6 +78,12 @@ class BugsnagTest extends TestCase
             $this->currentMock,
             'storeManager',
             $this->storeManagerMock
+        );
+
+        TestHelper::setProperty(
+            $this->currentMock,
+            'configHelper',
+            $this->configHelperMock
         );
     }
 
@@ -205,6 +212,7 @@ class BugsnagTest extends TestCase
         $this->storeManagerMock->expects(static::once())->method('getStore')->willReturnSelf();
         $this->storeManagerMock->expects(static::once())->method('getBaseUrl')->with(UrlInterface::URL_TYPE_WEB)
             ->willReturn(self::STORE_URL);
+        $this->configHelperMock->expects(static::once())->method('getComposerVersion')->willReturn(self::COMPOSER_VERSION);
         $this->bugsnagMock->expects(static::once())->method('registerCallback')->with(
             static::callback(
                 function ($callback) {
@@ -212,7 +220,8 @@ class BugsnagTest extends TestCase
                     $reportMock->expects(static::once())->method('addMetaData')->with(
                         [
                             'META DATA' => [
-                                'store_url' => self::STORE_URL
+                                'store_url' => self::STORE_URL,
+                                'composer_version' => self::COMPOSER_VERSION
                             ]
                         ]
                     );

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -18,6 +18,7 @@
 namespace Bolt\Boltpay\Test\Unit\Helper;
 
 use Bolt\Boltpay\Helper\Config as BoltConfig;
+use Bolt\Boltpay\Helper\Config;
 use Bolt\Boltpay\Model\Api\Data\BoltConfigSetting;
 use Bolt\Boltpay\Model\Api\Data\BoltConfigSettingFactory;
 use Magento\Framework\App\Config\ScopeConfigInterface;
@@ -30,6 +31,7 @@ use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Magento\Directory\Model\RegionFactory;
 use Bolt\Boltpay\Test\Unit\TestHelper;
+use Magento\Framework\Composer\ComposerFactory;
 
 /**
  * @coversDefaultClass \Bolt\Boltpay\Helper\Config
@@ -123,6 +125,16 @@ JSON;
     private $regionFactory;
 
     /**
+     * @var ComposerFactory
+     */
+    private $composerFactory;
+
+    /**
+     * @var BoltConfigSettingFactory
+     */
+    private $boltConfigSettingFactoryMock;
+
+    /**
      * @inheritdoc
      */
     public function setUp()
@@ -154,6 +166,8 @@ JSON;
             return new BoltConfigSetting();
         });
 
+        $this->composerFactory = $this->createPartialMock(ComposerFactory::class, ['create', 'getLocker', 'getLockedRepository', 'findPackage', 'getVersion']);
+
         $methods = ['getScopeConfig'];
         $this->initCurrentMock($methods);
 
@@ -179,7 +193,8 @@ JSON;
                                 $this->moduleResource,
                                 $this->productMetadata,
                                 $this->boltConfigSettingFactoryMock,
-                                $this->regionFactory
+                                $this->regionFactory,
+                                $this->composerFactory
                             ]
                         )
                         ->setMethods($methods);
@@ -1263,5 +1278,30 @@ Room 4000',
             ['value', ['value']],
             ['value1,value2', ['value1','value2']],
         ];
+    }
+
+    /**
+     * @test
+     */
+    public function getComposerVersion() {
+        $this->composerFactory->expects(self::once())->method('create')->willReturnSelf();
+        $this->composerFactory->expects(self::once())->method('getLocker')->willReturnSelf();
+        $this->composerFactory->expects(self::once())->method('getLockedRepository')->willReturnSelf();
+        $this->composerFactory->expects(self::once())->method('findPackage')->with(Config::BOLT_COMPOSER_NAME,'*')->willReturnSelf();
+        $this->composerFactory->expects(self::once())->method('getVersion')->willReturn('dev-test-feature');
+        $this->assertEquals('dev-test-feature', $this->currentMock->getComposerVersion());
+    }
+
+    /**
+     * @test
+     */
+    public function getComposerVersion_withException_returnNull() {
+        $this->composerFactory->expects(self::once())->method('create')->willReturnSelf();
+        $this->composerFactory->expects(self::once())->method('getLocker')->willReturnSelf();
+        $this->composerFactory->expects(self::once())->method('getLockedRepository')->willReturnSelf();
+        $this->composerFactory->expects(self::once())->method('findPackage')->with(Config::BOLT_COMPOSER_NAME,'*')->willReturnSelf();
+        $e = new \Exception(__('Test'));
+        $this->composerFactory->expects(self::once())->method('getVersion')->willThrowException($e);
+        $this->assertNull($this->currentMock->getComposerVersion());
     }
 }

--- a/Test/Unit/Model/Api/Data/DebugInfoTest.php
+++ b/Test/Unit/Model/Api/Data/DebugInfoTest.php
@@ -35,6 +35,7 @@ class DebugInfoTest extends TestCase
     {
         $this->debugInfo = new DebugInfo();
         $this->debugInfo->setPhpVersion('7.1');
+        $this->debugInfo->setComposerVersion('composer_version');
         $this->debugInfo->setPlatformVersion('magento231');
         $this->debugInfo->setOtherPluginVersions('other');
         $this->debugInfo->setBoltConfigSettings('boltConfigSetting');
@@ -47,6 +48,14 @@ class DebugInfoTest extends TestCase
     public function setAndGetPhpVersion()
     {
         $this->assertEquals('7.1', $this->debugInfo->getPhpVersion());
+    }
+
+    /**
+     * @test
+     */
+    public function setAndGetComposerVersion()
+    {
+        $this->assertEquals('composer_version', $this->debugInfo->getComposerVersion());
     }
 
     /**
@@ -92,6 +101,7 @@ class DebugInfoTest extends TestCase
                 'logs' => [],
                 'other_plugin_versions' => 'other',
                 'php_version' => '7.1',
+                'composer_version' => 'composer_version',
                 'platform_version' => 'magento231',
             ],
             $this->debugInfo->jsonSerialize()

--- a/Test/Unit/Model/Api/DebugTest.php
+++ b/Test/Unit/Model/Api/DebugTest.php
@@ -173,6 +173,7 @@ class DebugTest extends TestCase
                                                              ->setName('config_name2')
                                                              ->setValue('config_value2');
         $this->configHelperMock->method('getAllConfigSettings')->willReturn($boltSettings);
+        $this->configHelperMock->method('getComposerVersion')->willReturn('composer_version');
     }
 
     /**
@@ -189,6 +190,7 @@ class DebugTest extends TestCase
             'event' => 'integration.debug',
             'data' => [
                 'php_version' => PHP_VERSION,
+                'composer_version' => 'composer_version',
                 'platform_version' => '2.3.0',
                 'bolt_config_settings' => [
                     [


### PR DESCRIPTION
# Description
Sometimes, it’s useful to know the merchant’s composer version, especially for debugging an issue without the codebase access.

This PR provides the ability to log the composer version to Bugsnag and Debug Webhook.
See demo screenshots below: 
https://prnt.sc/ti602e
https://prnt.sc/tiyn61

Fixes: https://boltpay.atlassian.net/browse/M2P-149

#changelog M2P-149 Log composer version for debugging

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
