### PR TITLE
 M2P-226 Fix immutable_quote_id retriving in hook handling

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -949,12 +949,11 @@ class Order extends AbstractHelper
     /**
      * Save credit card information for logged-in customer based on their Bolt transaction reference and store id
      *
-     * @param $immutableQuoteId
      * @param $reference
      * @param $storeId
      * @return bool
      */
-    public function saveCustomerCreditCard($immutableQuoteId, $reference, $storeId)
+    public function saveCustomerCreditCard($reference, $storeId)
     {
         try {
             $transaction = $this->fetchTransactionInfo($reference, $storeId);
@@ -962,6 +961,8 @@ class Order extends AbstractHelper
             $quote = $this->cartHelper->getQuoteById($parentQuoteId);
 
             if (!$quote) {
+                // TODO(vitaliy): use helper in the next PR
+                $immutableQuoteId = @$transaction->order->cart->metadata->immutable_quote_id;
                 $quote = $this->cartHelper->getQuoteById($immutableQuoteId);
             }
 

--- a/Model/Api/OrderManagement.php
+++ b/Model/Api/OrderManagement.php
@@ -234,16 +234,6 @@ class OrderManagement implements OrderManagementInterface
             );
         }
 
-        if ($type === HookHelper::HT_CAPTURE && $this->decider->isIgnoreHookForInvoiceCreationEnabled()) {
-            $this->setSuccessResponse('Ignore the capture hook for the invoice creation');
-            return;
-        }
-
-        if ($type === HookHelper::HT_CREDIT && $this->decider->isIgnoreHookForCreditMemoCreationEnabled()) {
-            $this->setSuccessResponse('Ignore the credit hook for the credit memo creation');
-            return;
-        }
-
         if ($type === 'failed_payment' || $type === 'failed' || $type === 'rejected_irreversible') {
             $transaction = $this->orderHelper->fetchTransactionInfo($reference, $storeId);
             // TODO(vitaliy): use helper in the next PR
@@ -259,6 +249,16 @@ class OrderManagement implements OrderManagementInterface
                 $this->setSuccessResponse('Order was canceled due to declined payment: ' . $display_id);
                 return;
             }
+        }
+
+        if ($type === HookHelper::HT_CAPTURE && $this->decider->isIgnoreHookForInvoiceCreationEnabled()) {
+            $this->setSuccessResponse('Ignore the capture hook for the invoice creation');
+            return;
+        }
+
+        if ($type === HookHelper::HT_CREDIT && $this->decider->isIgnoreHookForCreditMemoCreationEnabled()) {
+            $this->setSuccessResponse('Ignore the credit hook for the credit memo creation');
+            return;
         }
 
         list(, $order) = $this->orderHelper->saveUpdateOrder(

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -4595,7 +4595,7 @@ class OrderTest extends TestCase
         $this->customerCreditCardFactory->expects(static::never())->method('create');
         $this->customerCreditCardFactory->expects(static::never())->method('saveCreditCard');
 
-        $result = $this->currentMock->saveCustomerCreditCard(self::DISPLAY_ID, OrderManagementTest::REFERENCE, OrderManagementTest::STORE_ID);
+        $result = $this->currentMock->saveCustomerCreditCard(OrderManagementTest::REFERENCE, OrderManagementTest::STORE_ID);
         $this->assertFalse($result);
     }
 
@@ -4630,6 +4630,8 @@ class OrderTest extends TestCase
         $transactionData->from_consumer->id = 1;
         $transactionData->from_credit_card->id = 1;
         $transactionData->order->cart->order_reference = self::QUOTE_ID;
+        $transactionData->order->cart->metadata = new \stdClass();
+        $transactionData->order->cart->metadata->immutable_quote_id = self::IMMUTABLE_QUOTE_ID;
 
         return $transactionData;
     }
@@ -4656,7 +4658,7 @@ class OrderTest extends TestCase
         $this->customerCreditCardFactory->expects(static::once())->method('create')->willReturnSelf();
         $this->customerCreditCardFactory->expects(static::once())->method('saveCreditCard')->willReturnSelf();
 
