### PR TITLE
M2P-151 Add feature switch to handle with virtual products as physical

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1363,6 +1363,15 @@ class Cart extends AbstractHelper
             $products[] = $product;
         }
 
+        if ($this->deciderHelper->isHandleVirtualProductsAsPhysical()) {
+            // In current Bolt checkout flow, the shipping and tax endpoint is not called for virtual carts,
+            // It means we don't support taxes for virtual product and should handle all products as physical
+            // TODO: Remove when issue will be solved https://boltpay.atlassian.net/browse/DC-181
+            foreach($products as $iterator => $product) {
+                $products[$iterator]['type'] = 'physical';
+            }
+        }
+
         /////////////////////////////////////////////////////////////////////////////////////////////////////////
         $this->appEmulation->stopEnvironmentEmulation();
         /////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1275,7 +1275,16 @@ class Cart extends AbstractHelper
                 $product['unit_price']   = CurrencyUtils::toMinor($unitPrice, $currencyCode);
                 $product['quantity']     = round($item->getQty());
                 $product['sku']          = trim($item->getSku());
-                $product['type']         = $item->getIsVirtual() ? self::ITEM_TYPE_DIGITAL : self::ITEM_TYPE_PHYSICAL;
+
+                // In current Bolt checkout flow, the shipping and tax endpoint is not called for virtual carts,
+                // It means we don't support taxes for virtual product and should handle all products as physical
+                // TODO: Remove the feature switch check when issue will be solved https://boltpay.atlassian.net/browse/DC-181
+                if ( $item->getIsVirtual() && !$this->deciderHelper->isHandleVirtualProductsAsPhysical()) {
+                    $product['type'] = self::ITEM_TYPE_DIGITAL;
+                } else {
+                    $product['type'] = self::ITEM_TYPE_PHYSICAL;
+                }
+
                 ///////////////////////////////////////////
                 // Get item attributes / product properties
                 ///////////////////////////////////////////
@@ -1361,15 +1370,6 @@ class Cart extends AbstractHelper
 
             $totalAmount +=  $product['total_amount'];
             $products[] = $product;
-        }
-
-        if ($this->deciderHelper->isHandleVirtualProductsAsPhysical()) {
-            // In current Bolt checkout flow, the shipping and tax endpoint is not called for virtual carts,
-            // It means we don't support taxes for virtual product and should handle all products as physical
-            // TODO: Remove when issue will be solved https://boltpay.atlassian.net/browse/DC-181
-            foreach($products as $iterator => $product) {
-                $products[$iterator]['type'] = 'physical';
-            }
         }
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1279,7 +1279,7 @@ class Cart extends AbstractHelper
                 // In current Bolt checkout flow, the shipping and tax endpoint is not called for virtual carts,
                 // It means we don't support taxes for virtual product and should handle all products as physical
                 // TODO: Remove the feature switch check when issue will be solved https://boltpay.atlassian.net/browse/DC-181
-                if ( $item->getIsVirtual() && !$this->deciderHelper->isHandleVirtualProductsAsPhysical()) {
+                if ( $item->getIsVirtual() && !$this->deciderHelper->handleVirtualProductsAsPhysical()) {
                     $product['type'] = self::ITEM_TYPE_DIGITAL;
                 } else {
                     $product['type'] = self::ITEM_TYPE_PHYSICAL;

--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -258,7 +258,7 @@ class Decider extends AbstractHelper
         return $this->isSwitchEnabled(Definitions::M2_IF_SHOULD_DISABLE_PREFILL_ADDRESS_FROM_BOLT_FOR_LOGGED_IN_CUSTOMER);
     }
 
-    public function isHandleVirtualProductsAsPhysical() {
+    public function handleVirtualProductsAsPhysical() {
         return $this->isSwitchEnabled(Definitions::M2_HANDLE_VIRTUAL_PRODUCTS_AS_PHYSICAL);
     }
 }

--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -257,4 +257,8 @@ class Decider extends AbstractHelper
     public function ifShouldDisablePrefillAddressForLoggedInCustomer() {
         return $this->isSwitchEnabled(Definitions::M2_IF_SHOULD_DISABLE_PREFILL_ADDRESS_FROM_BOLT_FOR_LOGGED_IN_CUSTOMER);
     }
+
+    public function isHandleVirtualProductsAsPhysical() {
+        return $this->isSwitchEnabled(Definitions::M2_HANDLE_VIRTUAL_PRODUCTS_AS_PHYSICAL);
+    }
 }

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -122,6 +122,11 @@ class Definitions
      */
     const M2_IF_SHOULD_DISABLE_PREFILL_ADDRESS_FROM_BOLT_FOR_LOGGED_IN_CUSTOMER = "M2_IF_SHOULD_DISABLE_PREFILL_ADDRESS_FROM_BOLT_FOR_LOGGED_IN_CUSTOMER";
 
