### PR TITLE
M2P-197 Allow merchant extensions to hide bolt button under certain conditions

### DIFF
--- a/Block/Js.php
+++ b/Block/Js.php
@@ -458,11 +458,18 @@ class Js extends Template
      */
     public function getButtonCssStyles()
     {
-        $buttonColor = $this->configHelper->getButtonColor();
-        if (!$buttonColor) {
-            return "";
+        $style = "";
+
+        $toggleCheckout = $this->configHelper->getToggleCheckout();
+        if ($toggleCheckout && $toggleCheckout->active) {
+            $style .= 'display:none;';
         }
-        return '--bolt-primary-action-color:' . $buttonColor;
+
+        $buttonColor = $this->configHelper->getButtonColor();
+        if ($buttonColor) {
+            $style .= '--bolt-primary-action-color:' . $buttonColor .';';
+        }
+        return $style;
     }
 
     /**

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -2208,10 +2208,10 @@ class Cart extends AbstractHelper
         }
 
         // get configured Product model getters that can restrict Bolt checkout usage
-        $productRestrictionMethods = $toggleCheckout->productRestrictionMethods ?: [];
+        $productRestrictionMethods = isset($toggleCheckout->productRestrictionMethods) ? $toggleCheckout->productRestrictionMethods : [];
 
         // get configured Quote Item getters that can restrict Bolt checkout usage
-        $itemRestrictionMethods = $toggleCheckout->itemRestrictionMethods ?: [];
+        $itemRestrictionMethods = isset($toggleCheckout->itemRestrictionMethods) ? $toggleCheckout->itemRestrictionMethods : [];
 
         if (!$productRestrictionMethods && !$itemRestrictionMethods) {
             return false;

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -1726,8 +1726,8 @@ JS;
             ['configButtonColor' => '', 'expectedResult' => ''],
             ['configButtonColor' => null, 'expectedResult' => ''],
             ['configButtonColor' => false, 'expectedResult' => ''],
-            ['configButtonColor' => '#AA00AA', 'expectedResult' => '--bolt-primary-action-color:#AA00AA'],
-            ['configButtonColor' => 'not validated', 'expectedResult' => '--bolt-primary-action-color:not validated'],
+            ['configButtonColor' => '#AA00AA', 'expectedResult' => '--bolt-primary-action-color:#AA00AA;'],
+            ['configButtonColor' => 'not validated', 'expectedResult' => '--bolt-primary-action-color:not validated;'],
         ];
     }
 

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -240,9 +240,9 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
         initiateCheckout: null,
 
         /**
-         * @var bool true if BoltCheckout.configure() called at least once
+         * @var bool true if we loaded all JS code from this module and extensions
          */
-        congigureCalled: false,
+        codeIsLoaded:  boltBarrier(),
 
         /**
          * @var boltBarrier allow extensions to postpone all configure() calls
@@ -260,8 +260,6 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
         cartRestricted: false,
 
     };
-    // resolve promise for now, but later extensions are able to set new promise
-    BoltState.beforeConfigureBarrier.resolve(true);
 
     ////////////////////////////////////////////////////
     // DI: Inserting required Magento objects
@@ -454,14 +452,15 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
         // if toggling is enabled.
         ////////////////////////////////////////////////////////
         var toggleCheckoutConfig = settings.toggle_checkout;
-        var toggleCheckoutIfNeeded = function(boltRestricted) {
+        var toggleCheckoutIfNeeded = function() {
             if (!toggleCheckoutConfig) {
                 return;
             }
-            if (BoltState.beforeConfigureBarrier.isResolved() === false) {
+            if (BoltState.codeIsLoaded.isResolved() === false || BoltState.beforeConfigureBarrier.isResolved() === false) {
+                // allow extensions to made their setup before we toggle buttons first time
                 return;
             }
-            boltRestricted = BoltState.globalRestricted || BoltState.cartRestricted;
+            var boltRestricted = BoltState.globalRestricted || BoltState.cartRestricted;
 
             // Show DOM nodes hidden by Global CSS. Usually buttons parent element, containter.
             $.each(toggleCheckoutConfig.showElementsOnLoad, function( index, element ) {
@@ -726,14 +725,14 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
                     whenDefined(window, 'BoltCheckout', callConfigure);
                     return;
                 }
-                if (BoltState.congigureCalled == false) {
-                    $(document).trigger('bolt:beforeFirstConfigure');
-                    BoltState.congigureCalled = true;
-                    // trigger callConfigure with zero delay to allow extension
-                    // make setup in bolt:beforeFirstConfigure event
-                    setTimeout(callConfigure, 0);
+                // waiting while all JS code is loaded
+                if (BoltState.codeIsLoaded.isResolved() === false) {
+                    BoltState.codeIsLoaded.promise.then(function(result){
+                        callConfigure();
+                    });
                     return;
                 }
+                // extensions can use this promise to postpone BoltCheckout.configure() calls
                 if (BoltState.beforeConfigureBarrier.isResolved() === false) {
                     BoltState.beforeConfigureBarrier.promise.then(function(result){
                         callConfigure();
@@ -1423,6 +1422,9 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
         createOrder();
         ////////////////////////////////////////////////////
         <?= /* @noEscape */ $block->getAdditionalJavascript(); ?>
+
+        // For now all JS code is loaded, we made all necessary settings and can call Boltcheckout.Configure()
+        BoltState.codeIsLoaded.resolve(true);
     });
 
     if (trim(location.pathname, '/') === 'checkout/cart') {

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -238,7 +238,30 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
          * @var bool|null true if we want to auto open bolt checkout
          */
         initiateCheckout: null,
+
+        /**
+         * @var bool true if BoltCheckout.configure() called at least once
+         */
+        congigureCalled: false,
+
+        /**
+         * @var boltBarrier allow extensions to postpone all configure() calls
+         */
+        beforeConfigureBarrier: boltBarrier(),
+
+        /**
+         * @var bool true if bolt checkout restricted for any cart
+         */
+        globalRestricted: false,
+
+        /**
+         * @var bool true if bolt checkout restricted for the current cart
+         */
+        cartRestricted: false,
+
     };
