### PR TITLE
Cleanup shipping address data after shipping estimation

### DIFF
--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -779,7 +779,9 @@ class ShippingMethods implements ShippingMethodsInterface
                 ->setTaxAmount($taxAmount);
         }
 
-        $shippingAddress->setShippingMethod(null)->save();
+        $shippingAddress->setShippingMethod(null);
+        $this->totalsCollector->collectAddressTotals($quote, $shippingAddress);
+        $shippingAddress->save();
 
         if ($errors) {
             $this->bugsnag->registerCallback(function ($report) use ($errors, $addressData) {


### PR DESCRIPTION
# Description
Shipping estimation currently saves shipping information of the last shipping method onto shipping address after shipping estimation webhook. It was detected during an integration as it caused a conflict with Mageplaza_Simpleshipping. This PR resolves the issue by re-collecting totals after the shipping estimation with the shipping method set to null.

Fixes: https://boltpay.atlassian.net/browse/M2P-182

#changelog

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [x] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
