### PR TITLE
Fix issue with conditionally notify greenkeeper step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,21 +74,21 @@ commands:
           when: on_fail
           command: |
             if [[ ${CIRCLE_BRANCH} == "master" ]]; then
-              export NOTIFY_FLAG=true
+              NOTIFY_FLAG=true
             else
               if [[ ${CIRCLE_BRANCH:0:3} == ci/ ]] && grep -n "^${CIRCLE_BRANCH:3}$" ./.circleci/scripts/auto-rebase-branches.txt >> /dev/null ; then
-                export NOTIFY_FLAG=true
+                NOTIFY_FLAG=true
               else
-                export NOTIFY_FLAG=false
+                NOTIFY_FLAG=false
               fi
             fi
-      - when:
-          condition: $NOTIFY_FLAG
-          steps:
-            - slack/status:
-                fail_only: true
-                failure_message: ':red_circle: M2: A $CIRCLE_JOB job has failed!'
-                webhook: $SLACK_GREENKEEPER_WEBHOOK
+            if [ "$NOTIFY_FLAG" == false ]; then
+              circleci-agent step halt
+            fi
+      - slack/status:
+          fail_only: true
+          failure_message: ':red_circle: M2: A $CIRCLE_JOB job has failed!'
+          webhook: $SLACK_GREENKEEPER_WEBHOOK
 
   m2-php-test-for-merchant-branches:
     description: PHP Unit tests for M2 on all merchant branches


### PR DESCRIPTION
when-condition things are compiled before executing, so we can't use shell variables in conditions.
As result we always notify greenkeeper slack channel if the build fails.

Solution: use `circleci-agent step halt` instead

# Description
Please include a summary of the change and which issue is fixed. Include the motivation for the changes, and comment on your PR if necessary for clarity.

Fixes: (link Jira ticket)

#changelog Fix issue with conditionally notify greenkeeper step

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
