### PR TITLE
Use plugin for afterPlace rather than observer for orders

### DIFF
--- a/Observer/TrackingSaveObserver.php
+++ b/Observer/TrackingSaveObserver.php
@@ -115,7 +115,7 @@ class TrackingSaveObserver implements ObserverInterface
 
             $isNonBoltOrder = !$payment || $payment->getMethod() != \Bolt\Boltpay\Model\Payment::METHOD_CODE;
             if ($isNonBoltOrder) {
-                $transactionReference = $payment->getBoltTransactionReference();
+                $transactionReference = $order->getBoltTransactionReference();
             } else {
                 $transactionReference = $payment->getAdditionalInformation('transaction_reference');
             }

--- a/Observer/TrackingSaveObserver.php
+++ b/Observer/TrackingSaveObserver.php
@@ -115,7 +115,7 @@ class TrackingSaveObserver implements ObserverInterface
 
             $isNonBoltOrder = !$payment || $payment->getMethod() != \Bolt\Boltpay\Model\Payment::METHOD_CODE;
             if ($isNonBoltOrder) {
-                $transactionReference = $payment->getAdditionalInformation('bolt_transaction_reference');
+                $transactionReference = $payment->getBoltTransactionReference();
             } else {
                 $transactionReference = $payment->getAdditionalInformation('transaction_reference');
             }

--- a/Plugin/NonBoltOrderPlugin.php
+++ b/Plugin/NonBoltOrderPlugin.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Bolt\Boltpay\Observer;
+namespace Bolt\Boltpay\Plugin;
 
 use Bolt\Boltpay\Helper\Api as ApiHelper;
 use Bolt\Boltpay\Helper\Bugsnag;
@@ -9,24 +9,23 @@ use Bolt\Boltpay\Helper\Cart as CartHelper;
 use Bolt\Boltpay\Helper\FeatureSwitch\Decider;
 use Bolt\Boltpay\Helper\Log as LogHelper;
 use Bolt\Boltpay\Helper\MetricsClient;
+use Bolt\Boltpay\Helper\Order;
 use Bolt\Boltpay\Model\Payment;
 use Bolt\Boltpay\Model\Response;
-use Error;
 use Exception;
 use Magento\Customer\Api\Data\CustomerInterface;
 use Magento\Framework\DataObjectFactory;
-use Magento\Framework\Event\ObserverInterface;
-use Magento\Framework\Event\Observer;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Quote\Api\CartRepositoryInterface as QuoteRepository;
+use Magento\Sales\Api\OrderManagementInterface;
 use Zend_Http_Client_Exception;
 
 /**
- * Class NonBoltOrderObserver
+ * Class NonBoltOrderPlugin
  *
- * @package Bolt\Boltpay\Observer
+ * @package Bolt\Boltpay\Plugin
  */
