### PR TITLE
M2P-181 Correct logic to get product images for the Bolt cart

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -34,7 +34,6 @@ use Zend_Http_Client_Exception;
 use Bolt\Boltpay\Helper\Log as LogHelper;
 use Bolt\Boltpay\Helper\Shared\CurrencyUtils;
 use Magento\Framework\DataObjectFactory;
-use Magento\Catalog\Helper\ImageFactory;
 use Magento\Store\Model\App\Emulation;
 use Magento\Customer\Model\Address;
 use Magento\Quote\Model\QuoteFactory;
@@ -61,6 +60,9 @@ use Bolt\Boltpay\Exception\BoltException;
 use Bolt\Boltpay\Model\ErrorResponse as BoltErrorResponse;
 use Bolt\Boltpay\Helper\MetricsClient;
 use Bolt\Boltpay\Helper\FeatureSwitch\Decider as DeciderHelper;
+use Magento\Catalog\Block\Product\ImageBuilder;
+use Magento\Catalog\Model\Product\Configuration\Item\ItemResolverInterface;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Boltpay Cart helper
@@ -121,11 +123,6 @@ class Cart extends AbstractHelper
      * @var DataObjectFactory
      */
     private $dataObjectFactory;
-
-    /**
-     * @var ImageFactory
-     */
-    private $imageHelperFactory;
 
     /**
      * @var Emulation
@@ -251,6 +248,14 @@ class Cart extends AbstractHelper
     private $deciderHelper;
 
     /**
+     * @var ImageBuilder
+     */
+    private $imageBuilder;
+
+    /** @var ItemResolverInterface */
+    private $itemResolver;
+
+    /**
      * @param Context           $context
      * @param CheckoutSession   $checkoutSession
      * @param ProductRepository $productRepository
@@ -260,7 +265,6 @@ class Cart extends AbstractHelper
      * @param LogHelper         $logHelper
      * @param Bugsnag           $bugsnag
      * @param DataObjectFactory $dataObjectFactory
-     * @param ImageFactory      $imageHelperFactory
      * @param Emulation         $appEmulation
      * @param QuoteFactory      $quoteFactory
      * @param TotalsCollector   $totalsCollector
@@ -279,6 +283,8 @@ class Cart extends AbstractHelper
      * @param Registry $coreRegistry
      * @param MetricsClient $metricsClient
      * @param DeciderHelper $deciderHelper
+     * @param ImageBuilder $imageBuilder
+     * @param ItemResolverInterface $itemResolver
      */
     public function __construct(
         Context $context,
@@ -290,7 +296,6 @@ class Cart extends AbstractHelper
         LogHelper $logHelper,
         Bugsnag $bugsnag,
         DataObjectFactory $dataObjectFactory,
-        ImageFactory $imageHelperFactory,
         Emulation $appEmulation,
         QuoteFactory $quoteFactory,
         TotalsCollector $totalsCollector,
@@ -308,7 +313,9 @@ class Cart extends AbstractHelper
         CustomerRepository $customerRepository,
         Registry $coreRegistry,
         MetricsClient $metricsClient,
-        DeciderHelper $deciderHelper
+        DeciderHelper $deciderHelper,
+        ImageBuilder $imageBuilder,
+        ItemResolverInterface $itemResolver = null
     ) {
         parent::__construct($context);
         $this->checkoutSession = $checkoutSession;
@@ -318,7 +325,6 @@ class Cart extends AbstractHelper
         $this->customerSession = $customerSession;
         $this->logHelper = $logHelper;
         $this->bugsnag = $bugsnag;
-        $this->imageHelperFactory = $imageHelperFactory;
         $this->appEmulation = $appEmulation;
         $this->dataObjectFactory = $dataObjectFactory;
         $this->quoteFactory = $quoteFactory;
@@ -338,6 +344,8 @@ class Cart extends AbstractHelper
         $this->coreRegistry = $coreRegistry;
         $this->metricsClient = $metricsClient;
         $this->deciderHelper = $deciderHelper;
+        $this->imageBuilder = $imageBuilder;
+        $this->itemResolver = $itemResolver ?: ObjectManager::getInstance()->get(ItemResolverInterface::class);
     }
 
     /**
@@ -1217,12 +1225,11 @@ class Cart extends AbstractHelper
             true
         );
         /////////////////////////////////////////////////////////////////////////////////////////////////////////
-        $imageHelper = $this->imageHelperFactory->create();
 
         $additionalAttributes = $this->configHelper->getProductAttributesList($storeId);
 
         $products = array_map(
-            function ($item) use ($imageHelper, &$totalAmount, &$diff, $storeId, $currencyCode, $additionalAttributes) {
+            function ($item) use (&$totalAmount, &$diff, $storeId, $currencyCode, $additionalAttributes) {
                 $product = [];
 
                 $unitPrice   = $item->getCalculationPrice();
@@ -1282,41 +1289,24 @@ class Cart extends AbstractHelper
                 // Get product description and image
                 ////////////////////////////////////
                 $product['description'] = strip_tags($_product->getDescription());
-                $variantProductToGetImage = $_product;
 
-                // This will override the $_product with the variant product to get the variant image rather than the main product image.
                 try {
-                    // If the cart item is type of bundle product, its SKU is a combination with bundle selections,
-                    // so we need to retrieve the sku of bundle product without bundle selections.
-                    $product_sku = 'bundle' == $item->getProductType()
-                                   ? $_product->getData('sku')
-                                   : $product['sku'];
-                    $variantProductToGetImage = $this->productRepository->get($product_sku, false, $storeId);
+                    $productToGetImage = $this->itemResolver->getFinalProduct($item);
+                    $image = $this->imageBuilder->create($productToGetImage,'cart_page_product_thumbnail');
+
+                    if ($image) {
+                        $product['image_url'] = ltrim($image->getImageUrl(), '/');
+                    }
                 } catch (\Exception $e) {
                     $this->bugsnag->registerCallback(function ($report) use ($product) {
                         $report->setMetaData([
                             'ITEM' => $product
                         ]);
                     });
-                    $this->bugsnag->notifyError('Could not retrieve product from repository', "ProductId: {$product['reference']}, SKU: {$product['sku']}");
+                    $this->bugsnag->notifyException($e);
+                    $this->bugsnag->notifyError('Item image missing', "SKU: {$product['sku']}");
                 }
-                try {
-                    $productImageUrl = $imageHelper->init($variantProductToGetImage, 'product_small_image')->getUrl();
-                } catch (\Exception $e) {
-                    try {
-                        $productImageUrl = $imageHelper->init($variantProductToGetImage, 'product_base_image')->getUrl();
-                    } catch (\Exception $e) {
-                        $this->bugsnag->registerCallback(function ($report) use ($product) {
-                            $report->setMetaData([
-                                'ITEM' => $product
-                            ]);
-                        });
-                        $this->bugsnag->notifyError('Item image missing', "SKU: {$product['sku']}");
-                    }
-                }
-                if (@$productImageUrl) {
-                    $product['image_url'] = ltrim($productImageUrl, '/');
-                }
+
                 ////////////////////////////////////
                 return  $product;
             },


### PR DESCRIPTION
# Description
This PR is to correct the logic to get the product images for the Bolt cart just like the logic to get the cart item images.

Fixes: https://boltpay.atlassian.net/browse/M2P-181

#changelog M2P-181 Correct logic to get product images for the Bolt cart

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
