### PR TITLE
Resolve issue with discounts applied from Bolt modal persisting after being removed

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -776,7 +776,7 @@ class Cart extends AbstractHelper
             $this->saveToCache(
                 $boltOrder,
                 $cacheIdentifier,
-                [self::BOLT_ORDER_TAG],
+                [self::BOLT_ORDER_TAG, self::BOLT_ORDER_TAG . '_' . $cart['order_reference']],
                 self::BOLT_ORDER_CACHE_LIFETIME
             );
         }

--- a/Model/Api/DiscountCodeValidation.php
+++ b/Model/Api/DiscountCodeValidation.php
@@ -248,7 +248,7 @@ class DiscountCodeValidation implements DiscountCodeValidationInterface
         $this->regionModel = $regionModel;
         $this->totalsCollector = $totalsCollector;
         $this->orderHelper = $orderHelper;
-        $this->cache = $cache ?? \Magento\Framework\App\ObjectManager::getInstance()
+        $this->cache = $cache ?: \Magento\Framework\App\ObjectManager::getInstance()
                 ->get(\Magento\Framework\App\CacheInterface::class);
     }
 

--- a/Model/Api/DiscountCodeValidation.php
+++ b/Model/Api/DiscountCodeValidation.php
@@ -18,6 +18,7 @@
 namespace Bolt\Boltpay\Model\Api;
 
 use Bolt\Boltpay\Api\DiscountCodeValidationInterface;
+use Magento\Framework\App\CacheInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Webapi\Rest\Request;
@@ -165,6 +166,10 @@ class DiscountCodeValidation implements DiscountCodeValidationInterface
      * @var OrderHelper
      */
     protected $orderHelper;
+    /**
+     * @var CacheInterface
+     */
+    private $cache;
 
     /**
      * DiscountCodeValidation constructor.
@@ -192,6 +197,7 @@ class DiscountCodeValidation implements DiscountCodeValidationInterface
      * @param RegionModel             $regionModel
      * @param TotalsCollector         $totalsCollector
      * @param OrderHelper             $orderHelper
+     * @param CacheInterface          $cache
      */
     public function __construct(
         Request $request,
@@ -216,7 +222,8 @@ class DiscountCodeValidation implements DiscountCodeValidationInterface
         DiscountHelper $discountHelper,
         RegionModel $regionModel,
         TotalsCollector $totalsCollector,
-        OrderHelper $orderHelper
+        OrderHelper $orderHelper,
+        CacheInterface $cache = null
     ) {
         $this->request = $request;
         $this->response = $response;
@@ -241,6 +248,8 @@ class DiscountCodeValidation implements DiscountCodeValidationInterface
         $this->regionModel = $regionModel;
         $this->totalsCollector = $totalsCollector;
         $this->orderHelper = $orderHelper;
+        $this->cache = $cache ?? \Magento\Framework\App\ObjectManager::getInstance()
+                ->get(\Magento\Framework\App\CacheInterface::class);
     }
 
     /**
@@ -451,6 +460,9 @@ class DiscountCodeValidation implements DiscountCodeValidationInterface
                 // Already sent a response with error, so just return.
                 return false;
             }
+
+            //remove previously cached Bolt order since we altered related immutable quote by applying a discount
+            $this->cache->clean([CartHelper::BOLT_ORDER_TAG . '_' . $parentQuoteId]);
 
             $this->sendSuccessResponse($result, $immutableQuote);
         } catch (WebApiException $e) {

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -2356,7 +2356,7 @@ ORDER
         $currentMock->expects(static::once())->method('saveToCache')->with(
             $boltOrder,
             self::CACHE_IDENTIFIER,
-            [BoltHelperCart::BOLT_ORDER_TAG],
+            [BoltHelperCart::BOLT_ORDER_TAG, BoltHelperCart::BOLT_ORDER_TAG . '_' . self::PARENT_QUOTE_ID],
             3600
         );
         $result = $currentMock->getBoltpayOrder(false, '');
@@ -2429,7 +2429,12 @@ ORDER
         $currentMock->expects(static::once())->method('boltCreateOrder')->with($cart, self::STORE_ID)
             ->willReturn($boltOrder);
         $currentMock->expects(static::once())->method('saveToCache')
-            ->with($boltOrder, self::CACHE_IDENTIFIER, [BoltHelperCart::BOLT_ORDER_TAG], 3600);
+            ->with(
+                $boltOrder,
+                self::CACHE_IDENTIFIER,
+                [BoltHelperCart::BOLT_ORDER_TAG, BoltHelperCart::BOLT_ORDER_TAG . '_' . self::PARENT_QUOTE_ID],
+                3600
+            );
         $result = $currentMock->getBoltpayOrder(false, '');
         static::assertEquals($result, $boltOrder);
         }

--- a/Test/Unit/Model/Api/DiscountCodeValidationTest.php
+++ b/Test/Unit/Model/Api/DiscountCodeValidationTest.php
@@ -196,6 +196,11 @@ class DiscountCodeValidationTest extends TestCase
     private $ruleRepositoryMock;
 
     /**
+     * @var MockObject|\Magento\Framework\App\CacheInterface system cache model
+     */
+    private $cache;
+
+    /**
      * @var MockObject|BoltDiscountCodeValidation
      */
     private $currentMock;
