### PR TITLE
M2P-226 Add backward compatibility for order_reference refactoring

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -805,8 +805,8 @@ class Order extends AbstractHelper
         $incrementId = isset($transaction->order->cart->display_id) ?
             $transaction->order->cart->display_id :
             null;
-        $quoteId = isset($transaction->order->cart->metadata->immutable_quote_id) ?
-            $transaction->order->cart->metadata->immutable_quote_id :
+        $quoteId = isset($transaction->order) ?
+            $this->cartHelper->getImmutableQuoteIdFromBoltOrder($transaction->order) :
             null;
 
         if (!$quoteId) {
@@ -1556,8 +1556,8 @@ class Order extends AbstractHelper
         $incrementId = isset($transaction->order->cart->display_id) ?
             $transaction->order->cart->display_id :
             null;
-        $quoteId = isset($transaction->order->cart->metadata->immutable_quote_id) ?
-            $transaction->order->cart->metadata->immutable_quote_id :
+        $quoteId = isset($transaction->order) ?
+            $this->cartHelper->getImmutableQuoteIdFromBoltOrder($transaction->order) :
             null;
 
         if (!$quoteId) {

--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -374,7 +374,7 @@ class ShippingMethods implements ShippingMethodsInterface
         $startTime = $this->metricsClient->getCurrentTime();
         try {
             // get immutable quote id stored with transaction
-            $quoteId = isset($cart['metadata']['immutable_quote_id']) ? $cart['metadata']['immutable_quote_id'] : '';
+            $quoteId = $this->cartHelper->getImmutableQuoteIdFromBoltCartArray($cart);
 
             // Load quote from entity id
             $this->quote = $this->getQuoteById($quoteId);

--- a/Model/Api/ShippingTax.php
+++ b/Model/Api/ShippingTax.php
@@ -309,7 +309,7 @@ abstract class ShippingTax
         $this->logHelper->addInfoLog(file_get_contents('php://input'));
         try {
             // get immutable quote id stored with transaction
-            $immutableQuoteId = isset($cart['metadata']['immutable_quote_id']) ? $cart['metadata']['immutable_quote_id'] : '';
+            $immutableQuoteId = $this->cartHelper->getImmutableQuoteIdFromBoltCartArray($cart);
             // Load immutable quote from entity id
             $immutableQuote = $this->loadQuote($immutableQuoteId);
 

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -1352,22 +1352,19 @@ class CartTest extends BoltTestCase
      */
     public function getImmutableQuoteIdFromBoltOrder_always_returnsImmutableQuote()
     {
-        $responseMock = $this->createPartialMock(Response::class, ['getResponse']);
-        $responseMock->expects(static::once())->method('getResponse')->willReturn(
-            (object)[
-                'cart' => (object)[
-                    'metadata' => (object)[
-                        'immutable_quote_id' => self::IMMUTABLE_QUOTE_ID
-                    ]
+        $boltOrder = (object)[
+            'cart' => (object)[
+                'metadata' => (object)[
+                    'immutable_quote_id' => self::IMMUTABLE_QUOTE_ID
                 ]
             ]
-        );
+        ];
         static::assertEquals(
             self::IMMUTABLE_QUOTE_ID,
             TestHelper::invokeMethod(
                 $this->currentMock,
                 'getImmutableQuoteIdFromBoltOrder',
-                [$responseMock]
+                [$boltOrder]
             )
         );
     }
@@ -2470,7 +2467,7 @@ ORDER
         $currentMock->expects(static::once())->method('getCartCacheIdentifier')->willReturn(self::CACHE_IDENTIFIER);
         $currentMock->expects(static::once())->method('loadFromCache')->with(self::CACHE_IDENTIFIER)
             ->willReturn($boltOrder);
-        $currentMock->expects(static::once())->method('getImmutableQuoteIdFromBoltOrder')->with($boltOrder)
+        $currentMock->expects(static::once())->method('getImmutableQuoteIdFromBoltOrder')->with($boltOrder->getResponse())
             ->willReturn(self::IMMUTABLE_QUOTE_ID);
         $currentMock->expects(static::once())->method('isQuoteAvailable')->with(self::IMMUTABLE_QUOTE_ID)
             ->willReturn(true);
@@ -2505,7 +2502,7 @@ ORDER
         $currentMock->expects(static::once())->method('getCartCacheIdentifier')->willReturn(self::CACHE_IDENTIFIER);
         $currentMock->expects(static::once())->method('loadFromCache')->with(self::CACHE_IDENTIFIER)
             ->willReturn($boltOrder);
-        $currentMock->expects(static::once())->method('getImmutableQuoteIdFromBoltOrder')->with($boltOrder)
+        $currentMock->expects(static::once())->method('getImmutableQuoteIdFromBoltOrder')->with($boltOrder->getResponse())
             ->willReturn(self::IMMUTABLE_QUOTE_ID);
         $currentMock->expects(static::once())->method('isQuoteAvailable')->with(self::IMMUTABLE_QUOTE_ID)->willReturn(
             false

--- a/Test/Unit/Model/Api/ShippingTaxTest.php
+++ b/Test/Unit/Model/Api/ShippingTaxTest.php
@@ -596,6 +596,7 @@ class ShippingTaxTest extends TestCase
             ->with(ShippingTax::METRICS_FAILURE_KEY, 1, ShippingTax::METRICS_LATENCY_KEY, $startTime);
 
         $this->expectErrorResponse($e->getCode(), $e->getMessage(), $e->getHttpCode());
+        $this->cartHelper->method('getImmutableQuoteIdFromBoltCartArray')->with($cart)->willReturn(self::IMMUTABLE_QUOTE_ID);
         $this->assertNull($this->currentMock->execute($cart, []));
     }
 
@@ -643,6 +644,8 @@ class ShippingTaxTest extends TestCase
             ->with(TestHelper::getProperty($this->currentMock, 'quote'));
         $this->cartHelper->expects(self::once())->method('handleSpecialAddressCases')
             ->with($shipping_address)->willReturn($shipping_address);
+        $this->cartHelper->method('getImmutableQuoteIdFromBoltCartArray')
+            ->with($cart)->willReturn(self::IMMUTABLE_QUOTE_ID);
 
         $e = new BoltException(
             __('Invalid email: %1', 'invalid email'),
@@ -730,6 +733,8 @@ class ShippingTaxTest extends TestCase
             ->with($shipping_address)->willReturn($shipping_address);
         $this->cartHelper->expects(self::once())->method('validateEmail')
             ->with(self::EMAIL)->willReturn(true);
+        $this->cartHelper->method('getImmutableQuoteIdFromBoltCartArray')
+            ->with($cart)->willReturn(self::IMMUTABLE_QUOTE_ID);
         $this->currentMock->expects(self::once())->method('getResult')
             ->with($shipping_address, $shipping_option);
         $this->logHelper->expects(self::exactly(4))->method('addInfoLog');


### PR DESCRIPTION
# Description
Allow users to finish checkout if the order was created in the previous plugin version.

Fixes: [M2P-226](https://boltpay.atlassian.net/browse/M2P-226)

#changelog M2P-226 Add backward compatibility for order_reference refactoring

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
