### PR TITLE
Compatibility fix for old versions of Mirasvit Store Credit plugin

### DIFF
--- a/Helper/Discount.php
+++ b/Helper/Discount.php
@@ -138,6 +138,11 @@ class Discount extends AbstractHelper
      * @var ThirdPartyModuleFactory
      */
     private $mirasvitStoreCreditCalculationConfig;
+    
+    /**
+     * @var ThirdPartyModuleFactory
+     */
+    protected $mirasvitStoreCreditCalculationConfigLegacy;
 
     /**
      * @var ThirdPartyModuleFactory
@@ -239,6 +244,7 @@ class Discount extends AbstractHelper
      * @param ThirdPartyModuleFactory $mirasvitStoreCreditHelper
      * @param ThirdPartyModuleFactory $mirasvitStoreCreditCalculationHelper
      * @param ThirdPartyModuleFactory $mirasvitStoreCreditCalculationConfig
+     * @param ThirdPartyModuleFactory $mirasvitStoreCreditCalculationConfigLegacy
      * @param ThirdPartyModuleFactory $mirasvitRewardsPurchaseHelper
      * @param ThirdPartyModuleFactory $mirasvitStoreCreditConfig
      * @param ThirdPartyModuleFactory $mageplazaGiftCardCollection
@@ -274,6 +280,7 @@ class Discount extends AbstractHelper
         ThirdPartyModuleFactory $mirasvitStoreCreditHelper,
         ThirdPartyModuleFactory $mirasvitStoreCreditCalculationHelper,
         ThirdPartyModuleFactory $mirasvitStoreCreditCalculationConfig,
+        ThirdPartyModuleFactory $mirasvitStoreCreditCalculationConfigLegacy,
         ThirdPartyModuleFactory $mirasvitStoreCreditConfig,
         ThirdPartyModuleFactory $mirasvitRewardsPurchaseHelper,
         ThirdPartyModuleFactory $mageplazaGiftCardCollection,
@@ -308,6 +315,7 @@ class Discount extends AbstractHelper
         $this->mirasvitStoreCreditHelper = $mirasvitStoreCreditHelper;
         $this->mirasvitStoreCreditCalculationHelper = $mirasvitStoreCreditCalculationHelper;
         $this->mirasvitStoreCreditCalculationConfig = $mirasvitStoreCreditCalculationConfig;
+        $this->mirasvitStoreCreditCalculationConfigLegacy = $mirasvitStoreCreditCalculationConfigLegacy;
         $this->mirasvitStoreCreditConfig = $mirasvitStoreCreditConfig;
         $this->mirasvitRewardsPurchaseHelper = $mirasvitRewardsPurchaseHelper;
         $this->mageplazaGiftCardCollection = $mageplazaGiftCardCollection;
@@ -802,6 +810,12 @@ class Discount extends AbstractHelper
         if (!$paymentOnly) {
             /** @var \Mirasvit\Credit\Api\Config\CalculationConfigInterface $miravitCalculationConfig */
             $miravitCalculationConfig = $this->mirasvitStoreCreditCalculationConfig->getInstance();
+            // For old version of Mirasvit Store Credit plugin,
+            // \Magento\Framework\ObjectManagerInterface can not create instance of \Mirasvit\Credit\Api\Config\CalculationConfigInterface properly,
+            // so we use \Mirasvit\Credit\Service\Config\CalculationConfig instead.
+            if (empty($miravitCalculationConfig)) {
+                $miravitCalculationConfig = $this->mirasvitStoreCreditCalculationConfigLegacy->getInstance();
+            }
             if ($miravitCalculationConfig->isTaxIncluded() || $miravitCalculationConfig->IsShippingIncluded()) {
                 return $miravitBalanceAmount;
             }

--- a/Test/Unit/Helper/DiscountTest.php
+++ b/Test/Unit/Helper/DiscountTest.php
@@ -138,6 +138,11 @@ class DiscountTest extends TestCase
      * @var MockObject|ThirdPartyModuleFactory mocked instance of the Mirasvit Store Credit calculation config model
      */
     private $mirasvitStoreCreditCalculationConfig;
