### PR TITLE
M2P-179 Return promise in check() callback

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -193,20 +193,30 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
     // barrier is externally-resolved promise
     var boltBarrier = function() {
         var resolveHolder;
+        var isResolved = false;
+        var value = null;
         var promise = new Promise(function(resolve){
             resolveHolder = resolve;
         });
-        return { promise: promise, resolve: function(t){resolveHolder(t)}};
+        return {
+            promise: promise,
+            resolve: function(t){
+                resolveHolder(t);
+                value = t;
+                isResolved = true;
+            },
+            value: function() { return value; },
+            isResolved: function() { return isResolved; },
+        };
     };
 
     var expectCartRendering = true;
     var waitingForResolvingPromises = false;
 
     var BoltState = {
-        checkBarrier: boltBarrier(),
-        checkResult: null,
+        check: boltBarrier(),
         magentoCart: null,
-        magentoCustomer: null
+        isUserLoggedIn: null,
     };
 
     ////////////////////////////////////////////////////
@@ -554,12 +564,12 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
             },
 
             check: function () {
-                if (BoltState.checkResult === null) {
+                if (BoltState.check.isResolved() === false) {
                     popUpOpen = true;
-                    return BoltState.checkBarrier.promise;
+                    return BoltState.check.promise;
                 }
-                if (!BoltState.checkResult) {
-                    if (!initiateCheckout && !BoltState.magentoCart.isGuestCheckoutAllowed && !BoltState.magentoCustomer.firstname ) {
+                if (!BoltState.check.value()) {
+                    if (!initiateCheckout && !BoltState.magentoCart.isGuestCheckoutAllowed && !BoltState.isUserLoggedIn ) {
                         authenticationPopup.showModal();
                     }
                     popUpOpen = false;
@@ -732,13 +742,12 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
 
         var resolveCheckPromise = function() {
             var resolveToValue = function(value) {
-                BoltState.checkBarrier.resolve(value);
-                BoltState.checkResult = value;
+                BoltState.check.resolve(value);
                 if (!value) {
                     popUpOpen = false;
                 }
             }
-            if (BoltState.checkResult !== null) {
+            if (BoltState.check.isResolved() === true) {
                 return;
             }
             if (BoltState.magentoCart === null) {
@@ -749,11 +758,15 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
                 return;
             }
             if (!initiateCheckout && !BoltState.magentoCart.isGuestCheckoutAllowed) {
-                if (BoltState.magentoCustomer === null) {
-                    // don't resolve promise, waiting for magento customer data
+                if (BoltState.isUserLoggedIn === null) {
+                    // initiate magento customer module to know if user logged in or not
+                    require(['Magento_Customer/js/model/customer'], function (customer) {
+                        BoltState.isUserLoggedIn = customer.isLoggedIn();
+                        resolveCheckPromise();
+                    });
                     return;
                 }
-                if (!BoltState.magentoCustomer.firstname) {
+                if (!BoltState.isUserLoggedIn) {
                     // if authentication is required for checkout set a cookie
                     // for auto opening Bolt checkout after login
                     setInitiateCheckoutCookie();
@@ -767,10 +780,6 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
             resolveToValue(true);
             return;
         }
-        customerData.get('customer').subscribe(function(data) {
-            BoltState.magentoCustomer = data;
-            resolveCheckPromise();
-        });
 
         if (getCheckoutType() !== 'payment') {
             callConfigureWithPromises();

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -213,10 +213,31 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
     var expectCartRendering = true;
     var waitingForResolvingPromises = false;
 
+    /**
+     * BoltState contains all global variables we need for interaction between
+     * this module and extensions.
+     * TODO(vitaliy): Move into BoltState cart, hints, callbacks
+     */
     var BoltState = {
+        /**
+         * @var boltBarrier return value for check() callback
+         */
         check: boltBarrier(),
+
+        /**
+         * @var object|null magento cart. null means cart isn't retrieved yet
+         */
         magentoCart: null,
+
+        /**
+         * @var bool|null true - logged in user, false - guest user, null - not known at the moment
+         */
         isUserLoggedIn: null,
+
+        /**
+         * @var bool|null true if we want to auto open bolt checkout
+         */
+        initiateCheckout: null,
     };
 
     ////////////////////////////////////////////////////
@@ -452,7 +473,7 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
         //////////////////////////////////////////////
 
         // flag that represents should the checkout auto-open
-        var initiateCheckout = settings.initiate_checkout && getInitiateCheckoutCookie();
+        BoltState.initiateCheckout = settings.initiate_checkout && getInitiateCheckoutCookie();
         unsetInitiateCheckoutCookie();
 
         // the open status of checkout modal
@@ -564,13 +585,21 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
             },
 
             check: function () {
+                /**
+                 * On Bolt button click check if guest checkout is allowed.
+                 * Display login popup to guest customers if it is not. The
+                 * Magento customer, customerData, authenticationPopup objects are
+                 * used.
+                 */
                 if (BoltState.check.isResolved() === false) {
                     popUpOpen = true;
                     return BoltState.check.promise;
                 }
                 if (!BoltState.check.value()) {
-                    if (!initiateCheckout && !BoltState.magentoCart.isGuestCheckoutAllowed && !BoltState.isUserLoggedIn ) {
-                        authenticationPopup.showModal();
+                    // If check resolved to false, guest checkout is disallowed, and user isn't logged in
+                    // show authentication popup
+                    if (!BoltState.initiateCheckout && !BoltState.magentoCart.isGuestCheckoutAllowed && !BoltState.isUserLoggedIn ) {
+                        showAuthenticationPopup();
                     }
                     popUpOpen = false;
                     return false;
@@ -740,6 +769,12 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
             boltCheckoutConfigure(cart, hints, callbacks, boltCheckoutConfig);
         }
 
+        var showAuthenticationPopup = function() {
+            // set a cookie for auto opening Bolt checkout after login
+            setInitiateCheckoutCookie();
+            authenticationPopup.showModal();
+        }
+
         var resolveCheckPromise = function() {
             var resolveToValue = function(value) {
                 BoltState.check.resolve(value);
@@ -757,7 +792,7 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
                 resolveToValue(false);
                 return;
             }
-            if (!initiateCheckout && !BoltState.magentoCart.isGuestCheckoutAllowed) {
+            if (!BoltState.initiateCheckout && !BoltState.magentoCart.isGuestCheckoutAllowed) {
                 if (BoltState.isUserLoggedIn === null) {
                     // initiate magento customer module to know if user logged in or not
                     require(['Magento_Customer/js/model/customer'], function (customer) {
@@ -767,11 +802,10 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
                     return;
                 }
                 if (!BoltState.isUserLoggedIn) {
-                    // if authentication is required for checkout set a cookie
-                    // for auto opening Bolt checkout after login
-                    setInitiateCheckoutCookie();
                     if (popUpOpen) {
-                        authenticationPopup.showModal();
+                        // If we resolve promises after user clicked checkout button
+                        // we should show authentication popup
+                        showAuthenticationPopup();
                     }
                     resolveToValue(false);
                     return;
@@ -905,7 +939,7 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
 
                             // open the checkout if auto-open flag is set
                             // one time only on page load
-                            if (initiateCheckout && allowAutoOpen) {
+                            if (BoltState.initiateCheckout && allowAutoOpen) {
                                 BC.open();
                                 allowAutoOpen = false;
                             }
@@ -965,7 +999,7 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
 
                         // open the checkout if auto-open flag is set
                         // one time only on page load
-                        if (initiateCheckout && allowAutoOpen) {
+                        if (BoltState.initiateCheckout && allowAutoOpen) {
                             BC.open();
                             allowAutoOpen = false;
                         }

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -202,6 +202,13 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
     var expectCartRendering = true;
     var waitingForResolvingPromises = false;
 
+    var BoltState = {
+        checkBarrier: boltBarrier(),
+        checkResult: null,
+        magentoCart: null,
+        magentoCustomer: null
+    };
+
     ////////////////////////////////////////////////////
     // DI: Inserting required Magento objects
     // the code below is dependant on.
@@ -222,10 +229,6 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
         }
 
         ////////////////////////////////////////////////////
-
-        // initialize customer and cart observables
-        var customer = customerData.get('customer');
-        var shoppingCart = customerData.get('cart');
 
             var showBoltErrorMessage = function (messsage, order_reference) {
                 var boltModal = $('#bolt-modal'),
@@ -551,26 +554,15 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
             },
 
             check: function () {
-                /**
-                 * On Bolt button click check if guest checkout is allowed.
-                 * Display login popup to guest customers if it is not. The
-                 * Magento customerData and authenticationPopup objects are
-                 * used.
-                 */
-                // check if / wait until the observable objects are set.
-                // proceed, allow checkout if initial checkout flag is set
-                if (!initiateCheckout && !shoppingCart().data_id) return false;
-
-                // do not open checkout if the cart is empty
-                if (shoppingCart().summary_count === 0) return false;
-
-                // check if login is required
-                // skip the check if initial checkout flag is set
-                if (!initiateCheckout && !customer().firstname && !shoppingCart().isGuestCheckoutAllowed) {
-                    // if authentication is required for checkout set a cookie
-                    // for auto opening Bolt checkout after login
-                    setInitiateCheckoutCookie();
-                    authenticationPopup.showModal();
+                if (BoltState.checkResult === null) {
+                    popUpOpen = true;
+                    return BoltState.checkBarrier.promise;
+                }
+                if (!BoltState.checkResult) {
+                    if (!initiateCheckout && !BoltState.magentoCart.isGuestCheckoutAllowed && !BoltState.magentoCustomer.firstname ) {
+                        authenticationPopup.showModal();
+                    }
+                    popUpOpen = false;
                     return false;
                 }
 
@@ -688,11 +680,10 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
             callConfigureWithPromises();
         }
 
-        var magentoCart;
         var boltCartDataID;
 
         var invalidateBoltCartIfOutdated = function() {
-            if (magentoCart === undefined || magentoCart.data_id === undefined) {
+            if (BoltState.magentoCart === undefined || BoltState.magentoCart.data_id === undefined) {
                 return;
             }
             if (boltCartDataID === undefined) {
@@ -702,12 +693,12 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
                 invalidateBoltCart();
                 return;
             }
-            if (magentoCart.data_id > boltCartDataID) {
+            if (BoltState.magentoCart.data_id > boltCartDataID) {
                 invalidateBoltCart();
                 return;
             }
-            if (magentoCart.data_id == boltCartDataID) {
-                var magentoTotal = magentoCart.subtotalAmount;
+            if (BoltState.magentoCart.data_id == boltCartDataID) {
+                var magentoTotal = BoltState.magentoCart.subtotalAmount;
                 if (magentoTotal === undefined) {
                     return;
                 }
@@ -739,10 +730,54 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
             boltCheckoutConfigure(cart, hints, callbacks, boltCheckoutConfig);
         }
 
+        var resolveCheckPromise = function() {
+            var resolveToValue = function(value) {
+                BoltState.checkBarrier.resolve(value);
+                BoltState.checkResult = value;
+                if (!value) {
+                    popUpOpen = false;
+                }
+            }
+            if (BoltState.checkResult !== null) {
+                return;
+            }
+            if (BoltState.magentoCart === null) {
+                return;
+            }
+            if (BoltState.magentoCart.summary_count === 0) {
+                resolveToValue(false);
+                return;
+            }
+            if (!initiateCheckout && !BoltState.magentoCart.isGuestCheckoutAllowed) {
+                if (BoltState.magentoCustomer === null) {
+                    // don't resolve promise, waiting for magento customer data
+                    return;
+                }
+                if (!BoltState.magentoCustomer.firstname) {
+                    // if authentication is required for checkout set a cookie
+                    // for auto opening Bolt checkout after login
+                    setInitiateCheckoutCookie();
+                    if (popUpOpen) {
+                        authenticationPopup.showModal();
+                    }
+                    resolveToValue(false);
+                    return;
+                }
+            }
+            resolveToValue(true);
+            return;
+        }
+        customerData.get('customer').subscribe(function(data) {
+            BoltState.magentoCustomer = data;
+            resolveCheckPromise();
+        });
+
         if (getCheckoutType() !== 'payment') {
             callConfigureWithPromises();
             customerData.get('cart').subscribe(function(data) {
-                magentoCart = data;
+                BoltState.magentoCart = data;
+                resolveCheckPromise();
+
                 // Call invalidateBoltCartIfOutdated with zero delay
                 // to make sure that it is added into the end of event loop.
                 // We need it in case when magento updated both 'cart' and 'boltcart' in one call.


### PR DESCRIPTION
# Description
Magento2 plugin needs to know Magento settings before answer on check() callback.
But this info loaded asynchronously and isn't available during 1-2 seconds after we show bolt button.

So right now if user clicks on bolt button very fast, we return false in check() callback.

It's not an ideal and by this PR we return promise in check(). Storm PR that allows this is under review. I've tested the workflow on my local dev site. 

By this PR we allow plugin to return promise in check() callback. Solution was discussed with @pschutz93 by slack.

Fixes: [M2P-179](https://boltpay.atlassian.net/browse/M2P-179)

#changelog M2P-179 Return promise in check() callback

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
