### PR TITLE
M2P-222 Specify Bolt keys and Bolt signing secret as sensitive settings

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -250,4 +250,12 @@
                 type="Bolt\Boltpay\Plugin\Magento\Framework\Session\ValidatorPlugin"
                 sortOrder="1"/>
     </type>
+    <type name="Magento\Config\Model\Config\TypePool">
+        <arguments>
+            <argument name="sensitive" xsi:type="array">
+                <item name="payment/boltpay/api_key" xsi:type="string">1</item>
+                <item name="payment/boltpay/signing_secret" xsi:type="string">1</item>
+            </argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
# Description
This PR is to add the bolt keys into the sensitive setting for security reasons.
See screenshot for testing here: https://prnt.sc/u6rv8n

Reference link: https://devdocs.magento.com/guides/v2.4/extension-dev-guide/configuration/sensitive-and-environment-settings.html

Fixes: https://boltpay.atlassian.net/browse/M2P-222

#changelog M2P-222 Specify Bolt keys and Bolt signing secret as sensitive settings

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
