### PR TITLE
M2P-178 Check if BoltCheckout loaded before we call it

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -1707,13 +1707,26 @@ if (!$block->isSaveCartInSections()) { ?>
         var cartBarrier;
         var countConfigureCalls = 0;
 
+        var boltCheckoutConfigure = function(cart, hints, callback, parameters = undefined) {
+            var callConfigure = function() {
+                BC = BoltCheckout.configure(cart, hints, callback, parameters);
+            }
+            // Check if BoltCheckout is defined (connect.js executed).
+            // If not, postpone processing until it is
+            if (!window.BoltCheckout) {
+                whenDefined(window, 'BoltCheckout', callConfigure);
+                return;
+            }
+            callConfigure();
+        }
+
         var callConfigureWithPromises = function() {
             if (waitingForResolvingPromises) {
                 return;
             }
             cartBarrier = boltBarrier();
             hintBarrier = boltBarrier();
-            BC = BoltCheckout.configure(cartBarrier.promise, hintBarrier.promise, callbacks);
+            boltCheckoutConfigure(cartBarrier.promise, hintBarrier.promise, callbacks);
             waitingForResolvingPromises = true;
             countConfigureCalls++;
             var localCallNumber = countConfigureCalls;
@@ -1764,13 +1777,13 @@ if (!$block->isSaveCartInSections()) { ?>
                 if (popUpOpen) {
                     return;
                 }
-                BC = BoltCheckout.configure(cartBarrier.promise, hintBarrier.promise, callbacks);
+                boltCheckoutConfigure(cartBarrier.promise, hintBarrier.promise, callbacks);
                 return;
             }
             if (!cart) {
                 return;
             }
-            BC = BoltCheckout.configure(cart, hints, callbacks, boltCheckoutConfig);
+            boltCheckoutConfigure(cart, hints, callbacks, boltCheckoutConfig);
         }
 
         if (getCheckoutType() !== 'payment') {
@@ -1904,7 +1917,7 @@ if (!$block->isSaveCartInSections()) { ?>
                         .always(function() {
                             createRequest = false;
                         })
-                        BC = BoltCheckout.configure(cart, hintBarrier.promise, callbacks);
+                        boltCheckoutConfigure(cart, hintBarrier.promise, callbacks);
                 });
             } else {
             customerData.get('boltcart').subscribe(function(data) {
@@ -1944,7 +1957,7 @@ if (!$block->isSaveCartInSections()) { ?>
                                 newItemAddedToCart = false;
                             }
                             // reconfigure bolt checkout with new values
-                            BC = BoltCheckout.configure(cart, hints, callbacks, boltCheckoutConfig);
+                            boltCheckoutConfigure(cart, hints, callbacks, boltCheckoutConfig);
                         }
                         waitingForResolvingPromises = false;
                         oldBoltCartValue = JSON.stringify(cart);
@@ -2066,7 +2079,7 @@ if (!$block->isSaveCartInSections()) { ?>
                         // ie. connect.js not loaded / executed yet,
                         // the button will be processed after connect.js loads.
                         if (window.BoltCheckout && !waitingForResolvingPromises) {
-                            BoltCheckout.configure(cart, hints, callbacks, boltCheckoutConfig);
+                            boltCheckoutConfigure(cart, hints, callbacks, boltCheckoutConfig);
                         }
                     });
                     /////////////////////////////////////////////////////
@@ -2144,7 +2157,7 @@ if (!$block->isSaveCartInSections()) { ?>
             }
             var new_hints = JSON.stringify(hints);
             if ((old_hints !== new_hints) && !waitingForResolvingPromises) {
-                BoltCheckout.configure(cart, hints, callbacks, boltCheckoutConfig);
+                boltCheckoutConfigure(cart, hints, callbacks, boltCheckoutConfig);
                 old_hints = new_hints;
             }
         };


### PR DESCRIPTION
In rare cases, connect.js can be loaded after JS plugin code is executed.
This PR adds check to all cases when we call BoltCheckout.configure.

Fixes: M2P-178

#changelog M2P-178 Check if BoltCheckout loaded before we call it

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
