### PR TITLE
M2P-199 Restock product saleable quantity when canceling order

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -1670,13 +1670,8 @@ class Order extends AbstractHelper
                 $order->setStatus($order->getConfig()->getStateDefaultStatus(OrderModel::STATE_HOLDED));
             }
         } elseif ($state == OrderModel::STATE_CANCELED) {
-            if ($order->canCancel()) {
-                $this->cancelOrder($order);
-                return;
-            }
-
             try {
-                // Restock product quantity when the payment is irreversibly rejected
+                // Use registerCancellation method to cancel order and restock product saleable quantity
                 $order->registerCancellation('', false);
             } catch (\Exception $e) {
                 // Put the order in "cancelled" state even if the previous call fails

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -2674,12 +2674,11 @@ class OrderTest extends TestCase
     {
         $state = Order::STATE_CANCELED;
         $this->orderMock->expects(static::once())->method('getState')->willReturn($state);
-        $this->orderMock->expects(static::once())->method('canCancel')->willReturn(true);
-        $this->currentMock->expects(static::once())->method('cancelOrder')->with($this->orderMock);
         $this->orderMock->expects(static::never())->method('hold');
         $this->orderMock->expects(static::never())->method('setState');
         $this->orderMock->expects(static::never())->method('setStatus');
-        $this->orderMock->expects(static::never())->method('save');
+        $this->orderMock->expects(static::once())->method('save');
+        $this->orderMock->expects(static::once())->method('registerCancellation');
         $this->currentMock->setOrderState($this->orderMock, $state);
     }
 
@@ -2692,8 +2691,6 @@ class OrderTest extends TestCase
     {
         $prevState = Order::STATE_PAYMENT_REVIEW;
         $this->orderMock->expects(static::once())->method('getState')->willReturn($prevState);
-        $this->orderMock->expects(static::once())->method('canCancel')->willReturn(false);
-        $this->currentMock->expects(static::never())->method('cancelOrder')->with($this->orderMock);
         $this->orderMock->expects(static::once())->method('registerCancellation')->willReturn($this->orderMock);
         $this->orderMock->expects(static::never())->method('setState');
         $this->orderMock->expects(static::never())->method('setStatus');
@@ -2710,8 +2707,6 @@ class OrderTest extends TestCase
     {
         $prevState = Order::STATE_PAYMENT_REVIEW;
         $this->orderMock->expects(static::once())->method('getState')->willReturn($prevState);
-        $this->orderMock->expects(static::once())->method('canCancel')->willReturn(false);
-        $this->currentMock->expects(static::never())->method('cancelOrder')->with($this->orderMock);
         $this->orderMock->expects(static::once())->method('registerCancellation')->willThrowException(new Exception());
         $this->orderMock->expects(static::once())->method('setState');
         $this->orderMock->expects(static::once())->method('setStatus');


### PR DESCRIPTION
# Description
Currently, if the merchant cancels the order on Bolt or the Magento admin, the order status goes to cancel. However, the order item status doesn’t. As a result, the salable quantity isn’t restored.

This PR resolves that issue by removing the issued code.

See screenshot for testing:
Before fix: https://prnt.sc/ttf2pe
After fix: https://prnt.sc/ttez8u

Fixes: https://boltpay.atlassian.net/browse/M2P-199

#changelog M2P-199 Restock product saleable quantity when canceling order

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
