### PR TITLE
M2P-217 Return empty discount type for empty coupon code

### DIFF
--- a/Helper/Discount.php
+++ b/Helper/Discount.php
@@ -1294,7 +1294,7 @@ class Discount extends AbstractHelper
     public function convertToBoltDiscountType($couponCode)
     {
         if ($couponCode == "") {
-            return "";
+            return "fixed_amount";
         }
         $coupon = $this->loadCouponCodeData($couponCode);
         // Load the coupon discount rule

--- a/Helper/Discount.php
+++ b/Helper/Discount.php
@@ -1320,7 +1320,7 @@ class Discount extends AbstractHelper
                 return "shipping";
         }
 
-        return "";
+        return "fixed_amount";
     }
     
     /**

--- a/Helper/Discount.php
+++ b/Helper/Discount.php
@@ -1293,6 +1293,9 @@ class Discount extends AbstractHelper
      */
     public function convertToBoltDiscountType($couponCode)
     {
+        if ($couponCode == "") {
+            return "";
+        }
         $coupon = $this->loadCouponCodeData($couponCode);
         // Load the coupon discount rule
         $rule = $this->ruleRepository->getById($coupon->getRuleId());        

--- a/Test/Unit/Helper/DiscountTest.php
+++ b/Test/Unit/Helper/DiscountTest.php
@@ -4333,6 +4333,17 @@ class DiscountTest extends TestCase
 
     /**
      * @test
+     * @covers ::convertToBoltDiscountType
+     */
+    public function convertToBoltDiscountType_withEmptyDiscountCode_returnsDefaultValue()
+    {
+        $this->initCurrentMock();
+        $couponCode = "";
+        static::assertEquals("fixed_amount", $this->currentMock->convertToBoltDiscountType($couponCode));
+    }
+
+    /**
+     * @test
      * that convertToBoltDiscountType returns the Bolt discount type value
      *
      * @covers ::convertToBoltDiscountType

--- a/Test/Unit/Helper/DiscountTest.php
+++ b/Test/Unit/Helper/DiscountTest.php
@@ -4389,8 +4389,8 @@ class DiscountTest extends TestCase
             ['types' => 'cart_fixed', 'expectedResult' => 'fixed_amount'],
             ['types' => 'by_percent', 'expectedResult' => 'percentage'],
             ['types' => 'by_shipping', 'expectedResult' => 'shipping'],
-            ['types' => 'none_list', 'expectedResult' => ''],
-            ['types' => '', 'expectedResult' => ''],
+            ['types' => 'none_list', 'expectedResult' => 'fixed_amount'],
+            ['types' => '', 'expectedResult' => 'fixed_amount'],
         ];
     }
 

--- a/Test/Unit/Helper/DiscountTest.php
+++ b/Test/Unit/Helper/DiscountTest.php
@@ -4390,6 +4390,7 @@ class DiscountTest extends TestCase
             ['types' => 'by_percent', 'expectedResult' => 'percentage'],
             ['types' => 'by_shipping', 'expectedResult' => 'shipping'],
             ['types' => 'none_list', 'expectedResult' => ''],
+            ['types' => '', 'expectedResult' => ''],
         ];
     }
 


### PR DESCRIPTION
For store integral discount coupon code could be empty and we need to return empty discount type.
Without this fix magento generates exception and checkout is blocked for users.

Fixes: (link Jira ticket)

#changelog M2P-217 Return empty discount type for empty coupon code

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
