### PR TITLE
M2P-204 Refactor the code to use assigned variable $parentProduct instead of item->getProduct() 

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1403,7 +1403,7 @@ class Cart extends AbstractHelper
         $parentProduct = $item->getProduct();
         /** @var \Magento\Quote\Model\Quote\Item\Option $option */
         $option = $item->getOptionByCode('simple_product');
-        $childProduct = $option ? $option->getProduct() : $item->getProduct();
+        $childProduct = $option ? $option->getProduct() : $parentProduct;
         $configValue = $this->configHelper->getScopeConfig()->getValue(
             'checkout/cart/configurable_product_image',
             ScopeInterface::SCOPE_STORE
@@ -1437,7 +1437,7 @@ class Cart extends AbstractHelper
         /** @var \Magento\Quote\Model\Quote\Item\Option $option */
         $option = $item->getOptionByCode('product_type');
         $childProduct = $item->getProduct();
-        $groupedProduct = $option ? $option->getProduct() : $item->getProduct();
+        $groupedProduct = $option ? $option->getProduct() : $childProduct;
 
         $configValue = $this->configHelper->getScopeConfig()->getValue(
             'checkout/cart/grouped_product_image',

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -4756,7 +4756,7 @@ ORDER
 
             $parentProductMock = $this->createMock(Product::class);
             $parentProductMock->method('getName')->willReturn('Parent Product Name');
-            $quoteItem->method('getProduct')->willReturn($parentProductMock);
+            $quoteItem->expects(self::once())->method('getProduct')->willReturn($parentProductMock);
             $quoteItem->method('getProductType')->willReturn(\Magento\ConfigurableProduct\Model\Product\Type\Configurable::TYPE_CODE);
 
 
@@ -4809,9 +4809,8 @@ ORDER
             $productMock = $this->createPartialMock(Product::class, ['getName','getThumbnail']);
             $productMock->method('getName')->willReturn('Child Product Name');
             $productMock->method('getThumbnail')->willReturn($childThumbnail);
-            $quoteItem->method('getProduct')->willReturn($productMock);
+            $quoteItem->expects(self::once())->method('getProduct')->willReturn($productMock);
             $quoteItem->method('getProductType')->willReturn(\Magento\GroupedProduct\Model\Product\Type\Grouped::TYPE_CODE);
-
 
             $groupedProductMock = $this->createPartialMock(Product::class, ['getName','getThumbnail']);
             $groupedProductMock->method('getName')->willReturn('Grouped Product Name');


### PR DESCRIPTION
# Description

Refactor the code to use assigned variable $parentProduct instead of item->getProduct() per Vitaliy’s feedback in PR https://github.com/BoltApp/bolt-magento2/pull/867/files

Fixes: https://boltpay.atlassian.net/browse/M2P-204

#changelog M2P-204 Refactor the code to use assigned variable $parentProduct instead of item->getProduct() 

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
