### PR TITLE
M2P-175 Reload bolt cart if we have Magento cart only

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -1734,7 +1734,11 @@ if (!$block->isSaveCartInSections()) { ?>
         var boltCartDataID;
 
         var invalidateBoltCartIfOutdated = function() {
-            if (magentoCart === undefined || magentoCart.data_id === undefined || boltCartDataID === undefined) {
+            if (magentoCart === undefined || magentoCart.data_id === undefined) {
+                return;
+            }
+            if (boltCartDataID === undefined) {
+                invalidateBoltCart();
                 return;
             }
             if (magentoCart.data_id > boltCartDataID) {

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -1738,6 +1738,9 @@ if (!$block->isSaveCartInSections()) { ?>
                 return;
             }
             if (boltCartDataID === undefined) {
+                // Usually Magento retrieves all sections data from backend, so boltCartDataID shouldn't be undefined.
+                // But if the first call was unsuccesful (user closed the page before answer was saved) Magento doesn't
+                // try to get data again. In this case we need manually invalidate bolt cart.
                 invalidateBoltCart();
                 return;
             }


### PR DESCRIPTION
When users open the first page of the site they don't have any data in local storage.
I assumed that in this case Magento2 always loads the data, including bolt cart.
So before this PR if we didn't have a bolt cart at all we did nothing because we were waiting to have a new bolt cart in a few seconds.
This assumption works well, but we have one exception:
When a user opens the first page, Magento asks all data from the server in one AJAX request. If a user closes their first page very quickly, we don't have data in local storage. Unfortunately, on the next page loading, Magento doesn't care about the issue. It just cares about its data like in this code.

It's not a big deal for us, because we ask for new bolt cart [in 10 seconds after page loaded](https://github.com/BoltApp/bolt-magento2/blob/ac7ee152a28cab9dc1ef0924b9d21a78a222236e/view/frontend/templates/js/replacejs.phtml#L1723)

But if a user click the bolt button during the first 1-2 seconds after page loading it's possible that bolt shows error: Storm waits only 10 seconds for cart content.
I am unable to reproduce this manually and even autotests fail not each time.

Steps to reproduce the issue:
1. Clear all browser cache
2. When the first page is loaded close it very quickly
3. Add product to cart and close page very quickly
4. Open cart page and click bolt button right after Magento show total

Even after these conditions test site should be slow enough otherwise data saves on step (2).



Fixes: [M2P-175]

#changelog M2P-175 Reload bolt cart if we have Magento cart only

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