-class NonBoltOrderObserver implements ObserverInterface
+class NonBoltOrderPlugin
 {
     /**
      * @var ApiHelper
@@ -107,37 +106,35 @@ class NonBoltOrderObserver implements ObserverInterface
     }
 
     /**
-     * @param Observer $observer
+     * @param OrderManagementInterface $orderManagementInterface
+     * @param Order
+     *
+     * @return Order
      */
-    public function execute(Observer $observer)
+    public function afterPlace(OrderManagementInterface $orderManagementInterface, $order)
     {
         if (!$this->decider->isNonBoltTrackingEnabled()) {
-            return;
+            return $order;
         }
 
         try {
-            $order = $observer->getEvent()->getOrder();
-            if ($order == null) {
-                return;
-            }
-
             $payment = $order->getPayment();
             $paymentMethod = $payment ? $payment->getMethod() : "unknown";
             if ($paymentMethod == Payment::METHOD_CODE) {
                 // ignore Bolt orders
-                return;
+                return $order;
             }
 
             $quote = $this->quoteRepository->get($order->getQuoteId());
             if (!$quote) {
                 $this->metricsClient->processCountMetric("non_bolt_order_creation.no_quote", 1);
-                return;
+                return $order;
             }
 
             $items = $quote->getAllVisibleItems();
             if (!$items) {
                 $this->metricsClient->processCountMetric("non_bolt_order_creation.no_items", 1);
-                return;
+                return $order;
             }
 
             $this->handleMissingName($quote);
@@ -149,7 +146,7 @@ class NonBoltOrderObserver implements ObserverInterface
             $response = $result->getResponse();
             if (empty($response)) {
                 $this->metricsClient->processCountMetric("non_bolt_order_creation.failure", 1);
-                return;
+                return $order;
             }
 
             $boltTransactionData = ['bolt_transaction_reference' => $response->reference];
@@ -160,10 +157,11 @@ class NonBoltOrderObserver implements ObserverInterface
         } catch (Exception $exception) {
             $this->metricsClient->processCountMetric("non_bolt_order_creation.failure", 1);
             $this->bugsnag->notifyException($exception);
-            return;
+            return $order;
         }
 
         $this->metricsClient->processCountMetric("non_bolt_order_creation.success", 1);
+        return $order;
     }
 
     /**

--- a/Plugin/NonBoltOrderPlugin.php
+++ b/Plugin/NonBoltOrderPlugin.php
@@ -149,10 +149,7 @@ class NonBoltOrderPlugin
                 return $order;
             }
 
-            $boltTransactionData = ['bolt_transaction_reference' => $response->reference];
-            $payment->setAdditionalInformation(
-                array_merge((array)$payment->getAdditionalInformation(), $boltTransactionData)
-            );
+            $payment->setBoltTransactionReference($response->reference);
             $payment->save();
         } catch (Exception $exception) {
             $this->metricsClient->processCountMetric("non_bolt_order_creation.failure", 1);

--- a/Plugin/NonBoltOrderPlugin.php
+++ b/Plugin/NonBoltOrderPlugin.php
@@ -149,8 +149,8 @@ class NonBoltOrderPlugin
                 return $order;
             }
 
-            $payment->setBoltTransactionReference($response->reference);
-            $payment->save();
+            $order->setBoltTransactionReference($response->reference);
+            $order->save();
         } catch (Exception $exception) {
             $this->metricsClient->processCountMetric("non_bolt_order_creation.failure", 1);
             $this->bugsnag->notifyException($exception);

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -79,6 +79,17 @@ class UpgradeSchema implements UpgradeSchemaInterface
             ['bolt_parent_quote_id']
         );
 
+        $setup->getConnection()->addColumn(
+            $setup->getTable('sales_order_payment'),
+            'bolt_transaction_reference',
+            [
+                'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                'length' => 64,
+                'nullable' => true,
+                'comment' => 'Bolt Transaction Reference'
+            ]
+        );
+
         $this->setupFeatureSwitchTable($setup);
 
         $this->setUpFeatureBoltCustomerCreditCardsTable($setup);

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -80,7 +80,7 @@ class UpgradeSchema implements UpgradeSchemaInterface
         );
 
         $setup->getConnection()->addColumn(
-            $setup->getTable('sales_order_payment'),
+            $setup->getTable('sales_order'),
             'bolt_transaction_reference',
             [
                 'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,

--- a/Test/Unit/Observer/TrackingSaveObserverTest.php
+++ b/Test/Unit/Observer/TrackingSaveObserverTest.php
@@ -224,18 +224,17 @@ class TrackingSaveObserverTest extends TestCase
         $shipmentItem = $this->getMockBuilder(\Magento\Sales\Model\Order\Shipment\Item::class)->disableOriginalConstructor()->getMock();
         $orderItem = $this->getMockBuilder(\Magento\Sales\Model\Order\Item::class)->disableOriginalConstructor()->getMock();
         $payment = $this->getMockBuilder(\Magento\Sales\Api\Data\OrderPaymentInterface::class)->getMockForAbstractClass();
-        $order = $this->getMockBuilder(\Magento\Sales\Model\Order::class)->disableOriginalConstructor()->getMock();
+        $order = $this->getMockBuilder("BoltOrder")
+            ->setMethods(['getPayment', 'getStoreId', 'getBoltTransactionReference'])
+            ->getMock();
         $track = $this->getMockBuilder(\Magento\Sales\Model\Order\Shipment\Track::class)->disableOriginalConstructor()->getMock();
 
-        $map = [
-            ['bolt_transaction_reference', '000123'],
-        ];
-        $payment->expects($this->once())
-            ->method('getAdditionalInformation')
-            ->will($this->returnValueMap($map));
         $payment->expects($this->once())
             ->method('getMethod')
             ->willReturn('otherpay');
+        $order->expects($this->once())
+            ->method('getBoltTransactionReference')
+            ->will($this->returnValue('ABCD-EFGH-1234'));
         $order->expects($this->once())
             ->method('getPayment')
             ->willReturn($payment);
@@ -290,7 +289,7 @@ class TrackingSaveObserverTest extends TestCase
             ->willReturn([$shipmentItem]);
 
         $expectedData = [
-            "transaction_reference" => "000123",
+            "transaction_reference" => "ABCD-EFGH-1234",
             "tracking_number"       => "EZ4000000004",
             "carrier"               => "United States Postal Service",
             "items"                 => [
@@ -324,15 +323,11 @@ class TrackingSaveObserverTest extends TestCase
         $shipmentItem = $this->getMockBuilder(\Magento\Sales\Model\Order\Shipment\Item::class)->disableOriginalConstructor()->getMock();
         $orderItem = $this->getMockBuilder(\Magento\Sales\Model\Order\Item::class)->disableOriginalConstructor()->getMock();
         $payment = $this->getMockBuilder(\Magento\Sales\Api\Data\OrderPaymentInterface::class)->getMockForAbstractClass();
-        $order = $this->getMockBuilder(\Magento\Sales\Model\Order::class)->disableOriginalConstructor()->getMock();
+        $order = $this->getMockBuilder("BoltOrder")
+            ->setMethods(['getPayment', 'getBoltTransactionReference'])
+            ->getMock();
         $track = $this->getMockBuilder(\Magento\Sales\Model\Order\Shipment\Track::class)->disableOriginalConstructor()->getMock();
 
-        $map = [
-            ['transaction_reference', '000123'],
-        ];
-        $payment->expects($this->never())
-            ->method('getAdditionalInformation')
-            ->will($this->returnValueMap($map));
         $payment->expects($this->never())
             ->method('getMethod')
             ->willReturn(\Bolt\Boltpay\Model\Payment::METHOD_CODE);
@@ -384,17 +379,17 @@ class TrackingSaveObserverTest extends TestCase
         $shipmentItem = $this->getMockBuilder(\Magento\Sales\Model\Order\Shipment\Item::class)->disableOriginalConstructor()->getMock();
         $orderItem = $this->getMockBuilder(\Magento\Sales\Model\Order\Item::class)->disableOriginalConstructor()->getMock();
         $payment = $this->getMockBuilder(\Magento\Sales\Api\Data\OrderPaymentInterface::class)->getMockForAbstractClass();
-        $order = $this->getMockBuilder(\Magento\Sales\Model\Order::class)->disableOriginalConstructor()->getMock();
+        $order = $this->getMockBuilder("BoltOrder")
+            ->setMethods(['getPayment', 'getQuoteId', 'getBoltTransactionReference'])
+            ->getMock();
         $track = $this->getMockBuilder(\Magento\Sales\Model\Order\Shipment\Track::class)->disableOriginalConstructor()->getMock();
 
-        $map = [
-        ];
-        $payment->expects($this->once())
-            ->method('getAdditionalInformation')
-            ->will($this->returnValueMap($map));
         $payment->expects($this->once())
             ->method('getMethod')
             ->willReturn('otherpay');
+        $order->expects($this->once())
+            ->method('getBoltTransactionReference')
+            ->will($this->returnValue(null));
         $order->expects($this->once())
             ->method('getPayment')
             ->willReturn($payment);

--- a/Test/Unit/Plugin/NonBoltOrderObserverTest.php
+++ b/Test/Unit/Plugin/NonBoltOrderObserverTest.php
@@ -16,7 +16,7 @@
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-namespace Bolt\Boltpay\Test\Unit\Observer;
+namespace Bolt\Boltpay\Test\Unit\Plugin;
 
 use Bolt\Boltpay\Helper\Api as ApiHelper;
 use Bolt\Boltpay\Helper\Cart as CartHelper;
@@ -24,27 +24,29 @@ use Bolt\Boltpay\Helper\FeatureSwitch\Decider;
 use Bolt\Boltpay\Helper\Log as LogHelper;
 use Bolt\Boltpay\Helper\MetricsClient;
 use Bolt\Boltpay\Model\Response;
+use Bolt\Boltpay\Plugin\NonBoltOrderPlugin;
 use Exception;
 use Magento\Customer\Api\Data\CustomerInterface;
 use Magento\Framework\DataObject;
 use Bolt\Boltpay\Helper\Config as ConfigHelper;
 use Magento\Framework\DataObjectFactory;
 use Bolt\Boltpay\Helper\Bugsnag;
-use Magento\Framework\Event;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Quote\Model\Quote;
 use Magento\Quote\Model\Quote\Address;
 use Magento\Quote\Model\Quote\Item;
+use Magento\Sales\Api\OrderManagementInterface;
 use Magento\Sales\Model\Order;
 use Magento\Quote\Api\CartRepositoryInterface as QuoteRepository;
 use Magento\Sales\Model\Order\Payment;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
-use Bolt\Boltpay\Observer\NonBoltOrderObserver as Observer;
+use Bolt\Boltpay\Plugin\NonBoltOrderPlugin as Plugin;
 use \PHPUnit\Framework\TestCase;
 use Bolt\Boltpay\Model\Request;
 
 /**
- * Class NonBoltOrderObserverTest
- * @coversDefaultClass \Bolt\Boltpay\Observer\NonBoltOrderObserver
+ * Class NonBoltOrderPluginTest
+ * @coversDefaultClass \Bolt\Boltpay\Plugin\NonBoltOrderPlugin
  */
 class NonBoltOrderObserverTest extends TestCase
 {
@@ -101,9 +103,14 @@ class NonBoltOrderObserverTest extends TestCase
     private $decider;
 
     /**
-     * @var Observer
+     * @var Plugin
      */
-    protected $observer;
+    protected $plugin;
+
+    /**
+     * @var OrderManagementInterface
+     */
+    protected $orderManagementInterface;
 
     protected function setUp()
     {
@@ -129,16 +136,21 @@ class NonBoltOrderObserverTest extends TestCase
         $logHelper = $this->createMock(LogHelper::class);
         $metricsClient = $this->createMock(MetricsClient::class);
         $this->quoteRepository = $this->createMock(QuoteRepository::class);
-        $this->observer = new Observer(
-            $this->apiHelper,
-            $bugsnag,
-            $this->cartHelper,
-            $configHelper,
-            $dataObjectFactory,
-            $logHelper,
-            $metricsClient,
-            $this->quoteRepository,
-            $this->decider
+        $this->orderManagementInterface = $this->createMock(OrderManagementInterface::class);
+        $objectManager = new ObjectManager($this);
+        $this->plugin = $objectManager->getObject(
+            NonBoltOrderPlugin::class,
+            [
+                'apiHelper' => $this->apiHelper,
+                'bugsnag' => $bugsnag,
+                'cartHelper' => $this->cartHelper,
+                'configHelper' => $configHelper,
+                'dataObjectFactory' => $dataObjectFactory,
+                'logHelper' => $logHelper,
+                'metricsClient' => $metricsClient,
+                'quoteRepository' => $this->quoteRepository,
+                'decider' => $this->decider
+            ]
         );
     }
 
@@ -176,19 +188,6 @@ class NonBoltOrderObserverTest extends TestCase
             ->method('setAdditionalInformation');
         $payment->expects($this->once())
             ->method('save');
-        $event = $this->getMockBuilder(Event::class)
-            ->setMethods(['getOrder'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $event->expects($this->once())
-            ->method('getOrder')
-            ->willReturn($order);
-        $eventObserver = $this->getMockBuilder(Event\Observer::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $eventObserver->expects($this->once())
-            ->method('getEvent')
-            ->willReturn($event);
 
         $this->cartHelper->method('buildCartFromQuote')->willReturn(self::CART);
         $expectedOrderData = [
@@ -212,30 +211,7 @@ class NonBoltOrderObserverTest extends TestCase
         $response = new Response();
         $response->setResponse(json_decode('{"reference": "ABCD-EFGH-1234"}'));
         $this->apiHelper->expects($this->once())->method('sendRequest')->willReturn($response);
-        $this->observer->execute($eventObserver);
-    }
-
-    /**
-     * @test
-     */
-    public function testExecuteNoOrder()
-    {
-        $this->decider->expects($this->once())->method('isNonBoltTrackingEnabled')->willReturn(true);
-        $event = $this->getMockBuilder(Event::class)
-            ->setMethods(['getOrder'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $event->expects($this->once())
-            ->method('getOrder')
-            ->willReturn(null);
-        $eventObserver = $this->getMockBuilder(Event\Observer::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $eventObserver->expects($this->once())
-            ->method('getEvent')
-            ->willReturn($event);
-        $this->apiHelper->expects($this->never())->method('sendRequest');
-        $this->observer->execute($eventObserver);
+        $this->plugin->afterPlace($this->orderManagementInterface, $order);
     }
 
     /**
@@ -248,21 +224,8 @@ class NonBoltOrderObserverTest extends TestCase
         $this->quoteRepository->expects($this->once())
             ->method('get')
             ->willReturn(null);
-        $event = $this->getMockBuilder(Event::class)
-            ->setMethods(['getOrder'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $event->expects($this->once())
-            ->method('getOrder')
-            ->willReturn($order);
-        $eventObserver = $this->getMockBuilder(Event\Observer::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $eventObserver->expects($this->once())
-            ->method('getEvent')
-            ->willReturn($event);
         $this->apiHelper->expects($this->never())->method('sendRequest');
-        $this->observer->execute($eventObserver);
+        $this->plugin->afterPlace($this->orderManagementInterface, $order);
     }
 
 
@@ -273,17 +236,9 @@ class NonBoltOrderObserverTest extends TestCase
     {
         $this->decider->expects($this->once())->method('isNonBoltTrackingEnabled')->willReturn(false);
         $this->quoteRepository->expects($this->never())->method('get');
-        $event = $this->getMockBuilder(Event::class)
-            ->setMethods(['getOrder'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $event->expects($this->never())->method('getOrder');
-        $eventObserver = $this->getMockBuilder(Event\Observer::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $eventObserver->expects($this->never())->method('getEvent');
         $this->apiHelper->expects($this->never())->method('sendRequest');
-        $this->observer->execute($eventObserver);
+        $order = $this->createMock(Order::class);
+        $this->plugin->afterPlace($this->orderManagementInterface, $order);
     }
 
     /**
@@ -303,21 +258,8 @@ class NonBoltOrderObserverTest extends TestCase
         $order->expects($this->once())
             ->method('getPayment')
             ->willReturn($payment);
-        $event = $this->getMockBuilder(Event::class)
-            ->setMethods(['getOrder'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $event->expects($this->once())
-            ->method('getOrder')
-            ->willReturn($order);
-        $eventObserver = $this->getMockBuilder(Event\Observer::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $eventObserver->expects($this->exactly(1))
-            ->method('getEvent')
-            ->willReturn($event);
         $this->apiHelper->expects($this->never())->method('sendRequest');
-        $this->observer->execute($eventObserver);
+        $this->plugin->afterPlace($this->orderManagementInterface, $order);
     }
 
     /**
@@ -339,31 +281,17 @@ class NonBoltOrderObserverTest extends TestCase
         $address->method('getFirstname')->willReturn(self::FIRST_NAME);
         $address->method('getLastname')->willReturn(self::LAST_NAME);
         $quote->method('getShippingAddress')->willReturn($address);
-
         $this->quoteRepository->expects($this->once())
             ->method('get')
             ->willReturn($quote);
-        $event = $this->getMockBuilder(Event::class)
-            ->setMethods(['getOrder'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $event->expects($this->once())
-            ->method('getOrder')
-            ->willReturn($order);
-        $eventObserver = $this->getMockBuilder(Event\Observer::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $eventObserver->expects($this->once())
-            ->method('getEvent')
-            ->willReturn($event);
-
         $this->cartHelper->method('buildCartFromQuote')->willReturnCallback(function () {
             trigger_error("Error", E_ERROR);
         });
         $this->dataObject->expects($this->never())->method("setApiData");
         $this->apiHelper->expects($this->never())->method('buildRequest');
         $this->apiHelper->expects($this->never())->method('sendRequest');
-        $this->observer->execute($eventObserver);
+
+        $this->plugin->afterPlace($this->orderManagementInterface, $order);
 
         // assert that an error was not thrown by the observer
         $this->assertTrue(true);
@@ -388,29 +316,15 @@ class NonBoltOrderObserverTest extends TestCase
         $address->method('getFirstname')->willReturn(self::FIRST_NAME);
         $address->method('getLastname')->willReturn(self::LAST_NAME);
         $quote->method('getShippingAddress')->willReturn($address);
-
         $this->quoteRepository->expects($this->once())
             ->method('get')
             ->willReturn($quote);
-        $event = $this->getMockBuilder(Event::class)
-            ->setMethods(['getOrder'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $event->expects($this->once())
-            ->method('getOrder')
-            ->willReturn($order);
-        $eventObserver = $this->getMockBuilder(Event\Observer::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $eventObserver->expects($this->once())
-            ->method('getEvent')
-            ->willReturn($event);
-
         $this->cartHelper->method('buildCartFromQuote')->willThrowException(new Exception());
         $this->dataObject->expects($this->never())->method("setApiData");
         $this->apiHelper->expects($this->never())->method('buildRequest');
         $this->apiHelper->expects($this->never())->method('sendRequest');
-        $this->observer->execute($eventObserver);
+
+        $this->plugin->afterPlace($this->orderManagementInterface, $order);
 
         // assert that an error was not thrown by the observer
         $this->assertTrue(true);
@@ -447,19 +361,6 @@ class NonBoltOrderObserverTest extends TestCase
             ->method('setAdditionalInformation');
         $payment->expects($this->once())
             ->method('save');
-        $event = $this->getMockBuilder(Event::class)
-            ->setMethods(['getOrder'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $event->expects($this->once())
-            ->method('getOrder')
-            ->willReturn($order);
-        $eventObserver = $this->getMockBuilder(Event\Observer::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $eventObserver->expects($this->once())
-            ->method('getEvent')
-            ->willReturn($event);
 
         $cartMissingPhone = self::CART;
         unset($cartMissingPhone['shipments']);
@@ -485,6 +386,7 @@ class NonBoltOrderObserverTest extends TestCase
         $response = new Response();
         $response->setResponse(json_decode('{"reference": "ABCD-EFGH-1234"}'));
         $this->apiHelper->expects($this->once())->method('sendRequest')->willReturn($response);
-        $this->observer->execute($eventObserver);
+
+        $this->plugin->afterPlace($this->orderManagementInterface, $order);
     }
 }

--- a/Test/Unit/Plugin/NonBoltOrderObserverTest.php
+++ b/Test/Unit/Plugin/NonBoltOrderObserverTest.php
@@ -159,7 +159,9 @@ class NonBoltOrderObserverTest extends TestCase
      */
     public function testExecute()
     {
-        $order = $this->createMock(Order::class);
+        $order = $this->getMockBuilder("BoltOrder")
+            ->setMethods(['getPayment', 'getQuoteId', 'getStoreId', 'setBoltTransactionReference', 'save'])
+            ->getMock();
         $payment = $this->createMock(Payment::class);
         $item = $this->createMock(Item::class);
         $quote = $this->createMock(Quote::class);
@@ -181,13 +183,13 @@ class NonBoltOrderObserverTest extends TestCase
         $order->expects($this->once())
             ->method('getPayment')
             ->willReturn($payment);
+        $order->expects($this->once())
+            ->method('setBoltTransactionReference');
+        $order->expects($this->once())
+            ->method('save');
         $payment->expects($this->once())
             ->method('getMethod')
             ->willReturn(self::PAYMENT_METHOD);
-        $payment->expects($this->once())
-            ->method('setAdditionalInformation');
-        $payment->expects($this->once())
-            ->method('save');
 
         $this->cartHelper->method('buildCartFromQuote')->willReturn(self::CART);
         $expectedOrderData = [
@@ -333,7 +335,9 @@ class NonBoltOrderObserverTest extends TestCase
     public function testExecuteShipmentsNotSet()
     {
         $this->decider->expects($this->once())->method('isNonBoltTrackingEnabled')->willReturn(true);
-        $order = $this->createMock(Order::class);
+        $order = $this->getMockBuilder("BoltOrder")
+            ->setMethods(['getPayment', 'getQuoteId', 'getStoreId', 'setBoltTransactionReference', 'save'])
+            ->getMock();
         $payment = $this->createMock(Payment::class);
         $item = $this->createMock(Item::class);
         $quote = $this->createMock(Quote::class);
@@ -357,10 +361,6 @@ class NonBoltOrderObserverTest extends TestCase
         $payment->expects($this->once())
             ->method('getMethod')
             ->willReturn(self::PAYMENT_METHOD);
-        $payment->expects($this->once())
-            ->method('setAdditionalInformation');
-        $payment->expects($this->once())
-            ->method('save');
 
         $cartMissingPhone = self::CART;
         unset($cartMissingPhone['shipments']);

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -261,6 +261,7 @@
         </arguments>
     </type>
 
+    <!-- When adding any plugin, you MUST wrap the plugin in a feature switch -->
     <type name="Magento\Quote\Model\Quote">
         <plugin name="Bolt_Boltpay_Quote_Plugin" type="Bolt\Boltpay\Plugin\QuotePlugin" sortOrder="1" />
     </type>
@@ -282,6 +283,12 @@
     <type name="Magento\Checkout\Model\Session">
         <plugin name="BoltBoltpayRestoreQuotePlugin"
                 type="Bolt\Boltpay\Plugin\RestoreQuotePlugin"
+                sortOrder="1"/>
+    </type>
+
+    <type name="Magento\Sales\Api\OrderManagementInterface">
+        <plugin name="BoltNonBoltOrderPlugin"
+                type="Bolt\Boltpay\Plugin\NonBoltOrderPlugin"
                 sortOrder="1"/>
     </type>
 


### PR DESCRIPTION
There were several issues with using an observer to ingest non-Bolt orders.
First of all, there isn't any consistency across various payment methods
on which events are emitted on order creation. Second of all, the order may
be in various states and possible incomplete/not saved at the time of the
event being emitted. This can lead to all sorts of weird behaviors. Instead,
this PR uses a plugin that should consistently fire after the initial order
is placed and saved.

# Description
Please include a summary of the change and which issue is fixed. Include the motivation for the changes, and comment on your PR if necessary for clarity.

Fixes: (link Jira ticket)

#changelog Use plugin for afterPlace rather than observer for orders

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
