### PR TITLE
Add feature switch around Non-Bolt Observer

### DIFF
--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -203,6 +203,14 @@ class Decider extends AbstractHelper
         return $this->isSwitchEnabled(Definitions::M2_TRACK_SHIPMENT);
     }
 
+    /**
+     * Checks whether the feature switch for ingesting Non-Bolt order information is enabled
+     */
+    public function isNonBoltTrackingEnabled()
+    {
+        return $this->isSwitchEnabled(Definitions::M2_TRACK_NON_BOLT);
+    }
+
     public function isOrderManagementEnabled()
     {
         return $this->isSwitchEnabled(Definitions::M2_ORDER_MANAGEMENT);

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -68,6 +68,11 @@ class Definitions
     const M2_TRACK_SHIPMENT = "M2_TRACK_SHIPMENT";
 
     /**
+     * Enable non-Bolt order tracking
+     */
+    const M2_TRACK_NON_BOLT = "M2_TRACK_NON_BOLT";
+
+    /**
      * Enable Order Management (account button)
      */
     const M2_ORDER_MANAGEMENT = "M2_ORDER_MANAGEMENT";
@@ -145,6 +150,12 @@ class Definitions
         ],
         self::M2_TRACK_SHIPMENT => [
             self::NAME_KEY            => self::M2_TRACK_SHIPMENT,
+            self::VAL_KEY             => true,
+            self::DEFAULT_VAL_KEY     => false,
+            self::ROLLOUT_KEY         => 100
+        ],
+        self::M2_TRACK_NON_BOLT => [
+            self::NAME_KEY            => self::M2_TRACK_NON_BOLT,
             self::VAL_KEY             => true,
             self::DEFAULT_VAL_KEY     => false,
             self::ROLLOUT_KEY         => 100

--- a/Observer/NonBoltOrderObserver.php
+++ b/Observer/NonBoltOrderObserver.php
@@ -6,6 +6,7 @@ use Bolt\Boltpay\Helper\Api as ApiHelper;
 use Bolt\Boltpay\Helper\Bugsnag;
 use Bolt\Boltpay\Helper\Config as ConfigHelper;
 use Bolt\Boltpay\Helper\Cart as CartHelper;
+use Bolt\Boltpay\Helper\FeatureSwitch\Decider;
 use Bolt\Boltpay\Helper\Log as LogHelper;
 use Bolt\Boltpay\Helper\MetricsClient;
 use Bolt\Boltpay\Model\Payment;
@@ -68,6 +69,11 @@ class NonBoltOrderObserver implements ObserverInterface
     private $quoteRepository;
 
     /**
+     * @var Decider
+     */
+    private $decider;
+
+    /**
      * @param ApiHelper $apiHelper
      * @param Bugsnag $bugsnag
      * @param CartHelper $cartHelper
@@ -76,6 +82,7 @@ class NonBoltOrderObserver implements ObserverInterface
      * @param LogHelper $logHelper
      * @param MetricsClient $metricsClient
      * @param QuoteRepository $quoteRepository
+     * @param Decider $decider
      */
     public function __construct(
         ApiHelper $apiHelper,
@@ -85,7 +92,8 @@ class NonBoltOrderObserver implements ObserverInterface
         DataObjectFactory $dataObjectFactory,
         LogHelper $logHelper,
         MetricsClient $metricsClient,
-        QuoteRepository $quoteRepository
+        QuoteRepository $quoteRepository,
+        Decider $decider
     ) {
         $this->apiHelper = $apiHelper;
         $this->bugsnag = $bugsnag;
@@ -95,6 +103,7 @@ class NonBoltOrderObserver implements ObserverInterface
         $this->logHelper = $logHelper;
         $this->metricsClient = $metricsClient;
         $this->quoteRepository = $quoteRepository;
+        $this->decider = $decider;
     }
 
     /**
@@ -102,6 +111,10 @@ class NonBoltOrderObserver implements ObserverInterface
      */
     public function execute(Observer $observer)
     {
+        if (!$this->decider->isNonBoltTrackingEnabled()) {
+            return;
+        }
+
         try {
             $order = $observer->getEvent()->getOrder();
             if ($order == null) {

--- a/Observer/NonBoltOrderObserver.php
+++ b/Observer/NonBoltOrderObserver.php
@@ -161,11 +161,6 @@ class NonBoltOrderObserver implements ObserverInterface
             $this->metricsClient->processCountMetric("non_bolt_order_creation.failure", 1);
             $this->bugsnag->notifyException($exception);
             return;
-        } catch (Error $error) {
-            // catch errors so failures here don't prevent orders from being created
-            $this->metricsClient->processCountMetric("non_bolt_order_creation.failure", 1);
-            $this->bugsnag->notifyException($error);
-            return;
         }
 
         $this->metricsClient->processCountMetric("non_bolt_order_creation.success", 1);

--- a/Observer/TrackingSaveObserver.php
+++ b/Observer/TrackingSaveObserver.php
@@ -55,6 +55,7 @@ class TrackingSaveObserver implements ObserverInterface
      * @param ApiHelper $apiHelper
      * @param Bugsnag $bugsnag
      * @param MetricsClient $metricsClient
+     * @param Decider $decider
      *
      */
     public function __construct(

--- a/Test/Unit/Observer/NonBoltOrderObserverTest.php
+++ b/Test/Unit/Observer/NonBoltOrderObserverTest.php
@@ -292,7 +292,7 @@ class NonBoltOrderObserverTest extends TestCase
     public function testExecuteBoltOrder()
     {
         $this->decider->expects($this->once())->method('isNonBoltTrackingEnabled')->willReturn(true);
-        $payment = $this->getMockForAbstractClass(Payment::class);
+        $payment = $this->createMock(Payment::class);
         $payment->expects($this->once())
             ->method('getMethod')
             ->willReturn(\Bolt\Boltpay\Model\Payment::METHOD_CODE);

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -4,11 +4,4 @@
     <event name="sales_order_shipment_track_save_after">
         <observer name="boltTrackSaveObserver" instance="Bolt\Boltpay\Observer\TrackingSaveObserver" />
     </event>
-    <!-- Need both events because PayPal does not emit the checkout_submit_all_after event -->
-    <event name="checkout_submit_all_after">
-        <observer name="nonBoltOrderObserver" instance="Bolt\Boltpay\Observer\NonBoltOrderObserver" />
-    </event>
-    <event name="paypal_express_place_order_success">
-        <observer name="nonBoltOrderObserver" instance="Bolt\Boltpay\Observer\NonBoltOrderObserver" />
-    </event>
 </config>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+    <!-- When adding any observer, you MUST wrap the observer in a feature switch -->
     <event name="sales_order_shipment_track_save_after">
         <observer name="boltTrackSaveObserver" instance="Bolt\Boltpay\Observer\TrackingSaveObserver" />
+    </event>
+    <!-- Need both events because PayPal does not emit the checkout_submit_all_after event -->
+    <event name="checkout_submit_all_after">
+        <observer name="nonBoltOrderObserver" instance="Bolt\Boltpay\Observer\NonBoltOrderObserver" />
+    </event>
+    <event name="paypal_express_place_order_success">
+        <observer name="nonBoltOrderObserver" instance="Bolt\Boltpay\Observer\NonBoltOrderObserver" />
     </event>
 </config>


### PR DESCRIPTION
# Description
Added a feature switch around the non-Bolt observer.

This does not re-register the observer, so as of now it still does not do anything.

Fixes: (link Jira ticket)

#changelog Add feature switch around Non-Bolt Observer and re-register event
Add a feature switch for the NonBoltOrderObserver
Re-register the observer with two order placed events

# Type of change

- [X] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [X] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] New and existing unit tests pass locally with my changes.
- [X] I have created or modified unit tests to sufficiently cover my changes.
- [X] I have added my Jira ticket link and provided a changelog message.
