### PR TITLE
M2P-223 Use parent quote id as a fallback to get the existing order

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -830,7 +830,7 @@ class Order extends AbstractHelper
         ///////////////////////////////////////////////////////////////
 
         // check if the order exists
-        $order = $this->getExistingOrder($incrementId);
+        $order = $this->getExistingOrder($incrementId, $parentQuoteId);
 
         // if not create the order
         if (!$order || !$order->getId()) {
@@ -1255,12 +1255,21 @@ class Order extends AbstractHelper
 
     /**
      * @param $orderIncrementId
-     * @return OrderModel|false
+     * @param null $quoteId
+     * @return false|OrderInterface|OrderModel
      */
-    public function getExistingOrder($orderIncrementId)
+    public function getExistingOrder($orderIncrementId, $quoteId = null)
     {
         /** @var OrderModel $order */
-        return $this->cartHelper->getOrderByIncrementId($orderIncrementId, true);
+        $order = $this->cartHelper->getOrderByIncrementId($orderIncrementId, true);
+
+        // If we had timeout issue on the create_order hook and the third party change the order increment id
+        // then we use the parent quote id as a fallback to get existing order
+        if ($quoteId && (!$order || !$order->getId())) {
+            $order = $this->getOrderByQuoteId($quoteId);
+        }
+
+        return $order;
     }
 
     /**

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -4893,4 +4893,25 @@ class OrderTest extends TestCase
             ['cartTotalAmount' => 100, 'grandTotal' => 99.99, 'priceFaultTolerance' => 2],
         ];
     }
+
+    /**
+     * @test
+     *
+     * @covers ::getExistingOrder
+     *
+     * @throws ReflectionException
+     */
+    public function getExistingOrder_byParenQuoteId() {
+        $this->initCurrentMock(['getOrderByQuoteId']);
+        $this->cartHelper->expects(self::once())->method('getOrderByIncrementId')->with(self::INCREMENT_ID, true)
+            ->willReturn(null);
+        $this->currentMock->expects(self::once())->method('getOrderByQuoteId')->with(self::QUOTE_ID)
+            ->willReturn($this->orderMock);
+
+        static::assertSame(
+            $this->orderMock,
+            TestHelper::invokeMethod($this->currentMock, 'getExistingOrder', [self::INCREMENT_ID, self::QUOTE_ID])
+        );
+
+    }
 }


### PR DESCRIPTION
# Description
This PR resolves the following case by using the parent quote id to get the existing order

1. The customer clicks the Pay button in the Bolt modal
2. The create_order hook is sent to Magento and receives a time out error
3. There is a third party that updates the Magento increment id for the created order
4. Because of #2, there isn’t any successful response sent back to Bolt, so the Bolt increment id isn’t updated on Bolt
5. The pending hook is sent to Magento, it isn’t able to get the existing order by the Bolt increment id, so it tries to create the order and then it throws an exception

=> The expected behavior for #5 is that the pending hook is able to get the existing order to authorize and update the order

Fixes: https://boltpay.atlassian.net/browse/M2P-223

#changelog M2P-223 Use parent quote id as a fallback to get the existing order

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
