### PR TITLE
Aheadworks Gift Card (General M2 3rd-Party Module Extension Architecture )

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -519,7 +519,7 @@ class Cart extends AbstractHelper
      *
      * @return CartInterface
      */
-    protected function getLastImmutableQuote()
+    public function getLastImmutableQuote()
     {
         return $this->lastImmutableQuote;
     }

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -1151,7 +1151,7 @@ class Order extends AbstractHelper
      * @param OrderModel $order
      * @throws \Exception
      */
-    protected function deleteOrder($order)
+    public function deleteOrder($order)
     {
         try {
             $order->cancel()->save()->delete();

--- a/Model/Api/DiscountCodeValidation.php
+++ b/Model/Api/DiscountCodeValidation.php
@@ -691,10 +691,10 @@ class DiscountCodeValidation implements DiscountCodeValidationInterface
      * @param \Magento\GiftCardAccount\Model\Giftcardaccount|\Unirgy\Giftcert\Model\Cert $giftCard
      * @param Quote $immutableQuote
      * @param Quote $parentQuote
-     * @return array
+     * @return array|false
      * @throws \Exception
      */
-    private function applyingGiftCardCode($code, $giftCard, $immutableQuote, $parentQuote)
+    public function applyingGiftCardCode($code, $giftCard, $immutableQuote, $parentQuote)
     {
         try {
             if ($giftCard instanceof \Amasty\GiftCard\Model\Account || $giftCard instanceof \Amasty\GiftCardAccount\Model\GiftCardAccount\Account) {
@@ -829,7 +829,7 @@ class DiscountCodeValidation implements DiscountCodeValidationInterface
      * @return void
      * @throws \Exception
      */
-    private function sendErrorResponse($errCode, $message, $httpStatusCode, $quote = null)
+    public function sendErrorResponse($errCode, $message, $httpStatusCode, $quote = null)
     {
         $additionalErrorResponseData = [];
         if ($quote) {

--- a/Model/ThirdPartyModuleFactory.php
+++ b/Model/ThirdPartyModuleFactory.php
@@ -72,8 +72,9 @@ class ThirdPartyModuleFactory
     }
     
     /**
-     * Check whether the class exists
-     * @return bool
+     * Check whether the configured third party class or interface exists
+     *
+     * @return bool true if exists, otherwise false
      */
     public function isExists()
     {
@@ -84,7 +85,7 @@ class ThirdPartyModuleFactory
         // Return false instead if any uncaught exceptions.
         ///////////////////////////////////////////////////////////////
         try {
-            return class_exists($this->className);
+            return class_exists($this->className) || interface_exists($this->className);
         } catch (\Exception $e) {
             return false;
         }

--- a/Plugin/ThirdPartySupport/AbstractPlugin.php
+++ b/Plugin/ThirdPartySupport/AbstractPlugin.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Plugin\ThirdPartySupport;
+
+/**
+ * Class AbstractPlugin
+ *
+ * @property \Bolt\Boltpay\Helper\Log                    logHelper Bolt logging helper
+ * @property \Bolt\Boltpay\Helper\Bugsnag                bugsnagHelper Bolt bugsnag helper
+ * @property \Magento\Framework\Module\Manager           moduleManager Magento module manager
+ * @property \Magento\Framework\Module\ResourceInterface moduleResource Magento module resourc
+ * @property string                                      supportedModule Defines the module that needs to be enabled in order for the plugin to execute
+ * @property string|null                                 versionFrom If set, defines the minimum version of the supported module that the plugin supports
+ * @property string|null                                 versionTo If set, defines the maximum version of the supported module that the plugin supports
+ *
+ * @package Bolt\Boltpay\Plugin\ThirdPartySupport
+ */
+abstract class AbstractPlugin
+{
+    /**
+     * @var CommonModuleContext  The common dependency injected interface used by plugins
+     */
+    private $context;
+
+    /**
+     * AbstractPlugin constructor.
+     *
+     * @param CommonModuleContext $context The common dependcy injected interface used by plugins abstracted away to keep a simple single parameter interface
+     */
+    public function __construct(CommonModuleContext $context)
+    {
+        $this->context = $context;
+    }
+
+    /**
+     * Determines if the plugin should execute its logic if supported module is enabled
+     * and version is inside the configured threshold
+     *
+     * @return bool true if plugin should run, otherwise false
+     */
+    public function shouldRun()
+    {
+        $moduleVersion = $this->moduleResource->getDataVersion($this->supportedModule);
+        return $this->moduleManager->isEnabled($this->supportedModule)
+            && ($this->versionFrom == null || version_compare($this->versionFrom, $moduleVersion, '<='))
+            && ($this->versionTo == null || version_compare($this->versionTo, $moduleVersion, '>='));
+    }
+
+    /**
+     * A convenience method that attempts to retrieve locally inaccessible properties from the local context
+     *
+     * @param string $propertyName The name of the accessed property
+     *
+     * @return mixed A value exposed via a context getter method for the property or null if this method does not exists
+     */
+    public function __get($propertyName)
+    {
+        $methodName = 'get' . ucfirst($propertyName);
+
+        return method_exists($this->context, $methodName)
+            ? $this->context->$methodName()
+            : null;
+    }
+}

--- a/Plugin/ThirdPartySupport/Aheadworks/Giftcard/V1/CartPlugin.php
+++ b/Plugin/ThirdPartySupport/Aheadworks/Giftcard/V1/CartPlugin.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Plugin\ThirdPartySupport\Aheadworks\Giftcard\V1;
+
+use Aheadworks\Giftcard\Api\GiftcardCartManagementInterface;
+use Bolt\Boltpay\Helper\Cart;
+use Bolt\Boltpay\Helper\Shared\CurrencyUtils;
+use Bolt\Boltpay\Model\ThirdPartyModuleFactory;
+use Bolt\Boltpay\Plugin\ThirdPartySupport\AbstractPlugin;
+use Bolt\Boltpay\Plugin\ThirdPartySupport\CommonModuleContext;
+use Exception;
+
+/**
+ * Plugin class for {@see \Bolt\Boltpay\Helper\Cart}
+ * Used to add support for Aheadworks Giftcard
+ */
+class CartPlugin extends AbstractPlugin
+{
+    /**
+     * @var GiftcardCartManagementInterface Aheadworks Giftcard management object factory
+     */
+    private $giftcardCartManagementFactory;
+
+    /**
+     * Cart plugin constructor
+     *
+     * @param CommonModuleContext     $context used to provide common dependencies and preconditions
+     * @param ThirdPartyModuleFactory $giftcardCartManagementFactory Aheadworks Giftcard management object factory
+     */
+    public function __construct(
+        CommonModuleContext $context,
+        ThirdPartyModuleFactory $giftcardCartManagementFactory
+    ) {
+        parent::__construct($context);
+        $this->giftcardCartManagementFactory = $giftcardCartManagementFactory;
+    }
+
+    /**
+     * Plugin for {@see \Bolt\Boltpay\Helper\Cart::collectDiscounts} method
+     * Adds Aheadworks Giftcards to discounts collected by Bolt
+     *
+     * @param Cart  $subject original Cart Helper instance
+     * @param array $result of the plugged method
+     *
+     * @return array original result appended with Aheadworks Giftcards
+     */
+    public function afterCollectDiscounts(Cart $subject, $result)
+    {
+        list ($discounts, $totalAmount, $diff) = $result;
+
+        if ($this->shouldRun() && $this->giftcardCartManagementFactory->isAvailable()
+            && $this->giftcardCartManagementFactory->isExists()
+        ) {
+            try {
+                $immutableQuote = $subject->getLastImmutableQuote();
+                $parentQuoteId = $immutableQuote->getData('bolt_parent_quote_id');
+                $currencyCode = $immutableQuote->getQuoteCurrencyCode();
+                /** @var GiftcardCartManagementInterface $aheadworksGiftcardManagement */
+                $aheadworksGiftcardManagement = $this->giftcardCartManagementFactory->getInstance();
+                foreach ($aheadworksGiftcardManagement->get($parentQuoteId, false) as $giftcardQuote) {
+                    $discounts[] = [
+                        'description' => "Gift Card ({$giftcardQuote->getGiftcardCode()})",
+                        'amount'      => CurrencyUtils::toMinor($giftcardQuote->getGiftcardBalance(), $currencyCode),
+                        'type'        => 'fixed_amount'
+                    ];
+                    $totalAmount -= CurrencyUtils::toMinor($giftcardQuote->getGiftcardAmount(), $currencyCode);
+                }
+            } catch (Exception $e) {
+                $this->bugsnagHelper->notifyException($e);
+            }
+        }
+        return [$discounts, $totalAmount, $diff];
+    }
+}

--- a/Plugin/ThirdPartySupport/Aheadworks/Giftcard/V1/DiscountCodeValidationPlugin.php
+++ b/Plugin/ThirdPartySupport/Aheadworks/Giftcard/V1/DiscountCodeValidationPlugin.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Plugin\ThirdPartySupport\Aheadworks\Giftcard\V1;
+
+use Aheadworks\Giftcard\Api\Data\GiftcardInterface;
+use Aheadworks\Giftcard\Api\GiftcardCartManagementInterface;
+use Aheadworks\Giftcard\Api\GiftcardRepositoryInterface;
+use Bolt\Boltpay\Helper\Shared\CurrencyUtils;
+use Bolt\Boltpay\Model\Api\DiscountCodeValidation;
+use Bolt\Boltpay\Model\ErrorResponse;
+use Bolt\Boltpay\Model\ThirdPartyModuleFactory;
+use Bolt\Boltpay\Plugin\ThirdPartySupport\AbstractPlugin;
+use Bolt\Boltpay\Plugin\ThirdPartySupport\CommonModuleContext;
+use Exception;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\GiftCardAccount\Model\Giftcardaccount;
+use Magento\Quote\Model\Quote;
+
+/**
+ * Plugin class for {@see \Bolt\Boltpay\Model\Api\DiscountCodeValidation}
+ * Used to add support for Aheadworks Giftcard
+ */
+class DiscountCodeValidationPlugin extends AbstractPlugin
+{
+    /**
+     * @var ThirdPartyModuleFactory that returns {@see \Aheadworks\Giftcard\Api\GiftcardRepositoryInterface}
+     */
+    private $aheadworksGiftcardRepositoryFactory;
+
+    /**
+     * @var ThirdPartyModuleFactory that returns {@see \Aheadworks\Giftcard\Api\GiftcardCartManagementInterface}
+     */
+    private $aheadworksGiftcardCartManagementFactory;
+
+    /**
+     * DiscountCodeValidation plugin constructor
+     *
+     * @param CommonModuleContext     $context used to provide common dependencies and preconditions
+     * @param ThirdPartyModuleFactory $aheadworksGiftcardRepositoryFactory Aheadworks Giftcard repository factory
+     * @param ThirdPartyModuleFactory $aheadworksGiftcardCartManagementFactory Aheadworks Cart management factory
+     */
+    public function __construct(
+        CommonModuleContext $context,
+        ThirdPartyModuleFactory $aheadworksGiftcardRepositoryFactory,
+        ThirdPartyModuleFactory $aheadworksGiftcardCartManagementFactory
+    ) {
+        parent::__construct($context);
+        $this->aheadworksGiftcardRepositoryFactory = $aheadworksGiftcardRepositoryFactory;
+        $this->aheadworksGiftcardCartManagementFactory = $aheadworksGiftcardCartManagementFactory;
+    }
+
+    /**
+     * Plugin for {@see \Bolt\Boltpay\Model\Api\DiscountCodeValidation::loadGiftCardData}
+     * Attempts to load Aheadworks Giftcard and, if found, returns an instance of the Giftcard object
+     * Otherwise returns the result of the original(plugged) method
+     *
+     * @param DiscountCodeValidation $subject plugged Bolt Discount Code Validation object
+     * @param callable               $proceed original method (or next plugin in line) reference
+     * @param string                 $code potential giftcard code
+     * @param int                    $websiteId quote website id
+     *
+     * @return GiftcardInterface|Giftcardaccount|null either Aheadworks giftcard or the result of the original method
+     */
+    public function aroundLoadGiftCardData(DiscountCodeValidation $subject, callable $proceed, $code, $websiteId)
+    {
+        if ($this->shouldRun() && $this->aheadworksGiftcardRepositoryFactory->isAvailable()
+            && $this->aheadworksGiftcardRepositoryFactory->isExists()) {
+            try {
+                /** @var GiftcardRepositoryInterface $aheadworksGiftcardRepository */
+                $aheadworksGiftcardRepository = $this->aheadworksGiftcardRepositoryFactory->getInstance();
+                return $aheadworksGiftcardRepository->getByCode($code, $websiteId);
+            } catch (LocalizedException $e) {
+                // Aheadworks Giftcard not found, proceed to original method call
+            }
+        }
+        return $proceed($code, $websiteId);
+    }
+
+    /**
+     * Plugin for {@see \Bolt\Boltpay\Model\Api\DiscountCodeValidation::applyingGiftCardCode}
+     * Applies Aheadworks Giftcard to both immutable and parent quotes if provided with appropriate giftcard object
+     *
+     * @param DiscountCodeValidation  $subject Bolt dicount code validation model
+     * @param callable                $proceed original (next in line) method call
+     * @param string                  $code giftcard code to be applied
+     * @param GiftcardInterface|mixed $giftCard object to be applied
+     * @param Quote                   $immutableQuote to apply the giftcard to
+     * @param Quote                   $parentQuote to apply the giftcard to
+     *
+     * @return array|false containing dicount code validation and application result or false on exception
+     *
+     * @throws Exception if unable to send error response
+     */
+    public function aroundApplyingGiftCardCode(
+        DiscountCodeValidation $subject,
+        callable $proceed,
+        $code,
+        $giftCard,
+        $immutableQuote,
+        $parentQuote
+    ) {
+        if ($this->shouldRun() && $this->aheadworksGiftcardCartManagementFactory->isAvailable()
+            && $this->aheadworksGiftcardCartManagementFactory->isExists()
+            && $giftCard instanceof GiftcardInterface
+        ) {
+            try {
+                /** @var GiftcardCartManagementInterface $giftcardCartManagement */
+                $giftcardCartManagement = $this->aheadworksGiftcardCartManagementFactory->getInstance();
+                try {
+                    // on subsequent validation calls from Bolt checkout
+                    // try removing the gift card before adding it
+                    $giftcardCartManagement->remove($parentQuote->getId(), $giftCard->getCode(), false);
+                } catch (Exception $e) {
+                    // gift card not yet added
+                }
+                $giftcardCartManagement->set($parentQuote->getId(), $giftCard->getCode(), false);
+
+                $result = [
+                    'status'          => 'success',
+                    'discount_code'   => $code,
+                    'discount_amount' => abs(
+                        CurrencyUtils::toMinor($giftCard->getBalance(), $parentQuote->getQuoteCurrencyCode())
+                    ),
+                    'description'     => __('Gift Card (%1)', $giftCard->getCode()),
+                    'discount_type'   => 'fixed_amount',
+                ];
+                $this->logHelper->addInfoLog('### Gift Card Result');
+                $this->logHelper->addInfoLog(json_encode($result));
+
+                return $result;
+            } catch (Exception $e) {
+                $this->bugsnagHelper->notifyException($e);
+                $subject->sendErrorResponse(
+                    ErrorResponse::ERR_SERVICE,
+                    $e->getMessage(),
+                    422,
+                    $immutableQuote
+                );
+
+                return false;
+            }
+        }
+        return $proceed($code, $giftCard, $immutableQuote, $parentQuote);
+    }
+}

--- a/Plugin/ThirdPartySupport/Aheadworks/Giftcard/V1/OrderPlugin.php
+++ b/Plugin/ThirdPartySupport/Aheadworks/Giftcard/V1/OrderPlugin.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Plugin\ThirdPartySupport\Aheadworks\Giftcard\V1;
+
+use Aheadworks\Giftcard\Plugin\Model\Service\OrderServicePlugin;
+use Bolt\Boltpay\Helper\Order;
+use Bolt\Boltpay\Model\ThirdPartyModuleFactory;
+use Bolt\Boltpay\Plugin\ThirdPartySupport\AbstractPlugin;
+use Bolt\Boltpay\Plugin\ThirdPartySupport\CommonModuleContext;
+use Magento\Sales\Model\Service\OrderService;
+
+/**
+ * Plugin class for {@see \Bolt\Boltpay\Helper\Order}
+ * Used to add support for Aheadworks Giftcard
+ */
+class OrderPlugin extends AbstractPlugin
+{
+    /**
+     * @var ThirdPartyModuleFactory that returns {@see \Aheadworks\Giftcard\Plugin\Model\Service\OrderServicePlugin}
+     */
+    private $aheadworksGiftcardOrderServicePluginFactory;
+
+    /**
+     * @var OrderService Magento order management model
+     */
+    private $orderService;
+
+    /**
+     * Order plugin constructor
+     *
+     * @param CommonModuleContext     $context used to provide common dependencies and preconditions
+     * @param ThirdPartyModuleFactory $aheadworksGiftcardOrderServicePluginFactory Aheadworks Giftcard order service plugin
+     * @param OrderService            $orderService Magento order service instance
+     */
+    public function __construct(
+        CommonModuleContext $context,
+        ThirdPartyModuleFactory $aheadworksGiftcardOrderServicePluginFactory,
+        OrderService $orderService
+    ) {
+        parent::__construct($context);
+        $this->aheadworksGiftcardOrderServicePluginFactory = $aheadworksGiftcardOrderServicePluginFactory;
+        $this->orderService = $orderService;
+    }
+
+    /**
+     * Plugin for {@see \Bolt\Boltpay\Helper\Order::deleteOrder}
+     * Used to restore Aheadworks Giftcard balance for failed payment orders by manually executing the appropriate
+     * plugin {@see \Aheadworks\Giftcard\Plugin\Model\Service\OrderServicePlugin::aroundCancel}
+     * because it is plugged into {@see \Magento\Sales\Api\OrderManagementInterface::cancel} instead of
+     * {@see \Magento\Sales\Model\Order::cancel} which we call in {@see \Bolt\Boltpay\Helper\Order::deleteOrder}
+     *
+     * @param Order                      $subject Bolt Order helper
+     * @param \Magento\Sales\Model\Order $order to be deleted
+     */
+    public function beforeDeleteOrder(Order $subject, $order)
+    {
+        if ($this->shouldRun() && $this->aheadworksGiftcardOrderServicePluginFactory->isAvailable()
+            && $this->aheadworksGiftcardOrderServicePluginFactory->isExists()
+        ) {
+            /** @var OrderServicePlugin $aheadworksGiftcardOrderServicePlugin */
+            $aheadworksGiftcardOrderServicePlugin = $this->aheadworksGiftcardOrderServicePluginFactory->getInstance();
+            $aheadworksGiftcardOrderServicePlugin->aroundCancel(
+                $this->orderService,
+                function ($orderId) {
+                    return true;
+                },
+                $order->getId()
+            );
+        }
+    }
+}

--- a/Plugin/ThirdPartySupport/CommonModuleContext.php
+++ b/Plugin/ThirdPartySupport/CommonModuleContext.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Plugin\ThirdPartySupport;
+
+/**
+ * Context class used to provide Third Party Support plugins with common dependencies
+ * like supported module and version thresholds
+ */
+class CommonModuleContext
+{
+
+    /**
+     * @var \Bolt\Boltpay\Helper\Bugsnag Bolt Bugsnag helper instance
+     */
+    protected $bugsnagHelper;
+
+    /**
+     * @var \Bolt\Boltpay\Helper\Log Bolt logging helper instance
+     */
+    protected $logHelper;
+
+    /**
+     * @var \Magento\Framework\Module\Manager Magento module manager
+     */
+    protected $moduleManager;
+
+    /**
+     * @var \Magento\Framework\Module\ResourceInterface Magento module resource
+     */
+    protected $moduleResource;
+
+    /**
+     * @var string Defines the module that needs to be enabled in order for the plugin to execute
+     */
+    protected $supportedModule;
+
+    /**
+     * @var string|null If set, defines the minimum version of the supported module that the plugin supports
+     */
+    protected $versionFrom;
+
+    /**
+     * @var string|null If set, defines the maximum version of the supported module that the plugin supports
+     */
+    protected $versionTo;
+
+    /**
+     * Context constructor
+     *
+     * @param \Bolt\Boltpay\Helper\Bugsnag                $bugsnag Bolt Bugsnag helper instance
+     * @param \Bolt\Boltpay\Helper\Log                    $logHelper Bolt logging helper instance
+     * @param \Magento\Framework\Module\Manager           $moduleManager Magento module manager instance
+     * @param \Magento\Framework\Module\ResourceInterface $moduleResource Magento module resource model
+     * @param string                                      $supportedModule supported module name
+     * @param string|null                                 $versionFrom minimum version of the supported module
+     * @param string|null                                 $versionTo maximum version of the supported module
+     */
+    public function __construct(
+        \Bolt\Boltpay\Helper\Bugsnag $bugsnag,
+        \Bolt\Boltpay\Helper\Log $logHelper,
+        \Magento\Framework\Module\Manager $moduleManager,
+        \Magento\Framework\Module\ResourceInterface $moduleResource,
+        $supportedModule = '',
+        $versionFrom = null,
+        $versionTo = null
+    ) {
+        $this->bugsnagHelper = $bugsnag;
+        $this->logHelper = $logHelper;
+        $this->moduleManager = $moduleManager;
+        $this->moduleResource = $moduleResource;
+        $this->supportedModule = $supportedModule;
+        $this->versionFrom = $versionFrom;
+        $this->versionTo = $versionTo;
+    }
+
+    /**
+     * Get Bolt bugsnag helper
+     *
+     * @return \Bolt\Boltpay\Helper\Bugsnag
+     */
+    public function getBugsnagHelper()
+    {
+        return $this->bugsnagHelper;
+    }
+
+    /**
+     * Get Bolt log helper
+     *
+     * @return \Bolt\Boltpay\Helper\Log
+     */
+    public function getLogHelper()
+    {
+        return $this->logHelper;
+    }
+
+    /**
+     * Get Magento Module Manager
+     *
+     * @return \Magento\Framework\Module\Manager
+     */
+    public function getModuleManager()
+    {
+        return $this->moduleManager;
+    }
+
+    /**
+     * Get Magento Module Resource
+     *
+     * @return \Magento\Framework\Module\ResourceInterface
+     */
+    public function getModuleResource()
+    {
+        return $this->moduleResource;
+    }
+
+    /**
+     * Get name of the supported module
+     *
+     * @return string
+     */
+    public function getSupportedModule()
+    {
+        return $this->supportedModule;
+    }
+
+    /**
+     * Get the maximum version of the supported module that the plugin supports
+     *
+     * @return string|null
+     */
+    public function getVersionTo()
+    {
+        return $this->versionTo;
+    }
+
+    /**
+     * Get the minimum version of the supported module that the plugin supports
+     *
+     * @return string|null
+     */
+    public function getVersionFrom()
+    {
+        return $this->versionFrom;
+    }
+}

--- a/Test/Unit/Plugin/ThirdPartySupport/AbstractPluginTest.php
+++ b/Test/Unit/Plugin/ThirdPartySupport/AbstractPluginTest.php
@@ -1,0 +1,244 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Test\Unit\Plugin\ThirdPartySupport;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Bolt\Boltpay\Plugin\ThirdPartySupport\AbstractPlugin
+ */
+class AbstractPluginTest extends TestCase
+{
+    /** @var string Test supported module */
+    const TEST_SUPPORTED_MODULE = 'Vendor_SupportedModule';
+
+    /** @var string Test minimum version of the supported module that the plugin supports */
+    const TEST_VERSION_FROM = '1.0.0';
+
+    /** @var string Test maximum version of the supported module that the plugin supports */
+    const TEST_VERSION_TO = '9.9.9';
+
+    /**
+     * @var \Bolt\Boltpay\Plugin\ThirdPartySupport\CommonModuleContext|MockObject mocked instance of the context class
+     */
+    private $contextMock;
+
+    /**
+     * @var \Bolt\Boltpay\Helper\Bugsnag|MockObject mocked instance of the Bolt Bugsnag helper
+     */
+    private $bugsnagHelperMock;
+
+    /**
+     * @var \Bolt\Boltpay\Helper\Log|MockObject mocked instance of the Bolt logging helper
+     */
+    private $logHelperMock;
+
+    /**
+     * @var \Magento\Framework\Module\Manager|MockObject mocked instance of the Magento module manager
+     */
+    private $moduleManagerMock;
+
+    /**
+     * @var \Magento\Framework\Module\ResourceInterface|MockObject mocked instance of the Magento Module resource model
+     */
+    private $moduleResourceMock;
+
+    /**
+     * @var \Bolt\Boltpay\Plugin\ThirdPartySupport\AbstractPlugin|MockObject mocked instance of the tested class
+     */
+    private $currentMock;
+
+    /**
+     * Setup test dependencies, called before each test
+     */
+    protected function setUp()
+    {
+        $this->bugsnagHelperMock = $this->createMock(\Bolt\Boltpay\Helper\Bugsnag::class);
+        $this->logHelperMock = $this->createMock(\Bolt\Boltpay\Helper\Log::class);
+        $this->moduleManagerMock = $this->createMock(\Magento\Framework\Module\Manager::class);
+        $this->moduleResourceMock = $this->createMock(\Magento\Framework\Module\ResourceInterface::class);
+        $this->contextMock = $this->getMockBuilder(\Bolt\Boltpay\Plugin\ThirdPartySupport\CommonModuleContext::class)
+            ->setConstructorArgs(
+                [
+                    $this->bugsnagHelperMock,
+                    $this->logHelperMock,
+                    $this->moduleManagerMock,
+                    $this->moduleResourceMock,
+                    self::TEST_SUPPORTED_MODULE,
+                    self::TEST_VERSION_FROM,
+                    self::TEST_VERSION_TO
+                ]
+            )
+            ->getMock();
+        $this->currentMock = $this->getMockBuilder(\Bolt\Boltpay\Plugin\ThirdPartySupport\AbstractPlugin::class)
+            ->setMethods()
+            ->setConstructorArgs([$this->contextMock])
+            ->getMockForAbstractClass();
+    }
+
+    /**
+     * @test
+     * that constuctor will populate properties using provided context's getter methods
+     *
+     * @covers ::__construct
+     */
+    public function __construct_always_configuresPropertyWithProvidedContext()
+    {
+        static::assertAttributeEquals($this->contextMock, 'context', $this->currentMock);
+    }
+
+    /**
+     * @test
+     * that shouldRun returns true only if the supported module is enabled and its version
+     * is inside the configured threshold
+     *
+     * @dataProvider shouldRunDataProvider
+     *
+     * @covers ::shouldRun
+     *
+     * @param string      $moduleVersion supported module version
+     * @param bool        $isModuleEnabled whether the supported module is enabled
+     * @param string|null $versionFrom minimum version of the supported module that the plugin supports
+     * @param string|null $versionTo maximum version of the supported module that the plugin supports
+     * @param bool        $expectedResult of the method call
+     *
+     * @throws \ReflectionException if unable to set versionFrom or versionTo property
+     */
+    public function shouldRun_withVariousContextStates_determinesIfThePluginShouldRun(
+        $moduleVersion,
+        $isModuleEnabled,
+        $versionFrom,
+        $versionTo,
+        $expectedResult
+    ) {
+        $this->contextMock->method('getVersionFrom')->willReturn($versionFrom);
+        $this->contextMock->method('getVersionTo')->willReturn($versionTo);
+        $this->contextMock->method('getSupportedModule')->willReturn(self::TEST_SUPPORTED_MODULE);
+        $this->contextMock->method('getModuleResource')->willReturn($this->moduleResourceMock);
+        $this->contextMock->method('getModuleManager')->willReturn($this->moduleManagerMock);
+        $this->moduleResourceMock->expects(static::once())->method('getDataVersion')
+            ->with(self::TEST_SUPPORTED_MODULE)->willReturn($moduleVersion);
+        $this->moduleManagerMock->expects(static::once())->method('isEnabled')
+            ->with(self::TEST_SUPPORTED_MODULE)->willReturn($isModuleEnabled);
+        static::assertEquals($expectedResult, $this->currentMock->shouldRun());
+    }
+
+    /**
+     * Data provider for {@see shouldRun_withVariousContextStates_determinesIfThePluginShouldRun}
+     *
+     * @return array containing supported module version,
+     * whether the supported module is enabled,
+     * minimum version of the supported module that the plugin supports,
+     * maximum version of the supported module that the plugin supports,
+     * and expected result of the method call
+     */
+    public function shouldRunDataProvider()
+    {
+        return [
+            'Module enabled and no version limit - should return true'             => [
+                'moduleVersion'   => '1.0.0',
+                'isModuleEnabled' => true,
+                'versionFrom'     => null,
+                'versionTo'       => null,
+                'expectedResult'  => true,
+            ],
+            'Module disabled and no version limit - should return false'           => [
+                'moduleVersion'   => '1.0.0',
+                'isModuleEnabled' => false,
+                'versionFrom'     => null,
+                'versionTo'       => null,
+                'expectedResult'  => false,
+            ],
+            'Module enabled below version limit - should return false'             => [
+                'moduleVersion'   => '1.0.0',
+                'isModuleEnabled' => true,
+                'versionFrom'     => '2.0.0',
+                'versionTo'       => null,
+                'expectedResult'  => false,
+            ],
+            'Module enabled above version limit - should return false'             => [
+                'moduleVersion'   => '3.0.1',
+                'isModuleEnabled' => true,
+                'versionFrom'     => '2.0.0',
+                'versionTo'       => '3.0.0',
+                'expectedResult'  => false,
+            ],
+            'Module enabled and version equal to upper limit - should return true' => [
+                'moduleVersion'   => '1.0.0',
+                'isModuleEnabled' => true,
+                'versionFrom'     => '0.0.1',
+                'versionTo'       => '1.0.0',
+                'expectedResult'  => true,
+            ],
+            'Module enabled and version equal to lower limit - should return true' => [
+                'moduleVersion'   => '0.0.1',
+                'isModuleEnabled' => true,
+                'versionFrom'     => '0.0.1',
+                'versionTo'       => '1.0.0',
+                'expectedResult'  => true,
+            ],
+            'Module enabled and version between limit - should return true'        => [
+                'moduleVersion'   => '0.5.3',
+                'isModuleEnabled' => true,
+                'versionFrom'     => '0.0.1',
+                'versionTo'       => '1.0.0',
+                'expectedResult'  => true,
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * that __get will provide properties from context if they are available, otherwise returns null
+     *
+     * @covers ::__get
+     *
+     * @dataProvider __get_withVariousPropertiesProvider
+     *
+     * @param string $propertyName of the property to be retrieved
+     * @param mixed $expectedResult of the method call
+     */
+    public function __get_withVariousProperties_returnsPropertyFromContextIfAvailable($propertyName, $expectedResult)
+    {
+        $methodName = 'get' . ucfirst($propertyName);
+        if (method_exists($this->contextMock, $methodName)) {
+            $this->contextMock->method($methodName)->willReturn($expectedResult);
+        }
+        static::assertEquals($expectedResult, $this->currentMock->$propertyName);
+    }
+
+    /**
+     * Data provider for {@see __get_withVariousProperties_returnsPropertyFromContextIfAvailable}
+     *
+     * @return array containing property name and expected result of the method call
+     */
+    public function __get_withVariousPropertiesProvider()
+    {
+        return [
+            ['propertyName' => 'logHelper', 'expectedResult' => $this->logHelperMock],
+            ['propertyName' => 'bugsnagHelper', 'expectedResult' => $this->bugsnagHelperMock],
+            ['propertyName' => 'moduleManager', 'expectedResult' => $this->moduleManagerMock],
+            ['propertyName' => 'moduleResource', 'expectedResult' => $this->moduleResourceMock],
+            ['propertyName' => 'supportedModule', 'expectedResult' => self::TEST_SUPPORTED_MODULE],
+            ['propertyName' => 'versionFrom', 'expectedResult' => self::TEST_VERSION_FROM],
+            ['propertyName' => 'versionTo', 'expectedResult' => self::TEST_VERSION_TO],
+            ['propertyName' => 'nonexistingproperty', 'expectedResult' => null],
+        ];
+    }
+}

--- a/Test/Unit/Plugin/ThirdPartySupport/Aheadworks/Giftcard/V1/CartPluginTest.php
+++ b/Test/Unit/Plugin/ThirdPartySupport/Aheadworks/Giftcard/V1/CartPluginTest.php
@@ -1,0 +1,337 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Test\Unit\Plugin\ThirdPartySupport\Aheadworks\Giftcard\V1;
+
+use Aheadworks\Giftcard\Api\GiftcardCartManagementInterface;
+use Bolt\Boltpay\Plugin\ThirdPartySupport\Aheadworks\Giftcard\V1\CartPlugin;
+use Magento\Framework\Exception\NoSuchEntityException;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Bolt\Boltpay\Plugin\ThirdPartySupport\Aheadworks\Giftcard\V1\CartPlugin
+ */
+class CartPluginTest extends TestCase
+{
+    /** @var int Test parent quote ID */
+    const PARENT_QUOTE_ID = 456;
+
+    /** @var string Default quote currency code */
+    const CURRENCY_CODE = 'USD';
+
+    /** @var array Default test result of {@see \Bolt\Boltpay\Helper\Cart::collectDiscounts} */
+    const TEST_DEFAULT_RESULT = [[], 12345, 0];
+
+    /**
+     * @var \Bolt\Boltpay\Plugin\ThirdPartySupport\CommonModuleContext|MockObject used to provide common dependencies
+     */
+    private $contextMock;
+
+    /**
+     * @var \Bolt\Boltpay\Model\ThirdPartyModuleFactory|MockObject mocked instance of the Aheadworks Giftcard Management
+     */
+    private $giftcardCartManagementFactoryMock;
+
+    /**
+     * @var CartPlugin|MockObject mocked instance of the tested class
+     */
+    private $currentMock;
+
+    /**
+     * @var \Bolt\Boltpay\Helper\Cart|MockObject mocked instance of the plugged class
+     */
+    private $subjectMock;
+
+    /**
+     * @var \Magento\Quote\Model\Quote|MockObject mocked instance of the Magento Quote model
+     */
+    private $immutableQuoteMock;
+
+    /**
+     * @var GiftcardCartManagementInterface|MockObject mocked instance of Aheadworks Giftcard Cart Manaagement
+     */
+    private $aheadworksGiftcardManagementMock;
+
+    /**
+     * @var \Bolt\Boltpay\Helper\Bugsnag|MockObject mocked instance of the Bolt Bugsnag helper
+     */
+    private $bugsnagHelperMock;
+
+    /**
+     * Setup test dependencies, called before each test
+     */
+    protected function setUp()
+    {
+        $this->contextMock = $this->createMock(\Bolt\Boltpay\Plugin\ThirdPartySupport\CommonModuleContext::class);
+        $this->giftcardCartManagementFactoryMock = $this->createMock(
+            \Bolt\Boltpay\Model\ThirdPartyModuleFactory::class
+        );
+        $this->subjectMock = $this->createMock(\Bolt\Boltpay\Helper\Cart::class);
+        $this->bugsnagHelperMock = $this->createMock(\Bolt\Boltpay\Helper\Bugsnag::class);
+        $this->contextMock->method('getBugsnagHelper')->willReturn($this->bugsnagHelperMock);
+        $this->currentMock = $this->getMockBuilder(CartPlugin::class)
+            ->setMethods(['shouldRun'])
+            ->setConstructorArgs([$this->contextMock, $this->giftcardCartManagementFactoryMock])
+            ->getMock();
+        $this->immutableQuoteMock = $this->createPartialMock(
+            \Magento\Quote\Model\Quote::class,
+            ['getQuoteCurrencyCode', 'getData']
+        );
+        $this->aheadworksGiftcardManagementMock = $this->getMockBuilder(
+            '\Aheadworks\Giftcard\Api\GiftcardCartManagementInterface'
+        )
+            ->disableOriginalClone()
+            ->disableOriginalConstructor()
+            ->disableProxyingToOriginalMethods()
+            ->setMethods(['get', 'set', 'remove'])
+            ->getMock();
+    }
+
+    /**
+     * @test
+     * that __construct sets internal properties
+     *
+     * @covers ::__construct
+     */
+    public function __construct_always_setsInternalProperties()
+    {
+        $instance = new CartPlugin($this->contextMock, $this->giftcardCartManagementFactoryMock);
+        static::assertAttributeEquals(
+            $this->giftcardCartManagementFactoryMock,
+            'giftcardCartManagementFactory',
+            $instance
+        );
+    }
+
+    /**
+     * @test
+     * that afterCollectDiscounts will not execute its logic if any of the preconditions are not met
+     *
+     * @covers ::afterCollectDiscounts
+     *
+     * @dataProvider afterCollectDiscounts_withVariousPreconditionUnmetStatesProvider
+     *
+     * @param bool $shouldRun stubbed result of {@see \Bolt\Boltpay\Plugin\ThirdPartySupport\AbstractPlugin::shouldRun}
+     * @param bool $isAvailable stubbed result of {@see \Bolt\Boltpay\Model\ThirdPartyModuleFactory::isAvailable}
+     * @param bool $isExists stubbed result of {@see \Bolt\Boltpay\Model\ThirdPartyModuleFactory::isExists}
+     */
+    public function afterCollectDiscounts_withVariousPreconditionUnmetStates_doesNotRunPluginLogic(
+        $shouldRun,
+        $isAvailable,
+        $isExists
+    ) {
+        $this->currentMock->method('shouldRun')->willReturn($shouldRun);
+        $this->giftcardCartManagementFactoryMock->method('isAvailable')->willReturn($isAvailable);
+        $this->giftcardCartManagementFactoryMock->method('isExists')->willReturn($isExists);
+        $result = self::TEST_DEFAULT_RESULT;
+        $this->subjectMock->expects(static::never())->method('getLastImmutableQuote');
+        $this->giftcardCartManagementFactoryMock->expects(static::never())->method('getInstance');
+        static::assertEquals($result, $this->currentMock->afterCollectDiscounts($this->subjectMock, $result));
+    }
+
+    /**
+     * Data provider for {@see afterCollectDiscounts_withVariousPreconditionUnmetStates_doesNotRunPluginLogic}
+     *
+     * @return array containing
+     * stubbed result of {@see \Bolt\Boltpay\Plugin\ThirdPartySupport\AbstractPlugin::shouldRun}
+     * stubbed result of {@see \Bolt\Boltpay\Model\ThirdPartyModuleFactory::isAvailable} for giftcard cart management
+     * stubbed result of {@see \Bolt\Boltpay\Model\ThirdPartyModuleFactory::isExists} for giftcard cart management
+     */
+    public function afterCollectDiscounts_withVariousPreconditionUnmetStatesProvider()
+    {
+        return [
+            ['shouldRun' => false, 'isAvailable' => false, 'isExists' => false],
+            ['shouldRun' => false, 'isAvailable' => false, 'isExists' => true],
+            ['shouldRun' => false, 'isAvailable' => true, 'isExists' => false],
+            ['shouldRun' => false, 'isAvailable' => true, 'isExists' => true],
+            ['shouldRun' => true, 'isAvailable' => false, 'isExists' => false],
+            ['shouldRun' => true, 'isAvailable' => false, 'isExists' => true],
+            ['shouldRun' => true, 'isAvailable' => true, 'isExists' => false],
+        ];
+    }
+
+    /**
+     * @test
+     * that afterCollectDiscounts properly adds giftcard data to already collected discounts
+     *
+     * @dataProvider afterCollectDiscounts_withVariousGiftcardStatesProvider
+     *
+     * @covers ::afterCollectDiscounts
+     *
+     * @param array $originalResult of the method call, before the plugin
+     * @param array $appliedGiftcards stubbed result of {@see \Aheadworks\Giftcard\Api\GiftcardCartManagementInterface::get}
+     * @param array $expectedResult after the plugin execution
+     */
+    public function afterCollectDiscounts_withVariousGiftcardStates_addsGiftcardDataToCollectedDiscounts(
+        $originalResult,
+        $appliedGiftcards,
+        $expectedResult
+    ) {
+        $this->currentMock->method('shouldRun')->willReturn(true);
+        $this->giftcardCartManagementFactoryMock->method('isAvailable')->willReturn(true);
+        $this->giftcardCartManagementFactoryMock->method('isExists')->willReturn(true);
+
+        $this->subjectMock->expects(static::once())->method('getLastImmutableQuote')
+            ->willReturn($this->immutableQuoteMock);
+        $this->immutableQuoteMock->expects(static::once())->method('getData')->with('bolt_parent_quote_id')
+            ->willReturn(self::PARENT_QUOTE_ID);
+        $this->immutableQuoteMock->expects(static::once())->method('getQuoteCurrencyCode')
+            ->willReturn(self::CURRENCY_CODE);
+        $this->giftcardCartManagementFactoryMock->expects(static::once())->method('getInstance')
+            ->willReturn($this->aheadworksGiftcardManagementMock);
+        $this->aheadworksGiftcardManagementMock->expects(static::once())->method('get')
+            ->with(self::PARENT_QUOTE_ID, false)->willReturn($appliedGiftcards);
+        static::assertEquals(
+            $expectedResult,
+            $this->currentMock->afterCollectDiscounts($this->subjectMock, $originalResult)
+        );
+    }
+
+    /**
+     * Data provider for @see afterCollectDiscounts_withVariousGiftcardStates_addsGiftcardDataToCollectedDiscounts
+     */
+    public function afterCollectDiscounts_withVariousGiftcardStatesProvider()
+    {
+        return [
+            'No applied giftcards'                      => [
+                'originalResult'   => self::TEST_DEFAULT_RESULT,
+                'appliedGiftcards' => [],
+                'expectedResult'   => self::TEST_DEFAULT_RESULT
+            ],
+            'Single giftcard'                           => [
+                'originalResult'   => self::TEST_DEFAULT_RESULT,
+                'appliedGiftcards' => [
+                    new \Magento\Framework\DataObject(
+                        ['giftcard_code' => 'QWERTY12345', 'giftcard_amount' => 12.34, 'giftcard_balance' => 1000]
+                    )
+                ],
+                'expectedResult'   => [
+                    [
+                        [
+                            'description' => 'Gift Card (QWERTY12345)',
+                            'amount'      => 100000,
+                            'type'        => 'fixed_amount'
+                        ]
+                    ],
+                    11111,
+                    0
+                ]
+            ],
+            'Multiple giftcards'                        => [
+                'originalResult'   => self::TEST_DEFAULT_RESULT,
+                'appliedGiftcards' => [
+                    new \Magento\Framework\DataObject(
+                        ['giftcard_code' => 'QWERTY12345', 'giftcard_amount' => 100, 'giftcard_balance' => 100]
+                    ),
+                    new \Magento\Framework\DataObject(
+                        ['giftcard_code' => 'ASDFG54321', 'giftcard_amount' => 23.45, 'giftcard_balance' => 500]
+                    ),
+                ],
+                'expectedResult'   => [
+                    [
+                        [
+                            'description' => 'Gift Card (QWERTY12345)',
+                            'amount'      => 10000,
+                            'type'        => 'fixed_amount'
+                        ],
+                        [
+                            'description' => 'Gift Card (ASDFG54321)',
+                            'amount'      => 50000,
+                            'type'        => 'fixed_amount'
+                        ],
+                    ],
+                    0,
+                    0
+                ]
+            ],
+            'Multiple giftcards with existing discount' => [
+                'originalResult'   => [
+                    [
+                        [
+                            'description' => 'Discount Test',
+                            'amount'      => 2000,
+                            'type'        => 'fixed_amount'
+                        ]
+                    ],
+                    10345,
+                    0
+                ],
+                'appliedGiftcards' => [
+                    new \Magento\Framework\DataObject(
+                        ['giftcard_code' => 'QWERTY12345', 'giftcard_amount' => 20, 'giftcard_balance' => 20]
+                    ),
+                    new \Magento\Framework\DataObject(
+                        ['giftcard_code' => 'ASDFG54321', 'giftcard_amount' => 23.45, 'giftcard_balance' => 500]
+                    ),
+                ],
+                'expectedResult'   => [
+                    [
+                        [
+                            'description' => 'Discount Test',
+                            'amount'      => 2000,
+                            'type'        => 'fixed_amount'
+                        ],
+                        [
+                            'description' => 'Gift Card (QWERTY12345)',
+                            'amount'      => 2000,
+                            'type'        => 'fixed_amount'
+                        ],
+                        [
+                            'description' => 'Gift Card (ASDFG54321)',
+                            'amount'      => 50000,
+                            'type'        => 'fixed_amount'
+                        ],
+                    ],
+                    6000,
+                    0
+                ]
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * that afterCollectDiscounts will not interrupt execution if an exception occurs when retireving quote giftcards
+     *
+     * @covers ::afterCollectDiscounts
+     */
+    public function afterCollectDiscounts_ifUnableToRetrieveGiftcards_notifiesException()
+    {
+        $this->currentMock->method('shouldRun')->willReturn(true);
+        $this->giftcardCartManagementFactoryMock->method('isAvailable')->willReturn(true);
+        $this->giftcardCartManagementFactoryMock->method('isExists')->willReturn(true);
+
+        $this->subjectMock->expects(static::once())->method('getLastImmutableQuote')
+            ->willReturn($this->immutableQuoteMock);
+        $this->immutableQuoteMock->expects(static::once())->method('getData')->with('bolt_parent_quote_id')
+            ->willReturn(self::PARENT_QUOTE_ID);
+        $this->immutableQuoteMock->expects(static::once())->method('getQuoteCurrencyCode')
+            ->willReturn(self::CURRENCY_CODE);
+
+        $this->giftcardCartManagementFactoryMock->expects(static::once())->method('getInstance')
+            ->willReturn($this->aheadworksGiftcardManagementMock);
+        $exception = new NoSuchEntityException(__('Cart %1 doesn\'t contain products', self::PARENT_QUOTE_ID));
+        $this->aheadworksGiftcardManagementMock->expects(static::once())->method('get')
+            ->with(self::PARENT_QUOTE_ID, false)->willThrowException($exception);
+        $this->bugsnagHelperMock->expects(static::once())->method('notifyException')->with($exception);
+        static::assertEquals(
+            self::TEST_DEFAULT_RESULT,
+            $this->currentMock->afterCollectDiscounts($this->subjectMock, self::TEST_DEFAULT_RESULT)
+        );
+    }
+}

--- a/Test/Unit/Plugin/ThirdPartySupport/Aheadworks/Giftcard/V1/DiscountCodeValidationPluginTest.php
+++ b/Test/Unit/Plugin/ThirdPartySupport/Aheadworks/Giftcard/V1/DiscountCodeValidationPluginTest.php
@@ -1,0 +1,581 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Test\Unit\Plugin\ThirdPartySupport\Aheadworks\Giftcard\V1;
+
+use Aheadworks\Giftcard\Api\GiftcardCartManagementInterface;
+use Aheadworks\Giftcard\Api\GiftcardRepositoryInterface;
+use Bolt\Boltpay\Model\Api\DiscountCodeValidation;
+use Bolt\Boltpay\Model\ThirdPartyModuleFactory;
+use Bolt\Boltpay\Plugin\ThirdPartySupport\Aheadworks\Giftcard\V1\DiscountCodeValidationPlugin;
+use Bolt\Boltpay\Plugin\ThirdPartySupport\CommonModuleContext;
+use Magento\Framework\Exception\CouldNotSaveException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Bolt\Boltpay\Plugin\ThirdPartySupport\Aheadworks\Giftcard\V1\DiscountCodeValidationPlugin
+ */
+class DiscountCodeValidationPluginTest extends TestCase
+{
+
+    /** @var string Test giftcard code */
+    const TEST_GIFTCARD_CODE = 'QWERTY12345';
+
+    /** @var int Test website ID */
+    const TEST_WEBSITE_ID = 1;
+
+    /** @var int Test parent quote id */
+    const PARENT_QUOTE_ID = 455;
+
+    /** @var string Test default currency code */
+    const CURRENCY_CODE = 'USD';
+
+    /**
+     * @var CommonModuleContext|MockObject mocked instance of the module context
+     */
+    private $contextMock;
+
+    /**
+     * @var ThirdPartyModuleFactory|MockObject mocked instance of the giftcard cart management factory
+     */
+    private $aheadworksGiftcardCartManagementFactoryMock;
+
+    /**
+     * @var ThirdPartyModuleFactory|MockObject mocked instance of the giftcard repostiory factory
+     */
+    private $aheadworksGiftcardRepositoryFactoryMock;
+
+    /**
+     * @var DiscountCodeValidation|MockObject mocked instance of the plugged class
+     */
+    private $subjectMock;
+
+    /**
+     * @var \Bolt\Boltpay\Helper\Bugsnag|MockObject mocked instance of the Bolt Bugsnag helper
+     */
+    private $bugsnagHelperMock;
+
+    /**
+     * @var DiscountCodeValidationPlugin|MockObject mocked instance of the tested method
+     */
+    private $currentMock;
+
+    /**
+     * @var GiftcardRepositoryInterface|MockObject mocked instance of the Aheadworks Giftcard repository
+     */
+    private $aheadworksGiftcardRepositoryMock;
+
+    /**
+     * @var GiftcardCartManagementInterface|MockObject mocked instance of the Aheadworks Giftcard cart management
+     */
+    private $aheadworksGiftcardManagementMock;
+
+    /**
+     * @var \Magento\Quote\Model\Quote|MockObject mocked instance of the Magento Quote
+     */
+    private $parentQuote;
+
+    /**
+     * @var \Magento\Quote\Model\Quote|MockObject mocked instance of the Magento Quote
+     */
+    private $immutableQuote;
+
+    /**
+     * @var \Bolt\Boltpay\Helper\Log|MockObject mocked instance of the Bolt logging helper
+     */
+    private $logHelperMock;
+
+    /**
+     * Setup test dependencies, called before each test
+     */
+    protected function setUp()
+    {
+        $this->contextMock = $this->createMock(CommonModuleContext::class);
+        $this->aheadworksGiftcardRepositoryFactoryMock = $this->createMock(ThirdPartyModuleFactory::class);
+        $this->aheadworksGiftcardCartManagementFactoryMock = $this->createMock(ThirdPartyModuleFactory::class);
+        $this->subjectMock = $this->createMock(DiscountCodeValidation::class);
+        $this->bugsnagHelperMock = $this->createMock(\Bolt\Boltpay\Helper\Bugsnag::class);
+        $this->logHelperMock = $this->createMock(\Bolt\Boltpay\Helper\Log::class);
+        $this->contextMock->method('getBugsnagHelper')->willReturn($this->bugsnagHelperMock);
+        $this->contextMock->method('getLogHelper')->willReturn($this->logHelperMock);
+        $this->currentMock = $this->getMockBuilder(DiscountCodeValidationPlugin::class)
+            ->setMethods(['shouldRun'])
+            ->setConstructorArgs(
+                [
+                    $this->contextMock,
+                    $this->aheadworksGiftcardRepositoryFactoryMock,
+                    $this->aheadworksGiftcardCartManagementFactoryMock
+                ]
+            )
+            ->getMock();
+        $this->aheadworksGiftcardRepositoryMock = $this->getMockBuilder(
+            '\Aheadworks\Giftcard\Api\GiftcardRepositoryInterface'
+        )
+            ->disableOriginalClone()
+            ->disableOriginalConstructor()
+            ->disableProxyingToOriginalMethods()
+            ->setMethods(
+                [
+                    'save',
+                    'get',
+                    'getByCode',
+                    'getList',
+                    'delete',
+                    'deleteById',
+                ]
+            )
+            ->getMock();
+
+        $this->aheadworksGiftcardManagementMock = $this->getMockBuilder(
+            '\Aheadworks\Giftcard\Api\GiftcardCartManagementInterface'
+        )
+            ->disableOriginalClone()
+            ->disableOriginalConstructor()
+            ->disableProxyingToOriginalMethods()
+            ->setMethods(['get', 'set', 'remove'])
+            ->getMock();
+        $this->parentQuote = $this->createPartialMock(
+            \Magento\Quote\Model\Quote::class,
+            ['getId', 'getQuoteCurrencyCode']
+        );
+        $this->parentQuote->method('getId')->willReturn(self::PARENT_QUOTE_ID);
+        $this->parentQuote->method('getQuoteCurrencyCode')->willReturn(self::CURRENCY_CODE);
+        $this->immutableQuote = $this->createMock(\Magento\Quote\Model\Quote::class);
+    }
+
+    /**
+     * @test
+     * that constructor assigns provided parameters to properties
+     *
+     * @covers ::__construct
+     */
+    public function __construct_always_configuresPropertiesWithProvidedParameters()
+    {
+        $instance = new DiscountCodeValidationPlugin(
+            $this->contextMock,
+            $this->aheadworksGiftcardRepositoryFactoryMock,
+            $this->aheadworksGiftcardCartManagementFactoryMock
+        );
+        static::assertAttributeEquals(
+            $this->aheadworksGiftcardRepositoryFactoryMock,
+            'aheadworksGiftcardRepositoryFactory',
+            $instance
+        );
+        static::assertAttributeEquals(
+            $this->aheadworksGiftcardCartManagementFactoryMock,
+            'aheadworksGiftcardCartManagementFactory',
+            $instance
+        );
+    }
+
+    /**
+     * @test
+     * that aroundLoadGiftCardData will not execute its logic and call proceed if any of the preconditions are not met
+     *
+     * @covers ::aroundLoadGiftCardData
+     *
+     * @dataProvider aroundLoadGiftCardData_withVariousPreconditionUnmetStatesProvider
+     *
+     * @param bool $shouldRun stubbed result of {@see \Bolt\Boltpay\Plugin\ThirdPartySupport\AbstractPlugin::shouldRun}
+     * @param bool $isAvailable stubbed result of {@see \Bolt\Boltpay\Model\ThirdPartyModuleFactory::isAvailable}
+     * @param bool $isExists stubbed result of {@see \Bolt\Boltpay\Model\ThirdPartyModuleFactory::isExists}
+     */
+    public function aroundLoadGiftCardData_withVariousPreconditionUnmetStates_doesNotRunPluginLogic(
+        $shouldRun,
+        $isAvailable,
+        $isExists
+    ) {
+        $this->currentMock->method('shouldRun')->willReturn($shouldRun);
+        $this->aheadworksGiftcardRepositoryFactoryMock->method('isAvailable')->willReturn($isAvailable);
+        $this->aheadworksGiftcardRepositoryFactoryMock->method('isExists')->willReturn($isExists);
+        $result = $this->getMockBuilder('\Magento\GiftCardAccount\Model\Giftcardaccount')
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableProxyingToOriginalMethods()
+            ->getMock();
+        $this->aheadworksGiftcardRepositoryFactoryMock->expects(static::never())->method('getInstance');
+
+        $this->subjectMock->expects(static::once())->method('loadGiftCardData')
+            ->with(self::TEST_GIFTCARD_CODE, self::TEST_WEBSITE_ID)
+            ->willReturn($result);
+
+        static::assertEquals(
+            $result,
+            $this->currentMock->aroundLoadGiftCardData(
+                $this->subjectMock,
+                [$this->subjectMock, 'loadGiftCardData'],
+                self::TEST_GIFTCARD_CODE,
+                self::TEST_WEBSITE_ID
+            )
+        );
+    }
+
+    /**
+     * Data provider for {@see aroundLoadGiftCardData_withVariousPreconditionUnmetStates_doesNotRunPluginLogic}
+     *
+     * @return array containing
+     * stubbed result of {@see \Bolt\Boltpay\Plugin\ThirdPartySupport\AbstractPlugin::shouldRun}
+     * stubbed result of {@see \Bolt\Boltpay\Model\ThirdPartyModuleFactory::isAvailable} for giftcard cart management
+     * stubbed result of {@see \Bolt\Boltpay\Model\ThirdPartyModuleFactory::isExists} for giftcard cart management
+     */
+    public function aroundLoadGiftCardData_withVariousPreconditionUnmetStatesProvider()
+    {
+        return [
+            ['shouldRun' => false, 'isAvailable' => false, 'isExists' => false],
+            ['shouldRun' => false, 'isAvailable' => false, 'isExists' => true],
+            ['shouldRun' => false, 'isAvailable' => true, 'isExists' => false],
+            ['shouldRun' => false, 'isAvailable' => true, 'isExists' => true],
+            ['shouldRun' => true, 'isAvailable' => false, 'isExists' => false],
+            ['shouldRun' => true, 'isAvailable' => false, 'isExists' => true],
+            ['shouldRun' => true, 'isAvailable' => true, 'isExists' => false],
+        ];
+    }
+
+    /**
+     * @test
+     * that aroundLoadGiftCardData will return Aheadworks Giftcard object if one is successfully loaded
+     * based on provided giftcard code and website id instead of calling (proceeding) to the original method
+     *
+     * @covers ::aroundLoadGiftCardData
+     */
+    public function aroundLoadGiftCardData_ifAheadworksGiftcardFound_returnsAheadworksGiftcard()
+    {
+        $this->currentMock->method('shouldRun')->willReturn(true);
+        $this->aheadworksGiftcardRepositoryFactoryMock->method('isAvailable')->willReturn(true);
+        $this->aheadworksGiftcardRepositoryFactoryMock->method('isExists')->willReturn(true);
+        $result = $this->getMockBuilder('\Aheadworks\Giftcard\Api\Data\GiftcardInterface')
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableProxyingToOriginalMethods()
+            ->getMock();
+        $this->aheadworksGiftcardRepositoryFactoryMock->expects(static::once())->method('getInstance')
+            ->willReturn($this->aheadworksGiftcardRepositoryMock);
+
+        $this->subjectMock->expects(static::never())->method('loadGiftCardData');
+
+        $this->aheadworksGiftcardRepositoryMock->expects(static::once())->method('getByCode')
+            ->with(self::TEST_GIFTCARD_CODE, self::TEST_WEBSITE_ID)
+            ->willReturn($result);
+
+        static::assertEquals(
+            $result,
+            $this->currentMock->aroundLoadGiftCardData(
+                $this->subjectMock,
+                [$this->subjectMock, 'loadGiftCardData'],
+                self::TEST_GIFTCARD_CODE,
+                self::TEST_WEBSITE_ID
+            )
+        );
+    }
+
+    /**
+     * @test
+     * that aroundLoadGiftCardData will proceed to the original method call if unable to load Aheadworks Giftcard
+     * one is successfully loaded based on provided giftcard code and website id
+     *
+     * @covers ::aroundLoadGiftCardData
+     */
+    public function aroundLoadGiftCardData_ifAheadworksGiftcardNotFound_proceedsToTheOriginalMethodCall()
+    {
+        $this->currentMock->method('shouldRun')->willReturn(true);
+        $this->aheadworksGiftcardRepositoryFactoryMock->method('isAvailable')->willReturn(true);
+        $this->aheadworksGiftcardRepositoryFactoryMock->method('isExists')->willReturn(true);
+        $result = $this->getMockBuilder('\Magento\GiftCardAccount\Model\Giftcardaccount')
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableProxyingToOriginalMethods()
+            ->getMock();
+
+        $this->aheadworksGiftcardRepositoryFactoryMock->expects(static::once())->method('getInstance')
+            ->willReturn($this->aheadworksGiftcardRepositoryMock);
+        $this->aheadworksGiftcardRepositoryMock->expects(static::once())->method('getByCode')
+            ->with(self::TEST_GIFTCARD_CODE, self::TEST_WEBSITE_ID)
+            ->willThrowException(NoSuchEntityException::singleField('giftcardCode', self::TEST_GIFTCARD_CODE));
+
+        $this->subjectMock->expects(static::once())->method('loadGiftCardData')
+            ->with(self::TEST_GIFTCARD_CODE, self::TEST_WEBSITE_ID)
+            ->willReturn($result);
+
+        static::assertEquals(
+            $result,
+            $this->currentMock->aroundLoadGiftCardData(
+                $this->subjectMock,
+                [$this->subjectMock, 'loadGiftCardData'],
+                self::TEST_GIFTCARD_CODE,
+                self::TEST_WEBSITE_ID
+            )
+        );
+    }
+
+    /**
+     * @test
+     * that aroundApplyingGiftCardCode will not execute its logic and call proceed if any of the preconditions are not met
+     *
+     * @covers ::aroundApplyingGiftCardCode
+     *
+     * @dataProvider aroundApplyingGiftCardCode_withVariousPreconditionStatesProvider
+     *
+     * @param bool $shouldRun stubbed result of {@see \Bolt\Boltpay\Plugin\ThirdPartySupport\AbstractPlugin::shouldRun}
+     * @param bool $isAvailable stubbed result of {@see \Bolt\Boltpay\Model\ThirdPartyModuleFactory::isAvailable}
+     * @param bool $isExists stubbed result of {@see \Bolt\Boltpay\Model\ThirdPartyModuleFactory::isExists}
+     * @param bool $giftcardIsAheadworks whether the provided giftcard belongs to Aheadworks
+     *
+     * @throws \Exception from the tested method
+     */
+    public function aroundApplyingGiftCardCode_withVariousPreconditionStates_runsPluginLogicIfPreconditionsAreMet(
+        $shouldRun,
+        $isAvailable,
+        $isExists,
+        $giftcardIsAheadworks
+    ) {
+        $this->currentMock->method('shouldRun')->willReturn($shouldRun);
+        $this->aheadworksGiftcardCartManagementFactoryMock->method('isAvailable')->willReturn($isAvailable);
+        $this->aheadworksGiftcardCartManagementFactoryMock->method('isExists')->willReturn($isExists);
+        $giftcard = $this->getMockBuilder(
+            $giftcardIsAheadworks
+                ? '\Aheadworks\Giftcard\Api\Data\GiftcardInterface'
+                : '\Magento\GiftCardAccount\Model\Giftcardaccount'
+        )
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableProxyingToOriginalMethods()
+            ->setMethods(
+                [
+                    'getId',
+                    'setId',
+                    'getCode',
+                    'setCode',
+                    'getType',
+                    'setType',
+                    'getCreatedAt',
+                    'setCreatedAt',
+                    'getExpireAt',
+                    'setExpireAt',
+                    'getWebsiteId',
+                    'setWebsiteId',
+                    'getBalance',
+                    'setBalance',
+                    'getInitialBalance',
+                    'setInitialBalance',
+                    'getState',
+                    'setState',
+                    'getOrderId',
+                    'setOrderId',
+                    'getProductId',
+                    'setProductId',
+                    'getEmailTemplate',
+                    'setEmailTemplate',
+                    'getSenderName',
+                    'setSenderName',
+                    'getSenderEmail',
+                    'setMessage',
+                    'setSenderEmail',
+                    'getRecipientName',
+                    'setRecipientName',
+                    'getRecipientEmail',
+                    'setRecipientEmail',
+                    'getDeliveryDate',
+                    'setDeliveryDate',
+                    'getDeliveryDateTimezone',
+                    'setDeliveryDateTimezone',
+                    'getEmailSent',
+                    'setEmailSent',
+                    'getHeadline',
+                    'setHeadline',
+                    'getMessage',
+                    'setExtensionAttributes',
+                    'getCurrentHistoryAction',
+                    'setCurrentHistoryAction',
+                    'getExtensionAttributes',
+                ]
+            )
+            ->getMock();
+        $giftcard->method('getCode')->willReturn(self::TEST_GIFTCARD_CODE);
+        $giftcard->method('getBalance')->willReturn(123.45);
+
+        $preconditionsMet = $shouldRun && $isAvailable && $isExists && $giftcardIsAheadworks;
+        $this->aheadworksGiftcardCartManagementFactoryMock->expects(
+            $preconditionsMet
+                ? static::once()
+                : static::never()
+        )->method('getInstance')->willReturn($this->aheadworksGiftcardManagementMock);
+        if ($preconditionsMet) {
+            $this->aheadworksGiftcardManagementMock->expects(static::once())
+                ->method('remove')->with(self::PARENT_QUOTE_ID, self::TEST_GIFTCARD_CODE, false)
+                ->willThrowException(new CouldNotSaveException(__('The specified Gift Card code not be removed')));
+            $this->aheadworksGiftcardManagementMock->expects(static::once())
+                ->method('set')->with(self::PARENT_QUOTE_ID, self::TEST_GIFTCARD_CODE, false);
+            $result = [
+                'status'          => 'success',
+                'discount_code'   => 'QWERTY12345',
+                'discount_amount' => 12345,
+                'description'     => __('Gift Card (%1)', self::TEST_GIFTCARD_CODE),
+                'discount_type'   => 'fixed_amount'
+            ];
+        } else {
+            $result = [];
+        }
+
+        $this->subjectMock->expects($preconditionsMet ? static::never() : static::once())
+            ->method('applyingGiftCardCode')
+            ->with(
+                self::TEST_GIFTCARD_CODE,
+                $giftcard,
+                $this->immutableQuote,
+                $this->parentQuote
+            )
+            ->willReturn($result);
+
+        static::assertEquals(
+            $result,
+            $this->currentMock->aroundApplyingGiftCardCode(
+                $this->subjectMock,
+                [$this->subjectMock, 'applyingGiftCardCode'],
+                self::TEST_GIFTCARD_CODE,
+                $giftcard,
+                $this->immutableQuote,
+                $this->parentQuote
+            )
+        );
+    }
+
+    /**
+     * Data provider for {@see aroundApplyingGiftCardCode_withVariousPreconditionStates_doesNotRunPluginLogic}
+     *
+     * @return array containing
+     * stubbed result of {@see \Bolt\Boltpay\Plugin\ThirdPartySupport\AbstractPlugin::shouldRun}
+     * stubbed result of {@see \Bolt\Boltpay\Model\ThirdPartyModuleFactory::isAvailable} for giftcard cart management
+     * stubbed result of {@see \Bolt\Boltpay\Model\ThirdPartyModuleFactory::isExists} for giftcard cart management
+     * and whether the provided giftcard belongs to Aheadworks
+     */
+    public function aroundApplyingGiftCardCode_withVariousPreconditionStatesProvider()
+    {
+        return \Bolt\Boltpay\Test\Unit\TestHelper::getAllBooleanCombinations(4);
+    }
+
+    /**
+     * @test
+     * that aroundApplyingGiftCardCode will send error response if unable to apply Aheadworks Giftcard
+     *
+     * @covers ::aroundApplyingGiftCardCode
+     *
+     * @throws \Exception from tested method
+     */
+    public function aroundApplyingGiftCardCode_ifUnableToApplyAheadworksGiftcard_sendsErrorResponse()
+    {
+        $this->currentMock->method('shouldRun')->willReturn(true);
+        $this->aheadworksGiftcardCartManagementFactoryMock->method('isAvailable')->willReturn(true);
+        $this->aheadworksGiftcardCartManagementFactoryMock->method('isExists')->willReturn(true);
+        $giftcard = $this->getMockBuilder('\Aheadworks\Giftcard\Api\Data\GiftcardInterface')
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableProxyingToOriginalMethods()
+            ->setMethods(
+                [
+                    'getId',
+                    'setId',
+                    'getCode',
+                    'setCode',
+                    'getType',
+                    'setType',
+                    'getCreatedAt',
+                    'setCreatedAt',
+                    'getExpireAt',
+                    'setExpireAt',
+                    'getWebsiteId',
+                    'setWebsiteId',
+                    'getBalance',
+                    'setBalance',
+                    'getInitialBalance',
+                    'setInitialBalance',
+                    'getState',
+                    'setState',
+                    'getOrderId',
+                    'setOrderId',
+                    'getProductId',
+                    'setProductId',
+                    'getEmailTemplate',
+                    'setEmailTemplate',
+                    'getSenderName',
+                    'setSenderName',
+                    'getSenderEmail',
+                    'setMessage',
+                    'setSenderEmail',
+                    'getRecipientName',
+                    'setRecipientName',
+                    'getRecipientEmail',
+                    'setRecipientEmail',
+                    'getDeliveryDate',
+                    'setDeliveryDate',
+                    'getDeliveryDateTimezone',
+                    'setDeliveryDateTimezone',
+                    'getEmailSent',
+                    'setEmailSent',
+                    'getHeadline',
+                    'setHeadline',
+                    'getMessage',
+                    'setExtensionAttributes',
+                    'getCurrentHistoryAction',
+                    'setCurrentHistoryAction',
+                    'getExtensionAttributes',
+                ]
+            )
+            ->getMock();
+        $giftcard->method('getCode')->willReturn(self::TEST_GIFTCARD_CODE);
+        $giftcard->method('getBalance')->willReturn(123.45);
+
+        $this->aheadworksGiftcardCartManagementFactoryMock->expects(static::once())
+            ->method('getInstance')->willReturn($this->aheadworksGiftcardManagementMock);
+        $this->aheadworksGiftcardManagementMock->expects(static::once())
+            ->method('remove')->with(self::PARENT_QUOTE_ID, self::TEST_GIFTCARD_CODE, false)
+            ->willThrowException(new CouldNotSaveException(__('The specified Gift Card code not be removed')));
+        $exception = new CouldNotSaveException(__('The specified Gift Card code not be added'));
+        $this->aheadworksGiftcardManagementMock->expects(static::once())
+            ->method('set')->with(self::PARENT_QUOTE_ID, self::TEST_GIFTCARD_CODE, false)
+            ->willThrowException($exception);
+
+        $this->subjectMock->expects(static::never())
+            ->method('applyingGiftCardCode')
+            ->with(
+                self::TEST_GIFTCARD_CODE,
+                $giftcard,
+                $this->immutableQuote,
+                $this->parentQuote
+            );
+
+        $this->subjectMock->expects(static::once())->method('sendErrorResponse')
+            ->with(
+                \Bolt\Boltpay\Model\ErrorResponse::ERR_SERVICE,
+                $exception->getMessage(),
+                422,
+                $this->immutableQuote
+            );
+
+        static::assertFalse(
+            $this->currentMock->aroundApplyingGiftCardCode(
+                $this->subjectMock,
+                [$this->subjectMock, 'applyingGiftCardCode'],
+                self::TEST_GIFTCARD_CODE,
+                $giftcard,
+                $this->immutableQuote,
+                $this->parentQuote
+            )
+        );
+    }
+}

--- a/Test/Unit/Plugin/ThirdPartySupport/Aheadworks/Giftcard/V1/OrderPluginTest.php
+++ b/Test/Unit/Plugin/ThirdPartySupport/Aheadworks/Giftcard/V1/OrderPluginTest.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Test\Unit\Plugin\ThirdPartySupport\Aheadworks\Giftcard\V1;
+
+use Bolt\Boltpay\Plugin\ThirdPartySupport\Aheadworks\Giftcard\V1\OrderPlugin;
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+
+/**
+ * @coversDefaultClass \Bolt\Boltpay\Plugin\ThirdPartySupport\Aheadworks\Giftcard\V1\OrderPlugin
+ */
+class OrderPluginTest extends TestCase
+{
+    /** @var int Test order ID */
+    const ORDER_ID = 10001;
+
+    /**
+     * @var \Bolt\Boltpay\Plugin\ThirdPartySupport\CommonModuleContext|MockObject
+     */
+    private $contextMock;
+
+    /**
+     * @var \Bolt\Boltpay\Model\ThirdPartyModuleFactory|MockObject
+     */
+    private $aheadworksGiftcardOrderServicePluginFactoryMock;
+
+    /**
+     * @var \Aheadworks\Giftcard\Api\GiftcardCartManagementInterface|MockObject
+     */
+    private $aheadworksGiftcardOrderServicePluginMock;
+
+    /**
+     * @var \Bolt\Boltpay\Helper\Order|MockObject
+     */
+    private $subjectMock;
+
+    /**
+     * @var \Magento\Sales\Model\Service\OrderService|MockObject
+     */
+    private $orderServiceMock;
+
+    /**
+     * @var OrderPlugin|MockObject
+     */
+    private $currentMock;
+
+    /**
+     * @var \Magento\Sales\Model\Order|MockObject
+     */
+    private $orderMock;
+
+    /**
+     * Setup test dependencies, called before each test
+     */
+    protected function setUp()
+    {
+        $this->contextMock = $this->createMock(\Bolt\Boltpay\Plugin\ThirdPartySupport\CommonModuleContext::class);
+        $this->aheadworksGiftcardOrderServicePluginFactoryMock = $this->createMock(
+            \Bolt\Boltpay\Model\ThirdPartyModuleFactory::class
+        );
+        $this->aheadworksGiftcardOrderServicePluginMock = $this->getMockBuilder(
+            '\Aheadworks\Giftcard\Plugin\Model\Service\OrderServicePlugin'
+        )
+            ->disableOriginalClone()
+            ->disableOriginalConstructor()
+            ->disableProxyingToOriginalMethods()
+            ->setMethods(['afterPlace', 'aroundCancel'])
+            ->getMock();
+        $this->subjectMock = $this->createMock(\Bolt\Boltpay\Helper\Order::class);
+        $this->orderServiceMock = $this->createMock(\Magento\Sales\Model\Service\OrderService::class);
+        $this->currentMock = $this->getMockBuilder(OrderPlugin::class)
+            ->setMethods(['shouldRun'])
+            ->setConstructorArgs(
+                [$this->contextMock, $this->aheadworksGiftcardOrderServicePluginFactoryMock, $this->orderServiceMock]
+            )
+            ->getMock();
+        $this->orderMock = $this->createMock(\Magento\Sales\Model\Order::class);
+        $this->orderMock->method('getId')->willReturn(self::ORDER_ID);
+    }
+
+    /**
+     * @test
+     * that __construct sets internal properties
+     *
+     * @covers ::__construct
+     */
+    public function __construct_always_setsInternalProperties()
+    {
+        $instance = new OrderPlugin(
+            $this->contextMock,
+            $this->aheadworksGiftcardOrderServicePluginFactoryMock,
+            $this->orderServiceMock
+        );
+        static::assertAttributeEquals(
+            $this->aheadworksGiftcardOrderServicePluginFactoryMock,
+            'aheadworksGiftcardOrderServicePluginFactory',
+            $instance
+        );
+        static::assertAttributeEquals($this->orderServiceMock, 'orderService', $instance);
+    }
+
+    /**
+     * @test
+     * that beforeDeleteOrder will not execute its logic and call proceed if any of the preconditions are not met
+     *
+     * @covers ::beforeDeleteOrder
+     *
+     * @dataProvider beforeDeleteOrder_withVariousPreconditionUnmetStatesProvider
+     *
+     * @param bool $shouldRun stubbed result of {@see \Bolt\Boltpay\Plugin\ThirdPartySupport\AbstractPlugin::shouldRun}
+     * @param bool $isAvailable stubbed result of {@see \Bolt\Boltpay\Model\ThirdPartyModuleFactory::isAvailable}
+     * @param bool $isExists stubbed result of {@see \Bolt\Boltpay\Model\ThirdPartyModuleFactory::isExists}
+     *
+     * @throws \Exception from the tested method
+     */
+    public function beforeDeleteOrder_withVariousPreconditionStates_runsPluginLogicIfPreconditionsAreMet(
+        $shouldRun,
+        $isAvailable,
+        $isExists
+    ) {
+        $this->currentMock->method('shouldRun')->willReturn($shouldRun);
+        $this->aheadworksGiftcardOrderServicePluginFactoryMock->method('isAvailable')->willReturn($isAvailable);
+        $this->aheadworksGiftcardOrderServicePluginFactoryMock->method('isExists')->willReturn($isExists);
+
+        $preconditionsMet = $shouldRun && $isAvailable && $isExists;
+        $this->aheadworksGiftcardOrderServicePluginFactoryMock->expects(
+            $preconditionsMet
+                ? static::once()
+                : static::never()
+        )->method('getInstance')->willReturn($this->aheadworksGiftcardOrderServicePluginMock);
+        $this->aheadworksGiftcardOrderServicePluginMock->expects(
+            $preconditionsMet
+                ? static::once()
+                : static::never()
+        )->method('aroundCancel')->with(
+            $this->orderServiceMock,
+            static::callback(
+                function ($callback) {
+                    return $callback(self::ORDER_ID);
+                }
+            ),
+            self::ORDER_ID
+        );
+
+        static::assertNull($this->currentMock->beforeDeleteOrder($this->subjectMock, $this->orderMock));
+    }
+
+    /**
+     * Data provider for {@see beforeDeleteOrder_withVariousPreconditionStates_doesNotRunPluginLogic}
+     *
+     * @return array containing
+     * stubbed result of {@see \Bolt\Boltpay\Plugin\ThirdPartySupport\AbstractPlugin::shouldRun}
+     * stubbed result of {@see \Bolt\Boltpay\Model\ThirdPartyModuleFactory::isAvailable} for giftcard cart management
+     * stubbed result of {@see \Bolt\Boltpay\Model\ThirdPartyModuleFactory::isExists} for giftcard cart management
+     */
+    public function beforeDeleteOrder_withVariousPreconditionUnmetStatesProvider()
+    {
+        return \Bolt\Boltpay\Test\Unit\TestHelper::getAllBooleanCombinations(3);
+    }
+}

--- a/Test/Unit/Plugin/ThirdPartySupport/CommonModuleContextTest.php
+++ b/Test/Unit/Plugin/ThirdPartySupport/CommonModuleContextTest.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Test\Unit\Plugin\ThirdPartySupport;
+
+use Bolt\Boltpay\Plugin\ThirdPartySupport\CommonModuleContext;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Bolt\Boltpay\Plugin\ThirdPartySupport\CommonModuleContext
+ */
+class CommonModuleContextTest extends TestCase
+{
+    /** @var string Test supported module */
+    const TEST_SUPPORTED_MODULE = 'Vendor_SupportedModule';
+
+    /** @var string Test minimum version of the supported module that the plugin supports */
+    const TEST_VERSION_FROM = '1.0.0';
+
+    /** @var string Test maximum version of the supported module that the plugin supports */
+    const TEST_VERSION_TO = '9.9.9';
+
+    /**
+     * @var CommonModuleContext|MockObject mocked instance of the context class
+     */
+    private $contextMock;
+
+    /**
+     * @var \Bolt\Boltpay\Helper\Bugsnag|MockObject mocked instance of the Bolt Bugsnag helper
+     */
+    private $bugsnagHelperMock;
+
+    /**
+     * @var \Bolt\Boltpay\Helper\Log|MockObject mocked instance of the Bolt logging helper
+     */
+    private $logHelperMock;
+
+    /**
+     * @var \Magento\Framework\Module\Manager|MockObject mocked instance of the Magento module manager instance
+     */
+    private $moduleManagerMock;
+
+    /**
+     * @var \Magento\Framework\Module\ResourceInterface|MockObject mocked instance of the Magento module resouce model
+     */
+    private $moduleResourceMock;
+
+    /**
+     * Setup test dependencies, called before each test
+     */
+    protected function setUp()
+    {
+        $this->bugsnagHelperMock = $this->createMock(\Bolt\Boltpay\Helper\Bugsnag::class);
+        $this->logHelperMock = $this->createMock(\Bolt\Boltpay\Helper\Log::class);
+        $this->moduleManagerMock = $this->createMock(\Magento\Framework\Module\Manager::class);
+        $this->moduleResourceMock = $this->createMock(\Magento\Framework\Module\ResourceInterface::class);
+        $this->contextMock = $this->getMockBuilder(CommonModuleContext::class)
+            ->setConstructorArgs(
+                [
+                    $this->bugsnagHelperMock,
+                    $this->logHelperMock,
+                    $this->moduleManagerMock,
+                    $this->moduleResourceMock,
+                    self::TEST_SUPPORTED_MODULE,
+                    self::TEST_VERSION_FROM,
+                    self::TEST_VERSION_TO
+                ]
+            )
+            ->enableOriginalConstructor()
+            ->enableProxyingToOriginalMethods()
+            ->getMock();
+    }
+
+    /**
+     * @test
+     * that constructor will populate properties with provided arguments
+     *
+     * @covers ::__construct
+     */
+    public function __construct_always_setsInternalProperties()
+    {
+        $instance = new CommonModuleContext(
+            $this->bugsnagHelperMock,
+            $this->logHelperMock,
+            $this->moduleManagerMock,
+            $this->moduleResourceMock,
+            self::TEST_SUPPORTED_MODULE,
+            self::TEST_VERSION_FROM,
+            self::TEST_VERSION_TO
+        );
+        static::assertAttributeEquals($this->bugsnagHelperMock, 'bugsnagHelper', $instance);
+        static::assertAttributeEquals($this->logHelperMock, 'logHelper', $instance);
+        static::assertAttributeEquals($this->moduleManagerMock, 'moduleManager', $instance);
+        static::assertAttributeEquals($this->moduleResourceMock, 'moduleResource', $instance);
+        static::assertAttributeEquals(self::TEST_SUPPORTED_MODULE, 'supportedModule', $instance);
+        static::assertAttributeEquals(self::TEST_VERSION_FROM, 'versionFrom', $instance);
+        static::assertAttributeEquals(self::TEST_VERSION_TO, 'versionTo', $instance);
+    }
+
+    /**
+     * @test
+     * that getLogHelper returns log helper from internal property
+     *
+     * @covers ::getLogHelper
+     */
+    public function getLogHelper()
+    {
+        static::assertEquals($this->logHelperMock, $this->contextMock->getLogHelper());
+    }
+
+    /**
+     * @test
+     * that getModuleResource returns module resource from internal property
+     *
+     * @covers ::getModuleResource
+     */
+    public function getModuleResource()
+    {
+        static::assertEquals($this->moduleResourceMock, $this->contextMock->getModuleResource());
+    }
+
+    /**
+     * @test
+     * that getBugsnagHelper returns bugsnag helper from internal property
+     *
+     * @covers ::getBugsnagHelper
+     */
+    public function getBugsnagHelper()
+    {
+        static::assertEquals($this->bugsnagHelperMock, $this->contextMock->getBugsnagHelper());
+    }
+
+    /**
+     * @test
+     * that getModuleManager returns module manager from internal property
+     *
+     * @covers ::getModuleManager
+     */
+    public function getModuleManager()
+    {
+        static::assertEquals($this->moduleManagerMock, $this->contextMock->getModuleManager());
+    }
+
+    /**
+     * @test
+     * that getSupportedModule returns supported module from internal property
+     *
+     * @covers ::getSupportedModule
+     */
+    public function getSupportedModule()
+    {
+        static::assertEquals(self::TEST_SUPPORTED_MODULE, $this->contextMock->getSupportedModule());
+    }
+
+    /**
+     * @test
+     * that getVersionFrom returns minimum version of the supported module that the plugin supports
+     *
+     * @covers ::getVersionFrom
+     */
+    public function getVersionFrom()
+    {
+        static::assertEquals(self::TEST_VERSION_FROM, $this->contextMock->getVersionFrom());
+    }
+
+    /**
+     * @test
+     * that getVersionTo returns maximum version of the supported module that the plugin supports
+     *
+     * @covers ::getVersionTo
+     */
+    public function getVersionTo()
+    {
+        static::assertEquals(self::TEST_VERSION_TO, $this->contextMock->getVersionTo());
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -346,4 +346,65 @@
                 sortOrder="1"/>
     </type>
 
+    <!-- Aheadworks Giftcard V1 support start -->
+    <virtualType name="AheadworksGiftcardV1SupportContext" type="Bolt\Boltpay\Plugin\ThirdPartySupport\CommonModuleContext">
+        <arguments>
+            <argument name="supportedModule" xsi:type="string">Aheadworks_Giftcard</argument>
+            <argument name="versionFrom" xsi:type="null"></argument>
+            <argument name="versionTo" xsi:type="null"></argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="AheadworksGiftcardV1GiftcardCartManagement" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
+        <arguments>
+            <argument name="moduleName" xsi:type="string">Aheadworks_Giftcard</argument>
+            <argument name="className" xsi:type="string">Aheadworks\Giftcard\Api\GiftcardCartManagementInterface</argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="AheadworksGiftcardV1GiftcardOrderServicePlugin" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
+        <arguments>
+            <argument name="moduleName" xsi:type="string">Aheadworks_Giftcard</argument>
+            <argument name="className" xsi:type="string">Aheadworks\Giftcard\Plugin\Model\Service\OrderServicePlugin</argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="AheadworksGiftcardRepository" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
+        <arguments>
+            <argument name="moduleName" xsi:type="string">Aheadworks_Giftcard</argument>
+            <argument name="className" xsi:type="string">Aheadworks\Giftcard\Api\GiftcardRepositoryInterface</argument>
+        </arguments>
+    </virtualType>
+    <type name="Bolt\Boltpay\Plugin\ThirdPartySupport\Aheadworks\Giftcard\V1\CartPlugin">
+        <arguments>
+            <argument name="context" xsi:type="object">AheadworksGiftcardV1SupportContext</argument>
+            <argument name="giftcardCartManagementFactory" xsi:type="object">AheadworksGiftcardV1GiftcardCartManagement</argument>
+        </arguments>
+    </type>
+    <type name="Bolt\Boltpay\Plugin\ThirdPartySupport\Aheadworks\Giftcard\V1\DiscountCodeValidationPlugin">
+        <arguments>
+            <argument name="context" xsi:type="object">AheadworksGiftcardV1SupportContext</argument>
+            <argument name="aheadworksGiftcardRepositoryFactory" xsi:type="object">AheadworksGiftcardRepository</argument>
+            <argument name="aheadworksGiftcardCartManagementFactory" xsi:type="object">AheadworksGiftcardV1GiftcardCartManagement</argument>
+        </arguments>
+    </type>
+    <type name="Bolt\Boltpay\Plugin\ThirdPartySupport\Aheadworks\Giftcard\V1\OrderPlugin">
+        <arguments>
+            <argument name="context" xsi:type="object">AheadworksGiftcardV1SupportContext</argument>
+            <argument name="aheadworksGiftcardOrderServicePluginFactory" xsi:type="object">AheadworksGiftcardV1GiftcardOrderServicePlugin</argument>
+        </arguments>
+    </type>
+    <type name="Bolt\Boltpay\Helper\Cart">
+        <plugin name="AheadworksGiftcardV1DiscountCartPlugin"
+                type="Bolt\Boltpay\Plugin\ThirdPartySupport\Aheadworks\Giftcard\V1\CartPlugin"
+                sortOrder="1"/>
+    </type>
+    <type name="Bolt\Boltpay\Helper\Order">
+        <plugin name="AheadworksGiftcardV1OrderPlugin"
+                type="Bolt\Boltpay\Plugin\ThirdPartySupport\Aheadworks\Giftcard\V1\OrderPlugin"
+                sortOrder="10"/>
+    </type>
+    <type name="Bolt\Boltpay\Model\Api\DiscountCodeValidation">
+        <plugin name="AheadworksGiftcardV1DiscountCodeValidationPlugin"
+                type="Bolt\Boltpay\Plugin\ThirdPartySupport\Aheadworks\Giftcard\V1\DiscountCodeValidationPlugin"
+                sortOrder="10"/>
+    </type>
+    <!-- Aheadworks Giftcard V1 support end -->
 </config>


### PR DESCRIPTION
# Description
This pull request adds support for Aheadworks Gift Cards while introducing a concise, robust architecture for adding support of 3rd-party modules to the Bolt plugin.

I will post a document here outlining the features and rationale as time permits, which will most likely be on Monday.
*** update: This will have to come next week 24.8-30.8 ***

Fixes: [M2P-92](https://boltpay.atlassian.net/browse/M2P-92)

#changelog Aheadworks Gift Card (General M2 3rd-Party Module Extension Architecture )

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
