### PR TITLE
M2P-155 Bugfix - Unable to remove Amasty GiftCard

### DIFF
--- a/Test/Unit/Model/Api/DiscountCodeValidationTest.php
+++ b/Test/Unit/Model/Api/DiscountCodeValidationTest.php
@@ -74,6 +74,7 @@ class DiscountCodeValidationTest extends TestCase
     const USAGE_LIMIT = 100;
     const COUPON_CODE = 'TEST_COUPON';
     const STORE_ID = 1;
+    const CACHE_IDENTIFIER = 'de6571d30123102e4a49a9483881a05f';
 
     /**
      * @var CouponFactory
@@ -395,6 +396,9 @@ class DiscountCodeValidationTest extends TestCase
 
         $this->cartHelper->method('getQuoteById')
             ->willReturnMap($getQuoteByIdMap);
+        
+        $this->cartHelper->method('getQuoteCacheIdentifier')
+            ->willReturn(self::CACHE_IDENTIFIER);
 
         $result = $this->currentMock->validate();
 
@@ -500,6 +504,9 @@ class DiscountCodeValidationTest extends TestCase
 
         $this->cartHelper->method('getQuoteById')
             ->willReturnMap($getQuoteByIdMap);
+        
+        $this->cartHelper->method('getQuoteCacheIdentifier')
+            ->willReturn(self::CACHE_IDENTIFIER);
 
         $this->cartHelper->method('handleSpecialAddressCases')
             ->willReturn((object)$request_shipping_addr);
@@ -623,6 +630,9 @@ class DiscountCodeValidationTest extends TestCase
 
         $this->cartHelper->method('getQuoteById')
             ->willReturnMap($getQuoteByIdMap);
+        
+        $this->cartHelper->method('getQuoteCacheIdentifier')
+            ->willReturn(self::CACHE_IDENTIFIER);
 
         $this->expectErrorResponse(
             BoltErrorResponse::ERR_CODE_INVALID,
@@ -983,6 +993,9 @@ class DiscountCodeValidationTest extends TestCase
 
         $this->cartHelper->method('getQuoteById')
             ->willReturnMap($getQuoteByIdMap);
+            
+        $this->cartHelper->method('getQuoteCacheIdentifier')
+            ->willReturn(self::CACHE_IDENTIFIER);
 
         $this->ruleMock->expects(self::once())->method('getSimpleAction')->willReturn('cart_fixed');
 
@@ -1059,6 +1072,9 @@ class DiscountCodeValidationTest extends TestCase
 
         $this->cartHelper->method('getQuoteById')
             ->willReturnMap($getQuoteByIdMap);
+        
+        $this->cartHelper->method('getQuoteCacheIdentifier')
+            ->willReturn(self::CACHE_IDENTIFIER);
 
         $this->moduleGiftCardAccountMock->method('getInstance')->willReturnSelf();
 
@@ -1812,6 +1828,7 @@ class DiscountCodeValidationTest extends TestCase
                 $giftCard,
                 $immutableQuoteMock,
                 $parentQuoteMock,
+                self::CACHE_IDENTIFIER
             ]
         );
 
@@ -1859,6 +1876,7 @@ class DiscountCodeValidationTest extends TestCase
                     $giftCard,
                     $immutableQuoteMock,
                     $parentQuoteMock,
+                    self::CACHE_IDENTIFIER
                 ]
             )
         );
@@ -1916,6 +1934,7 @@ class DiscountCodeValidationTest extends TestCase
                 $giftCardMock,
                 $immutableQuoteMock,
                 $parentQuoteMock,
+                self::CACHE_IDENTIFIER
             ]
         );
 
@@ -1978,6 +1997,7 @@ class DiscountCodeValidationTest extends TestCase
                 $giftCardMock,
                 $immutableQuoteMock,
                 $parentQuoteMock,
+                self::CACHE_IDENTIFIER
             ]
         );
 
@@ -2253,7 +2273,9 @@ class DiscountCodeValidationTest extends TestCase
                     'getQuoteById',
                     'handleSpecialAddressCases',
                     'validateEmail',
-                    'getCartData'
+                    'getCartData',
+                    'getQuoteCacheIdentifier',
+                    'removeFromCache'
                 ]
             )
             ->disableOriginalConstructor()


### PR DESCRIPTION
# Description
```
Steps to reproduce: 

1. Purchase a gift card (generated by Amasty GiftCard)
2. Add a simple product to cart
3. Go to cart page
4. Open Bolt modal and apply the gift card in the "Delivery" or "Payment" step
5. Keep the Bolt modal open and directly reload the cart page
6. Delete the applied gift card by clicking “Remove” button of Amasty GiftCard 
7. Open the Bolt modal

Expected behavior:
The Bolt modal does not have any applied gift card

Actual behavior:
The Bolt modal still has the previous gift card
```

Root cause:
When loading the cart page, we save the current quote without giftcard into cache, also an associated cart is created on Bolt side. Then we apply giftcard through Bolt modal, the Bolt cart get updated while the cache stay the same. So when we remove the giftcard from cart page, the plugin just retrieve the cache and wont refresh the cart on Bolt side, it result in a mismatch.

Fixes: https://boltpay.atlassian.net/browse/M2P-155

#changelog Bugfix - Unable to remove Amasty GiftCard

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
