### PR TITLE
[M2P-161] Fix issue with IE11: cart total isn't shown under some condition

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -2288,9 +2288,10 @@ if (!$block->isSaveCartInSections()) { ?>
     if (trim(location.pathname, '/') === 'checkout/cart') {
         require([
         'jquery',
+        'Magento_Customer/js/customer-data',
         'Magento_Checkout/js/model/quote',
         'domReady!'
-        ], function ($, quote) {
+        ], function ($, customerData, quote) {
             // If quote total was changed through a method we didn't create,
             // we should reload the bolt cart since totals are probably now out of sync.
             quote.totals.subscribe(function (newValue) {


### PR DESCRIPTION
# Description
Please include a summary of the change and which issue is fixed. Include the motivation for the changes, and comment on your PR if necessary for clarity.

An issue was introduced in https://github.com/BoltApp/bolt-magento2/pull/801 (2.10.0)
After this PR it's possible that we use Magento sections functional before it initialized properly.
It happens on cart page only, when Magento tried to render order total.
As a result, the order total isn't rendered. Bolt button is shown and it can work if bolt order was loaded before the issue happened.
If, for example, a user clicked add to cart, wait 10 seconds and then go to cart page we can expect bolt button works.
If a user goes to the cart page right after they added something to the cart bolt button doesn't work.
If the bolt button doesn't work, we don't show any error, just nothing happens when clicking it.
Page reload fixes the issue.

The issue doesn't happen on Magento >= 2.3.3, because some sort of protection was introduced 

Usually, the issue shouldn't happen because sections initialized even if we didn't check it.
We are able to reproduce the issue on IE11 only, but we can't be sure it doesn't happen on other envs.
This is a race condition issue, so it doesn't happen on IE11 each time, only sometimes.


#changelog [M2P-161] Fix issue with IE11: cart total isn't shown under some condition

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [x] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [x] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
