### PR TITLE
M2P-184 Add gift wrapping info into the cart cache identifier

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -587,12 +587,39 @@ class Cart extends AbstractHelper
         // extend cache identifier with custom address fields
         $immutableQuote = $this->getLastImmutableQuote();
         $identifier .= $this->convertCustomAddressFieldsToCacheIdentifier($immutableQuote);
-
-        if($giftMessageId = $immutableQuote->getGiftMessageId()) {
-            $identifier .= $giftMessageId;
-        }
+        $identifier .= $this->convertExternalFieldsToCacheIdentifier($immutableQuote);
 
         return md5($identifier);
+    }
+
+    /**
+     * @param $immutableQuote
+     * @return string
+     */
+    private function convertExternalFieldsToCacheIdentifier($immutableQuote)
+    {
+        $cacheIdentifier = "";
+        // add gift message id into cart cache identifier
+        if($giftMessageId = $immutableQuote->getGiftMessageId()) {
+            $cacheIdentifier .= $giftMessageId;
+        }
+
+        // add gift wrapping id into cart cache identifier
+        if ($giftWrappingId = $immutableQuote->getGwId()) {
+            $cacheIdentifier .= $giftWrappingId;
+        }
+
+        // add gift wrapping item ids into cart cache identifier
+        $quoteItems = $immutableQuote->getAllVisibleItems();
+        if ($quoteItems) {
+            foreach ($quoteItems as $item) {
+                if ($item->getGwId()) {
+                    $cacheIdentifier .= $item->getItemId() . '-' . $item->getGwId();
+                }
+            }
+        }
+
+        return $cacheIdentifier;
     }
 
     /**

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -137,6 +137,8 @@ class CartTest extends TestCase
     const HINT = 'hint!';
 
     const GIFT_MESSAGE_ID = '122';
+    const GIFT_WRAPPING_ID = '123';
+    const QUOTE_ITEM_ID = '124';
 
     /** @var array Address data containing all required fields */
     const COMPLETE_ADDRESS_DATA = [
@@ -359,7 +361,8 @@ class CartTest extends TestCase
             'getTotals','getStore','getStoreId',
             'getData','isVirtual','getId','getShippingAddress',
             'getBillingAddress','reserveOrderId','addProduct',
-            'assignCustomer','setIsActive','getGiftMessageId'
+            'assignCustomer','setIsActive','getGiftMessageId',
+            'getGwId'
         ]);
         $this->checkoutSession = $this->createPartialMock(CheckoutSession::class, ['getQuote']);
         $this->productRepository = $this->createPartialMock(ProductRepository::class, ['get', 'getbyId']);
@@ -1206,6 +1209,69 @@ class CartTest extends TestCase
         $result = TestHelper::invokeMethod($currentMock, 'getCartCacheIdentifier', [$testCartData]);
         unset($testCartData['display_id']);
         static::assertEquals(md5(json_encode($testCartData) . $addressCacheIdentifier. self::GIFT_MESSAGE_ID), $result);
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::getCartCacheIdentifier
+     * @throws ReflectionException
+     */
+    public function getCartCacheIdentifier_withGiftWrappingId_returnsCartCacheIdentifier()
+    {
+        $currentMock = $this->getCurrentMock(
+            [
+                'convertCustomAddressFieldsToCacheIdentifier',
+                'getLastImmutableQuote',
+            ]
+        );
+        $testCartData = $this->getTestCartData();
+        $addressCacheIdentifier = 'Test_Test_Test';
+        $this->quoteMock->expects(static::once())->method('getGwId')->willReturn(self::GIFT_WRAPPING_ID);
+        $currentMock->expects(static::once())->method('getLastImmutableQuote')->willReturn($this->quoteMock);
+        $currentMock->expects(static::once())->method('convertCustomAddressFieldsToCacheIdentifier')
+            ->with($this->quoteMock)->willReturn($addressCacheIdentifier);
+        $result = TestHelper::invokeMethod($currentMock, 'getCartCacheIdentifier', [$testCartData]);
+        unset($testCartData['display_id']);
+        static::assertEquals(hash('md5',json_encode($testCartData) . $addressCacheIdentifier. self::GIFT_WRAPPING_ID), $result);
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::getCartCacheIdentifier
+     * @throws ReflectionException
+     */
+    public function getCartCacheIdentifier_withGiftWrappingItemIds_returnsCartCacheIdentifier()
+    {
+        $currentMock = $this->getCurrentMock(
+            [
+                'convertCustomAddressFieldsToCacheIdentifier',
+                'getLastImmutableQuote',
+            ]
+        );
+        $testCartData = $this->getTestCartData();
+        $addressCacheIdentifier = 'Test_Test_Test';
+
+        $quoteItem = $this->getMockBuilder(Item::class)
+            ->setMethods(
+                [
+                    'getItemId',
+                    'getGwId'
+                ]
+            )
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $quoteItem->method('getItemId')->willReturn(self::QUOTE_ITEM_ID);
+        $quoteItem->method('getGwId')->willReturn(self::GIFT_WRAPPING_ID);
+        $this->quoteMock->method('getAllVisibleItems')->willReturn([$quoteItem]);
+        $currentMock->expects(static::once())->method('getLastImmutableQuote')->willReturn($this->quoteMock);
+        $currentMock->expects(static::once())->method('convertCustomAddressFieldsToCacheIdentifier')
+            ->with($this->quoteMock)->willReturn($addressCacheIdentifier);
+        $result = TestHelper::invokeMethod($currentMock, 'getCartCacheIdentifier', [$testCartData]);
+        unset($testCartData['display_id']);
+        static::assertEquals(hash('md5',json_encode($testCartData) . $addressCacheIdentifier. self::QUOTE_ITEM_ID.'-'.self::GIFT_WRAPPING_ID), $result);
     }
 
     /**


### PR DESCRIPTION
# Description
Currently, the module can’t detect the updates after adding the Gift Wrapping and it is using the previous token which doesn’t have any Gift Wrapping.

This PR is to add gift wrapping info into the cart cache identifier

Fixes: 
https://boltpay.atlassian.net/browse/M2P-184
https://app.asana.com/0/1142111051828235/1181220571495009

#changelog M2P-184 Add gift wrapping info into the cart cache identifier

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