-        $result = $this->currentMock->saveCustomerCreditCard(self::DISPLAY_ID, OrderManagementTest::REFERENCE, OrderManagementTest::STORE_ID);
+        $result = $this->currentMock->saveCustomerCreditCard(OrderManagementTest::REFERENCE, OrderManagementTest::STORE_ID);
         $this->assertTrue($result);
     }
 
@@ -4684,7 +4686,7 @@ class OrderTest extends TestCase
         $this->customerCreditCardFactory->expects(static::once())->method('create')->willReturnSelf();
         $this->customerCreditCardFactory->expects(static::once())->method('saveCreditCard')->willReturnSelf();
 
-        $result = $this->currentMock->saveCustomerCreditCard(self::IMMUTABLE_QUOTE_ID, OrderManagementTest::REFERENCE, OrderManagementTest::STORE_ID);
+        $result = $this->currentMock->saveCustomerCreditCard(OrderManagementTest::REFERENCE, OrderManagementTest::STORE_ID);
         $this->assertTrue($result);
     }
 
@@ -4706,7 +4708,7 @@ class OrderTest extends TestCase
             ->willReturnOnConsecutiveCalls(null, null);
 
 
-        $result = $this->currentMock->saveCustomerCreditCard(self::IMMUTABLE_QUOTE_ID, OrderManagementTest::REFERENCE, OrderManagementTest::STORE_ID);
+        $result = $this->currentMock->saveCustomerCreditCard(OrderManagementTest::REFERENCE, OrderManagementTest::STORE_ID);
         $this->assertFalse($result);
     }
 
@@ -4732,7 +4734,7 @@ class OrderTest extends TestCase
         $this->customerCreditCardFactory->expects(static::once())->method('create')->willReturnSelf();
         $this->customerCreditCardFactory->expects(static::once())->method('saveCreditCard')->willThrowException(new \Exception());
 
-        $result = $this->currentMock->saveCustomerCreditCard(self::DISPLAY_ID, OrderManagementTest::REFERENCE, OrderManagementTest::STORE_ID);
+        $result = $this->currentMock->saveCustomerCreditCard(OrderManagementTest::REFERENCE, OrderManagementTest::STORE_ID);
         $this->assertFalse($result);
     }
 
@@ -4759,7 +4761,7 @@ class OrderTest extends TestCase
         $this->customerCreditCardFactory->expects(static::never())->method('create');
         $this->customerCreditCardFactory->expects(static::never())->method('saveCreditCard');
 
-        $result = $this->currentMock->saveCustomerCreditCard(self::DISPLAY_ID, OrderManagementTest::REFERENCE, OrderManagementTest::STORE_ID);
+        $result = $this->currentMock->saveCustomerCreditCard(OrderManagementTest::REFERENCE, OrderManagementTest::STORE_ID);
         $this->assertFalse($result);
     }
 

--- a/Test/Unit/Model/Api/OrderManagementTest.php
+++ b/Test/Unit/Model/Api/OrderManagementTest.php
@@ -126,7 +126,8 @@ class OrderManagementTest extends TestCase
                 'getStoreIdByQuoteId',
                 'tryDeclinedPaymentCancelation',
                 'deleteOrderByIncrementId',
-                'saveCustomerCreditCard'
+                'saveCustomerCreditCard',
+                'fetchTransactionInfo'
             ]
         );
         $this->logHelper = $this->createMock(LogHelper::class);
@@ -218,6 +219,16 @@ class OrderManagementTest extends TestCase
         );
     }
 
