### PR TITLE
M2P-215 Support product page checkout for the bundle product

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -377,7 +377,8 @@ class Config extends AbstractHelper
         \Magento\Catalog\Model\Product\Type::TYPE_SIMPLE,
         \Magento\Catalog\Model\Product\Type::TYPE_VIRTUAL,
         \Magento\ConfigurableProduct\Model\Product\Type\Configurable::TYPE_CODE,
-        \Magento\Downloadable\Model\Product\Type::TYPE_DOWNLOADABLE
+        \Magento\Downloadable\Model\Product\Type::TYPE_DOWNLOADABLE,
+        \Magento\Catalog\Model\Product\Type::TYPE_BUNDLE
     ];
     /**
      * @var ResourceInterface

--- a/Test/Unit/Block/JsProductPageTest.php
+++ b/Test/Unit/Block/JsProductPageTest.php
@@ -200,7 +200,7 @@ class JsProductPageTest extends \PHPUnit\Framework\TestCase
             ['grouped', false],
             ['configurable', true],
             ['virtual', true],
-            ['bundle', false],
+            ['bundle', true],
             ['downloadable', true]
         ];
     }

--- a/view/frontend/layout/catalog_product_view_type_bundle.xml
+++ b/view/frontend/layout/catalog_product_view_type_bundle.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="product.info.addtocart.bundle">
+            <block class="Bolt\Boltpay\Block\JsProductPage" name="bolt.button" template="Bolt_Boltpay::button_product_page.phtml" before="-" />
+        </referenceBlock>
+    </body>
+</page>

--- a/view/frontend/templates/button_product_page.phtml
+++ b/view/frontend/templates/button_product_page.phtml
@@ -209,7 +209,7 @@ $additionalClass = $block->getAdditionalCheckoutButtonClass();
 
             var setupProductPage = function () {
                 var options = {};
-                var compositeAttributes = ['super_attribute', 'options'];
+                var compositeAttributes = ['super_attribute', 'options', 'bundle_option', 'bundle_option_qty'];
                 formData = $("#product_addtocart_form").serializeArray();
                 $.each( formData, function( key, input ) {
                     var name = input.name, value = input.value;


### PR DESCRIPTION
# Description
Currently, the product page checkout doesn’t work for the bundle product. This PR adds the ability to support it.
Here is the screenshot for testing - https://prnt.sc/u2hjna

 Fixes: https://boltpay.atlassian.net/browse/M2P-215

#changelog

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
