### PR TITLE
Remove yogibo and nmwa from auto rebases branches

### DIFF
--- a/.circleci/scripts/auto-rebase-branches.txt
+++ b/.circleci/scripts/auto-rebase-branches.txt
@@ -1,3 +1,1 @@
 jz/rebase-custom1
-yogibo
-nmwa


### PR DESCRIPTION
We can return them once we update branches. We can't auto rebase them for now.

Fixes: (link Jira ticket)

#changelog Remove yogibo and nmwa from auto rebases branches

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