+    /**
+     * Handle virtual cart as physical. Workarond for known issue with taxable virtual products.
+     */
+    const M2_HANDLE_VIRTUAL_PRODUCTS_AS_PHYSICAL = "M2_HANDLE_VIRTUAL_PRODUCTS_AS_PHYSICAL";
+
     const DEFAULT_SWITCH_VALUES = [
         self::M2_SAMPLE_SWITCH_NAME =>  [
           self::NAME_KEY            => self::M2_SAMPLE_SWITCH_NAME,
@@ -230,6 +235,12 @@ class Definitions
             self::VAL_KEY             => true,
             self::DEFAULT_VAL_KEY     => false,
             self::ROLLOUT_KEY         => 0
-        ]
+        ],
+        self::M2_HANDLE_VIRTUAL_PRODUCTS_AS_PHYSICAL => [
+            self::NAME_KEY            => self::M2_HANDLE_VIRTUAL_PRODUCTS_AS_PHYSICAL,
+            self::VAL_KEY             => true,
+            self::DEFAULT_VAL_KEY     => false,
+            self::ROLLOUT_KEY         => 0
+        ],
     ];
 }

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -416,7 +416,7 @@ class CartTest extends TestCase
         $this->customerMock = $this->createPartialMock(Customer::class, ['getEmail']);
         $this->coreRegistry = $this->createMock(Registry::class);
         $this->metricsClient = $this->createMock(MetricsClient::class);
-        $this->deciderHelper = $this->createPartialMock(DeciderHelper::class, ['ifShouldDisablePrefillAddressForLoggedInCustomer']);
+        $this->deciderHelper = $this->createPartialMock(DeciderHelper::class, ['ifShouldDisablePrefillAddressForLoggedInCustomer','isHandleVirtualProductsAsPhysical']);
         $this->currentMock = $this->getCurrentMock(null);
     }
 
@@ -4637,6 +4637,67 @@ ORDER
         static::assertEquals(10000, $totalAmount);
         static::assertEquals(0, $diff);
         }
+
+    /**
+     * @test
+     * that getCartItems will notify 'Item image missing' error if both attempts to retrieve image url fail
+     *
+     * @covers ::getCartItems
+     */
+    public function getCartItems_withFeatureSwitchIsHandleVirtualProductsAsPhysical_returnPhysicalCart()
+    {
+        $this->deciderHelper->expects(self::once())->method('isHandleVirtualProductsAsPhysical')->willReturn(true);
+        $quoteItem = $this->createPartialMock(
+            Item::class,
+            [
+                'getCalculationPrice',
+                'getQty',
+                'getProduct',
+                'getProductId',
+                'getName',
+                'getSku',
+                'getIsVirtual',
+            ]
+        );
+        $productMock = $this->createMock(Product::class);
+        $quoteItem->method('getName')->willReturn('Test Product');
+        $quoteItem->method('getSku')->willReturn(self::PRODUCT_SKU);
+        $quoteItem->method('getQty')->willReturn(1);
+        $quoteItem->method('getCalculationPrice')->willReturn(self::PRODUCT_PRICE);
+        $quoteItem->method('getIsVirtual')->willReturn(true);
+        $quoteItem->method('getProductId')->willReturn(self::PRODUCT_ID);
+        $quoteItem->method('getProduct')->willReturn($productMock);
+        $productMock->expects(static::once())->method('getTypeInstance')->willReturnSelf();
+
+        $this->imageHelper->method('init')
+        ->withConsecutive([$productMock, 'product_small_image'], [$productMock, 'product_base_image'])
+        ->willThrowException(new Exception());
+
+        $this->quoteMock->method('getAllVisibleItems')->willReturn([$quoteItem]);
+        $this->quoteMock->method('getQuoteCurrencyCode')->willReturn(self::CURRENCY_CODE);
+        $this->quoteMock->method('getTotals')->willReturnSelf();
+
+        list($products, $totalAmount, $diff) = $this->currentMock->getCartItems(
+            $this->quoteMock,
+            self::STORE_ID
+        );
+        static::assertEquals(
+            [
+                [
+                    'reference'    => 20102,
+                    'name'         => 'Test Product',
+                    'total_amount' => 10000,
+                    'unit_price'   => 10000,
+                    'quantity'     => 1.0,
+                    'sku'          => self::PRODUCT_SKU,
+                    'type'         => 'physical',
+                    'description'  => '',
+                ],
+            ],
+            $products
+        );
+    }
+
 
 
       /**

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -416,7 +416,7 @@ class CartTest extends TestCase
         $this->customerMock = $this->createPartialMock(Customer::class, ['getEmail']);
         $this->coreRegistry = $this->createMock(Registry::class);
         $this->metricsClient = $this->createMock(MetricsClient::class);
-        $this->deciderHelper = $this->createPartialMock(DeciderHelper::class, ['ifShouldDisablePrefillAddressForLoggedInCustomer','isHandleVirtualProductsAsPhysical']);
+        $this->deciderHelper = $this->createPartialMock(DeciderHelper::class, ['ifShouldDisablePrefillAddressForLoggedInCustomer','handleVirtualProductsAsPhysical']);
         $this->currentMock = $this->getCurrentMock(null);
     }
 
@@ -4644,9 +4644,9 @@ ORDER
      *
      * @covers ::getCartItems
      */
-    public function getCartItems_withFeatureSwitchIsHandleVirtualProductsAsPhysical_returnPhysicalCart()
+    public function getCartItems_withFeatureSwitchHandleVirtualProductsAsPhysical_returnPhysicalCart()
     {
-        $this->deciderHelper->expects(self::once())->method('isHandleVirtualProductsAsPhysical')->willReturn(true);
+        $this->deciderHelper->expects(self::once())->method('handleVirtualProductsAsPhysical')->willReturn(true);
         $quoteItem = $this->createPartialMock(
             Item::class,
             [


### PR DESCRIPTION
In current Bolt checkout flow, the shipping and tax endpoint is not called for virtual carts,
It means we don't support taxes for virtual product.
In this PR we add feature switch to handle all virtual products as physical, so it's a workaround for known issue.
 and should handle all products as physical


Fixes: [M2P-151]

#changelog M2P-151 Add feature switch to handle with virtual products as physical

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
