### PR TITLE
M2P-137 General plugin support for Amasty GiftCard 2.0.0 or later

### DIFF
--- a/Helper/Discount.php
+++ b/Helper/Discount.php
@@ -30,7 +30,6 @@ use \Magento\Framework\Event\Observer;
 use \Magento\Backend\App\Area\FrontNameResolver;
 use \Magento\Framework\App\State as AppState;
 use Bolt\Boltpay\Helper\Log as LogHelper;
-use Magento\Customer\Model\Session as CustomerSession;
 
 /**
  * Boltpay Discount helper class
@@ -198,11 +197,6 @@ class Discount extends AbstractHelper
      * @var LogHelper
      */
     private $logHelper;
-    
-    /**
-     * @var CustomerSession
-     */
-    private $customerSession;
 
     /**
      * Discount constructor.
@@ -237,7 +231,6 @@ class Discount extends AbstractHelper
      * @param AppState                $appState
      * @param Session                 $sessionHelper
      * @param LogHelper               $logHelper
-     * @param CustomerSession         $customerSession
      */
     public function __construct(
         Context $context,
@@ -269,8 +262,7 @@ class Discount extends AbstractHelper
         Bugsnag $bugsnag,
         AppState $appState,
         Session $sessionHelper,
-        LogHelper $logHelper,
-        CustomerSession $customerSession
+        LogHelper $logHelper
     ) {
         parent::__construct($context);
         $this->resource = $resource;
@@ -302,7 +294,6 @@ class Discount extends AbstractHelper
         $this->appState = $appState;
         $this->sessionHelper = $sessionHelper;
         $this->logHelper = $logHelper;
-        $this->customerSession = $customerSession;
     }
     
     /**

--- a/Helper/Discount.php
+++ b/Helper/Discount.php
@@ -30,6 +30,7 @@ use \Magento\Framework\Event\Observer;
 use \Magento\Backend\App\Area\FrontNameResolver;
 use \Magento\Framework\App\State as AppState;
 use Bolt\Boltpay\Helper\Log as LogHelper;
+use Magento\Customer\Model\Session as CustomerSession;
 
 /**
  * Boltpay Discount helper class
@@ -59,32 +60,47 @@ class Discount extends AbstractHelper
     /**
      * @var ThirdPartyModuleFactory
      */
+    protected $amastyLegacyAccountFactory;
+    
+    /**
+     * @var ThirdPartyModuleFactory
+     */
+    protected $amastyLegacyGiftCardManagement;
+    
+    /**
+     * @var ThirdPartyModuleFactory
+     */
+    protected $amastyLegacyQuoteFactory;
+    
+    /**
+     * @var ThirdPartyModuleFactory
+     */
+    protected $amastyLegacyQuoteResource;
+    
+    /**
+     * @var ThirdPartyModuleFactory
+     */
+    protected $amastyLegacyQuoteRepository;
+    
+    /**
+     * @var ThirdPartyModuleFactory
+     */
+    protected $amastyLegacyAccountCollection;
+    
+    /**
+     * @var ThirdPartyModuleFactory
+     */
     protected $amastyAccountFactory;
-
+    
     /**
      * @var ThirdPartyModuleFactory
      */
-    private $amastyGiftCardManagement;
-
+    protected $amastyGiftCardAccountManagement;
+    
     /**
      * @var ThirdPartyModuleFactory
      */
-    protected $amastyQuoteFactory;
-
-    /**
-     * @var ThirdPartyModuleFactory
-     */
-    protected $amastyQuoteResource;
-
-    /**
-     * @var ThirdPartyModuleFactory
-     */
-    protected $amastyQuoteRepository;
-
-    /**
-     * @var ThirdPartyModuleFactory
-     */
-    protected $amastyAccountCollection;
+    protected $amastyGiftCardAccountCollection;
 
     /**
      * @var ThirdPartyModuleFactory
@@ -182,18 +198,26 @@ class Discount extends AbstractHelper
      * @var LogHelper
      */
     private $logHelper;
+    
+    /**
+     * @var CustomerSession
+     */
+    private $customerSession;
 
     /**
      * Discount constructor.
      *
      * @param Context                 $context
      * @param ResourceConnection      $resource
+     * @param ThirdPartyModuleFactory $amastyLegacyAccountFactory
+     * @param ThirdPartyModuleFactory $amastyLegacyGiftCardManagement
+     * @param ThirdPartyModuleFactory $amastyLegacyQuoteFactory
+     * @param ThirdPartyModuleFactory $amastyLegacyQuoteResource
+     * @param ThirdPartyModuleFactory $amastyLegacyQuoteRepository
+     * @param ThirdPartyModuleFactory $amastyLegacyAccountCollection
      * @param ThirdPartyModuleFactory $amastyAccountFactory
-     * @param ThirdPartyModuleFactory $amastyGiftCardManagement
-     * @param ThirdPartyModuleFactory $amastyQuoteFactory
-     * @param ThirdPartyModuleFactory $amastyQuoteResource
-     * @param ThirdPartyModuleFactory $amastyQuoteRepository
-     * @param ThirdPartyModuleFactory $amastyAccountCollection
+     * @param ThirdPartyModuleFactory $amastyGiftCardAccountManagement
+     * @param ThirdPartyModuleFactory $amastyGiftCardAccountCollection
      * @param ThirdPartyModuleFactory $unirgyCertRepository
      * @param ThirdPartyModuleFactory $mirasvitStoreCreditHelper
      * @param ThirdPartyModuleFactory $mirasvitStoreCreditCalculationHelper
@@ -213,16 +237,20 @@ class Discount extends AbstractHelper
      * @param AppState                $appState
      * @param Session                 $sessionHelper
      * @param LogHelper               $logHelper
+     * @param CustomerSession         $customerSession
      */
     public function __construct(
         Context $context,
         ResourceConnection $resource,
+        ThirdPartyModuleFactory $amastyLegacyAccountFactory,
+        ThirdPartyModuleFactory $amastyLegacyGiftCardManagement,
+        ThirdPartyModuleFactory $amastyLegacyQuoteFactory,
+        ThirdPartyModuleFactory $amastyLegacyQuoteResource,
+        ThirdPartyModuleFactory $amastyLegacyQuoteRepository,
+        ThirdPartyModuleFactory $amastyLegacyAccountCollection,
         ThirdPartyModuleFactory $amastyAccountFactory,
-        ThirdPartyModuleFactory $amastyGiftCardManagement,
-        ThirdPartyModuleFactory $amastyQuoteFactory,
-        ThirdPartyModuleFactory $amastyQuoteResource,
-        ThirdPartyModuleFactory $amastyQuoteRepository,
-        ThirdPartyModuleFactory $amastyAccountCollection,
+        ThirdPartyModuleFactory $amastyGiftCardAccountManagement,
+        ThirdPartyModuleFactory $amastyGiftCardAccountCollection,
         ThirdPartyModuleFactory $unirgyCertRepository,
         ThirdPartyModuleFactory $mirasvitStoreCreditHelper,
         ThirdPartyModuleFactory $mirasvitStoreCreditCalculationHelper,
@@ -241,16 +269,20 @@ class Discount extends AbstractHelper
         Bugsnag $bugsnag,
         AppState $appState,
         Session $sessionHelper,
-        LogHelper $logHelper
+        LogHelper $logHelper,
+        CustomerSession $customerSession
     ) {
         parent::__construct($context);
         $this->resource = $resource;
+        $this->amastyLegacyAccountFactory = $amastyLegacyAccountFactory;
+        $this->amastyLegacyGiftCardManagement = $amastyLegacyGiftCardManagement;
+        $this->amastyLegacyQuoteFactory = $amastyLegacyQuoteFactory;
+        $this->amastyLegacyQuoteResource = $amastyLegacyQuoteResource;
+        $this->amastyLegacyQuoteRepository = $amastyLegacyQuoteRepository;
+        $this->amastyLegacyAccountCollection = $amastyLegacyAccountCollection;
         $this->amastyAccountFactory = $amastyAccountFactory;
-        $this->amastyGiftCardManagement = $amastyGiftCardManagement;
-        $this->amastyQuoteFactory = $amastyQuoteFactory;
-        $this->amastyQuoteResource = $amastyQuoteResource;
-        $this->amastyQuoteRepository = $amastyQuoteRepository;
-        $this->amastyAccountCollection = $amastyAccountCollection;
+        $this->amastyGiftCardAccountManagement = $amastyGiftCardAccountManagement;
+        $this->amastyGiftCardAccountCollection = $amastyGiftCardAccountCollection;
         $this->unirgyCertRepository = $unirgyCertRepository;
         $this->mirasvitStoreCreditHelper = $mirasvitStoreCreditHelper;
         $this->mirasvitStoreCreditCalculationHelper = $mirasvitStoreCreditCalculationHelper;
@@ -270,17 +302,9 @@ class Discount extends AbstractHelper
         $this->appState = $appState;
         $this->sessionHelper = $sessionHelper;
         $this->logHelper = $logHelper;
+        $this->customerSession = $customerSession;
     }
