### PR TITLE
[M2P-140] Call bolt with promises when 3p module updated the quote total

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -2288,10 +2288,9 @@ if (!$block->isSaveCartInSections()) { ?>
     if (trim(location.pathname, '/') === 'checkout/cart') {
         require([
         'jquery',
-        'Magento_Customer/js/customer-data',
         'Magento_Checkout/js/model/quote',
         'domReady!'
-        ], function ($, customerData, quote) {
+        ], function ($, quote) {
             // If quote total was changed through a method we didn't create,
             // we should reload the bolt cart since totals are probably now out of sync.
             quote.totals.subscribe(function (newValue) {
@@ -2304,7 +2303,7 @@ if (!$block->isSaveCartInSections()) { ?>
                 if (waitingForResolvingPromises) {
                     return;
                 }
-                customerData.reload(['boltcart'], true);
+                $(document).trigger('bolt:createOrder');
             });
        })
     }


### PR DESCRIPTION
When we handle quote total updating we need to do:
- call BoltCheckout.Configure with promises
- invalidate bolt cart
- resolve promises once we receive a new bolt cart

It allows us to handle properly clicks that users do while we update bolt cart.
It the same as we do in all other situations when we know that Magento cart was updated.

Fixes: [M2P-140]

#changelog [M2P-140] Call bolt with promises when 3p module updated the quote total

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [x] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
