### PR TITLE
[M2P-152] [WIP] Removed quote id from response

### DIFF
--- a/Model/Api/CreateOrder.php
+++ b/Model/Api/CreateOrder.php
@@ -226,7 +226,7 @@ class CreateOrder implements CreateOrderInterface
             $this->sendResponse(200, [
                 'status'    => 'success',
                 'message'   => "Order create was successful. Order Data: $orderData",
-                'display_id' => $createdOrder->getIncrementId() . ' / ' . $immutableQuoteId,
+                'display_id' => $createdOrder->getIncrementId(),
                 'total'      => CurrencyUtils::toMinor($createdOrder->getGrandTotal(), $currency),
                 'order_received_url' => $this->getReceivedUrl($immutableQuote),
             ]);

--- a/Test/Unit/Model/Api/CreateOrderTest.php
+++ b/Test/Unit/Model/Api/CreateOrderTest.php
@@ -418,7 +418,7 @@ class CreateOrderTest extends TestCase
         $this->currentMock->expects(self::once())->method('sendResponse')->with(
             200,
             [
-                'display_id'   => 'XXXXX / 456',
+                'display_id'   => 'XXXXX',
                 'message'   => 'Order create was successful. Order Data: {"id":"1111","increment_id":"XXXXX","grand_total":"11.00"}',
                 'order_received_url'   => '',
                 'status'    => 'success',


### PR DESCRIPTION
# Description
As a simple interim step for cleaning up the display ID, we've removed the quote id from the response. I've not been able to get this to change things on my devbox but that's probably more due to my devbox set-up. It's possible there's something I'm missing here so figured opening a PR to get eyes on it makes more sense. This solution seems _too_ easy.

Still need to update unit test

Fixes: go/j/M2P-152

#changelog [M2P-152] [WIP] Removed quote id from response

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