-
-    /**
-     * Check whether the Amasty Gift Card module is available (installed and enabled)
-     * @return bool
-     */
-    public function isAmastyGiftCardAvailable()
-    {
-        return $this->amastyAccountFactory->isAvailable();
-    }
-
+    
     /**
      * Collect and update quote totals.
      * @param Quote $quote
@@ -295,6 +319,20 @@ class Discount extends AbstractHelper
     }
 
     /**
+     * Check whether the Amasty Gift Card module is available (installed and enabled)
+     * @return bool
+     */
+    public function isAmastyGiftCardAvailable()
+    {
+        return ($this->amastyAccountFactory->isAvailable() || $this->amastyLegacyAccountFactory->isAvailable());
+    }
+    
+    public function isAmastyGiftCardLegacyVersion()
+    {
+        return $this->amastyLegacyAccountFactory->isExists();
+    }
+
+    /**
      * Load Amasty Gift Card account object.
      * @param string $code Gift Card coupon code
      * @param string|int $websiteId
@@ -306,10 +344,17 @@ class Discount extends AbstractHelper
             if (!$this->isAmastyGiftCardAvailable()) {
                 return null;
             }
-
-            $accountModel = $this->amastyAccountFactory->getInstance()
-                ->create()
-                ->loadByCode($code);
+            
+            if ($this->isAmastyGiftCardLegacyVersion()) {
+                $accountModel = $this->amastyLegacyAccountFactory->getInstance()
+                    ->create()
+                    ->loadByCode($code);
+            } else {
+                $accountModel = $this->amastyAccountFactory->getInstance()
+                    ->create()
+                    ->getByCode($code);    
+            }
+                
             return $accountModel && $accountModel->getId()
                    && (! $accountModel->getWebsiteId() || $accountModel->getWebsiteId() == $websiteId)
                    ? $accountModel : null;
@@ -322,61 +367,80 @@ class Discount extends AbstractHelper
      * Apply Amasty Gift Card coupon to cart
      *
      * @param string $code Gift Card coupon code
-     * @param \Amasty\GiftCard\Model\Account $accountModel
+     * @param \Amasty\GiftCardAccount\Model\GiftCardAccount\Account $accountModel
      * @param Quote $quote
      * @return float
      * @throws LocalizedException
      */
     public function applyAmastyGiftCard($code, $accountModel, $quote)
     {
+        if (!$this->isAmastyGiftCardAvailable()) {
+            return null;
+        }
+            
         // Get current gift card balance before applying it to the quote
         // in case "fixed_amount" / "pay for everything" discount type is used
         $giftAmount = $accountModel->getCurrentValue();
 
         $quoteId = $quote->getId();
+        
+        if ($this->isAmastyGiftCardLegacyVersion()) {
+            $isValid = $this->amastyLegacyGiftCardManagement->getInstance()->validateCode($quote, $code);
 
-        $isValid = $this->amastyGiftCardManagement->getInstance()->validateCode($quote, $code);
-
-        if (!$isValid) {
-            throw new LocalizedException(__('Coupon with specified code "%1" is not valid.', $code));
-        }
-
-        if ($accountModel->canApplyCardForQuote($quote)) {
-            $quoteGiftCard = $this->amastyQuoteFactory->getInstance()->create();
-            $this->amastyQuoteResource->getInstance()->load($quoteGiftCard, $quoteId, 'quote_id');
-            $subtotal = $quoteGiftCard->getSubtotal($quote);
-
-            if ($quoteGiftCard->getCodeId() && $accountModel->getCodeId() == $quoteGiftCard->getCodeId()) {
-
-                throw new LocalizedException(__('This gift card account is already in the quote.'));
-
-            } elseif ($quoteGiftCard->getGiftAmount() && $subtotal == $quoteGiftCard->getGiftAmount()) {
-
-                throw new LocalizedException(__('Gift card can\'t be applied. Maximum discount reached.'));
-
-            } else {
-                $quoteGiftCard->unsetData($quoteGiftCard->getIdFieldName());
-                $quoteGiftCard->setQuoteId($quoteId);
-                $quoteGiftCard->setCodeId($accountModel->getCodeId());
-                $quoteGiftCard->setAccountId($accountModel->getId());
-
-                $this->amastyQuoteRepository->getInstance()->save($quoteGiftCard);
-                $this->updateTotals($quote);
-
-                if ($this->getAmastyPayForEverything()) {
-                    // pay for everything, items, shipping, tax
-                    return $giftAmount;
+            if (!$isValid) {
+                throw new LocalizedException(__('Coupon with specified code "%1" is not valid.', $code));
+            }
+    
+            if ($accountModel->canApplyCardForQuote($quote)) {
+                $quoteGiftCard = $this->amastyLegacyQuoteFactory->getInstance()->create();
+                $this->amastyLegacyQuoteResource->getInstance()->load($quoteGiftCard, $quoteId, 'quote_id');
+                $subtotal = $quoteGiftCard->getSubtotal($quote);
+    
+                if ($quoteGiftCard->getCodeId() && $accountModel->getCodeId() == $quoteGiftCard->getCodeId()) {
+    
+                    throw new LocalizedException(__('This gift card account is already in the quote.'));
+    
+                } elseif ($quoteGiftCard->getGiftAmount() && $subtotal == $quoteGiftCard->getGiftAmount()) {
+    
+                    throw new LocalizedException(__('Gift card can\'t be applied. Maximum discount reached.'));
+    
                 } else {
-                    // pay for items only
-                    $totals = $quote->getTotals();
-                    return $totals[self::AMASTY_GIFTCARD]->getValue();
+                    $quoteGiftCard->unsetData($quoteGiftCard->getIdFieldName());
+                    $quoteGiftCard->setQuoteId($quoteId);
+                    $quoteGiftCard->setCodeId($accountModel->getCodeId());
+                    $quoteGiftCard->setAccountId($accountModel->getId());
+    
+                    $this->amastyLegacyQuoteRepository->getInstance()->save($quoteGiftCard);
+                    $this->updateTotals($quote);
+    
+                    if ($this->getAmastyPayForEverything()) {
+                        // pay for everything, items, shipping, tax
+                        return $giftAmount;
+                    } else {
+                        // pay for items only
+                        $totals = $quote->getTotals();
+                        return $totals[self::AMASTY_GIFTCARD]->getValue();
+                    }
                 }
+            } else {
+                throw new LocalizedException(__('Gift card can\'t be applied.'));
             }
         } else {
-            throw new LocalizedException(__('Gift card can\'t be applied.'));
-        }
-    }
+            $giftCardCode = $this->amastyGiftCardAccountManagement->getInstance()->applyGiftCardToCart($quoteId, $code);
+            
+            if ($this->getAmastyPayForEverything()) {
+                // pay for everything, items, shipping, tax
+                return $giftAmount;
+            } else {
+                $activeQuote = $this->quoteRepository->getActive($quoteId);
+                // pay for items only
+                $totals = $activeQuote->getTotals();
 
+                return $totals[self::AMASTY_GIFTCARD]->getValue();
+            }
+        }        
+    }
+    
     /**
      * Copy Amasty Gift Cart data from source to destination quote
      *
@@ -391,16 +455,30 @@ class Discount extends AbstractHelper
         $connection = $this->resource->getConnection();
         $connection->beginTransaction();
         try {
-            $giftCardTable = $this->resource->getTableName('amasty_amgiftcard_quote');
+            if ($this->isAmastyGiftCardLegacyVersion()) {
+                $giftCardTable = $this->resource->getTableName('amasty_amgiftcard_quote');
 
-            // Clear previously applied gift cart codes from the immutable quote
-            $sql = "DELETE FROM {$giftCardTable} WHERE quote_id = :destination_quote_id";
-            $connection->query($sql, ['destination_quote_id' => $destinationQuoteId]);
+                // Clear previously applied gift cart codes from the immutable quote
+                $sql = "DELETE FROM {$giftCardTable} WHERE quote_id = :destination_quote_id";
+                $connection->query($sql, ['destination_quote_id' => $destinationQuoteId]);
+    
+                // Copy all gift cart codes applied to the parent quote to the immutable quote
+                $sql = "INSERT INTO {$giftCardTable} (quote_id, code_id, account_id, base_gift_amount, code) 
+                        SELECT :destination_quote_id, code_id, account_id, base_gift_amount, code
+                        FROM {$giftCardTable} WHERE quote_id = :source_quote_id";
+            } else {
+                $giftCardTable = $this->resource->getTableName('amasty_giftcard_quote');
+    
+                // Clear previously applied gift cart codes from the immutable quote
+                $sql = "DELETE FROM {$giftCardTable} WHERE quote_id = :destination_quote_id";
+                $connection->query($sql, ['destination_quote_id' => $destinationQuoteId]);
+    
+                // Copy all gift cart codes applied to the parent quote to the immutable quote
+                $sql = "INSERT INTO {$giftCardTable} (quote_id, gift_cards, gift_amount, base_gift_amount, gift_amount_used, base_gift_amount_used) 
+                        SELECT :destination_quote_id, gift_cards, gift_amount, base_gift_amount, gift_amount_used, base_gift_amount_used
+                        FROM {$giftCardTable} WHERE quote_id = :source_quote_id";
+            }
 
-            // Copy all gift cart codes applied to the parent quote to the immutable quote
-            $sql = "INSERT INTO {$giftCardTable} (quote_id, code_id, account_id, base_gift_amount, code) 
-                    SELECT :destination_quote_id, code_id, account_id, base_gift_amount, code
-                    FROM {$giftCardTable} WHERE quote_id = :source_quote_id";
             $connection->query($sql, ['destination_quote_id' => $destinationQuoteId, 'source_quote_id' => $sourceQuoteId]);
 
             $connection->commit();
@@ -422,7 +500,11 @@ class Discount extends AbstractHelper
         }
         $connection = $this->resource->getConnection();
         try {
-            $giftCardTable = $this->resource->getTableName('amasty_amgiftcard_quote');
+            if ($this->isAmastyGiftCardLegacyVersion()) {
+                $giftCardTable = $this->resource->getTableName('amasty_amgiftcard_quote');
+            } else {
+                $giftCardTable = $this->resource->getTableName('amasty_giftcard_quote');    
+            }
 
             $sql = "DELETE FROM {$giftCardTable} WHERE quote_id = :quote_id";
             $bind = [
@@ -447,12 +529,18 @@ class Discount extends AbstractHelper
         }
         $connection = $this->resource->getConnection();
         try {
-            $giftCardTable = $this->resource->getTableName('amasty_amgiftcard_quote');
+            if ($this->isAmastyGiftCardLegacyVersion()) {
+                $giftCardTable = $this->resource->getTableName('amasty_amgiftcard_quote');
+            } else {
+                $giftCardTable = $this->resource->getTableName('amasty_giftcard_quote');    
+            }
+
             $quoteTable = $this->resource->getTableName('quote');
 
             $sql = "DELETE FROM {$giftCardTable} WHERE quote_id IN 
                     (SELECT entity_id FROM {$quoteTable} 
                     WHERE bolt_parent_quote_id = :bolt_parent_quote_id AND entity_id != :entity_id)";
+            
             $bind = [
                 'bolt_parent_quote_id' => $quote->getBoltParentQuoteId(),
                 'entity_id' => $quote->getBoltParentQuoteId()
@@ -475,15 +563,38 @@ class Discount extends AbstractHelper
         if (! $this->isAmastyGiftCardAvailable()) {
             return;
         }
-        $connection = $this->resource->getConnection();
+        
         try {
-            $giftCardTable = $this->resource->getTableName('amasty_amgiftcard_quote');
+            $connection = $this->resource->getConnection();
+            if ($this->isAmastyGiftCardLegacyVersion()) {                
+                $giftCardTable = $this->resource->getTableName('amasty_amgiftcard_quote');
 
-            $sql = "DELETE FROM {$giftCardTable} WHERE code_id = :code_id AND quote_id = :quote_id";
-            $connection->query($sql, ['code_id' => $codeId, 'quote_id' => $quote->getId()]);
+                $sql = "DELETE FROM {$giftCardTable} WHERE code_id = :code_id AND quote_id = :quote_id";
+                $connection->query($sql, ['code_id' => $codeId, 'quote_id' => $quote->getId()]);
+    
+                $this->updateTotals($quote);
+            } else {
+                if ($quote->getExtensionAttributes() && $quote->getExtensionAttributes()->getAmGiftcardQuote()) {
+                    $cards = $quote->getExtensionAttributes()->getAmGiftcardQuote()->getGiftCards();
+                }
 
-            $this->updateTotals($quote);
+                $giftCodeExists = false;
+                $giftCode = '';
+                foreach ($cards as $k => $card) {
+                    if($card['id'] == $codeId) {
+                        $giftCodeExists = true;
+                        $giftCode = $card['code'];
+                        break;
+                    }
+                }
+                
+                if($giftCodeExists) {
+                    $this->amastyGiftCardAccountManagement->getInstance()->removeGiftCardFromCart($quote->getId(), $giftCode);                   
+                }                
+            }
         } catch (\Zend_Db_Statement_Exception $e) {
+            $this->bugsnag->notifyException($e);
+        } catch (\Exception $e) {
             $this->bugsnag->notifyException($e);
         }
     }
@@ -526,13 +637,30 @@ class Discount extends AbstractHelper
      */
     public function getAmastyGiftCardCodesCurrentValue($giftCardCodes)
     {
-        $data = $this->amastyAccountCollection
-            ->getInstance()
-            ->joinCode()
-            ->addFieldToFilter('gift_code', ['in'=>$giftCardCodes])
-            ->getData();
-
-        return array_sum(array_column($data, 'current_value'));
+        if (! $this->isAmastyGiftCardAvailable()) {
+            return;
+        }
+        
+        try {
+            if ($this->isAmastyGiftCardLegacyVersion()) {
+                $data = $this->amastyLegacyAccountCollection
+                    ->getInstance()
+                    ->joinCode()
+                    ->addFieldToFilter('gift_code', ['in'=>$giftCardCodes])
+                    ->getData();
+            } else {
+                $data = $this->amastyGiftCardAccountCollection
+                    ->getInstance()
+                    ->addCodeTable()
+                    ->addFieldToFilter('code', ['in'=>$giftCardCodes])
+                    ->getData();    
+            }        
+    
+            return array_sum(array_column($data, 'current_value'));
+        } catch (\Exception $e) {
+            $this->bugsnag->notifyException($e);
+            return null;
+        }
     }
 
 

--- a/Helper/Discount.php
+++ b/Helper/Discount.php
@@ -327,6 +327,10 @@ class Discount extends AbstractHelper
         return ($this->amastyAccountFactory->isAvailable() || $this->amastyLegacyAccountFactory->isAvailable());
     }
     