+    private function mockTransactionData()
+    {
+        $transactionData = new \stdClass();
+        $transactionData->order = new \stdClass();
+        $transactionData->order->cart = new \stdClass();
+        $transactionData->order->cart->metadata = new \stdClass();
+        $transactionData->order->cart->metadata->immutable_quote_id = self::QUOTE_ID;
+        return $transactionData;
+    }
+
     /**
      * @test
      * @depends manage_common
@@ -230,6 +241,8 @@ class OrderManagementTest extends TestCase
 
         $this->orderHelperMock->expects(self::once())->method('tryDeclinedPaymentCancelation')
             ->willReturn(true);
+        $this->orderHelperMock->expects(self::once())->method('fetchTransactionInfo')
+            ->willReturn($this->mockTransactionData());
         $this->response->expects(self::once())->method('setHttpResponseCode')->with(200);
         $this->response->expects(self::once())->method('setBody')->with(json_encode([
             'status' => 'success',
@@ -260,6 +273,8 @@ class OrderManagementTest extends TestCase
 
         $this->orderHelperMock->expects(self::once())->method('tryDeclinedPaymentCancelation')
             ->willReturn(false);
+        $this->orderHelperMock->expects(self::once())->method('fetchTransactionInfo')
+            ->willReturn($this->mockTransactionData());
         $this->request->expects(self::once())->method('getHeader')->with(ConfigHelper::BOLT_TRACE_ID_HEADER)
             ->willReturn(self::REQUEST_HEADER_TRACE_ID);
         $this->orderHelperMock->expects(self::once())->method('saveUpdateOrder')
@@ -309,6 +324,8 @@ class OrderManagementTest extends TestCase
             ->with(self::DISPLAY_ID)->willThrowException(
                 $exception
             );
+        $this->orderHelperMock->expects(self::once())->method('fetchTransactionInfo')
+            ->willReturn($this->mockTransactionData());
         $this->bugsnag->expects(self::once())->method('notifyException')->with($exception);
         $this->metricsClient->expects(self::once())->method('processMetric')
             ->with('webhooks.failure', 1, "webhooks.latency", self::anything());
@@ -345,6 +362,8 @@ class OrderManagementTest extends TestCase
 
         $this->orderHelperMock->expects(self::once())->method('deleteOrderByIncrementId')
             ->with(self::DISPLAY_ID);
+        $this->orderHelperMock->expects(self::once())->method('fetchTransactionInfo')
+            ->willReturn($this->mockTransactionData());
         $this->response->expects(self::once())->method('setHttpResponseCode')->with(200);
         $this->response->expects(self::once())->method('setBody')->with(json_encode([
             'status' => 'success',
@@ -389,6 +408,8 @@ class OrderManagementTest extends TestCase
 
         $this->orderHelperMock->expects(self::once())->method('deleteOrderByIncrementId')
             ->with(self::DISPLAY_ID)->willThrowException($exception);
+        $this->orderHelperMock->expects(self::once())->method('fetchTransactionInfo')
+            ->willReturn($this->mockTransactionData());
         $this->response->expects(self::once())->method('setHttpResponseCode')->with(422);
         $this->response->expects(self::once())->method('setBody')->with(json_encode([
             'status' => 'failure',
@@ -424,6 +445,8 @@ class OrderManagementTest extends TestCase
 
         $this->orderHelperMock->expects(self::once())->method('deleteOrderByIncrementId')
             ->with(self::DISPLAY_ID);
+        $this->orderHelperMock->expects(self::once())->method('fetchTransactionInfo')
+            ->willReturn($this->mockTransactionData());
         $this->response->expects(self::once())->method('setHttpResponseCode')->with(200);
         $this->response->expects(self::once())->method('setBody')->with(json_encode([
             'status' => 'success',
@@ -824,7 +847,7 @@ class OrderManagementTest extends TestCase
     {
         $type = "pending";
         $this->orderHelperMock->expects(self::once())->method('saveCustomerCreditCard')
-            ->with(self::QUOTE_ID, self::REFERENCE, self::STORE_ID)->willReturnSelf();
+            ->with(self::REFERENCE, self::STORE_ID)->willReturnSelf();
 
         $this->currentMock->manage(
             self::ID,


### PR DESCRIPTION
# Description
Fix issue we added recently around working with immutable_quote_id in hook handling.

Fixes: [M2P-226](https://boltpay.atlassian.net/browse/M2P-226) 

#changelog  M2P-226 Fix immutable_quote_id retriving in hook handling

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