+    // resolve promise for now, but later extensions are able to set new promise
+    BoltState.beforeConfigureBarrier.resolve(true);
 
     ////////////////////////////////////////////////////
     // DI: Inserting required Magento objects
@@ -432,7 +455,13 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
         ////////////////////////////////////////////////////////
         var toggleCheckoutConfig = settings.toggle_checkout;
         var toggleCheckoutIfNeeded = function(boltRestricted) {
-            if (!toggleCheckoutConfig) return;
+            if (!toggleCheckoutConfig) {
+                return;
+            }
+            if (BoltState.beforeConfigureBarrier.isResolved() === false) {
+                return;
+            }
+            boltRestricted = BoltState.globalRestricted || BoltState.cartRestricted;
 
             // Show DOM nodes hidden by Global CSS. Usually buttons parent element, containter.
             $.each(toggleCheckoutConfig.showElementsOnLoad, function( index, element ) {
@@ -443,8 +472,14 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
             $(bolt_button_selector).toggle(!boltRestricted);
 
             // Show magento buttons if bolt checkout is restricted, otherwise hide it
+            var style;
+            if (boltRestricted) {
+                style = 'display:inline-block !important'
+            } else {
+                style = 'display:none !important'
+            }
             $.each(toggleCheckoutConfig.magentoButtons, function( index, button ) {
-                $(button).toggle(boltRestricted);
+                $(button).attr('style', style);
             });
         };
         ////////////////////////////////////////////////////////
@@ -685,13 +720,28 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
 
         var boltCheckoutConfigure = function(cart, hints, callback, parameters) {
             var callConfigure = function() {
+                // Check if BoltCheckout is defined (connect.js executed).
+                // If not, postpone processing until it is
+                if (!window.BoltCheckout) {
+                    whenDefined(window, 'BoltCheckout', callConfigure);
+                    return;
+                }
+                if (BoltState.congigureCalled == false) {
+                    $(document).trigger('bolt:beforeFirstConfigure');
+                    BoltState.congigureCalled = true;
+                    // trigger callConfigure with zero delay to allow extension
+                    // make setup in bolt:beforeFirstConfigure event
+                    setTimeout(callConfigure, 0);
+                    return;
+                }
+                if (BoltState.beforeConfigureBarrier.isResolved() === false) {
+                    BoltState.beforeConfigureBarrier.promise.then(function(result){
+                        callConfigure();
+                    });
+                    return;
+                }
+                toggleCheckoutIfNeeded();
                 BC = BoltCheckout.configure(cart, hints, callback, parameters);
-            }
-            // Check if BoltCheckout is defined (connect.js executed).
-            // If not, postpone processing until it is
-            if (!window.BoltCheckout) {
-                whenDefined(window, 'BoltCheckout', callConfigure);
-                return;
             }
             callConfigure();
         }
@@ -898,9 +948,7 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
                     $.get(settings.create_order_url, params)
                         .done(function (data) {
 
-                            var boltRestricted = !!data.restrict;
-
-                            toggleCheckoutIfNeeded(boltRestricted);
+                            BoltState.cartRestricted = !!data.restrict;
 
                             // Stop if Bolt checkout is restricted
                             if (boltRestricted) {
@@ -961,12 +1009,11 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
                     return;
                 }
 
-                        var boltRestricted = !!data.restrict;
-
-                        toggleCheckoutIfNeeded(boltRestricted);
+                        BoltState.cartRestricted = !!data.restrict;
+                        toggleCheckoutIfNeeded();
 
                         // Stop if Bolt checkout is restricted
-                        if (boltRestricted) {
+                        if (BoltState.cartRestricted) {
                             cart = {};
                             hints = {};
                         } else {

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -471,14 +471,11 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
             $(bolt_button_selector).toggle(!boltRestricted);
 
             // Show magento buttons if bolt checkout is restricted, otherwise hide it
-            var style;
-            if (boltRestricted) {
-                style = 'display:inline-block !important'
-            } else {
-                style = 'display:none !important'
-            }
-            $.each(toggleCheckoutConfig.magentoButtons, function( index, button ) {
-                $(button).attr('style', style);
+            $.each(toggleCheckoutConfig.magentoButtons, function( index, buttonSelector ) {
+                document.querySelectorAll(buttonSelector).forEach(function(button) {
+                    button.style.removeProperty('display');
+                    button.style.setProperty('display', boltRestricted ? 'inline-block' : 'none', 'important');
+                });
             });
         };
         ////////////////////////////////////////////////////////


### PR DESCRIPTION
* Reuse existing bolt plugin setting toggle_checkout. It was developed to allow toggle Bolt/Magento checkout depends on the cart content
* If toggle_checkout enabled hide bolt button by default. We show it again when call configure() if conditions are met
* Change the method how we show/hide Magento buttons for toggle_checkout. Now it works with “display:none!important” which is default setting.
* Move variable restricted for toggle_checkout into BoltState
* Create variable globalRestricted for disabling bolt for each cart (for example, depending on user type)
* Add barrier to allow extensions postpone configure() calls


Extension JS code example (it shows native Magento buttons after 10 seconds:  
```
BoltState.beforeConfigureBarrier = boltBarrier();
setTimeout(function () {
    BoltState.globalRestricted = true;
    BoltState.beforeConfigureBarrier.resolve(true);                
}, 10000);
```

Additional configuration should be

```
     {
       "toggleCheckout": {
         "active": true,
         "magentoButtons": [                       
           "#top-cart-btn-checkout",
           "button[data-role=proceed-to-checkout]"
         ],
         "showElementsOnLoad": [                      
           ".checkout-methods-items",                
           ".block-minicart .block-content > .actions > .primary"
         ]
       }
     }
```

Fixes: M2P-197

#changelog M2P-197 Allow merchant extensions to hide bolt button under certain conditions

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
