### PR TITLE
M2P-201 - Magento 2.4 requirements update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,11 +2,11 @@
     "name": "boltpay/bolt-magento2",
     "description": "Bolt payment gateway integration",
     "require": {
-        "magento/module-sales": "100.*|101.*|102.*",
-        "magento/module-checkout": "100.*|101.*|102.*",
-        "magento/module-payment": "100.*|101.*|102.*",
-        "magento/module-tax": "100.*|101.*|102.*",
-        "magento/framework": "100.*|101.*|102.*",
+        "magento/module-sales": "100.*|101.*|102.*|103.*",
+        "magento/module-checkout": "100.*|101.*|102.*|103.*",
+        "magento/module-payment": "100.*|101.*|102.*|103.*",
+        "magento/module-tax": "100.*|101.*|102.*|103.*",
+        "magento/framework": "100.*|101.*|102.*|103.*",
         "bugsnag/bugsnag": "^3.4"
     },
     "require-dev": {


### PR DESCRIPTION
# Description
Fix composer requirements so plugin installs on Magento 2.4.

Note: You must install Elasticsearch before installing Magento Commerce or Magento Open Source 2.4.0. See https://devdocs.magento.com/guides/v2.4/install-gde/prereq/elasticsearch.html for details.
Also, there's a Two-Factor Authorization enabled by default for the admin area. It can be turned off by disabling Magento_TwoFactorAuth module.


Fixes: [https://boltpay.atlassian.net/browse/M2P-201]

#changelog M2P-201 - Magento 2.4 requirements update

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