+    /**
+     * Check whether the Amasty Gift Card module is legacy version
+     * @return bool
+     */
     public function isAmastyGiftCardLegacyVersion()
     {
         return $this->amastyLegacyAccountFactory->isExists();

--- a/Model/Api/DiscountCodeValidation.php
+++ b/Model/Api/DiscountCodeValidation.php
@@ -685,7 +685,7 @@ class DiscountCodeValidation implements DiscountCodeValidationInterface
     private function applyingGiftCardCode($code, $giftCard, $immutableQuote, $parentQuote)
     {
         try {
-            if ($giftCard instanceof \Amasty\GiftCard\Model\Account) {
+            if ($giftCard instanceof \Amasty\GiftCard\Model\Account || $giftCard instanceof \Amasty\GiftCardAccount\Model\GiftCardAccount\Account) {
                 // Remove Amasty Gift Card if already applied
                 // to avoid errors on multiple calls to discount validation API
                 // from the Bolt checkout (changing the address, going back and forth)

--- a/Model/ThirdPartyModuleFactory.php
+++ b/Model/ThirdPartyModuleFactory.php
@@ -77,7 +77,17 @@ class ThirdPartyModuleFactory
      */
     public function isExists()
     {
-        return class_exists($this->className);
+        ///////////////////////////////////////////////////////////////
+        // Due to a known bug https://github.com/magento/magento2/pull/21435,
+        // the autoloader throws an exception on class_exists.
+        // Add try-catch block to avoid uncaught exceptions during autoloading.
+        // Return false instead if any uncaught exceptions.
+        ///////////////////////////////////////////////////////////////
+        try {
+            return class_exists($this->className);
+        } catch (\Exception $e) {
+            return false;
+        }
     }
 
     /**

--- a/Model/ThirdPartyModuleFactory.php
+++ b/Model/ThirdPartyModuleFactory.php
@@ -70,6 +70,15 @@ class ThirdPartyModuleFactory
     {
         return $this->_moduleManager->isEnabled($this->moduleName);
     }
+    
+    /**
+     * Check whether the class exists
+     * @return bool
+     */
+    public function isExists()
+    {
+        return class_exists($this->className);
+    }
 
     /**
      * @param array $data
@@ -77,7 +86,7 @@ class ThirdPartyModuleFactory
      */
     public function getInstance(array $data = [])
     {
-        if ($this->isAvailable()) {
+        if ($this->isAvailable() && $this->isExists()) {
             $this->logHelper->addInfoLog('# Module is Enabled: ' . $this->moduleName);
             $this->logHelper->addInfoLog('# Class: ' . $this->className);
             return $this->_objectManager->create($this->className, $data);

--- a/Test/Unit/Helper/DiscountTest.php
+++ b/Test/Unit/Helper/DiscountTest.php
@@ -1166,8 +1166,8 @@ class DiscountTest extends TestCase
         $deleteSql = "DELETE FROM {$testTableName} WHERE quote_id = :destination_quote_id";
 
         $sqlInsert = "INSERT INTO {$testTableName} (quote_id, gift_cards, gift_amount, base_gift_amount, gift_amount_used, base_gift_amount_used) 
-                    SELECT :destination_quote_id, gift_cards, gift_amount, base_gift_amount, gift_amount_used, base_gift_amount_used
-                    FROM {$testTableName} WHERE quote_id = :source_quote_id";
+                        SELECT :destination_quote_id, gift_cards, gift_amount, base_gift_amount, gift_amount_used, base_gift_amount_used
+                        FROM {$testTableName} WHERE quote_id = :source_quote_id";
 
         $this->connectionMock->expects(static::exactly(2))->method('query')->withConsecutive(
             [$deleteSql, ['destination_quote_id' => $destinationQuoteId]],
@@ -1205,8 +1205,8 @@ class DiscountTest extends TestCase
         $deleteSql = "DELETE FROM {$testTableName} WHERE quote_id = :destination_quote_id";
 
         $sqlInsert = "INSERT INTO {$testTableName} (quote_id, code_id, account_id, base_gift_amount, code) 
-                      SELECT :destination_quote_id, code_id, account_id, base_gift_amount, code
-                      FROM {$testTableName} WHERE quote_id = :source_quote_id";
+                        SELECT :destination_quote_id, code_id, account_id, base_gift_amount, code
+                        FROM {$testTableName} WHERE quote_id = :source_quote_id";
 
         $this->connectionMock->expects(static::exactly(2))->method('query')->withConsecutive(
             [$deleteSql, ['destination_quote_id' => $destinationQuoteId]],

--- a/Test/Unit/Helper/DiscountTest.php
+++ b/Test/Unit/Helper/DiscountTest.php
@@ -726,8 +726,8 @@ class DiscountTest extends TestCase
             ->setMethods(['getInstance', 'validateCode'])
             ->disableOriginalConstructor()
             ->getMock();
-
-        TestHelper::setProperty($this->currentMock, 'amastyGiftCardManagement', $amastyGiftCardMock);
+                                                     
+        TestHelper::setProperty($this->currentMock, 'amastyLegacyGiftCardManagement', $amastyGiftCardMock);
 
         $amastyGiftCardMock->expects(static::once())->method('getInstance')->willReturnSelf();
         $amastyGiftCardMock->expects(static::once())->method('validateCode')->with($quote, $code)->willReturn($isValid);
@@ -755,7 +755,7 @@ class DiscountTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        TestHelper::setProperty($this->currentMock, 'amastyQuoteFactory', $quoteGiftCard);
+        TestHelper::setProperty($this->currentMock, 'amastyLegacyQuoteFactory', $quoteGiftCard);
 
         $quoteGiftCard->expects($applyForQuote ? static::once() : static::never())
             ->method('getInstance')
@@ -767,7 +767,7 @@ class DiscountTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        TestHelper::setProperty($this->currentMock, 'amastyQuoteResource', $amastyResourceMock);
+        TestHelper::setProperty($this->currentMock, 'amastyLegacyQuoteResource', $amastyResourceMock);
 
         $amastyResourceMock->expects($applyForQuote ? static::once() : static::never())
             ->method('getInstance')
@@ -995,7 +995,7 @@ class DiscountTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        TestHelper::setProperty($this->currentMock, 'amastyGiftCardManagement', $amastyGiftCardMock);
+        TestHelper::setProperty($this->currentMock, 'amastyLegacyGiftCardManagement', $amastyGiftCardMock);
 
         $amastyGiftCardMock->expects(static::once())->method('getInstance')->willReturnSelf();
         $amastyGiftCardMock->expects(static::once())->method('validateCode')->with($quote, $code)->willReturn(true);
@@ -1020,7 +1020,7 @@ class DiscountTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        TestHelper::setProperty($this->currentMock, 'amastyQuoteFactory', $quoteGiftCard);
+        TestHelper::setProperty($this->currentMock, 'amastyLegacyQuoteFactory', $quoteGiftCard);
 
         $quoteGiftCard->expects(static::once())->method('getInstance')->willReturnSelf();
         $quoteGiftCard->expects(static::once())->method('create')->willReturnSelf();
@@ -1030,7 +1030,7 @@ class DiscountTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        TestHelper::setProperty($this->currentMock, 'amastyQuoteResource', $amastyResourceMock);
+        TestHelper::setProperty($this->currentMock, 'amastyLegacyQuoteResource', $amastyResourceMock);
 
         $amastyResourceMock->expects(static::once())->method('getInstance')->willReturnSelf();
         $amastyResourceMock->expects(static::once())
@@ -1071,7 +1071,7 @@ class DiscountTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        TestHelper::setProperty($this->currentMock, 'amastyQuoteRepository', $amastyQuoteMock);
+        TestHelper::setProperty($this->currentMock, 'amastyLegacyQuoteRepository', $amastyQuoteMock);
 
         $amastyQuoteMock->expects(static::once())->method('getInstance')->willReturnSelf();
         $amastyQuoteMock->expects(static::once())->method('save')->with($quoteGiftCard)->willReturnSelf();

--- a/Test/Unit/Helper/DiscountTest.php
+++ b/Test/Unit/Helper/DiscountTest.php
@@ -40,6 +40,8 @@ use ReflectionException;
 use Zend_Db_Statement_Exception;
 use Magento\Framework\DB\Adapter\Pdo\Mysql;
 use Magento\Checkout\Model\Session as CheckoutSession;
+use Magento\Quote\Api\Data\CartExtension;
+use Magento\Framework\Api\ExtensibleDataInterface; as GiftCardQuote;
 
 /**
  * Class DiscountTest
@@ -98,6 +100,54 @@ class DiscountTest extends TestCase
      * @var MockObject|ThirdPartyModuleFactory mocked instance of the Amasty GiftCard Account collection
      */
     private $amastyAccountCollection;
+    
+    
+    
+    
+    /**
+     * @var MockObject|ThirdPartyModuleFactory mocked instance of the legacy Amasty GiftCard model Account factory
+     */
+    private $amastyLegacyAccountFactory;
+    
+    /**
+     * @var MockObject|ThirdPartyModuleFactory mocked instance of the legacy Amasty GiftCard model GiftCardManagement
+     */
+    private $amastyLegacyGiftCardManagement;
+    
+    /**
+     * @var MockObject|ThirdPartyModuleFactory mocked instance of the legacy Amasty GiftCard model Quote factory
+     */
+    private $amastyLegacyQuoteFactory;
+    
+    /**
+     * @var MockObject|ThirdPartyModuleFactory mocked instance of the legacy Amasty GiftCard model ResourceModel\Quote
+     */
+    private $amastyLegacyQuoteResource;
+    
+    /**
+     * @var MockObject|ThirdPartyModuleFactory mocked instance of the legacy Amasty GiftCard model Repository\QuoteRepository
+     */
+    private $amastyLegacyQuoteRepository;
+    
+    /**
+     * @var MockObject|ThirdPartyModuleFactory mocked instance of the legacy Amasty GiftCard model ResourceModel\Account\Collection
+     */
+    private $amastyLegacyAccountCollection;
+    
+    /**
+     * @var MockObject|ThirdPartyModuleFactory mocked instance of the legacy Amasty GiftCardAccount model GiftCardAccount\Repository
+     */
+    private $amastyAccountFactory;
+    
+    /**
+     * @var MockObject|ThirdPartyModuleFactory mocked instance of the legacy Amasty GiftCardAccount model GiftCardAccount\GiftCardAccountManagement
+     */
+    private $amastyGiftCardAccountManagement;
+    
+    /**
+     * @var MockObject|ThirdPartyModuleFactory mocked instance of the legacy Amasty GiftCardAccount model GiftCardAccount\ResourceModel\Collection
+     */
+    private $amastyGiftCardAccountCollection;
 
     /**
      * @var MockObject|ThirdPartyModuleFactory mocked instance of the Unirgy Giftcert repository
@@ -205,13 +255,16 @@ class DiscountTest extends TestCase
     protected function setUp()
     {
         $this->context = $this->createMock(Context::class);
-        $this->resource = $this->createMock(ResourceConnection::class);
+        $this->resource = $this->createMock(ResourceConnection::class);        
+        $this->amastyLegacyAccountFactory = $this->createMock(ThirdPartyModuleFactory::class);
+        $this->amastyLegacyGiftCardManagement = $this->createMock(ThirdPartyModuleFactory::class);
+        $this->amastyLegacyQuoteFactory = $this->createMock(ThirdPartyModuleFactory::class);
+        $this->amastyLegacyQuoteResource = $this->createMock(ThirdPartyModuleFactory::class);
+        $this->amastyLegacyQuoteRepository = $this->createMock(ThirdPartyModuleFactory::class);
+        $this->amastyLegacyAccountCollection = $this->createMock(ThirdPartyModuleFactory::class);
         $this->amastyAccountFactory = $this->createMock(ThirdPartyModuleFactory::class);
-        $this->amastyGiftCardManagement = $this->createMock(ThirdPartyModuleFactory::class);
-        $this->amastyQuoteFactory = $this->createMock(ThirdPartyModuleFactory::class);
-        $this->amastyQuoteResource = $this->createMock(ThirdPartyModuleFactory::class);
-        $this->amastyQuoteRepository = $this->createMock(ThirdPartyModuleFactory::class);
-        $this->amastyAccountCollection = $this->createMock(ThirdPartyModuleFactory::class);
+        $this->amastyGiftCardAccountManagement = $this->createMock(ThirdPartyModuleFactory::class);
+        $this->amastyGiftCardAccountCollection = $this->createMock(ThirdPartyModuleFactory::class);        
         $this->unirgyCertRepository = $this->createMock(ThirdPartyModuleFactory::class);
         $this->mirasvitStoreCreditHelper = $this->createMock(ThirdPartyModuleFactory::class);
         $this->mirasvitStoreCreditCalculationHelper = $this->createMock(ThirdPartyModuleFactory::class);
@@ -255,12 +308,15 @@ class DiscountTest extends TestCase
                 [
                     $this->context,
                     $this->resource,
+                    $this->amastyLegacyAccountFactory,
+                    $this->amastyLegacyGiftCardManagement,
+                    $this->amastyLegacyQuoteFactory,
+                    $this->amastyLegacyQuoteResource,
+                    $this->amastyLegacyQuoteRepository,
+                    $this->amastyLegacyAccountCollection,
                     $this->amastyAccountFactory,
-                    $this->amastyGiftCardManagement,
-                    $this->amastyQuoteFactory,
-                    $this->amastyQuoteResource,
-                    $this->amastyQuoteRepository,
-                    $this->amastyAccountCollection,
+                    $this->amastyGiftCardAccountManagement,
+                    $this->amastyGiftCardAccountCollection,
                     $this->unirgyCertRepository,
                     $this->mirasvitStoreCreditHelper,
                     $this->mirasvitStoreCreditCalculationHelper,
@@ -302,12 +358,15 @@ class DiscountTest extends TestCase
         $instance = new Discount(
             $this->context,
             $this->resource,
+            $this->amastyLegacyAccountFactory,
+            $this->amastyLegacyGiftCardManagement,
+            $this->amastyLegacyQuoteFactory,
+            $this->amastyLegacyQuoteResource,
+            $this->amastyLegacyQuoteRepository,
+            $this->amastyLegacyAccountCollection,
             $this->amastyAccountFactory,
-            $this->amastyGiftCardManagement,
-            $this->amastyQuoteFactory,
-            $this->amastyQuoteResource,
-            $this->amastyQuoteRepository,
-            $this->amastyAccountCollection,
+            $this->amastyGiftCardAccountManagement,
+            $this->amastyGiftCardAccountCollection,
             $this->unirgyCertRepository,
             $this->mirasvitStoreCreditHelper,
             $this->mirasvitStoreCreditCalculationHelper,
@@ -330,12 +389,15 @@ class DiscountTest extends TestCase
         );
 
         static::assertAttributeEquals($this->resource, 'resource', $instance);
+        static::assertAttributeEquals($this->amastyLegacyAccountFactory, 'amastyLegacyAccountFactory', $instance);
+        static::assertAttributeEquals($this->amastyLegacyGiftCardManagement, 'amastyLegacyGiftCardManagement', $instance);
+        static::assertAttributeEquals($this->amastyLegacyQuoteFactory, 'amastyLegacyQuoteFactory', $instance);
+        static::assertAttributeEquals($this->amastyLegacyQuoteResource, 'amastyLegacyQuoteResource', $instance);
+        static::assertAttributeEquals($this->amastyLegacyQuoteRepository, 'amastyLegacyQuoteRepository', $instance);
+        static::assertAttributeEquals($this->amastyLegacyAccountCollection, 'amastyLegacyAccountCollection', $instance);
         static::assertAttributeEquals($this->amastyAccountFactory, 'amastyAccountFactory', $instance);
-        static::assertAttributeEquals($this->amastyGiftCardManagement, 'amastyGiftCardManagement', $instance);
-        static::assertAttributeEquals($this->amastyQuoteFactory, 'amastyQuoteFactory', $instance);
-        static::assertAttributeEquals($this->amastyQuoteResource, 'amastyQuoteResource', $instance);
-        static::assertAttributeEquals($this->amastyQuoteRepository, 'amastyQuoteRepository', $instance);
-        static::assertAttributeEquals($this->amastyAccountCollection, 'amastyAccountCollection', $instance);
+        static::assertAttributeEquals($this->amastyGiftCardAccountManagement, 'amastyGiftCardAccountManagement', $instance);
+        static::assertAttributeEquals($this->amastyGiftCardAccountCollection, 'amastyGiftCardAccountCollection', $instance);        
         static::assertAttributeEquals($this->unirgyCertRepository, 'unirgyCertRepository', $instance);
         static::assertAttributeEquals($this->mirasvitStoreCreditHelper, 'mirasvitStoreCreditHelper', $instance);
         static::assertAttributeEquals(
@@ -378,14 +440,17 @@ class DiscountTest extends TestCase
      * @dataProvider isAmastyGiftCardAvailable_withVariousAmastyModuleAvailabilityProvider
      *
      * @param bool $amastyModuleAvailable stubbed result of {@see \Bolt\Boltpay\Model\ThirdPartyModuleFactory::isAvailable}
+     * @param bool $amastyLegacyModuleAvailable stubbed result of {@see \Bolt\Boltpay\Model\ThirdPartyModuleFactory::isAvailable}
      * @param bool $expectedResult of the method call
      */
     public function isAmastyGiftCardAvailable_withVariousAmastyModuleAvailability_returnsAvailability(
         $amastyModuleAvailable,
+        $amastyLegacyModuleAvailable,
         $expectedResult
     ) {
         $this->initCurrentMock();
         $this->amastyAccountFactory->expects(static::once())->method('isAvailable')->willReturn($amastyModuleAvailable);
+        $this->amastyLegacyAccountFactory->expects(static::once())->method('isAvailable')->willReturn($amastyLegacyModuleAvailable);
 
         static::assertEquals($expectedResult, $this->currentMock->isAmastyGiftCardAvailable());
     }
@@ -398,8 +463,43 @@ class DiscountTest extends TestCase
     public function isAmastyGiftCardAvailable_withVariousAmastyModuleAvailabilityProvider()
     {
         return [
-            ['amastyModuleAvailable' => true, 'expectedResult' => true],
-            ['amastyModuleAvailable' => false, 'expectedResult' => false],
+            ['amastyModuleAvailable' => false, 'amastyLegacyModuleAvailable' => true, 'expectedResult' => true],
+            ['amastyModuleAvailable' => true, 'amastyLegacyModuleAvailable' => false, 'expectedResult' => true],
+            ['amastyModuleAvailable' => false, 'amastyLegacyModuleAvailable' => false, 'expectedResult' => false],
+        ];
+    }
+    
+    /**
+     * @test
+     * that isAmastyGiftCardLegacyVersion returns if the Amasty Gift Card module is a legacy version or not
+     *
+     * @covers ::isAmastyGiftCardLegacyVersion
+     *
+     * @dataProvider isAmastyGiftCardLegacyVersion__withVariousAmastyModuleVersionProvider
+     *
+     * @param bool $amastyClassExistence stubbed result of {@see \Bolt\Boltpay\Model\ThirdPartyModuleFactory::isExists}
+     * @param bool $expectedResult of the method call
+     */
+    public function isAmastyGiftCardLegacyVersion__withVariousAmastyModuleVersion_returnsProperResult(
+        $amastyClassExistence,
+        $expectedResult
+    ) {
+        $this->initCurrentMock();
+        $this->amastyLegacyAccountFactory->expects(static::once())->method('isExists')->willReturn($amastyClassExistence);
+
+        static::assertEquals($expectedResult, $this->currentMock->isAmastyGiftCardLegacyVersion());
+    }
+    
+    /**
+     * Data provider for {@see isAmastyGiftCardLegacyVersion__withVariousAmastyModuleVersion_returnsProperResult}
+     *
+     * @return array[] containing Amasty Gift Card class existence flag and expected result of the method call
+     */
+    public function isAmastyGiftCardLegacyVersion__withVariousAmastyModuleVersionProvider()
+    {
+        return [
+            ['amastyClassExistence' => true, 'expectedResult' => true],
+            ['amastyClassExistence' => false, 'expectedResult' => false],
         ];
     }
 
@@ -451,7 +551,7 @@ class DiscountTest extends TestCase
 
     /**
      * @test
-     * that loadAmastyGiftCard returns Amasty Gift Card Account object
+     * that loadAmastyGiftCard returns Amasty Gift Card GiftCardAccount\Repository object
      * if one is available for the provided giftcard code and website id
      *
      * @covers ::loadAmastyGiftCard
@@ -460,10 +560,50 @@ class DiscountTest extends TestCase
      */
     public function loadAmastyGiftCard_withAmastyGiftCardAvailableForWebsite_returnsAmastyGiftCardAccountModel()
     {
-        $this->initCurrentMock(['isAmastyGiftCardAvailable', 'create']);
+        $this->initCurrentMock(['isAmastyGiftCardAvailable', 'isAmastyGiftCardLegacyVersion', 'create']);
         $couponCode = 'testCouponCode';
         $websiteId = 1111;
         $this->currentMock->expects(static::once())->method('isAmastyGiftCardAvailable')->willReturn(true);
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardLegacyVersion')->willReturn(false);
+
+        $accountModelMock = $this->getMockBuilder(ThirdPartyModuleFactory::class)->setMethods(
+            [
+                'getInstance',
+                'create',
+                'getByCode',
+                'getId',
+                'getWebsiteId',
+            ]
+        )->disableOriginalConstructor()->getMock();
+
+        TestHelper::setProperty($this->currentMock, 'amastyAccountFactory', $accountModelMock);
+
+        $accountModelMock->expects(static::once())->method('getInstance')->willReturnSelf();
+        $accountModelMock->expects(static::once())->method('create')->willReturnSelf();
+        $accountModelMock->expects(static::once())->method('getByCode')->with($couponCode)->willReturnSelf();
+        $accountModelMock->expects(static::once())->method('getId')->with()->willReturnSelf();
+        $accountModelMock->expects(static::exactly(2))->method('getWebsiteId')->with()
+            ->willReturnOnConsecutiveCalls($websiteId, $websiteId);
+
+        static::assertEquals($accountModelMock, $this->currentMock->loadAmastyGiftCard($couponCode, $websiteId));
+    }
+    
+    /**
+     * @test
+     * that loadAmastyGiftCard returns Amasty Gift Card legacy Account object
+     * if one is available for the provided giftcard code and website id
+     *
+     * @covers ::loadAmastyGiftCard
+     *
+     * @throws ReflectionException if unable to set internal mock properties
+     */
+    public function loadAmastyGiftCard_legacyVersion_withAmastyGiftCardAvailableForWebsite_returnsAmastyGiftCardAccountModel()
+    {
+        $this->initCurrentMock(['isAmastyGiftCardAvailable', 'isAmastyGiftCardLegacyVersion', 'create']);
+        $couponCode = 'testCouponCode';
+        $websiteId = 1111;
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardAvailable')->willReturn(true);
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardLegacyVersion')->willReturn(true);
 
         $accountModelMock = $this->getMockBuilder(ThirdPartyModuleFactory::class)->setMethods(
             [
@@ -475,7 +615,7 @@ class DiscountTest extends TestCase
             ]
         )->disableOriginalConstructor()->getMock();
 
-        TestHelper::setProperty($this->currentMock, 'amastyAccountFactory', $accountModelMock);
+        TestHelper::setProperty($this->currentMock, 'amastyLegacyAccountFactory', $accountModelMock);
 
         $accountModelMock->expects(static::once())->method('getInstance')->willReturnSelf();
         $accountModelMock->expects(static::once())->method('create')->willReturnSelf();
@@ -497,16 +637,17 @@ class DiscountTest extends TestCase
      */
     public function loadAmastyGiftCard_whenUnableToLoadCardDueToException_returnsNull()
     {
-        $this->initCurrentMock(['isAmastyGiftCardAvailable', 'create']);
+        $this->initCurrentMock(['isAmastyGiftCardAvailable', 'isAmastyGiftCardLegacyVersion', 'create']);
         $couponCode = 'testCouponCode';
         $websiteId = 1111;
         $this->currentMock->expects(static::once())->method('isAmastyGiftCardAvailable')->willReturn(true);
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardLegacyVersion')->willReturn(false);
 
         $accountModelMock = $this->getMockBuilder(ThirdPartyModuleFactory::class)->setMethods(
             [
                 'getInstance',
                 'create',
-                'loadByCode',
+                'getByCode',
                 'getId',
                 'getWebsiteId',
             ]
@@ -519,7 +660,41 @@ class DiscountTest extends TestCase
 
         static::assertNull($this->currentMock->loadAmastyGiftCard($couponCode, $websiteId));
     }
+    
+    /**
+     * @test
+     * that loadAmastyGiftCard returns null if an exception occurs during gift card loading
+     *
+     * @covers ::loadAmastyGiftCard
+     *
+     * @throws ReflectionException if unable to set internal mock properties
+     */
+    public function loadAmastyGiftCard_legacyVersion_whenUnableToLoadCardDueToException_returnsNull()
+    {
+        $this->initCurrentMock(['isAmastyGiftCardAvailable', 'isAmastyGiftCardLegacyVersion', 'create']);
+        $couponCode = 'testCouponCode';
+        $websiteId = 1111;
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardAvailable')->willReturn(true);
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardLegacyVersion')->willReturn(true);
 
+        $accountModelMock = $this->getMockBuilder(ThirdPartyModuleFactory::class)->setMethods(
+            [
+                'getInstance',
+                'create',
+                'loadByCode',
+                'getId',
+                'getWebsiteId',
+            ]
+        )->disableOriginalConstructor()->getMock();
+
+        TestHelper::setProperty($this->currentMock, 'amastyLegacyAccountFactory', $accountModelMock);
+
+        $exceptionMock = $this->createMock(\Exception::class);
+        $accountModelMock->expects(static::once())->method('getInstance')->willThrowException($exceptionMock);
+
+        static::assertNull($this->currentMock->loadAmastyGiftCard($couponCode, $websiteId));
+    }
+    
     /**
      * @test
      * that applyAmastyGiftCard throws a localized exception if one of the following is true:
@@ -530,7 +705,7 @@ class DiscountTest extends TestCase
      *
      * @covers ::applyAmastyGiftCard
      *
-     * @dataProvider applyAmastyGiftCard_withVariousCouponPropertiesProvider
+     * @dataProvider applyAmastyGiftCard_legacyVersion_withVariousCouponPropertiesProvider
      *
      * @param bool   $isValid stubbed result of the giftcard code validation call
      * {@see \Amasty\GiftCard\Model\GiftCardManagement::validateCode}
@@ -546,7 +721,7 @@ class DiscountTest extends TestCase
      * @throws ReflectionException if unable to set internal mock properties
      * @throws LocalizedException from tested method
      */
-    public function applyAmastyGiftCard_withVariousCouponProperties_throwsException(
+    public function applyAmastyGiftCard_legacyVersion_withVariousCouponProperties_throwsException(
         $isValid,
         $code,
         $applyForQuote,
@@ -662,7 +837,7 @@ class DiscountTest extends TestCase
     }
 
     /**
-     * Data provider for {@see applyAmastyGiftCard_withVariousCouponProperties_throwsException}
+     * Data provider for {@see applyAmastyGiftCard_legacyVersion_withVariousCouponProperties_throwsException}
      *
      * @return array[] containing
      * 1. stubbed flag result of the giftcard code validation call
@@ -674,7 +849,7 @@ class DiscountTest extends TestCase
      * 7. value of the Quote Gift Amount
      * 8. the expected exception message
      */
-    public function applyAmastyGiftCard_withVariousCouponPropertiesProvider()
+    public function applyAmastyGiftCard_legacyVersion_withVariousCouponPropertiesProvider()
     {
         return [
             [
@@ -719,7 +894,7 @@ class DiscountTest extends TestCase
             ],
         ];
     }
-
+    
     /**
      * @test
      * that applyAmastyGiftCard returns pay items everything or pay for items only after meeting the following conditions:
@@ -746,9 +921,85 @@ class DiscountTest extends TestCase
         $totalsAmastyGiftCard,
         $expectedResult
     ) {
-        $this->initCurrentMock(['getAmastyPayForEverything']);
+        $this->initCurrentMock(['isAmastyGiftCardAvailable', 'isAmastyGiftCardLegacyVersion', 'getAmastyPayForEverything']);
         $code = 321312;
         $quoteId = 2;
+        
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardAvailable')->willReturn(true);
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardLegacyVersion')->willReturn(false);
+
+        $accountModel = $this->getMockBuilder('Amasty\GiftCardAccount\Model\GiftCardAccount\RepositoryFactory')
+            ->setMethods(['getCurrentValue'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $accountModel->expects(static::once())->method('getCurrentValue')->willReturn($giftAmount);
+
+        $quote = $this->createPartialMock(
+            Quote::class,
+            [
+                'getId',
+                'getTotals'
+            ]
+        );
+        $quote->expects(static::once())->method('getId')->willReturn($quoteId);
+
+        $amastyGiftCardMock = $this->getMockBuilder(ThirdPartyModuleFactory::class)
+            ->setMethods(['getInstance', 'applyGiftCardToCart'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        TestHelper::setProperty($this->currentMock, 'amastyGiftCardAccountManagement', $amastyGiftCardMock);
+
+        $amastyGiftCardMock->expects(static::once())->method('getInstance')->willReturnSelf();
+        $amastyGiftCardMock->expects(static::once())->method('applyGiftCardToCart')->with($quoteId, $code)->willReturn($code);
+
+        $this->currentMock->expects(static::once())
+            ->method('getAmastyPayForEverything')
+            ->willReturn($amastyPayForEverything);
+
+        $quote->expects(!$amastyPayForEverything ? static::once() : static::never())
+            ->method('getTotals')
+            ->willReturn([Discount::AMASTY_GIFTCARD => new DataObject(['value' => $totalsAmastyGiftCard])]);
+            
+        $this->quoteRepository->expects(!$amastyPayForEverything ? static::once() : static::never())
+            ->method('getActive')->with($quoteId)->willReturn($quote);
+
+        static::assertEquals($expectedResult, $this->currentMock->applyAmastyGiftCard($code, $accountModel, $quote));
+    }
+
+    /**
+     * @test
+     * that applyAmastyGiftCard returns pay items everything or pay for items only after meeting the following conditions:
+     * 1. Amasty Gift Card code is valid
+     * 2. provided Amasty Gift Card Account model can apply the provided card to quote
+     * 3. gift card is not already applied to the quote
+     * 4. maximum discount is not already reached
+     *
+     * @covers ::applyAmastyGiftCard
+     *
+     * @dataProvider applyAmastyGiftCard_withVariousPayForItemsProvider
+     *
+     * @param bool $amastyPayForEverything stubbed result of {@see \Bolt\Boltpay\Helper\Discount::getAmastyPayForEverything}
+     * @param int  $giftAmount current gift card balance before applying it to the quote
+     * @param int  $totalsAmastyGiftCard value of the Amasty Gift Card quote total
+     * @param int  $expectedResult of the method call
+     *
+     * @throws LocalizedException from tested method
+     * @throws ReflectionException if unable to set internal mock properties
+     */
+    public function applyAmastyGiftCard_legacyVersion_withVariousPayForItems_returnsPayItems(
+        $amastyPayForEverything,
+        $giftAmount,
+        $totalsAmastyGiftCard,
+        $expectedResult
+    ) {
+        $this->initCurrentMock(['isAmastyGiftCardAvailable', 'isAmastyGiftCardLegacyVersion', 'getAmastyPayForEverything']);
+        $code = 321312;
+        $quoteId = 2;
+        
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardAvailable')->willReturn(true);
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardLegacyVersion')->willReturn(true);
 
         $accountModel = $this->getMockBuilder('Amasty\GiftCard\Model\Account')
             ->setMethods(['getCurrentValue', 'canApplyCardForQuote', 'getCodeId', 'getId'])
@@ -930,10 +1181,51 @@ class DiscountTest extends TestCase
      */
     public function cloneAmastyGiftCards_ifAmastyGiftCardIsAvailable_commitsTheQuery()
     {
-        $this->initCurrentMock(['isAmastyGiftCardAvailable']);
+        $this->initCurrentMock(['isAmastyGiftCardAvailable', 'isAmastyGiftCardLegacyVersion']);        
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardAvailable')->willReturn(true);
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardLegacyVersion')->willReturn(false);
         $sourceQuoteId = 232;
         $destinationQuoteId = 1111;
+
+        $this->resource->method('getConnection')->willReturn($this->connectionMock);
+        $this->connectionMock->expects(static::once())->method('beginTransaction')->willReturnSelf();
+        $testTableName = 'amasty_giftcard_quote';
+        $this->resource->method('getTableName')->with('amasty_giftcard_quote')->willReturn($testTableName);
+
+        $deleteSql = "DELETE FROM {$testTableName} WHERE quote_id = :destination_quote_id";
+
+        $sqlInsert = "INSERT INTO {$giftCardTable} (quote_id, gift_cards, gift_amount, base_gift_amount, gift_amount_used, base_gift_amount_used) 
+                    SELECT :destination_quote_id, gift_cards, gift_amount, base_gift_amount, gift_amount_used, base_gift_amount_used
+                    FROM {$giftCardTable} WHERE quote_id = :source_quote_id";
+
+        $this->connectionMock->expects(static::exactly(2))->method('query')->withConsecutive(
+            [$deleteSql, ['destination_quote_id' => $destinationQuoteId]],
+            [$sqlInsert, ['destination_quote_id' => $destinationQuoteId, 'source_quote_id' => $sourceQuoteId]]
+        )->willReturnSelf();
+
+        $this->connectionMock->expects(static::once())->method('commit')->willReturnSelf();
+
+        $this->currentMock->cloneAmastyGiftCards($sourceQuoteId, $destinationQuoteId);
+    }
+    
+    /**
+     * @test
+     * that cloneAmastyGiftCards:
+     * 1. connects to the database
+     * 2. clears gift cart codes previously applied to the immutable quote
+     * 3. copies all gift cart codes applied to the parent quote onto the immutable quote
+     * 4. commits the queries
+     *
+     * @covers ::cloneAmastyGiftCards
+     */
+    public function cloneAmastyGiftCards_legacyVersion_ifAmastyGiftCardIsAvailable_commitsTheQuery()
+    {
+        $this->initCurrentMock(['isAmastyGiftCardAvailable', 'isAmastyGiftCardLegacyVersion']);        
         $this->currentMock->expects(static::once())->method('isAmastyGiftCardAvailable')->willReturn(true);
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardLegacyVersion')->willReturn(true);
+        $sourceQuoteId = 232;
+        $destinationQuoteId = 1111;
+
         $this->resource->method('getConnection')->willReturn($this->connectionMock);
         $this->connectionMock->expects(static::once())->method('beginTransaction')->willReturnSelf();
         $testTableName = 'amasty_amgiftcard_quotes';
@@ -954,7 +1246,7 @@ class DiscountTest extends TestCase
 
         $this->currentMock->cloneAmastyGiftCards($sourceQuoteId, $destinationQuoteId);
     }
-
+    
     /**
      * @test
      * that cloneAmastyGiftCards will rollback the SQL query and notify the Bugsnag if
@@ -964,13 +1256,49 @@ class DiscountTest extends TestCase
      */
     public function cloneAmastyGiftCards_ifQueryExceptionIsThrown_notifiesBugSnag()
     {
-        $this->initCurrentMock(['isAmastyGiftCardAvailable']);
+        $this->initCurrentMock(['isAmastyGiftCardAvailable', 'isAmastyGiftCardLegacyVersion']);
         $sourceQuoteId = 232;
         $destinationQuoteId = 1111;
         $this->currentMock->expects(static::once())->method('isAmastyGiftCardAvailable')->willReturn(true);
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardLegacyVersion')->willReturn(false);
         $this->resource->method('getConnection')->willReturn($this->connectionMock);
         $this->connectionMock->expects(static::once())->method('beginTransaction')->willReturnSelf();
-        $testTableName = 'amasty_amgiftcard_quotes';
+        $testTableName = 'amasty_giftcard_quote';
+        $this->resource->method('getTableName')->with('amasty_giftcard_quote')->willReturn($testTableName);
+
+        $deleteSql = "DELETE FROM {$testTableName} WHERE quote_id = :destination_quote_id";
+
+        $exception = $this->createMock(Zend_Db_Statement_Exception::class);
+
+        $this->connectionMock->expects(static::once())
+            ->method('query')
+            ->with($deleteSql, ['destination_quote_id' => $destinationQuoteId])
+            ->willThrowException($exception);
+
+        $this->connectionMock->expects(static::once())->method('rollBack')->willReturnSelf();
+
+        $this->bugsnag->expects(static::once())->method('notifyException')->with($exception)->willReturnSelf();
+
+        $this->currentMock->cloneAmastyGiftCards($sourceQuoteId, $destinationQuoteId);
+    }
+
+    /**
+     * @test
+     * that cloneAmastyGiftCards will rollback the SQL query and notify the Bugsnag if
+     * the SQL query execution throws an exception
+     *
+     * @covers ::cloneAmastyGiftCards
+     */
+    public function cloneAmastyGiftCards_legacyVersion_ifQueryExceptionIsThrown_notifiesBugSnag()
+    {
+        $this->initCurrentMock(['isAmastyGiftCardAvailable', 'isAmastyGiftCardLegacyVersion']);
+        $sourceQuoteId = 232;
+        $destinationQuoteId = 1111;
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardAvailable')->willReturn(true);
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardLegacyVersion')->willReturn(true);
+        $this->resource->method('getConnection')->willReturn($this->connectionMock);
+        $this->connectionMock->expects(static::once())->method('beginTransaction')->willReturnSelf();
+        $testTableName = 'amasty_amgiftcard_quote';
         $this->resource->method('getTableName')->with('amasty_amgiftcard_quote')->willReturn($testTableName);
 
         $deleteSql = "DELETE FROM {$testTableName} WHERE quote_id = :destination_quote_id";
@@ -1011,10 +1339,39 @@ class DiscountTest extends TestCase
      */
     public function clearAmastyGiftCard_ifAmastyGiftCardIsAvailable_removesCardInfo()
     {
-        $this->initCurrentMock(['isAmastyGiftCardAvailable']);
+        $this->initCurrentMock(['isAmastyGiftCardAvailable', 'isAmastyGiftCardLegacyVersion']);
         $this->currentMock->expects(static::once())->method('isAmastyGiftCardAvailable')->willReturn(true);
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardLegacyVersion')->willReturn(false);
         $this->resource->method('getConnection')->willReturn($this->connectionMock);
-        $testTableName = 'amasty_amgiftcard_quotes';
+        $testTableName = 'amasty_giftcard_quote';
+        $this->resource->method('getTableName')->with('amasty_giftcard_quote')->willReturn($testTableName);
+
+        $quoteId = 11;
+        $quoteMock = $this->createPartialMock(Quote::class, ['getId']);
+        $quoteMock->method('getId')->willReturn($quoteId);
+
+        $sql = "DELETE FROM {$testTableName} WHERE quote_id = :quote_id";
+        $bind = [
+            'quote_id' => $quoteId
+        ];
+
+        $this->connectionMock->expects(static::once())->method('query')->with($sql, $bind)->willReturnSelf();
+        $this->currentMock->clearAmastyGiftCard($quoteMock);
+    }
+    
+    /**
+     * @test
+     * that clearAmastyGiftCard removes Amasty Gift Card from the provided quote using a custom SQL query
+     *
+     * @covers ::clearAmastyGiftCard
+     */
+    public function clearAmastyGiftCard_legacyVersion_ifAmastyGiftCardIsAvailable_removesCardInfo()
+    {
+        $this->initCurrentMock(['isAmastyGiftCardAvailable', 'isAmastyGiftCardLegacyVersion']);
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardAvailable')->willReturn(true);
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardLegacyVersion')->willReturn(true);
+        $this->resource->method('getConnection')->willReturn($this->connectionMock);
+        $testTableName = 'amasty_amgiftcard_quote';
         $this->resource->method('getTableName')->with('amasty_amgiftcard_quote')->willReturn($testTableName);
 
         $quoteId = 11;
@@ -1038,10 +1395,42 @@ class DiscountTest extends TestCase
      */
     public function clearAmastyGiftCard_ifQueryThrowsException_notifiesBugSnag()
     {
-        $this->initCurrentMock(['isAmastyGiftCardAvailable']);
+        $this->initCurrentMock(['isAmastyGiftCardAvailable', 'isAmastyGiftCardLegacyVersion']);
         $this->currentMock->expects(static::once())->method('isAmastyGiftCardAvailable')->willReturn(true);
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardLegacyVersion')->willReturn(false);
         $this->resource->method('getConnection')->willReturn($this->connectionMock);
-        $testTableName = 'amasty_amgiftcard_quotes';
+        $testTableName = 'amasty_giftcard_quote';
+        $this->resource->method('getTableName')->with('amasty_giftcard_quote')->willReturn($testTableName);
+
+        $quoteId = 11;
+        $quoteMock = $this->createPartialMock(Quote::class, ['getId']);
+        $quoteMock->method('getId')->willReturn($quoteId);
+
+        $sql = "DELETE FROM {$testTableName} WHERE quote_id = :quote_id";
+        $bind = [
+            'quote_id' => $quoteId
+        ];
+        $exception = $this->createMock(Zend_Db_Statement_Exception::class);
+        $this->connectionMock->expects(static::once())->method('query')->with($sql, $bind)
+            ->willThrowException($exception);
+
+        $this->bugsnag->expects(static::once())->method('notifyException')->with($exception)->willReturnSelf();
+        $this->currentMock->clearAmastyGiftCard($quoteMock);
+    }
+    
+    /**
+     * @test
+     * that clearAmastyGiftCard only notifies the Bugsnag if the SQL query throws an exception
+     *
+     * @covers ::clearAmastyGiftCard
+     */
+    public function clearAmastyGiftCard_legacyVersion_ifQueryThrowsException_notifiesBugSnag()
+    {
+        $this->initCurrentMock(['isAmastyGiftCardAvailable', 'isAmastyGiftCardLegacyVersion']);
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardAvailable')->willReturn(true);
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardLegacyVersion')->willReturn(true);
+        $this->resource->method('getConnection')->willReturn($this->connectionMock);
+        $testTableName = 'amasty_amgiftcard_quote';
         $this->resource->method('getTableName')->with('amasty_amgiftcard_quote')->willReturn($testTableName);
 
         $quoteId = 11;
@@ -1083,8 +1472,48 @@ class DiscountTest extends TestCase
      */
     public function deleteRedundantAmastyGiftCards_ifAmastyGiftCardIsAvailable_executesQuery()
     {
-        $this->initCurrentMock(['isAmastyGiftCardAvailable']);
+        $this->initCurrentMock(['isAmastyGiftCardAvailable', 'isAmastyGiftCardLegacyVersion']);
         $this->currentMock->expects(static::once())->method('isAmastyGiftCardAvailable')->willReturn(true);
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardLegacyVersion')->willReturn(false);
+        $this->resource->method('getConnection')->willReturn($this->connectionMock);
+        $testTableName = 'quotes';
+        $giftCardTable = 'test_table';
+        $this->resource->expects(static::exactly(2))
+            ->method('getTableName')
+            ->withConsecutive(['amasty_giftcard_quote'], ['quote'])
+            ->willReturnOnConsecutiveCalls($giftCardTable, $testTableName);
+
+        $quoteId = 11;
+        $quoteMock = $this->createPartialMock(Quote::class, ['getId', 'getBoltParentQuoteId']);
+        $quoteMock->expects(static::exactly(2))->method('getBoltParentQuoteId')
+            ->willReturnOnConsecutiveCalls($quoteId, $quoteId);
+
+        $sql = "DELETE FROM {$giftCardTable} WHERE quote_id IN 
+                    (SELECT entity_id FROM {$testTableName} 
+                    WHERE bolt_parent_quote_id = :bolt_parent_quote_id AND entity_id != :entity_id)";
+
+        $bind = [
+            'bolt_parent_quote_id' => $quoteId,
+            'entity_id'            => $quoteId
+        ];
+
+        $this->connectionMock->expects(static::once())->method('query')->with($sql, $bind)->willReturnSelf();
+
+        $this->currentMock->deleteRedundantAmastyGiftCards($quoteMock);
+    }
+    
+    /**
+     * @test
+     * that deleteRedundantAmastyGiftCards deletes redundant Amasty Giftcards for the provided quote
+     * using a custom SQL query if the Amasty Giftcards module is available
+     *
+     * @covers ::deleteRedundantAmastyGiftCards
+     */
+    public function deleteRedundantAmastyGiftCards_legacyVersion_ifAmastyGiftCardIsAvailable_executesQuery()
+    {
+        $this->initCurrentMock(['isAmastyGiftCardAvailable', 'isAmastyGiftCardLegacyVersion']);
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardAvailable')->willReturn(true);
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardLegacyVersion')->willReturn(true);
         $this->resource->method('getConnection')->willReturn($this->connectionMock);
         $testTableName = 'quotes';
         $giftCardTable = 'test_table';
@@ -1120,8 +1549,49 @@ class DiscountTest extends TestCase
      */
     public function deleteRedundantAmastyGiftCards_ifAmastyGiftCardIsAvailableAndQueryThrowsException_notifiesBugSnag()
     {
-        $this->initCurrentMock(['isAmastyGiftCardAvailable']);
+        $this->initCurrentMock(['isAmastyGiftCardAvailable', 'isAmastyGiftCardLegacyVersion']);
         $this->currentMock->expects(static::once())->method('isAmastyGiftCardAvailable')->willReturn(true);
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardLegacyVersion')->willReturn(false);
+        $this->resource->method('getConnection')->willReturn($this->connectionMock);
+        $testTableName = 'quotes';
+        $giftCardTable = 'test_table';
+        $this->resource->expects(static::exactly(2))->method('getTableName')->withConsecutive(
+            ['amasty_giftcard_quote'],
+            ['quote']
+        )->willReturnOnConsecutiveCalls($giftCardTable, $testTableName);
+
+        $quoteId = 11;
+        $quoteMock = $this->createPartialMock(Quote::class, ['getId', 'getBoltParentQuoteId']);
+        $quoteMock->expects(static::exactly(2))->method('getBoltParentQuoteId')
+            ->willReturnOnConsecutiveCalls($quoteId, $quoteId);
+
+        $sql = "DELETE FROM {$giftCardTable} WHERE quote_id IN 
+                    (SELECT entity_id FROM {$testTableName} 
+                    WHERE bolt_parent_quote_id = :bolt_parent_quote_id AND entity_id != :entity_id)";
+        $bind = [
+            'bolt_parent_quote_id' => $quoteId,
+            'entity_id'            => $quoteId
+        ];
+
+        $exception = $this->createMock(Zend_Db_Statement_Exception::class);
+        $this->connectionMock->expects(static::once())->method('query')->with($sql, $bind)->willThrowException(
+            $exception
+        );
+        $this->bugsnag->expects(static::once())->method('notifyException')->with($exception)->willReturnSelf();
+        $this->currentMock->deleteRedundantAmastyGiftCards($quoteMock);
+    }
+    
+    /**
+     * @test
+     * that deleteRedundantAmastyGiftCards only notifies Bugsnag if the SQL query throws an exception
+     *
+     * @covers ::deleteRedundantAmastyGiftCards
+     */
+    public function deleteRedundantAmastyGiftCards_legacyVersion_ifAmastyGiftCardIsAvailableAndQueryThrowsException_notifiesBugSnag()
+    {
+        $this->initCurrentMock(['isAmastyGiftCardAvailable', 'isAmastyGiftCardLegacyVersion']);
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardAvailable')->willReturn(true);
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardLegacyVersion')->willReturn(true);
         $this->resource->method('getConnection')->willReturn($this->connectionMock);
         $testTableName = 'quotes';
         $giftCardTable = 'test_table';
@@ -1165,7 +1635,7 @@ class DiscountTest extends TestCase
 
         static::assertNull($this->currentMock->removeAmastyGiftCard($testCodeId, $this->quote));
     }
-
+    
     /**
      * @test
      * that removeAmastyGiftCard collects totals and saves the quote if the Amasty Gift Card module is available
@@ -1174,12 +1644,67 @@ class DiscountTest extends TestCase
      */
     public function removeAmastyGiftCard_ifAmastyGiftCardIsAvailable_collectsTotalsAndSavesQuote()
     {
-        $this->initCurrentMock(['isAmastyGiftCardAvailable']);
+        $this->initCurrentMock(['isAmastyGiftCardAvailable', 'isAmastyGiftCardLegacyVersion']);
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardAvailable')->willReturn(true);
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardLegacyVersion')->willReturn(false);
+        $codeId = 5;
+        $code = 'BOLTTESTCARD';
+        $quoteId = 11;
+        $cardInfo = [
+            [
+                'id' => 5,
+                'code' => $code,
+                'amount' => 10,
+                'b_amount' => 10
+            ]
+        ];
+        $quoteMock = $this->createPartialMock(
+            Quote::class,
+            [
+                'getId',
+                'getExtensionAttributes'
+            ]
+        );
+        $extensionAttributes = $this->createPartialMock(CartExtension::class, ['getAmGiftcardQuote']);
+        $gCardQuote = $this->createPartialMock(GiftCardQuote::class, ['getGiftCards']);
+        
+        $gCardQuote->expects($this->atLeastOnce())->method('getGiftCards')
+            ->willReturn($cardInfo);
+        
+        $extensionAttributes->expects($this->atLeastOnce())->method('getAmGiftcardQuote')
+            ->willReturn($gCardQuote);        
+        
+        $quoteMock->expects(static::once())->method('getId')->willReturn($quoteId);
+        $quote->expects($this->atLeastOnce())->method('getExtensionAttributes')
+            ->willReturn($extensionAttributes);
+
+        $amastyGiftCardMock = $this->getMockBuilder(ThirdPartyModuleFactory::class)
+            ->setMethods(['getInstance', 'removeGiftCardFromCart'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        TestHelper::setProperty($this->currentMock, 'amastyGiftCardAccountManagement', $amastyGiftCardMock);
+
+        $amastyGiftCardMock->expects(static::once())->method('getInstance')->willReturnSelf();
+        $amastyGiftCardMock->expects(static::once())->method('removeGiftCardFromCart')->with($quoteId, $code)->willReturn($code);
+        $this->currentMock->removeAmastyGiftCard($codeId, $quoteMock);
+    }
+
+    /**
+     * @test
+     * that removeAmastyGiftCard collects totals and saves the quote if the Amasty Gift Card module is available
+     *
+     * @covers ::removeAmastyGiftCard
+     */
+    public function removeAmastyGiftCard_legacyVersion_ifAmastyGiftCardIsAvailable_collectsTotalsAndSavesQuote()
+    {
+        $this->initCurrentMock(['isAmastyGiftCardAvailable', 'isAmastyGiftCardLegacyVersion']);
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardAvailable')->willReturn(true);
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardLegacyVersion')->willReturn(true);
         $codeId = 5;
 
-        $this->currentMock->expects(static::once())->method('isAmastyGiftCardAvailable')->willReturn(true);
         $this->resource->expects(static::once())->method('getConnection')->willReturn($this->connectionMock);
-        $testTableName = 'amasty_amgiftcard_quotes';
+        $testTableName = 'amasty_amgiftcard_quote';
         $this->resource->method('getTableName')->with('amasty_amgiftcard_quote')->willReturn($testTableName);
 
         $quoteId = 11;
@@ -1216,12 +1741,13 @@ class DiscountTest extends TestCase
      *
      * @covers ::removeAmastyGiftCard
      */
-    public function removeAmastyGiftCard_queryThrowsException_notifiesBugSnag()
+    public function removeAmastyGiftCard_legacyVersion_queryThrowsException_notifiesBugSnag()
     {
-        $this->initCurrentMock(['isAmastyGiftCardAvailable']);
+        $this->initCurrentMock(['isAmastyGiftCardAvailable', 'isAmastyGiftCardLegacyVersion']);
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardAvailable')->willReturn(true);
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardLegacyVersion')->willReturn(true);
         $codeId = 5;
 
-        $this->currentMock->expects(static::once())->method('isAmastyGiftCardAvailable')->willReturn(true);
         $this->resource->expects(static::once())->method('getConnection')->willReturn($this->connectionMock);
         $testTableName = 'amasty_amgiftcard_quotes';
         $this->resource->method('getTableName')->with('amasty_amgiftcard_quote')->willReturn($testTableName);
@@ -1315,7 +1841,7 @@ class DiscountTest extends TestCase
             )
         );
     }
-
+    
     /**
      * @test
      * that getAmastyGiftCardCodesCurrentValue returns accumulated unused balances
@@ -1327,7 +1853,54 @@ class DiscountTest extends TestCase
      */
     public function getAmastyGiftCardCodesCurrentValue_always_returnsGiftCardsUnusedBalance()
     {
-        $this->initCurrentMock();
+        $this->initCurrentMock(['isAmastyGiftCardAvailable', 'isAmastyGiftCardLegacyVersion']);
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardAvailable')->willReturn(true);
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardLegacyVersion')->willReturn(false);
+        
+        $giftCardCodes = [22, 33, 44, 55];
+
+        $amastyAccountMock = $this->getMockBuilder(ThirdPartyModuleFactory::class)
+            ->setMethods(['getInstance', 'addCodeTable', 'addFieldToFilter', 'getData'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        TestHelper::setProperty($this->currentMock, 'amastyGiftCardAccountCollection', $amastyAccountMock);
+
+        $amastyAccountMock->expects(static::once())->method('getInstance')->willReturnSelf();
+        $amastyAccountMock->expects(static::once())->method('addCodeTable')->willReturnSelf();
+        $amastyAccountMock->expects(static::once())
+            ->method('addFieldToFilter')
+            ->with('code', ['in' => $giftCardCodes])
+            ->willReturnSelf();
+        $giftCardCodesUnusedBalance = [
+            ["current_value" => 20],
+            ["current_value" => 30],
+            ["current_value" => 40],
+            ["current_value" => 50],
+        ];
+        $amastyAccountMock->expects(static::once())->method('getData')->willReturn($giftCardCodesUnusedBalance);
+
+        static::assertEquals(
+            array_sum(array_column($giftCardCodesUnusedBalance, 'current_value')),
+            $this->currentMock->getAmastyGiftCardCodesCurrentValue($giftCardCodes)
+        );
+    }
+
+    /**
+     * @test
+     * that getAmastyGiftCardCodesCurrentValue returns accumulated unused balances
+     * of the provided Amasty Gift Card codes
+     *
+     * @covers ::getAmastyGiftCardCodesCurrentValue
+     *
+     * @throws ReflectionException if unable to set internal mock properties
+     */
+    public function getAmastyGiftCardCodesCurrentValue_legacyVersion_always_returnsGiftCardsUnusedBalance()
+    {
+        $this->initCurrentMock(['isAmastyGiftCardAvailable', 'isAmastyGiftCardLegacyVersion']);
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardAvailable')->willReturn(true);
+        $this->currentMock->expects(static::once())->method('isAmastyGiftCardLegacyVersion')->willReturn(true);
+        
         $giftCardCodes = [22, 33, 44, 55];
 
         $amastyAccountMock = $this->getMockBuilder(ThirdPartyModuleFactory::class)
@@ -1335,7 +1908,7 @@ class DiscountTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        TestHelper::setProperty($this->currentMock, 'amastyAccountCollection', $amastyAccountMock);
+        TestHelper::setProperty($this->currentMock, 'amastyLegacyAccountCollection', $amastyAccountMock);
 
         $amastyAccountMock->expects(static::once())->method('getInstance')->willReturnSelf();
         $amastyAccountMock->expects(static::once())->method('joinCode')->willReturnSelf();

--- a/Test/Unit/Helper/DiscountTest.php
+++ b/Test/Unit/Helper/DiscountTest.php
@@ -69,40 +69,7 @@ class DiscountTest extends TestCase
     /**
      * @var MockObject|ResourceConnection mocked instance of the resource collection
      */
-    private $resource;
-
-    /**
-     * @var MockObject|ThirdPartyModuleFactory mocked instance of the Amasty GiftCard account factory
-     */
-    private $amastyAccountFactory;
-
-    /**
-     * @var MockObject|ThirdPartyModuleFactory mocked instance of the Amasty GiftCard quote management model
-     */
-    private $amastyGiftCardManagement;
-
-    /**
-     * @var MockObject|ThirdPartyModuleFactory mocked instance of the Amasty GiftCard quote factory
-     */
-    private $amastyQuoteFactory;
-
-    /**
-     * @var MockObject|ThirdPartyModuleFactory mocked instance of the Amasty GiftCard quote resouce model
-     */
-    private $amastyQuoteResource;
-
-    /**
-     * @var MockObject|ThirdPartyModuleFactory mocked instance of the Amasty GiftCard quote repository
-     */
-    private $amastyQuoteRepository;
-
-    /**
-     * @var MockObject|ThirdPartyModuleFactory mocked instance of the Amasty GiftCard Account collection
-     */
-    private $amastyAccountCollection;
-    
-    
-    
+    private $resource;    
     
     /**
      * @var MockObject|ThirdPartyModuleFactory mocked instance of the legacy Amasty GiftCard model Account factory

--- a/Test/Unit/Helper/DiscountTest.php
+++ b/Test/Unit/Helper/DiscountTest.php
@@ -41,7 +41,7 @@ use Zend_Db_Statement_Exception;
 use Magento\Framework\DB\Adapter\Pdo\Mysql;
 use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\Quote\Api\Data\CartExtension;
-use Magento\Framework\Api\ExtensibleDataInterface; as GiftCardQuote;
+use Magento\Framework\Api\ExtensibleDataInterface as GiftCardQuote;
 
 /**
  * Class DiscountTest

--- a/Test/Unit/Model/ThirdPartyModuleFactoryTest.php
+++ b/Test/Unit/Model/ThirdPartyModuleFactoryTest.php
@@ -31,7 +31,7 @@ use Magento\Framework\Module\Manager;
 class ThirdPartyModuleFactoryTest extends TestCase
 {
     const MODULE_NAME = 'Bolt_Boltpay';
-    const CLASS_NAME = 'Bolt\Boltpay\Model\ClassName';
+    const CLASS_NAME = 'Bolt\Boltpay\Model\ThirdPartyModuleFactory';
 
     /**
      * @var Manager
@@ -109,7 +109,7 @@ class ThirdPartyModuleFactoryTest extends TestCase
         $this->logHelper->expects(self::exactly(2))->method('addInfoLog')
             ->withConsecutive(
                 ['# Module is Enabled: Bolt_Boltpay'],
-                ['# Class: Bolt\Boltpay\Model\ClassName']
+                ['# Class: Bolt\Boltpay\Model\ThirdPartyModuleFactory']
             );
 
         $this->_objectManager->expects(self::once())->method('create')->willReturnSelf();
@@ -127,5 +127,14 @@ class ThirdPartyModuleFactoryTest extends TestCase
             ->willReturn(true);
 
         $this->assertTrue($this->currentMock->isAvailable());
+    }
+    
+    /**
+     * @test
+     * @covers ::isExists
+     */
+    public function isExists()
+    {
+        $this->assertTrue($this->currentMock->isExists());
     }
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -92,52 +92,73 @@
         </arguments>
     </type>
 
-    <virtualType name="boltAmastyAccount" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
+    <virtualType name="boltAmastyLegacyAccount" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
         <arguments>
             <argument name="moduleName" xsi:type="string">Amasty_GiftCard</argument>
             <argument name="className" xsi:type="string">Amasty\GiftCard\Model\Account</argument>
         </arguments>
     </virtualType>
 
-    <virtualType name="boltAmastyAccountFactory" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
+    <virtualType name="boltAmastyLegacyAccountFactory" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
         <arguments>
             <argument name="moduleName" xsi:type="string">Amasty_GiftCard</argument>
             <argument name="className" xsi:type="string">Amasty\GiftCard\Model\AccountFactory</argument>
         </arguments>
     </virtualType>
 
-    <virtualType name="boltAmastyGiftCardManagement" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
+    <virtualType name="boltAmastyLegacyGiftCardManagement" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
         <arguments>
             <argument name="moduleName" xsi:type="string">Amasty_GiftCard</argument>
             <argument name="className" xsi:type="string">Amasty\GiftCard\Model\GiftCardManagement</argument>
         </arguments>
     </virtualType>
 
-    <virtualType name="boltAmastyQuoteFactory" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
+    <virtualType name="boltAmastyLegacyQuoteFactory" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
         <arguments>
             <argument name="moduleName" xsi:type="string">Amasty_GiftCard</argument>
             <argument name="className" xsi:type="string">Amasty\GiftCard\Model\QuoteFactory</argument>
         </arguments>
     </virtualType>
 
-    <virtualType name="boltAmastyQuoteResource" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
+    <virtualType name="boltAmastyLegacyQuoteResource" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
         <arguments>
             <argument name="moduleName" xsi:type="string">Amasty_GiftCard</argument>
             <argument name="className" xsi:type="string">Amasty\GiftCard\Model\ResourceModel\Quote</argument>
         </arguments>
     </virtualType>
 
-    <virtualType name="boltAmastyQuoteRepository" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
+    <virtualType name="boltAmastyLegacyQuoteRepository" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
         <arguments>
             <argument name="moduleName" xsi:type="string">Amasty_GiftCard</argument>
             <argument name="className" xsi:type="string">Amasty\GiftCard\Model\Repository\QuoteRepository</argument>
         </arguments>
     </virtualType>
 
-    <virtualType name="boltAmastyAccountCollection" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
+    <virtualType name="boltAmastyLegacyAccountCollection" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
         <arguments>
             <argument name="moduleName" xsi:type="string">Amasty_GiftCard</argument>
             <argument name="className" xsi:type="string">Amasty\GiftCard\Model\ResourceModel\Account\Collection</argument>
+        </arguments>
+    </virtualType>
+    
+    <virtualType name="boltAmastyAccountFactory" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
+        <arguments>
+            <argument name="moduleName" xsi:type="string">Amasty_GiftCardAccount</argument>
+            <argument name="className" xsi:type="string">Amasty\GiftCardAccount\Model\GiftCardAccount\RepositoryFactory</argument>
+        </arguments>
+    </virtualType>
+    
+    <virtualType name="boltAmastyGiftCardAccountManagement" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
+        <arguments>
+            <argument name="moduleName" xsi:type="string">Amasty_GiftCardAccount</argument>
+            <argument name="className" xsi:type="string">Amasty\GiftCardAccount\Model\GiftCardAccount\GiftCardAccountManagement</argument>
+        </arguments>
+    </virtualType>
+    
+    <virtualType name="boltAmastyGiftCardAccountCollection" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
+        <arguments>
+            <argument name="moduleName" xsi:type="string">Amasty_GiftCardAccount</argument>
+            <argument name="className" xsi:type="string">Amasty\GiftCardAccount\Model\GiftCardAccount\ResourceModel\Collection</argument>
         </arguments>
     </virtualType>
 
@@ -239,12 +260,15 @@
 
     <type name="Bolt\Boltpay\Helper\Discount">
         <arguments>
+            <argument name="amastyLegacyAccountFactory" xsi:type="object">boltAmastyLegacyAccountFactory</argument>
+            <argument name="amastyLegacyGiftCardManagement" xsi:type="object">boltAmastyLegacyGiftCardManagement</argument>
+            <argument name="amastyLegacyQuoteFactory" xsi:type="object">boltAmastyLegacyQuoteFactory</argument>
+            <argument name="amastyLegacyQuoteResource" xsi:type="object">boltAmastyLegacyQuoteResource</argument>
+            <argument name="amastyLegacyQuoteRepository" xsi:type="object">boltAmastyLegacyQuoteRepository</argument>
+            <argument name="amastyLegacyAccountCollection" xsi:type="object">boltAmastyLegacyAccountCollection</argument>            
             <argument name="amastyAccountFactory" xsi:type="object">boltAmastyAccountFactory</argument>
-            <argument name="amastyGiftCardManagement" xsi:type="object">boltAmastyGiftCardManagement</argument>
-            <argument name="amastyQuoteFactory" xsi:type="object">boltAmastyQuoteFactory</argument>
-            <argument name="amastyQuoteResource" xsi:type="object">boltAmastyQuoteResource</argument>
-            <argument name="amastyQuoteRepository" xsi:type="object">boltAmastyQuoteRepository</argument>
-            <argument name="amastyAccountCollection" xsi:type="object">boltAmastyAccountCollection</argument>
+            <argument name="amastyGiftCardAccountManagement" xsi:type="object">boltAmastyGiftCardAccountManagement</argument>
+            <argument name="amastyGiftCardAccountCollection" xsi:type="object">boltAmastyGiftCardAccountCollection</argument>
             <argument name="unirgyCertRepository" xsi:type="object">boltUnirgyCertRepository</argument>
             <argument name="mirasvitStoreCreditHelper" xsi:type="object">boltMirasvitStoreCreditHelper</argument>
             <argument name="mirasvitStoreCreditCalculationHelper" xsi:type="object">boltMirasvitStoreCreditCalculationHelper</argument>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -91,70 +91,70 @@
             <argument name="moduleUnirgyGiftCertHelper" xsi:type="object">boltUnirgyGiftCertHelper</argument>
         </arguments>
     </type>
-
+    <!-- For Amasty Gift Card v1.8.15 and before -->
     <virtualType name="boltAmastyLegacyAccount" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
         <arguments>
             <argument name="moduleName" xsi:type="string">Amasty_GiftCard</argument>
             <argument name="className" xsi:type="string">Amasty\GiftCard\Model\Account</argument>
         </arguments>
     </virtualType>
-
+    <!-- For Amasty Gift Card v1.8.15 and before -->
     <virtualType name="boltAmastyLegacyAccountFactory" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
         <arguments>
             <argument name="moduleName" xsi:type="string">Amasty_GiftCard</argument>
             <argument name="className" xsi:type="string">Amasty\GiftCard\Model\AccountFactory</argument>
         </arguments>
     </virtualType>
-
+    <!-- For Amasty Gift Card v1.8.15 and before -->
     <virtualType name="boltAmastyLegacyGiftCardManagement" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
         <arguments>
             <argument name="moduleName" xsi:type="string">Amasty_GiftCard</argument>
             <argument name="className" xsi:type="string">Amasty\GiftCard\Model\GiftCardManagement</argument>
         </arguments>
     </virtualType>
-
+    <!-- For Amasty Gift Card v1.8.15 and before -->
     <virtualType name="boltAmastyLegacyQuoteFactory" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
         <arguments>
             <argument name="moduleName" xsi:type="string">Amasty_GiftCard</argument>
             <argument name="className" xsi:type="string">Amasty\GiftCard\Model\QuoteFactory</argument>
         </arguments>
     </virtualType>
-
+    <!-- For Amasty Gift Card v1.8.15 and before -->
     <virtualType name="boltAmastyLegacyQuoteResource" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
         <arguments>
             <argument name="moduleName" xsi:type="string">Amasty_GiftCard</argument>
             <argument name="className" xsi:type="string">Amasty\GiftCard\Model\ResourceModel\Quote</argument>
         </arguments>
     </virtualType>
-
+    <!-- For Amasty Gift Card v1.8.15 and before -->
     <virtualType name="boltAmastyLegacyQuoteRepository" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
         <arguments>
             <argument name="moduleName" xsi:type="string">Amasty_GiftCard</argument>
             <argument name="className" xsi:type="string">Amasty\GiftCard\Model\Repository\QuoteRepository</argument>
         </arguments>
     </virtualType>
-
+    <!-- For Amasty Gift Card v1.8.15 and before -->
     <virtualType name="boltAmastyLegacyAccountCollection" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
         <arguments>
             <argument name="moduleName" xsi:type="string">Amasty_GiftCard</argument>
             <argument name="className" xsi:type="string">Amasty\GiftCard\Model\ResourceModel\Account\Collection</argument>
         </arguments>
     </virtualType>
-    
+    <!-- For Amasty Gift Card v2.0.0 and later -->
     <virtualType name="boltAmastyAccountFactory" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
         <arguments>
             <argument name="moduleName" xsi:type="string">Amasty_GiftCardAccount</argument>
             <argument name="className" xsi:type="string">Amasty\GiftCardAccount\Model\GiftCardAccount\RepositoryFactory</argument>
         </arguments>
     </virtualType>
-    
+    <!-- For Amasty Gift Card v2.0.0 and later -->
     <virtualType name="boltAmastyGiftCardAccountManagement" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
         <arguments>
             <argument name="moduleName" xsi:type="string">Amasty_GiftCardAccount</argument>
             <argument name="className" xsi:type="string">Amasty\GiftCardAccount\Model\GiftCardAccount\GiftCardAccountManagement</argument>
         </arguments>
     </virtualType>
-    
+    <!-- For Amasty Gift Card v2.0.0 and later -->
     <virtualType name="boltAmastyGiftCardAccountCollection" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
         <arguments>
             <argument name="moduleName" xsi:type="string">Amasty_GiftCardAccount</argument>
@@ -260,12 +260,14 @@
 
     <type name="Bolt\Boltpay\Helper\Discount">
         <arguments>
+            <!-- For Amasty Gift Card v1.8.15 and before -->
             <argument name="amastyLegacyAccountFactory" xsi:type="object">boltAmastyLegacyAccountFactory</argument>
             <argument name="amastyLegacyGiftCardManagement" xsi:type="object">boltAmastyLegacyGiftCardManagement</argument>
             <argument name="amastyLegacyQuoteFactory" xsi:type="object">boltAmastyLegacyQuoteFactory</argument>
             <argument name="amastyLegacyQuoteResource" xsi:type="object">boltAmastyLegacyQuoteResource</argument>
             <argument name="amastyLegacyQuoteRepository" xsi:type="object">boltAmastyLegacyQuoteRepository</argument>
             <argument name="amastyLegacyAccountCollection" xsi:type="object">boltAmastyLegacyAccountCollection</argument>            
+            <!-- For Amasty Gift Card v2.0.0 and later -->
             <argument name="amastyAccountFactory" xsi:type="object">boltAmastyAccountFactory</argument>
             <argument name="amastyGiftCardAccountManagement" xsi:type="object">boltAmastyGiftCardAccountManagement</argument>
             <argument name="amastyGiftCardAccountCollection" xsi:type="object">boltAmastyGiftCardAccountCollection</argument>


### PR DESCRIPTION
# Description
Since v2.0.0, the Amasty team completely overhauled Amasty GiftCard module, as a result, Bolt M2 plugin does not work with the latest version of Amasty GiftCard. So we need to update the related code to support.

Fixes: https://boltpay.atlassian.net/browse/M2P-137

#changelog General plugin support for Amasty GiftCard 2.0.0 or later

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
