### PR TITLE
Support product page checkout for grouped product

### DIFF
--- a/Block/JsProductPage.php
+++ b/Block/JsProductPage.php
@@ -19,13 +19,13 @@ namespace Bolt\Boltpay\Block;
 
 use Bolt\Boltpay\Helper\Config;
 use Bolt\Boltpay\Helper\FeatureSwitch\Decider;
-use Magento\Checkout\Helper\Data;
-use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Element\Template\Context;
 use Magento\Checkout\Model\Session as CheckoutSession;
 use Bolt\Boltpay\Helper\Cart as CartHelper;
 use Bolt\Boltpay\Helper\Bugsnag;
 use Magento\Catalog\Block\Product\View as ProductView;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use \Magento\Catalog\Model\ProductRepository;
 
 /**
  * Js Block. The block class used in replace.phtml and track.phtml blocks.
@@ -40,6 +40,16 @@ class JsProductPage extends Js
      */
     private $_product;
 
+    /**
+     * @var ProductRepository
+     */
+    private $_productRepository;
+
+    /**
+     * @var SearchCriteriaBuilder
+     */
+    private $searchCriteriaBuilder;
+
     public function __construct(
         Context $context,
         Config $configHelper,
@@ -48,10 +58,13 @@ class JsProductPage extends Js
         Bugsnag $bugsnag,
         ProductView $productView,
         Decider $featureSwitches,
+        ProductRepository $productRepository,
+        SearchCriteriaBuilder $searchCriteriaBuilder,
         array $data = []
     ) {
         $this->_product = $productView->getProduct();
-
+        $this->searchCriteriaBuilder = $searchCriteriaBuilder;
+        $this->_productRepository = $productRepository;
         parent::__construct($context, $configHelper, $checkoutSession, $cartHelper, $bugsnag, $featureSwitches, $data);
     }
 
