### PR TITLE
Check display_id using in discount validation class

### DIFF
--- a/Model/Api/DiscountCodeValidation.php
+++ b/Model/Api/DiscountCodeValidation.php
@@ -251,13 +251,9 @@ class DiscountCodeValidation implements DiscountCodeValidationInterface
                 $displayId = isset($requestArray['cart']['display_id']) ? $requestArray['cart']['display_id'] : '';
                 // check if the cart / quote exists and it is active
                 try {
-                    // get parent quote id, order increment id and child quote id
-                    // the latter two are transmitted as display_id field, separated by " / "
-                    list($incrementId, $immutableQuoteId) = array_pad(
-                        explode(' / ', $displayId),
-                        2,
-                        null
-                    );
+                    $incrementId = $displayId;
+                    // TODO(vitaliy): use helper in the next PR
+                    $immutableQuoteId = @$requestArray['cart']['metadata']['immutable_quote_id'];
 
                     if (!$immutableQuoteId) {
                         $immutableQuoteId = $parentQuoteId;

--- a/Test/Unit/Model/Api/DiscountCodeValidationTest.php
+++ b/Test/Unit/Model/Api/DiscountCodeValidationTest.php
@@ -65,7 +65,7 @@ class DiscountCodeValidationTest extends TestCase
     const PARENT_QUOTE_ID = "1000";
     const IMMUTABLE_QUOTE_ID = "1001";
     const INCREMENT_ID = 100050001;
-    const DISPLAY_ID = self::INCREMENT_ID . ' / ' . self::IMMUTABLE_QUOTE_ID;
+    const DISPLAY_ID = self::INCREMENT_ID;
     const RULE_ID = 6;
     const COUPON_ID = 5;
     const WEBSITE_ID = 1;
@@ -705,7 +705,10 @@ class DiscountCodeValidationTest extends TestCase
         $requestContent = [
             'cart' => [
                 'order_reference' => self::PARENT_QUOTE_ID,
-                'display_id'      => self::DISPLAY_ID
+                'display_id'      => self::DISPLAY_ID,
+                'metadata'        => [
+                    'immutable_quote_id' => self::IMMUTABLE_QUOTE_ID,
+                ]
             ]
         ];
 
@@ -740,7 +743,10 @@ class DiscountCodeValidationTest extends TestCase
             'cart' => [
                 'order_reference' => self::PARENT_QUOTE_ID,
                 'display_id'      => self::DISPLAY_ID,
-                'discount_code'   => self::COUPON_CODE
+                'discount_code'   => self::COUPON_CODE,
+                'metadata'        => [
+                    'immutable_quote_id' => self::IMMUTABLE_QUOTE_ID,
+                ]
             ]
         ];
 
@@ -777,7 +783,10 @@ class DiscountCodeValidationTest extends TestCase
             'cart' => [
                 'order_reference' => self::PARENT_QUOTE_ID,
                 'display_id'      => self::DISPLAY_ID,
-                'discount_code'   => self::COUPON_CODE
+                'discount_code'   => self::COUPON_CODE,
+                'metadata'        => [
+                    'immutable_quote_id' => self::IMMUTABLE_QUOTE_ID,
+                ]
             ]
         ];
 
@@ -820,7 +829,10 @@ class DiscountCodeValidationTest extends TestCase
             'cart' => [
                 'order_reference' => self::PARENT_QUOTE_ID,
                 'display_id'      => self::DISPLAY_ID,
-                'discount_code'   => self::COUPON_CODE
+                'discount_code'   => self::COUPON_CODE,
+                'metadata'        => [
+                    'immutable_quote_id' => self::IMMUTABLE_QUOTE_ID,
+                ]
             ]
         ];
 
@@ -868,7 +880,10 @@ class DiscountCodeValidationTest extends TestCase
             'cart' => [
                 'order_reference' => self::PARENT_QUOTE_ID,
                 'display_id'      => self::DISPLAY_ID,
-                'discount_code'   => self::COUPON_CODE
+                'discount_code'   => self::COUPON_CODE,
+                'metadata'        => [
+                    'immutable_quote_id' => self::IMMUTABLE_QUOTE_ID,
+                ]
             ]
         ];
 
@@ -919,7 +934,10 @@ class DiscountCodeValidationTest extends TestCase
             'discount_code' => self::COUPON_CODE,
             'cart' => [
                 'order_reference' => self::PARENT_QUOTE_ID,
-                'display_id'      => self::DISPLAY_ID
+                'display_id'      => self::DISPLAY_ID,
+                'metadata'        => [
+                    'immutable_quote_id' => self::IMMUTABLE_QUOTE_ID,
+                ]
             ]
         ];
 
@@ -1019,7 +1037,10 @@ class DiscountCodeValidationTest extends TestCase
             'cart' => [
                 'order_reference' => self::PARENT_QUOTE_ID,
                 'display_id'      => self::DISPLAY_ID,
-                'discount_code'   => self::COUPON_CODE
+                'discount_code'   => self::COUPON_CODE,
+                'metadata'        => [
+                    'immutable_quote_id' => self::IMMUTABLE_QUOTE_ID,
+                ]
             ]
         ];
         $result = [
@@ -1100,7 +1121,10 @@ class DiscountCodeValidationTest extends TestCase
             'cart' => [
                 'order_reference' => self::PARENT_QUOTE_ID,
                 'display_id'      => self::DISPLAY_ID,
-                'discount_code'   => self::COUPON_CODE
+                'discount_code'   => self::COUPON_CODE,
+                'metadata'        => [
+                    'immutable_quote_id' => self::IMMUTABLE_QUOTE_ID,
+                ]
             ]
         ];
         $this->request->expects(self::atLeastOnce())->method('getContent')
@@ -1151,7 +1175,15 @@ class DiscountCodeValidationTest extends TestCase
      */
     public function validate_webhookPreProcessException()
     {
-        $requestContent = ['cart' => ['order_reference' => self::PARENT_QUOTE_ID, 'display_id' => self::DISPLAY_ID]];
+        $requestContent = [
+            'cart' => [
+                'order_reference' => self::PARENT_QUOTE_ID,
+                'display_id' => self::DISPLAY_ID,
+                'metadata'        => [
+                    'immutable_quote_id' => self::IMMUTABLE_QUOTE_ID,
+                ]
+            ]
+        ];
 
         $this->request->expects(self::atLeastOnce())->method('getContent')
             ->willReturn(json_encode($requestContent));
@@ -1185,7 +1217,15 @@ class DiscountCodeValidationTest extends TestCase
      */
     public function validate_validationException()
     {
-        $requestContent = ['cart' => ['order_reference' => self::PARENT_QUOTE_ID, 'display_id' => self::DISPLAY_ID]];
+        $requestContent = [
+            'cart' => [
+                'order_reference' => self::PARENT_QUOTE_ID,
+                'display_id' => self::DISPLAY_ID,
+                'metadata'        => [
+                    'immutable_quote_id' => self::IMMUTABLE_QUOTE_ID,
+                ]
+            ]
+        ];
 
         $this->request->expects(self::atLeastOnce())->method('getContent')
             ->willReturn(json_encode($requestContent));


### PR DESCRIPTION
Fix display_id using and immutable_quote_id retrieving after refactoring we did recently.
This bug didn't lead to any serious issues, because we use parent_id when we don't have immutable_quote_id

Fixes: (link Jira ticket)

#changelog Check display_id using in discount validation class

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