@@ -396,6 +401,9 @@ class DiscountCodeValidationTest extends TestCase
         $this->cartHelper->method('getQuoteById')
             ->willReturnMap($getQuoteByIdMap);
 
+        $this->cache->expects(static::once())->method('clean')
+            ->with([CartHelper::BOLT_ORDER_TAG . '_' . self::PARENT_QUOTE_ID]);
+
         $result = $this->currentMock->validate();
 
         // If another exception happens, the test will fail.
@@ -505,6 +513,9 @@ class DiscountCodeValidationTest extends TestCase
             ->willReturn((object)$request_shipping_addr);
         $this->cartHelper->method('validateEmail')
             ->willReturn(true);
+
+        $this->cache->expects(static::once())->method('clean')
+            ->with([CartHelper::BOLT_ORDER_TAG . '_' . self::PARENT_QUOTE_ID]);
 
         $result = $this->currentMock->validate();
 
@@ -1007,6 +1018,9 @@ class DiscountCodeValidationTest extends TestCase
 
         $this->response->expects(self::once())->method('setBody')->with(json_encode($result));
 
+        $this->cache->expects(static::once())->method('clean')
+            ->with([CartHelper::BOLT_ORDER_TAG . '_' . self::PARENT_QUOTE_ID]);
+
         self::assertTrue($this->currentMock->validate());
     }
 
@@ -1084,6 +1098,9 @@ class DiscountCodeValidationTest extends TestCase
         $immutableQuoteMock->expects(self::once())->method('getItemsCount')->willReturn(1);
 
         $this->expectSuccessResponse($result);
+
+        $this->cache->expects(static::once())->method('clean')
+            ->with([CartHelper::BOLT_ORDER_TAG . '_' . self::PARENT_QUOTE_ID]);
 
         self::assertTrue($this->currentMock->validate());
     }
@@ -2276,6 +2293,10 @@ class DiscountCodeValidationTest extends TestCase
             ->setMethods(['notifyException', 'notifyError'])
             ->disableOriginalConstructor()
             ->getMock();
+
+        $this->cache = $this->getMockBuilder(\Magento\Framework\App\CacheInterface::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
     }
 
     protected function initRequiredMocks()
@@ -2410,7 +2431,8 @@ class DiscountCodeValidationTest extends TestCase
                     $this->discountHelper,
                     $this->regionModel,
                     $this->totalsCollector,
-                    $this->orderHelper
+                    $this->orderHelper,
+                    $this->cache
                 ]
             )->getMock();
     }


### PR DESCRIPTION
# Description
Improvement upon https://github.com/BoltApp/bolt-magento2/pull/806
Actually proved to be a bigger issue affecting other (all?) discounts applied from Bolt modal where cached Bolt cart (order token) would be re-used. This was confirmed and tested for Amasty_GiftCard and Magento Discount Coupon.

Fixes: https://boltpay.atlassian.net/browse/M2P-155

#changelog Resolve issue with discounts applied from Bolt modal persisting after being removed

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
