### PR TITLE
M2P-145 Update logic for applying Mageplaza gift card via Bolt modal on the latest version

### DIFF
--- a/Test/Unit/Helper/DiscountTest.php
+++ b/Test/Unit/Helper/DiscountTest.php
@@ -2687,6 +2687,7 @@ class DiscountTest extends TestCase
      * @param int           $accountModelStoreId value of Mageplaza Gift Card Model store id
      * @param int           $storeId value of provided store id
      * @param bool          $expectException flag value
+     * @param bool          $isActive
      * @param \Mageplaza\GiftCard\Model\GiftCard|null $expectedResult of the tested method
      *
      * @throws ReflectionException if unable to set internal mock properties
@@ -2697,6 +2698,7 @@ class DiscountTest extends TestCase
         $accountModelId,
         $accountModelStoreId,
         $storeId,
+        $isActive,
         $expectException,
         $expectedResult
     ) {
@@ -2710,6 +2712,7 @@ class DiscountTest extends TestCase
                 'load',
                 'getId',
                 'getStoreId',
+                'isActive'
             ]
         )->disableOriginalConstructor()->getMock();
 
@@ -2722,6 +2725,7 @@ class DiscountTest extends TestCase
             ->method('load')
             ->with($code, 'code')
             ->willReturn($accountModel);
+
         $exception = $this->createMock(\Exception::class);
         if ($accountModel) {
             $accountModel->expects($isMageplazaGiftCardAvailable ? static::once() : static::never())
@@ -2730,6 +2734,7 @@ class DiscountTest extends TestCase
             $accountModel->expects(
                 $isMageplazaGiftCardAvailable && !$expectException ? static::exactly(2) : static::never()
             )->method('getStoreId')->willReturnOnConsecutiveCalls($accountModelStoreId, $accountModelStoreId);
+            $accountModel->method('isActive')->willReturn($isActive);
         }
         static::assertEquals($expectedResult, $this->currentMock->loadMageplazaGiftCard($code, $storeId));
     }
@@ -2753,12 +2758,14 @@ class DiscountTest extends TestCase
                         'getInstance',
                         'load',
                         'getId',
-                        'getStoreId'
+                        'getStoreId',
+                        'isActive'
                     ]
                 ),
                 'accountModelId'               => 1,
                 'accountModelStoreId'          => 22,
                 'storeId'                      => 23,
+                'isActive'                     => true,
                 'expectException'              => false,
                 'expectedResult'               => null,
             ],
@@ -2768,6 +2775,7 @@ class DiscountTest extends TestCase
                 'accountModelId'               => null,
                 'accountModelStoreId'          => 42,
                 'storeId'                      => 22,
+                'isActive'                     => true,
                 'expectException'              => false,
                 'expectedResult'               => null,
             ],
@@ -2779,12 +2787,14 @@ class DiscountTest extends TestCase
                         'getInstance',
                         'load',
                         'getId',
-                        'getStoreId'
+                        'getStoreId',
+                        'isActive'
                     ]
                 ),
                 'accountModelId'               => null,
                 'accountModelStoreId'          => 22,
                 'storeId'                      => 22,
+                'isActive'                     => true,
                 'expectException'              => false,
                 'expectedResult'               => null,
             ],
@@ -2796,12 +2806,14 @@ class DiscountTest extends TestCase
                         'getInstance',
                         'load',
                         'getId',
-                        'getStoreId'
+                        'getStoreId',
+                        'isActive'
                     ]
                 ),
                 'accountModelId'               => 66,
                 'accountModelStoreId'          => 22,
                 'storeId'                      => 84,
+                'isActive'                     => true,
                 'expectException'              => false,
                 'expectedResult'               => null,
             ],
@@ -2813,12 +2825,14 @@ class DiscountTest extends TestCase
                         'getInstance',
                         'load',
                         'getId',
-                        'getStoreId'
+                        'getStoreId',
+                        'isActive'
                     ]
                 ),
                 'accountModelId'               => 62,
                 'accountModelStoreId'          => 54,
                 'storeId'                      => 54,
+                'isActive'                     => true,
                 'expectException'              => true,
                 'expectedResult'               => null,
             ],
@@ -2830,12 +2844,14 @@ class DiscountTest extends TestCase
                         'getInstance',
                         'load',
                         'getId',
-                        'getStoreId'
+                        'getStoreId',
+                        'isActive'
                     ]
                 ),
                 'accountModelId'               => 62,
                 'accountModelStoreId'          => 54,
                 'storeId'                      => 54,
+                'isActive'                     => true,
                 'expectException'              => false,
                 'expectedResult'               => $this->createPartialMock(
                     ThirdPartyModuleFactory::class,
@@ -2843,9 +2859,29 @@ class DiscountTest extends TestCase
                         'getInstance',
                         'load',
                         'getId',
-                        'getStoreId'
+                        'getStoreId',
+                        'isActive'
                     ]
                 ),
+            ],
+            [
+                'isMageplazaGiftCardAvailable' => true,
+                'accountModel'                 => $this->createPartialMock(
+                    ThirdPartyModuleFactory::class,
+                    [
+                        'getInstance',
+                        'load',
+                        'getId',
+                        'getStoreId',
+                        'isActive'
+                    ]
+                ),
+                'accountModelId'               => 62,
+                'accountModelStoreId'          => 54,
+                'storeId'                      => 54,
+                'isActive'                     => false,
+                'expectException'              => false,
+                'expectedResult'               => null
             ],
         ];
     }
@@ -3166,14 +3202,15 @@ class DiscountTest extends TestCase
                     'setTotalsCollectedFlag',
                     'collectTotals',
                     'setDataChanges',
+                    'setMpGiftCards'
                 ]
             )
             ->disableOriginalConstructor()
             ->getMock();
 
-        $code = 1232;
+        $code = 'Bolt_MpGiftCard';
         $this->currentMock->expects(static::once())->method('isMageplazaGiftCardAvailable')->willReturn(true);
-
+        $quote->expects(static::once())->method('setMpGiftCards')->with('{"Bolt_MpGiftCard":0}')->willReturnSelf();
         $giftCardMock = $this->getMockBuilder(ThirdPartyModuleFactory::class)
             ->setMethods(['getGiftCardsData', 'getCheckoutSession'])
             ->disableOriginalConstructor()


### PR DESCRIPTION
# Description

On the latest Mageplaza_GiftCard, we can’t apply the gift card code via the Bolt modal
This PR resolves it.

Fixes: https://boltpay.atlassian.net/browse/M2P-145

#changelog M2P-145 Update logic for applying Mageplaza gift card via Bolt modal on the latest version

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