@@ -96,6 +109,24 @@ class JsProductPage extends Js
     public function isDownloadable()
     {
         return $this->_product->getTypeId() == \Magento\Downloadable\Model\Product\Type::TYPE_DOWNLOADABLE;
+    }
+
+    /**
+     * Check if current product has type grouped
+     *
+     * @return bool
+     */
+    public function isGrouped(){
+        return $this->_product->getTypeId() == \Magento\GroupedProduct\Model\Product\Type\Grouped::TYPE_CODE;
+    }
+
+    /**
+     * @return \Magento\Catalog\Api\Data\ProductInterface[]
+     */
+    public function getGroupedProductChildren(){
+        $ids = $this->_product->getTypeInstance()->getChildrenIds($this->_product->getId());
+        $searchCriteria = $this->searchCriteriaBuilder->addFilter('entity_id', $ids, 'in');
+        return $this->_productRepository->getList($searchCriteria->create())->getItems();
     }
 
     /**

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -2264,36 +2264,37 @@ class Cart extends AbstractHelper
         }
 
         //add item to quote
-        $item = $request['items'][0];
-        $product = $this->productRepository->getbyId($item['reference']);
+        foreach ($request['items'] as $item) {
+            $product = $this->productRepository->getbyId($item['reference']);
 
-        $options = json_decode($item['options'], true);
-        if (isset($options['storeId']) && $options['storeId']) {
-            $quote->setStoreId($options['storeId']);
-        }
-        unset($options['storeId']);
-        unset($options['form_key']);
-        $options['qty'] = $item['quantity'];
-        $options = new \Magento\Framework\DataObject($options);
-
-        try {
-            $quote->addProduct($product, $options);
-        } catch (\Exception $e) {
-            $error_message = $e->getMessage();
-            if ($error_message == 'Product that you are trying to add is not available.') {
-                throw new BoltException(
-                    __($error_message),
-                    null,
-                    BoltErrorResponse::ERR_PPC_OUT_OF_STOCK
-                );
-            } else {
-                throw new BoltException(
-                    __('The requested qty is not available'),
-                    null,
-                    BoltErrorResponse::ERR_PPC_INVALID_QUANTITY
-                );
+            $options = json_decode($item['options'], true);
+            if (isset($options['storeId']) && $options['storeId']) {
+                $quote->setStoreId($options['storeId']);
             }
-        };
+            unset($options['storeId']);
+            unset($options['form_key']);
+            $options['qty'] = $item['quantity'];
+            $options = new \Magento\Framework\DataObject($options);
+
+            try {
+                $quote->addProduct($product, $options);
+            } catch (\Exception $e) {
+                $error_message = $e->getMessage();
+                if ($error_message == 'Product that you are trying to add is not available.') {
+                    throw new BoltException(
+                        __($error_message),
+                        null,
+                        BoltErrorResponse::ERR_PPC_OUT_OF_STOCK
+                    );
+                } else {
+                    throw new BoltException(
+                        __('The requested qty is not available'),
+                        null,
+                        BoltErrorResponse::ERR_PPC_INVALID_QUANTITY
+                    );
+                }
+            };
+        }
 
         $quote->reserveOrderId();
 

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -378,7 +378,8 @@ class Config extends AbstractHelper
         \Magento\Catalog\Model\Product\Type::TYPE_VIRTUAL,
         \Magento\ConfigurableProduct\Model\Product\Type\Configurable::TYPE_CODE,
         \Magento\Downloadable\Model\Product\Type::TYPE_DOWNLOADABLE,
-        \Magento\Catalog\Model\Product\Type::TYPE_BUNDLE
+        \Magento\Catalog\Model\Product\Type::TYPE_BUNDLE,
+        \Magento\GroupedProduct\Model\Product\Type\Grouped::TYPE_CODE
     ];
     /**
      * @var ResourceInterface

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -5266,6 +5266,127 @@ ORDER
         static::assertEquals($expectedCartData, $cartMock->createCartByRequest($request));
         }
 
+
+    /**
+     * @test
+     * that that createCartByRequest creates cart with grouped product's children and returns expected cart data using
+     * @see \Bolt\Boltpay\Helper\Cart::getCartData
+     *
+     * @covers ::createCartByRequest
+     *
+     * @throws Exception from tested method
+     */
+    public function createCartByRequest_withGroupedProductChildren_returnsExpectedCartData()
+    {
+        $request = [
+            'type'     => 'cart.create',
+            'items'    =>
+                [
+                    [
+                        'reference'    => CartTest::PRODUCT_ID,
+                        'name'         => 'Affirm Water Bottle 1',
+                        'description'  => null,
+                        'options'      => json_encode(['storeId' => CartTest::STORE_ID]),
+                        'total_amount' => CartTest::PRODUCT_PRICE,
+                        'unit_price'   => CartTest::PRODUCT_PRICE,
+                        'tax_amount'   => 0,
+                        'quantity'     => 1,
+                        'uom'          => null,
+                        'upc'          => null,
+                        'sku'          => null,
+                        'isbn'         => null,
+                        'brand'        => null,
+                        'manufacturer' => null,
+                        'category'     => null,
+                        'tags'         => null,
+                        'properties'   => null,
+                        'color'        => null,
+                        'size'         => null,
+                        'weight'       => null,
+                        'weight_unit'  => null,
+                        'image_url'    => null,
+                        'details_url'  => null,
+                        'tax_code'     => null,
+                        'type'         => 'unknown'
+                    ],
+                    [
+                        'reference'    => CartTest::PRODUCT_ID,
+                        'name'         => 'Affirm Water Bottle 1',
+                        'description'  => null,
+                        'options'      => json_encode(['storeId' => CartTest::STORE_ID]),
+                        'total_amount' => CartTest::PRODUCT_PRICE,
+                        'unit_price'   => CartTest::PRODUCT_PRICE,
+                        'tax_amount'   => 0,
+                        'quantity'     => 1,
+                        'uom'          => null,
+                        'upc'          => null,
+                        'sku'          => null,
+                        'isbn'         => null,
+                        'brand'        => null,
+                        'manufacturer' => null,
+                        'category'     => null,
+                        'tags'         => null,
+                        'properties'   => null,
+                        'color'        => null,
+                        'size'         => null,
+                        'weight'       => null,
+                        'weight_unit'  => null,
+                        'image_url'    => null,
+                        'details_url'  => null,
+                        'tax_code'     => null,
+                        'type'         => 'unknown'
+                    ]
+                ],
+            'currency' => self::CURRENCY_CODE,
+            'metadata' => null,
+        ];
+
+        $expectedCartData = [
+            'order_reference' => self::IMMUTABLE_QUOTE_ID,
+            'display_id'      => self::ORDER_INCREMENT_ID . ' / ' . self::IMMUTABLE_QUOTE_ID,
+            'currency'        => self::CURRENCY_CODE,
+            'items'           => [
+                [
+                    'reference'    => self::PRODUCT_ID,
+                    'name'         => 'Affirm Water Bottle 1',
+                    'total_amount' => self::PRODUCT_PRICE,
+                    'unit_price'   => self::PRODUCT_PRICE,
+                    'quantity'     => 1,
+                    'sku'          => self::PRODUCT_SKU,
+                    'type'         => 'physical',
+                    'description'  => 'Product description',
+                ],
+                [
+                    'reference'    => self::PRODUCT_ID,
+                    'name'         => 'Affirm Water Bottle 2',
+                    'total_amount' => self::PRODUCT_PRICE,
+                    'unit_price'   => self::PRODUCT_PRICE,
+                    'quantity'     => 1,
+                    'sku'          => self::PRODUCT_SKU,
+                    'type'         => 'physical',
+                    'description'  => 'Product description',
+                ],
+            ],
+            'discounts'       => [],
+            'total_amount'    => self::PRODUCT_PRICE,
+            'tax_amount'      => 0,
+        ];
+
+        $cartMock = $this->getCurrentMock(['getCartData']);
+        $cartMock->expects(static::once())->method('getCartData')->with(false, '', $this->quoteMock)
+            ->willReturn($expectedCartData);
+        $this->quoteManagement->expects(static::once())->method('createEmptyCart')
+            ->willReturn(self::QUOTE_ID);
+        $this->quoteFactory->method('create')->withAnyParameters()->willReturnSelf();
+        $this->quoteFactory->method('load')->with(self::QUOTE_ID)->willReturn($this->quoteMock);
+        $this->productRepository->expects(static::exactly(2))->method('getById')->with(self::PRODUCT_ID)
+            ->willReturn($this->productMock);
+        $this->quoteMock->expects(static::once())->method('reserveOrderId');
+        $this->quoteMock->expects(static::once())->method('setIsActive')->with(false);
+
+        static::assertEquals($expectedCartData, $cartMock->createCartByRequest($request));
+    }
+
         /**
         * @test
         * that createCartByRequest creates cart with configurable product and returns expected cart data using

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -26,6 +26,7 @@
             <module name="Magento_Tax"/>
             <module name="Magento_GiftCardAccount"/>
             <module name="Magento_Customer"/>
+            <module name="Magento_GroupedProduct"/>
         </sequence>
     </module>
 </config>

--- a/view/frontend/templates/button_product_page.phtml
+++ b/view/frontend/templates/button_product_page.phtml
@@ -181,6 +181,11 @@ $additionalClass = $block->getAdditionalCheckoutButtonClass();
                 var quantity = Number($('#qty').val());
                 return quantity > 0 ? quantity : 1;
             };
+
+            var getGroupedProductChildQty = function(productId) {
+                return Number($('input[name="super_group['+productId+']').val());
+            };
+
             <?php if ($block->isSaveHintsInSections()): ?>
             var hintsSection = customerData.get('bolthints');
             var hints = hintsSection.data !== undefined ? hintsSection.data : {};
@@ -207,7 +212,7 @@ $additionalClass = $block->getAdditionalCheckoutButtonClass();
             });
             <?php endif; ?>
 
-            var setupProductPage = function () {
+            var getItemsData = function () {
                 var options = {};
                 var compositeAttributes = ['super_attribute', 'options', 'bundle_option', 'bundle_option_qty'];
                 formData = $("#product_addtocart_form").serializeArray();
@@ -227,15 +232,38 @@ $additionalClass = $block->getAdditionalCheckoutButtonClass();
                     options[name] = value;
                 });
                 options['storeId'] = '<?= /* @noEscape */ $block->getStoreId(); ?>';
