### PR TITLE
EN-674 Ensure the returned order in the create_order hook is the latest updated order

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -432,6 +432,24 @@ class Cart extends AbstractHelper
     }
 
     /**
+     * Load Order by order id
+     *
+     * @param $orderId
+     * @return OrderInterface|mixed
+     */
+    public function getOrderById($orderId)
+    {
+        $searchCriteria = $this->searchCriteriaBuilder
+            ->addFilter('main_table.entity_id', $orderId)->create();
+
+        $collection = $this->orderRepository
+            ->getList($searchCriteria)
+            ->getItems();
+
+        return reset($collection);
+    }
+
+    /**
      * Save quote via repository
      *
      * @param CartInterface $quote

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -1095,7 +1095,8 @@ class Order extends AbstractHelper
     {
         /** @var OrderModel $order */
         $order = $this->quoteManagement->submit($quote);
-        if ($order === null) {
+
+        if (!$order) {
             $this->bugsnag->registerCallback(function ($report) use ($quote) {
                 $report->setMetaData([
                     'CREATE ORDER' => [
@@ -1115,6 +1116,21 @@ class Order extends AbstractHelper
                 CreateOrder::E_BOLT_GENERAL_ERROR
             );
         }
+        // When the create_order hook (thread 1) takes a lot of time to execute and returns a timeout, the authorize/payment hook (thread 2) is sent to Magento.
+        // It updates the order prior to the create_order hook (thread 1) process.
+        // This ensures that the returned order in the create_order hook is the latest updated order.
+        $existingOrder =  $this->cartHelper->getOrderById($order->getId());
+        $orderPayment = $existingOrder->getPayment();
+        if ($orderPayment && $orderPayment->getMethod() !== Payment::METHOD_CODE) {
+            throw new LocalizedException(__(
+                'Payment method assigned to order %1 is: %2',
+                $order->getIncrementId(),
+                $orderPayment->getMethod()
+            ));
+        }
+
+        $order = $existingOrder;
+
         $order->addStatusHistoryComment(
             "BOLTPAY INFO :: This order was created via Bolt Pre-Auth Webhook"
         );

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -2403,6 +2403,28 @@ ORDER
         }
 
         /**
+         * @test
+         */
+        public function getOrderById()
+        {
+            $orderId = 1;
+
+            $searchCriteria = $this->createMock(\Magento\Framework\Api\SearchCriteria::class);
+
+            $this->searchCriteriaBuilder->expects($this->once())->method('addFilter')->with('main_table.entity_id', $orderId)->willReturnSelf();
+            $this->searchCriteriaBuilder->expects($this->once())->method('create')->willReturn($searchCriteria);
+
+            $orderInterface = $this->createMock(\Magento\Sales\Api\Data\OrderInterface::class);
+            $orderInterface2 = $this->createMock(\Magento\Sales\Api\Data\OrderInterface::class);
+            $collection = [$orderInterface, $orderInterface2];
+            $orderSearchResultInterface = $this->createMock(\Magento\Sales\Api\Data\OrderSearchResultInterface::class);
+            $orderSearchResultInterface->expects($this->once())->method('getItems')->willReturn($collection);
+
+            $this->orderRepository->expects($this->once())->method('getList')->with($searchCriteria)->willReturn($orderSearchResultInterface);
+            $this->assertSame($orderInterface, $this->currentMock->getOrderById($orderId));
+        }
+
+        /**
         * @test
         * that getBoltpayOrder creates new Bolt order when cache is enabled but current cart cannot be loaded
         *

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -374,6 +374,7 @@ class OrderTest extends TestCase
                 'getCartData',
                 'getOrderByQuoteId',
                 'validateEmail',
+                'getOrderById'
             ])
             ->getMock();
 
@@ -1843,6 +1844,12 @@ class OrderTest extends TestCase
         $transaction = new stdClass();
         $this->quoteManagement->expects(self::once())->method('submit')
             ->with($this->quoteMock)->willReturn($this->orderMock);
+        $this->orderMock->method('getId')->willReturn(self::ORDER_ID);
+        $paymentMock = $this->createMock(OrderPaymentInterface::class);
+        $paymentMock->expects(self::any())->method('getMethod')->willReturn(Payment::METHOD_CODE);
+        $this->orderMock->expects(self::once())->method('getPayment')->willReturn($paymentMock);
+        $this->cartHelper->expects(self::once())->method('getOrderById')->with(self::ORDER_ID)->willReturn($this->orderMock);
+
         $this->orderMock->expects(self::once())->method('addStatusHistoryComment')
             ->with('BOLTPAY INFO :: This order was created via Bolt Pre-Auth Webhook');
         $this->currentMock->expects(self::once())->method('orderPostprocess')
@@ -1851,6 +1858,27 @@ class OrderTest extends TestCase
             $this->currentMock->processNewOrder($this->quoteMock, $transaction),
             $this->orderMock
         );
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::processNewOrder
+     */
+    public function processNewOrder_withNonBoltOrder()
+    {
+        $transaction = new stdClass();
+        $this->quoteManagement->expects(self::once())->method('submit')
+            ->with($this->quoteMock)->willReturn($this->orderMock);
+        $this->orderMock->method('getId')->willReturn(self::ORDER_ID);
+        $this->orderMock->method('getIncrementId')->willReturn(self::INCREMENT_ID);
+        $paymentMock = $this->createMock(OrderPaymentInterface::class);
+        $paymentMock->expects(self::any())->method('getMethod')->willReturn('paypal');
+        $this->orderMock->expects(self::once())->method('getPayment')->willReturn($paymentMock);
+        $this->cartHelper->expects(self::once())->method('getOrderById')->with(self::ORDER_ID)->willReturn($this->orderMock);
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage('Payment method assigned to order 1234 is: paypal');
+        $this->currentMock->processNewOrder($this->quoteMock, $transaction);
     }
 
     /**


### PR DESCRIPTION
# Description
This PR resolves the following case:
1. The customer clicked the Pay button on the Bolt modal
2. The create_order hook (thread 1) was sent to Magento and received a timeout response because **$this->quoteManagement->submit($quote);** took a long time to run. See here - https://prnt.sc/u97pim . The order was created with the status of Pending Payment, and the create_hook process was still running.
3. The authorize/payment hook (thread 2) was sent to Magento to update the order state to processing.
4. The create_order hook (thread 1) updated the order state to pending payment.

This PR fixes the above case by ensuring the returned order in the create_order hook is the latest updated order to prevent #4 from happening.

Fixes: https://boltpay.atlassian.net/browse/EN-674

#changelog Ensure the returned order in the create_order hook is the latest updated order

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
