### PR TITLE
M2P-50 Add option to show bolt management button after the specific dom element

### DIFF
--- a/Block/Js.php
+++ b/Block/Js.php
@@ -251,6 +251,8 @@ class Js extends Template
             'is_instant_checkout_button' => $this->getIsInstantCheckoutButton(),
             'cdn_url' => $this->configHelper->getCdnUrl(),
             'always_present_checkout' => $this->enableAlwaysPresentCheckoutButton(),
+            'account_url' => $this->getAccountJsUrl(),
+            'order_management_selector' => $this->getOrderManagementSelector(),
         ]);
     }
 
@@ -460,6 +462,18 @@ class Js extends Template
     {
         return $this->configHelper->isOrderManagementEnabled() &&
             $this->featureSwitches->isOrderManagementEnabled();
+    }
+
+    /**
+     * Return true if Order Management is enabled
+     * @return bool
+     */
+    public function getOrderManagementSelector()
+    {
+        if (!$this->configHelper->isOrderManagementEnabled() || !$this->featureSwitches->isOrderManagementEnabled()) {
+            return '';
+        }
+        return $this->configHelper->getOrderManagementSelector();
     }
 
     /**

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -127,6 +127,11 @@ class Config extends AbstractHelper
      */
     const XML_PATH_PRODUCT_ORDER_MANAGEMENT = 'payment/boltpay/order_management';
 
+    /**
+     * Enable Bolt order management CSS selector
+     */
+    const XML_PATH_PRODUCT_ORDER_MANAGEMENT_SELECTOR = 'payment/boltpay/order_management_selector';
+
 
     /**
      * Prefetch shipping
@@ -732,6 +737,22 @@ class Config extends AbstractHelper
     {
         return $this->getScopeConfig()->isSetFlag(
             self::XML_PATH_PRODUCT_ORDER_MANAGEMENT,
+            ScopeInterface::SCOPE_STORE,
+            $store
+        );
+    }
+
+    /**
+     * Get Order management CSS selector from config
+     *
+     * @param int|string|Store $store
+     *
+     * @return  string
+     */
+    public function getOrderManagementSelector($store = null)
+    {
+        return $this->getScopeConfig()->getValue(
+            self::XML_PATH_PRODUCT_ORDER_MANAGEMENT_SELECTOR,
             ScopeInterface::SCOPE_STORE,
             $store
         );

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -33,7 +33,7 @@ use Magento\Framework\App\Request\Http;
 class JsTest extends \PHPUnit\Framework\TestCase
 {
     // Number of settings in method getSettings()
-    const SETTINGS_NUMBER = 23;
+    const SETTINGS_NUMBER = 25;
     const STORE_ID = 1;
     const CONFIG_API_KEY = 'test_api_key';
     const CONFIG_SIGNING_SECRET = 'test_signing_secret';
@@ -108,7 +108,8 @@ class JsTest extends \PHPUnit\Framework\TestCase
             'getReplaceSelectors', 'getGlobalCSS', 'getPrefetchShipping', 'getQuoteIsVirtual',
             'getTotalsChangeSelectors', 'getAdditionalCheckoutButtonClass', 'getAdditionalConfigString', 'getIsPreAuth',
             'shouldTrackCheckoutFunnel','isPaymentOnlyCheckoutEnabled', 'isIPRestricted', 'getPageBlacklist',
-            'getMinicartSupport', 'getIPWhitelistArray', 'getApiKey', 'getSigningSecret', 'getButtonColor', 'isAlwaysPresentCheckoutEnabled'
+            'getMinicartSupport', 'getIPWhitelistArray', 'getApiKey', 'getSigningSecret', 'getButtonColor', 'isAlwaysPresentCheckoutEnabled',
+            'getOrderManagementSelector',
         ];
 
         $this->configHelper = $this->getMockBuilder(HelperConfig::class)
@@ -367,6 +368,8 @@ class JsTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey('default_error_message', $array, $message . 'default_error_message');
         $this->assertArrayHasKey('button_css_styles', $array, $message . 'button_css_styles');
         $this->assertArrayHasKey('always_present_checkout', $array, $message . 'always_present_checkout');
+        $this->assertArrayHasKey('account_url', $array, $message . 'account_url');
+        $this->assertArrayHasKey('order_management_selector', $array, $message . 'order_management_selector');
     }
 
     /**

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -109,7 +109,7 @@ class JsTest extends \PHPUnit\Framework\TestCase
             'getTotalsChangeSelectors', 'getAdditionalCheckoutButtonClass', 'getAdditionalConfigString', 'getIsPreAuth',
             'shouldTrackCheckoutFunnel','isPaymentOnlyCheckoutEnabled', 'isIPRestricted', 'getPageBlacklist',
             'getMinicartSupport', 'getIPWhitelistArray', 'getApiKey', 'getSigningSecret', 'getButtonColor', 'isAlwaysPresentCheckoutEnabled',
-            'getOrderManagementSelector',
+            'getOrderManagementSelector','isOrderManagementEnabled',
         ];
 
         $this->configHelper = $this->getMockBuilder(HelperConfig::class)

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -611,6 +611,7 @@ JSON;
             ['getOnClose', BoltConfig::XML_PATH_TRACK_CLOSE],
             ['getMinimumOrderAmount', BoltConfig::XML_PATH_MINIMUM_ORDER_AMOUNT],
             ['getOnShippingOptionsComplete', BoltConfig::XML_PATH_TRACK_SHIPPING_OPTIONS_COMPLETE],
+            ['getOrderManagementSelector', BoltConfig::XML_PATH_PRODUCT_ORDER_MANAGEMENT_SELECTOR],
         ];
     }
 

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -95,7 +95,13 @@
                         <config_path>payment/boltpay/order_management</config_path>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     </field>
-                    <field id="always_present_checkout" translate="label" type="select" sortOrder="83" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <field id="order_management_selector" translate="label" type="text" sortOrder="83" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>CSS selector for Bolt order management button</label>
+                        <depends><field id="order_management">1</field></depends>
+                        <comment>Leave empty for show button in header.</comment>
+                        <config_path>payment/boltpay/order_management_selector</config_path>
+                    </field>
+                    <field id="always_present_checkout" translate="label" type="select" sortOrder="84" showInDefault="1" showInWebsite="1" showInStore="0">
                         <label>(BETA) Enable Always Present Checkout Button</label>
                         <config_path>payment/boltpay/always_present_checkout</config_path>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>

--- a/view/frontend/templates/boltaccount.phtml
+++ b/view/frontend/templates/boltaccount.phtml
@@ -20,11 +20,18 @@
  *
  * @var $block \Bolt\Boltpay\Block\Js
  */
