### PR TITLE
M2P-181 Correct logic to get product images for the Bolt cart (compatible with all Magento version)

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -61,6 +61,7 @@ use Bolt\Boltpay\Exception\BoltException;
 use Bolt\Boltpay\Model\ErrorResponse as BoltErrorResponse;
 use Bolt\Boltpay\Helper\MetricsClient;
 use Bolt\Boltpay\Helper\FeatureSwitch\Decider as DeciderHelper;
+use Magento\Catalog\Model\Config\Source\Product\Thumbnail as ThumbnailSource;;
 
 /**
  * Boltpay Cart helper
@@ -1313,19 +1314,14 @@ class Cart extends AbstractHelper
 
                 // This will override the $_product with the variant product to get the variant image rather than the main product image.
                 try {
-                    // If the cart item is type of bundle product, its SKU is a combination with bundle selections,
-                    // so we need to retrieve the sku of bundle product without bundle selections.
-                    $product_sku = 'bundle' == $item->getProductType()
-                                   ? $_product->getData('sku')
-                                   : $product['sku'];
-                    $variantProductToGetImage = $this->productRepository->get($product_sku, false, $storeId);
+                    $variantProductToGetImage = $this->getProductToGetImageForQuoteItem($item);
                 } catch (\Exception $e) {
                     $this->bugsnag->registerCallback(function ($report) use ($product) {
                         $report->setMetaData([
                             'ITEM' => $product
                         ]);
                     });
-                    $this->bugsnag->notifyError('Could not retrieve product from repository', "ProductId: {$product['reference']}, SKU: {$product['sku']}");
+                    $this->bugsnag->notifyError('Could not retrieve product', "ProductId: {$product['reference']}, SKU: {$product['sku']}");
                 }
                 try {
                     $productImageUrl = $imageHelper->init($variantProductToGetImage, 'product_small_image')->getUrl();
@@ -1372,6 +1368,93 @@ class Cart extends AbstractHelper
         /////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         return [$products, $totalAmount, $diff];
+    }
+
+    /**
+     * @param $item
+     * @return \Magento\Catalog\Model\Product
+     */
+    public function getProductToGetImageForQuoteItem($item)
+    {
+        $productType = $item->getProductType();
+        if ($productType == \Magento\ConfigurableProduct\Model\Product\Type\Configurable::TYPE_CODE) {
+            return $this->getProductToGetImageForConfigurableItem($item);
+        }
+
+        if ($productType == \Magento\GroupedProduct\Model\Product\Type\Grouped::TYPE_CODE) {
+            return $this->getProductToGetImageForGroupedItem($item);
+        }
+
+        return $item->getProduct();
+    }
+
+    /**
+     * @see \Magento\ConfigurableProduct\Block\Cart\Item\Renderer\Configurable::getProductForThumbnail logic
+     * (Magento version is less than 2.2.7)
+     *
+     * @see \Magento\ConfigurableProduct\Model\Product\Configuration\Item\ItemProductResolver::getProductForThumbnail logic
+     * (Magento version is greater or equal to 2.2.7)
+     *
+     * @param $item
+     * @return \Magento\Catalog\Model\Product
+     */
+    private function getProductToGetImageForConfigurableItem($item)
+    {
+        $parentProduct = $item->getProduct();
+        /** @var \Magento\Quote\Model\Quote\Item\Option $option */
+        $option = $item->getOptionByCode('simple_product');
+        $childProduct = $option ? $option->getProduct() : $item->getProduct();
+        $configValue = $this->configHelper->getScopeConfig()->getValue(
+            'checkout/cart/configurable_product_image',
+            ScopeInterface::SCOPE_STORE
+        );
+
+        /**
+         * Show parent product thumbnail if it must be always shown according to the related setting in system config
+         * or if child thumbnail is not available
+         */
+        if ($configValue == ThumbnailSource::OPTION_USE_PARENT_IMAGE ||
+            !($childProduct && $childProduct->getThumbnail() && $childProduct->getThumbnail() != 'no_selection')
+        ) {
+            return $parentProduct;
+        }
+
+        return $childProduct;
+    }
+
+    /**
+     * @see \Magento\GroupedProduct\Block\Cart\Item\Renderer\Grouped::getProductForThumbnail logic
+     * (Magento version is less than 2.2.7)
+     *
+     * @see \Magento\GroupedProduct\Model\Product\Configuration\Item\ItemProductResolver::getProductForThumbnail logic
+     * (Magento version is greater or equal to 2.2.7)
+     *
+     * @param $item
+     * @return \Magento\Catalog\Model\Product
+     */
+    private function getProductToGetImageForGroupedItem ($item)
+    {
+        /** @var \Magento\Quote\Model\Quote\Item\Option $option */
+        $option = $item->getOptionByCode('product_type');
+        $childProduct = $item->getProduct();
+        $groupedProduct = $option ? $option->getProduct() : $item->getProduct();
+
+        $configValue = $this->configHelper->getScopeConfig()->getValue(
+            'checkout/cart/grouped_product_image',
+            ScopeInterface::SCOPE_STORE
+        );
+
+        /**
+         * Show grouped product thumbnail if it must be always shown according to the related setting in system config
+         * or if child product thumbnail is not available
+         */
+        if ($configValue == ThumbnailSource::OPTION_USE_PARENT_IMAGE ||
+            !($childProduct && $childProduct->getThumbnail() && $childProduct->getThumbnail() != 'no_selection')
+        ) {
+            return $groupedProduct;
+        }
+
+        return $childProduct;
     }
 
     /**


### PR DESCRIPTION

# Description

Correct logic to get product images for the Bolt cart (compatible with all Magento version)

Fixes:  https://boltpay.atlassian.net/browse/M2P-181

#changelog M2P-181 Correct logic to get product images for the Bolt cart (compatible with all Magento version)

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