-                var cart = {
-                    currency: "<?= /* @noEscape */ $block->getStoreCurrencyCode(); ?>",
-                    items: [{
+
+                var items = [];
+                <?php if ($block->isGrouped()): ?>
+                    <?php foreach ($block->getGroupedProductChildren() as $childProduct):?>
+                        var childProductQty = getGroupedProductChildQty(<?= /* @noEscape */ $childProduct->getId(); ?>);
+                        if (childProductQty > 0) {
+                            items.push({
+                                reference: '<?= /* @noEscape */ $childProduct->getId(); ?>',
+                                price: '<?php echo $childProduct->getPrice() ?>',
+                                name: '<?= /* @noEscape */ addcslashes($childProduct->getName(), "'"); ?>',
+                                quantity: childProductQty,
+                                options: JSON.stringify(options)
+                            });
+                        }
+                    <?php endforeach; ?>
+                <?php else: ?>
+                    items.push({
                         reference: '<?= /* @noEscape */ $block->getProduct()->getId(); ?>',
                         price: itemPrice,
                         name: '<?= /* @noEscape */ addcslashes($block->getProduct()->getName(), "'"); ?>',
                         quantity: getQty(),
                         options: JSON.stringify(options)
-                    }]
+                    });
+                <?php endif; ?>
+
+                return items;
+            };
+
+            var setupProductPage = function () {
+                var cart = {
+                    currency: "<?= /* @noEscape */ $block->getStoreCurrencyCode(); ?>",
+                    items: getItemsData()
                 };
 
                 // if connect.js is not loaded postpone until it is
@@ -246,6 +274,7 @@ $additionalClass = $block->getAdditionalCheckoutButtonClass();
 
             setupProductPage();
             $('#qty').on('change', setupProductPage);
+            $('.table-wrapper.grouped .input-text.qty').on('change', setupProductPage);
 
             // Object holding the base item price
             // and price deltas for every custom option selected.


### PR DESCRIPTION
# Description
Currently, the product page checkout doesn’t work for the grouped product. This PR adds the ability to support it.
Here is the screenshot for testing - https://prnt.sc/u3nv9m

Fixes: https://boltpay.atlassian.net/browse/M2P-218

#changelog Support product page chekcout for grouped product

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
