### PR TITLE
M2P-179 JS refactoring

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -352,7 +352,6 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
             var publishableKey = getCheckoutKey();
             if (scriptTag) {
                 scriptTag.setAttribute('data-publishable-key', publishableKey);
-                createOrder();
                 return;
             }
             scriptTag = document.createElement('script');
@@ -361,7 +360,6 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
             scriptTag.setAttribute('src', settings.connect_url);
             scriptTag.setAttribute('id', 'bolt-connect');
             scriptTag.setAttribute('data-publishable-key', publishableKey);
-            scriptTag.onload = createOrder;
             document.head.appendChild(scriptTag);
         };
 
@@ -739,23 +737,11 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
             boltCheckoutConfigure(cart, hints, callbacks, boltCheckoutConfig);
         }
 
-        if (getCheckoutType() !== 'payment') {
-            callConfigureWithPromises();
-            customerData.get('cart').subscribe(function(data) {
-                magentoCart = data;
-                // Call invalidateBoltCartIfOutdated with zero delay
-                // to make sure that it is added into the end of event loop.
-                // We need it in case when magento updated both 'cart' and 'boltcart' in one call.
-                // After zero delay boltCartDataID will have actual value anyway.
-                setTimeout(invalidateBoltCartIfOutdated, 0);
-            })
-        }
-
-        var createOrder = function (el, dataChanged) {
+        var boltCheckoutSetup = function (el, dataChanged) {
             // Check if BoltCheckout is defined (connect.js executed).
             // If not, postpone processing until it is
             if (!window.BoltCheckout) {
-                whenDefined(window, 'BoltCheckout', createOrder);
+                whenDefined(window, 'BoltCheckout', boltCheckoutSetup);
                 return;
             }
 
@@ -875,13 +861,30 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
                         boltCheckoutConfigure(cart, hintBarrier.promise, callbacks);
                 });
             } else {
-            customerData.get('boltcart').subscribe(function(data) {
-                boltCartDataID = data.data_id;
+                callConfigureWithPromises();
 
-                cart = data.cart !== undefined ? data.cart : {};
-                if ((JSON.stringify(cart) === oldBoltCartValue) && !waitingForResolvingPromises) {
-                    return;
+                magentoCartDataListener = function(data) {
+                    magentoCart = data;
+                    // Call invalidateBoltCartIfOutdated with zero delay
+                    // to make sure that it is added into the end of event loop.
+                    // We need it in case when magento updated both 'cart' and 'boltcart' in one call.
+                    // After zero delay boltCartDataID will have actual value anyway.
+                    setTimeout(invalidateBoltCartIfOutdated, 0);
                 }
+
+                customerData.get('cart').subscribe(magentoCartDataListener);
+                // check if magento section was initialized before our code execution
+                if (customerData.get('cart')().data_id !== undefined) {
+                    magentoCartDataListener(customerData.get('cart')());
+                }
+
+                boltCartDataListener = function(data) {
+                    boltCartDataID = data.data_id;
+
+                    cart = data.cart !== undefined ? data.cart : {};
+                    if ((JSON.stringify(cart) === oldBoltCartValue) && !waitingForResolvingPromises) {
+                        return;
+                    }
 
                         var boltRestricted = !!data.restrict;
 
@@ -928,8 +931,13 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
 
                         // prefetch Shipping and Tax for multi-step checkout
                         prefetchShipping();
-                    });
-        }
+                }
+                customerData.get('boltcart').subscribe(boltCartDataListener);
+                // check if magento section was initialized before our code execution
+                if (customerData.get('boltcart')().data_id !== undefined) {
+                    boltCartDataListener(customerData.get('boltcart')());
+                }
+            }
         }
         /////////////////////////////////////////////////////
 
@@ -948,7 +956,7 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
 
             if (address !== billing_address_value) {
                 billing_address_value = address;
-                createOrder();
+                boltCheckoutSetup();
             }
         });
         /////////////////////////////////////////////////////
@@ -967,7 +975,7 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
 
             if (email !== customer_email_value) {
                 customer_email_value = email;
-                createOrder();
+                boltCheckoutSetup();
             }
         });
         }
@@ -1287,7 +1295,7 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
                 }
             }
             setupOrderManagementReplacement();
-        };
+        }
 
         ////////////////////////////////////////////////////
         // Initially configures BoltCheckout.
@@ -1295,7 +1303,7 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
         // enables Bolt checkout or opens authentication
         // popup when button is clicked.
         ////////////////////////////////////////////////////
-        createOrder();
+        boltCheckoutSetup();
         ////////////////////////////////////////////////////
         <?= /* @noEscape */ $block->getAdditionalJavascript(); ?>
     });


### PR DESCRIPTION
This refactoring opens the opportunity to use promises from the beginning of the code.
In IE11 we use polyfill library from connect.js that allows promises.
So if we use promises before connect.js loading it's not IE compatible.

In this PR:
- move Magento cart listener into function createOrder
- check if Magento cart or Bolt cart was initialized before we setup listener (I can't reproduce this but potentially it could be an issue.
- make sure we call createOrder exactly once (for multistep for now; will fix payment only in the corresponding task
- rename createOrder to boltCheckoutSetup

Fixes: (link Jira ticket)

#changelog M2P-179 JS refactoring

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
