### PR TITLE
M2P-214 Support product page checkout for the downloadable product

### DIFF
--- a/Block/JsProductPage.php
+++ b/Block/JsProductPage.php
@@ -89,12 +89,26 @@ class JsProductPage extends Js
     }
 
     /**
+     * Check if current product has type downloadable
+     *
+     * @return boolean
+     */
+    public function isDownloadable()
+    {
+        return $this->_product->getTypeId() == \Magento\Downloadable\Model\Product\Type::TYPE_DOWNLOADABLE;
+    }
+
+    /**
      * Check if guest checkout is allowed
      *
      * @return int 1 if guest checkout is allowed, 0 if not
      */
     public function isGuestCheckoutAllowed()
     {
+        if ($this->isDownloadable() && $this->configHelper->isGuestCheckoutForDownloadableProductDisabled()) {
+            return 0;
+        }
+
         return (int)$this->configHelper->isGuestCheckoutAllowed();
     }
 

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -362,6 +362,7 @@ class Config extends AbstractHelper
         \Magento\Catalog\Model\Product\Type::TYPE_SIMPLE,
         \Magento\Catalog\Model\Product\Type::TYPE_VIRTUAL,
         \Magento\ConfigurableProduct\Model\Product\Type\Configurable::TYPE_CODE,
+        \Magento\Downloadable\Model\Product\Type::TYPE_DOWNLOADABLE
     ];
     /**
      * @var ResourceInterface
@@ -1534,6 +1535,18 @@ class Config extends AbstractHelper
     {
         return $this->getScopeConfig()->isSetFlag(
             \Magento\Checkout\Helper\Data::XML_PATH_GUEST_CHECKOUT,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+        );
+    }
+
+    /**
+     * Check if guest checkout for downloadable product is disabled
+     * @return bool
+     */
+    public function isGuestCheckoutForDownloadableProductDisabled()
+    {
+        return $this->getScopeConfig()->isSetFlag(
+            \Magento\Downloadable\Observer\IsAllowedGuestCheckoutObserver::XML_PATH_DISABLE_GUEST_CHECKOUT,
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
         );
     }

--- a/Test/Unit/Block/JsProductPageTest.php
+++ b/Test/Unit/Block/JsProductPageTest.php
@@ -61,7 +61,7 @@ class JsProductPageTest extends \PHPUnit\Framework\TestCase
     protected $checkoutSessionMock;
 
     /**
-     * @var BlockJs
+     * @var BlockJsProductPage
      */
     protected $block;
 
@@ -111,7 +111,7 @@ class JsProductPageTest extends \PHPUnit\Framework\TestCase
             'getPublishableKeyPayment', 'getPublishableKeyCheckout', 'getPublishableKeyBackOffice',
             'getReplaceSelectors', 'getGlobalCSS', 'getPrefetchShipping', 'getQuoteIsVirtual',
             'getTotalsChangeSelectors', 'getAdditionalCheckoutButtonClass', 'getAdditionalConfigString', 'getIsPreAuth',
-            'shouldTrackCheckoutFunnel', 'isPaymentOnlyCheckoutEnabled', 'isGuestCheckoutAllowed'
+            'shouldTrackCheckoutFunnel', 'isPaymentOnlyCheckoutEnabled', 'isGuestCheckoutAllowed','isGuestCheckoutForDownloadableProductDisabled'
         ];
 
         $this->configHelper = $this->getMockBuilder(HelperConfig::class)
@@ -201,7 +201,7 @@ class JsProductPageTest extends \PHPUnit\Framework\TestCase
             ['configurable', true],
             ['virtual', true],
             ['bundle', false],
-            ['downloadable', false]
+            ['downloadable', true]
         ];
     }
 
@@ -230,21 +230,56 @@ class JsProductPageTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
-     * @dataProvider providerIsGuestCheckoutAllowed
+     * @dataProvider providerIsDownloadable
+     *
+     * @param $typeId
+     * @param $expectedResult
      */
-    public function isGuestCheckoutAllowed($flag, $expected_result)
+    public function isDownloadable($typeId, $expectedResult)
+    {
+        $this->product->method('getTypeId')->willReturn($typeId);
+        $result = $this->block->isDownloadable();
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function providerIsDownloadable()
+    {
+        return [
+            ['simple', false],
+            ['grouped', false],
+            ['configurable', false],
+            ['virtual', false],
+            ['bundle', false],
+            ['downloadable', true]
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider providerIsGuestCheckoutAllowed
+     *
+     * @param $isGuestCheckoutAllowed
+     * @param $isGuestCheckoutForDownloadableProductDisabled
+     * @param $expectedResult
+     * @param $productType
+     */
+    public function isGuestCheckoutAllowed($isGuestCheckoutAllowed, $isGuestCheckoutForDownloadableProductDisabled, $expectedResult, $productType = 'simple')
     {
         $this->configHelper->method('isGuestCheckoutAllowed')
-            ->willReturn($flag);
+            ->willReturn($isGuestCheckoutAllowed);
+        $this->configHelper->method('isGuestCheckoutForDownloadableProductDisabled')
+            ->willReturn($isGuestCheckoutForDownloadableProductDisabled);
+        $this->product->method('getTypeId')->willReturn($productType);
         $result = $this->block->isGuestCheckoutAllowed();
-        $this->assertEquals($expected_result, $result);
+        $this->assertEquals($expectedResult, $result);
     }
 
     public function providerIsGuestCheckoutAllowed()
     {
         return [
-            [true,1],
-            [false,0],
+            [true, true, 0, 'downloadable'],
+            [true, true, 1],
+            [true, false, 1, 'configurable'],
         ];
     }
 

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -956,6 +956,20 @@ JSON;
 
     /**
      * @test
+     * @dataProvider providerTrueAndFalse
+     * @param $booleanValue
+     */
+    public function isGuestCheckoutForDownloadableProductDisabled($booleanValue)
+    {
+        $this->scopeConfig->method('isSetFlag')
+            ->with('catalog/downloadable/disable_guest_checkout', 'store')
+            ->willReturn($booleanValue);
+        $result = $this->currentMock->isGuestCheckoutForDownloadableProductDisabled();
+        $this->assertEquals($booleanValue, $result);
+    }
+
+    /**
+     * @test
      */
     public function getAllConfigSettings()
     {


### PR DESCRIPTION
# Description
Currently, the product page checkout doesn’t work for the downloadable product. This PR adds the ability to support it.
Here is the screenshot for testing - https://prnt.sc/u2btgj

Fixes: https://boltpay.atlassian.net/browse/M2P-214

#changelog M2P-214 Support product page checkout for the downloadable product

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
