### PR TITLE
M2P-161 Stop pushing model/quote JS script

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -2321,12 +2321,12 @@ if (!$block->isSaveCartInSections()) { ?>
     });
 
     if (trim(location.pathname, '/') === 'checkout/cart') {
+        require(['domReady!'], function() {
         require([
         'jquery',
-        'Magento_Customer/js/customer-data',
         'Magento_Checkout/js/model/quote',
         'domReady!'
-        ], function ($, customerData, quote) {
+        ], function ($, quote) {
             // If quote total was changed through a method we didn't create,
             // we should reload the bolt cart since totals are probably now out of sync.
             quote.totals.subscribe(function (newValue) {
@@ -2341,6 +2341,7 @@ if (!$block->isSaveCartInSections()) { ?>
                 }
                 $(document).trigger('bolt:createOrder');
             });
+       })
        })
     }
 </script>

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -2322,26 +2322,25 @@ if (!$block->isSaveCartInSections()) { ?>
 
     if (trim(location.pathname, '/') === 'checkout/cart') {
         require(['domReady!'], function() {
-        require([
-        'jquery',
-        'Magento_Checkout/js/model/quote',
-        'domReady!'
-        ], function ($, quote) {
-            // If quote total was changed through a method we didn't create,
-            // we should reload the bolt cart since totals are probably now out of sync.
-            quote.totals.subscribe(function (newValue) {
-                if (expectCartRendering) {
-                    expectCartRendering = false;
-                    return;
-                }
+            require([
+            'jquery',
+            'Magento_Checkout/js/model/quote',
+            ], function ($, quote) {
+                // If quote total was changed through a method we didn't create,
+                // we should reload the bolt cart since totals are probably now out of sync.
+                quote.totals.subscribe(function (newValue) {
+                    if (expectCartRendering) {
+                        expectCartRendering = false;
+                        return;
+                    }
 
-                expectCartRendering = false;
-                if (waitingForResolvingPromises) {
-                    return;
-                }
-                $(document).trigger('bolt:createOrder');
-            });
-       })
+                    expectCartRendering = false;
+                    if (waitingForResolvingPromises) {
+                        return;
+                    }
+                    $(document).trigger('bolt:createOrder');
+                });
+            })
        })
     }
 </script>


### PR DESCRIPTION
We introduced an issue in https://github.com/BoltApp/bolt-magento2/pull/796. Actually it was known magento issue that was fixed in new Magento versions, see https://github.com/magento/magento2/pull/23099 , https://github.com/magento/magento2/issues/14412, https://github.com/magento/magento2/pull/21432

Under some conditions, Magento JS script produced an error because they initialated wrong.

We had a fix https://github.com/BoltApp/bolt-magento2/pull/808 but now I see it doesn't affect the root of the issue.

In PR 796 we added `require(['Magento_Checkout/js/model/quote'] ...)` thing. This requireJS API means we push `model/quote` script to load if it wasn't loaded before. Under some very rare conditions, it triggers incorrect initializing.

So solution the same as in https://github.com/magento/magento2/pull/21432 : don't load module/quote script before DOM.loaded. We know that when DOM.loaded we have all parameters to initialize this script.

The issue about a race condition, so it's quite hard to reproduce it. Looks like it happens very rarely.
We need some (or all) of the following conditions:
- site works slowly
- browser work slowly (IE11 for example)
- the first page load, so we don't have scripts in browser cache.
- site works in developer mode



Fixes: [M2P-161]

#changelog M2P-161 Stop pushing model/quote JS script

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