+    
+    /**
+     * @var MockObject|ThirdPartyModuleFactory mocked instance of the Mirasvit Store Credit calculation config model
+     */
+    private $mirasvitStoreCreditCalculationConfigLegacy;
 
     /**
      * @var MockObject|ThirdPartyModuleFactory mocked instance of the Mirasvit Store Credit config model
@@ -254,6 +259,7 @@ class DiscountTest extends TestCase
         $this->mirasvitStoreCreditHelper = $this->createMock(ThirdPartyModuleFactory::class);
         $this->mirasvitStoreCreditCalculationHelper = $this->createMock(ThirdPartyModuleFactory::class);
         $this->mirasvitStoreCreditCalculationConfig = $this->createMock(ThirdPartyModuleFactory::class);
+        $this->mirasvitStoreCreditCalculationConfigLegacy = $this->createMock(ThirdPartyModuleFactory::class);
         $this->mirasvitStoreCreditConfig = $this->createMock(ThirdPartyModuleFactory::class);
         $this->mirasvitRewardsPurchaseHelper = $this->createMock(ThirdPartyModuleFactory::class);
         $this->mageplazaGiftCardCollection = $this->createMock(ThirdPartyModuleFactory::class);
@@ -309,6 +315,7 @@ class DiscountTest extends TestCase
                     $this->mirasvitStoreCreditHelper,
                     $this->mirasvitStoreCreditCalculationHelper,
                     $this->mirasvitStoreCreditCalculationConfig,
+                    $this->mirasvitStoreCreditCalculationConfigLegacy,
                     $this->mirasvitStoreCreditConfig,
                     $this->mirasvitRewardsPurchaseHelper,
                     $this->mageplazaGiftCardCollection,
@@ -362,6 +369,7 @@ class DiscountTest extends TestCase
             $this->mirasvitStoreCreditHelper,
             $this->mirasvitStoreCreditCalculationHelper,
             $this->mirasvitStoreCreditCalculationConfig,
+            $this->mirasvitStoreCreditCalculationConfigLegacy,
             $this->mirasvitStoreCreditConfig,
             $this->mirasvitRewardsPurchaseHelper,
             $this->mageplazaGiftCardCollection,
@@ -402,6 +410,11 @@ class DiscountTest extends TestCase
         static::assertAttributeEquals(
             $this->mirasvitStoreCreditCalculationConfig,
             'mirasvitStoreCreditCalculationConfig',
+            $instance
+        );
+        static::assertAttributeEquals(
+            $this->mirasvitStoreCreditCalculationConfigLegacy,
+            'mirasvitStoreCreditCalculationConfigLegacy',
             $instance
         );
         static::assertAttributeEquals($this->mirasvitStoreCreditConfig, 'mirasvitStoreCreditConfig', $instance);
@@ -2371,6 +2384,52 @@ class DiscountTest extends TestCase
 
         $mirasvitStoreCCCMock->expects(static::once())->method('getInstance')->willReturnSelf();
         $mirasvitStoreCCCMock->expects(static::once())->method('isTaxIncluded')->willReturn(true);
+
+        static::assertEquals(
+            $mirasvitBalanceAmount,
+            $this->currentMock->getMirasvitStoreCreditAmount($quoteMock, false)
+        );
+    }
+    
+    /**
+     * @test
+     * that getMirasvitStoreCreditAmount returns balance amount retrieved from with old version of Mirasvit Store Credit plugin
+     * {@see \Bolt\Boltpay\Helper\Discount::getMirasvitStoreCreditUsedAmount} if provided paymentOnly parameter is true
+     * and Mirasvit calculation tax is configured to be included
+     *
+     * @covers ::getMirasvitStoreCreditAmount
+     *
+     * @throws ReflectionException if unable to set internal mock properties
+     */
+    public function getMirasvitStoreCreditAmount_ifPaymentOnlyAndTaxIncludedWithLegency_returnsBalanceAmount()
+    {
+        $this->initCurrentMock(['getMirasvitStoreCreditUsedAmount']);
+        $quoteMock = $this->createPartialMock(
+            Quote::class,
+            ['getGrandTotal', 'getCreditAmountUsed', 'getTotals', 'getValue']
+        );
+        $mirasvitBalanceAmount = 100;
+        $this->currentMock->expects(static::once())
+            ->method('getMirasvitStoreCreditUsedAmount')
+            ->with($quoteMock)
+            ->willReturn($mirasvitBalanceAmount);
+
+        $mirasvitStoreCCCMock = $this->getMockBuilder(ThirdPartyModuleFactory::class)
+            ->setMethods(['getInstance'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        
+        $mirasvitStoreCCCLegencyMock = $this->getMockBuilder(ThirdPartyModuleFactory::class)
+            ->setMethods(['getInstance', 'isTaxIncluded', 'IsShippingIncluded'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        TestHelper::setProperty($this->currentMock, 'mirasvitStoreCreditCalculationConfig', $mirasvitStoreCCCMock);
+        TestHelper::setProperty($this->currentMock, 'mirasvitStoreCreditCalculationConfigLegacy', $mirasvitStoreCCCLegencyMock);
+
+        $mirasvitStoreCCCMock->expects(static::once())->method('getInstance')->willReturn(null);
+        $mirasvitStoreCCCLegencyMock->expects(static::once())->method('getInstance')->willReturnSelf();
+        $mirasvitStoreCCCLegencyMock->expects(static::once())->method('isTaxIncluded')->willReturn(true);
 
         static::assertEquals(
             $mirasvitBalanceAmount,

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -181,6 +181,13 @@
             <argument name="className" xsi:type="string">Mirasvit\Credit\Helper\Calculation</argument>
         </arguments>
     </virtualType>
+    <!-- For Mirasvit Store Credit Old versions -->
+    <virtualType name="boltMirasvitStoreCreditCalculationConfigLegacy" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
+        <arguments>
+            <argument name="moduleName" xsi:type="string">Mirasvit_Credit</argument>
+            <argument name="className" xsi:type="string">Mirasvit\Credit\Service\Config\CalculationConfig</argument>
+        </arguments>
+    </virtualType>
 
     <virtualType name="boltMirasvitStoreCreditCalculationConfig" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
         <arguments>
@@ -274,6 +281,7 @@
             <argument name="mirasvitStoreCreditHelper" xsi:type="object">boltMirasvitStoreCreditHelper</argument>
             <argument name="mirasvitStoreCreditCalculationHelper" xsi:type="object">boltMirasvitStoreCreditCalculationHelper</argument>
             <argument name="mirasvitStoreCreditCalculationConfig" xsi:type="object">boltMirasvitStoreCreditCalculationConfig</argument>
+            <argument name="mirasvitStoreCreditCalculationConfigLegacy" xsi:type="object">boltMirasvitStoreCreditCalculationConfigLegacy</argument>
             <argument name="mirasvitStoreCreditConfig" xsi:type="object">boltMirasvitStoreCreditConfig</argument>
             <argument name="mirasvitRewardsPurchaseHelper" xsi:type="object">boltMirasvitRewardsPurchaseHelper</argument>
             <argument name="mageplazaGiftCardCollection" xsi:type="object">boltMageplazaGiftCardCollection</argument>


### PR DESCRIPTION
# Description
The merchant `Andrew Christian B2C & Wholesale` use an old version of Mirasvit Store Credit plugin in their site, and the Bolt plugin can not create instance of \Mirasvit\Credit\Api\Config\CalculationConfigInterface properly with that version, so we need to fix this compatibility issue.

Fixes: (link Jira ticket)

#changelog Compatibility fix for old versions of Mirasvit Store Credit plugin

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