-if ($block->shouldDisableBoltCheckout()) { return;
+if ($block->shouldDisableBoltCheckout()) {
+    return;
 }
-if (!$block->isOrderManagementEnabled()) { return;
+if (!$block->isOrderManagementEnabled()) {
+    return;
 }
-if ($block->isBlockAlreadyShown('account')) { return;
+// If CSS selector is set we want to insert button via fronend after this selector.
+if ($block->getOrderManagementSelector()) {
+    return;
+}
+if ($block->isBlockAlreadyShown('account')) {
+    return;
 }
 $accountJsUrl = $block->getAccountJsUrl();
 $checkoutKey = $block->getCheckoutKey();

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -2274,6 +2274,41 @@ if (!$block->isSaveCartInSections()) { ?>
             invalidateBoltCart();
         });
 
+        // insert Bolt order managenent button into DOM
+        if (settings.order_management_selector) {
+            var insertAccountScript = function () {
+                var scriptTag = document.getElementById('bolt-account');
+                if (scriptTag) {
+                    return;
+                }
+                var publishableKey = getCheckoutKey();
+                scriptTag = document.createElement('script');
+                scriptTag.setAttribute('type', 'text/javascript');
+                scriptTag.setAttribute('async', '');
+                scriptTag.setAttribute('src', settings.account_url);
+                scriptTag.setAttribute('id', 'bolt-account');
+                scriptTag.setAttribute('data-publishable-key', publishableKey);
+                document.head.appendChild(scriptTag);
+            }
+            var insertManagementButtonDivAfterElement = function(element) {
+                var orderMagagementButton = document.createElement('div');
+                orderMagagementButton.setAttribute('class', 'bolt-account-login');
+                element.parentNode.insertBefore(orderMagagementButton, element.nextSibling);
+                insertAccountScript();
+            }
+            var setupOrderManagementReplacement = function() {
+                element = document.querySelector(settings.order_management_selector);
+                if (element) {
+                    insertManagementButtonDivAfterElement(element);
+                } else {
+                    onElementReady(settings.order_management_selector, function(element) {
+                        insertManagementButtonDivAfterElement(element);
+                    });
+                }
+            }
+            setupOrderManagementReplacement();
+        };
+
         ////////////////////////////////////////////////////
         // Initially configures BoltCheckout.
         // Required for setting check callback which either


### PR DESCRIPTION
Now we can the bolt management button only into the header menu. We do it via backend.
This way doesn't work for some Magento themes, so in this PR we add an alternative approach, insterting necessary div after CSS selector added into plugin setting.

For example if we add *#newsletter* into settings it looks like:

![image](https://user-images.githubusercontent.com/7270718/88168047-8032f900-cc22-11ea-9153-2d4cf5b4c580.png)

Fixes: [M2P-50]

#changelog Add option to show bolt management button after the specific dom element

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [x] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
