### PR TITLE
Refactor the Create Order Web hook [MP-1302]

### DIFF
--- a/Model/Api/CreateOrder.php
+++ b/Model/Api/CreateOrder.php
@@ -208,12 +208,10 @@ class CreateOrder implements CreateOrderInterface
             $immutableQuote = $this->loadQuoteData($immutableQuoteId);
 
             $this->preProcessWebhook($immutableQuote->getStoreId());
-            $immutableQuote->getStore()->setCurrentCurrencyCode($immutableQuote->getQuoteCurrencyCode());
 
             $transaction = json_decode($payload);
             $createdOrder = $this->createOrder($transaction, $immutableQuote);
             $orderData = json_encode($createdOrder->getData());
-
             $this->sendResponse(200, [
                 'status'    => 'success',
                 'message'   => "Order create was successful. Order Data: $orderData",
@@ -284,7 +282,7 @@ class CreateOrder implements CreateOrderInterface
      */
     public function createOrder($transaction, $immutableQuote)
     {
-        $this->logHelper->addInfoLog('IN NEW FUNCTION');
+        $immutableQuote->getStore()->setCurrentCurrencyCode($immutableQuote->getQuoteCurrencyCode());
         /** @var Quote $quote */
         $quote = $this->orderHelper->prepareQuote($immutableQuote, $transaction);
 

--- a/Test/Unit/Model/Api/CreateOrderTest.php
+++ b/Test/Unit/Model/Api/CreateOrderTest.php
@@ -375,6 +375,7 @@ class CreateOrderTest extends TestCase
      * @test
      * @covers ::execute
      * @covers ::preProcessWebhook
+     * @covers ::createOrder
      * @covers ::getQuoteIdFromPayloadOrder
      * @covers ::getDisplayId
      * @covers ::getOrderReference
@@ -501,6 +502,7 @@ class CreateOrderTest extends TestCase
     /**
      * @test
      * @covers ::execute
+     * @covers ::createOrder
      * @covers ::validateQuoteData
      * @covers ::validateMinimumAmount
      * @covers ::validateCartItems
@@ -567,6 +569,7 @@ class CreateOrderTest extends TestCase
     /**
      * @test
      * @covers ::execute
+     * @covers ::createOrder
      */
     public function execute_localizedException()
     {
@@ -604,6 +607,7 @@ class CreateOrderTest extends TestCase
     /**
      * @test
      * @covers ::execute
+     * @covers ::createOrder
      */
     public function execute_otherException()
     {


### PR DESCRIPTION
# Description

Move the order creation portion of the web hook into a helper function. This will be useful when we implement the universal merchant api because then we can just use dependency injection to inject this class into the universal endpoint and then just call this helper function. 

Fixes: [MP-1302]

#changelog Refactor the Create Order Web hook [MP-1302]

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.


[MP-1302]: https://boltpay.atlassian.net/browse/MP-1302