### PR TITLE
M2P-185 Fix Uncaught Error: Call to a member function getVersion() on null

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -479,16 +479,15 @@ class Config extends AbstractHelper
     public function getComposerVersion()
     {
         try {
-            $boltComposerVersion = $this->composerFactory->create()
+            $boltPackage = $this->composerFactory->create()
                 ->getLocker()
                 ->getLockedRepository()
-                ->findPackage(self::BOLT_COMPOSER_NAME, '*')
-                ->getVersion();
+                ->findPackage(self::BOLT_COMPOSER_NAME, '*');
+
+            return ($boltPackage) ? $boltPackage->getVersion() : null;
         }catch (\Exception $exception) {
             return null;
         }
-
-        return $boltComposerVersion;
     }
 
     /**

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -1283,6 +1283,7 @@ Room 4000',
 
     /**
      * @test
+     * @covers ::getComposerVersion
      */
     public function getComposerVersion() {
         $this->composerFactory->expects(self::once())->method('create')->willReturnSelf();
@@ -1295,6 +1296,7 @@ Room 4000',
 
     /**
      * @test
+     * @covers ::getComposerVersion
      */
     public function getComposerVersion_withException_returnNull() {
         $this->composerFactory->expects(self::once())->method('create')->willReturnSelf();
@@ -1303,6 +1305,19 @@ Room 4000',
         $this->composerFactory->expects(self::once())->method('findPackage')->with(Config::BOLT_COMPOSER_NAME,'*')->willReturnSelf();
         $e = new \Exception(__('Test'));
         $this->composerFactory->expects(self::once())->method('getVersion')->willThrowException($e);
+        $this->assertNull($this->currentMock->getComposerVersion());
+    }
+
+    /**
+     * @test
+     * @covers ::getComposerVersion
+     */
+    public function getComposerVersion_withFindPackageWillReturnNull() {
+        $this->composerFactory->expects(self::once())->method('create')->willReturnSelf();
+        $this->composerFactory->expects(self::once())->method('getLocker')->willReturnSelf();
+        $this->composerFactory->expects(self::once())->method('getLockedRepository')->willReturnSelf();
+        $this->composerFactory->expects(self::once())->method('findPackage')->with(Config::BOLT_COMPOSER_NAME,'*')->willReturn(null);
+        $this->composerFactory->expects(self::never())->method('getVersion');
         $this->assertNull($this->currentMock->getComposerVersion());
     }
 }


### PR DESCRIPTION
# Description
Fix Uncaught Error: Call to a member function getVersion() on null 
See here: https://prnt.sc/tqsidc

This error occurs in case Bolt is installed in the folder app/code, not via the composer

Fixes: https://boltpay.atlassian.net/browse/M2P-185

#changelog Fix Uncaught Error: Call to a member function getVersion() on null

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
