### PR TITLE
Fix update_order after display_id refactoring

### DIFF
--- a/Model/Api/UpdateCart.php
+++ b/Model/Api/UpdateCart.php
@@ -94,15 +94,10 @@ class UpdateCart extends UpdateCartCommon implements UpdateCartInterface
         try {
             $this->cartRequest = $cart;
             
-            // TODO the display_id will be updated in this PR https://github.com/BoltApp/bolt-magento2/pull/863, and we need to adjust per change
-            list($incrementId, $immutableQuoteId) = array_pad(
-                explode(' / ', $cart['display_id']),
-                2,
-                null
-            );
-            $parentQuoteId = $cart['order_reference'];
+            // Bolt server sends immutableQuoteId as order reference
+            $immutableQuoteId = $cart['order_reference'];
             
-            $result = $this->validateQuote($parentQuoteId, $immutableQuoteId, $incrementId);
+            $result = $this->validateQuote($immutableQuoteId);
             
             if(!$result){
                 // Already sent a response with error, so just return.

--- a/Model/Api/UpdateCartCommon.php
+++ b/Model/Api/UpdateCartCommon.php
@@ -120,7 +120,7 @@ abstract class UpdateCartCommon
             if (!$immutableQuote) {
                 $this->sendErrorResponse(
                     BoltErrorResponse::ERR_INSUFFICIENT_INFORMATION,
-                    sprintf('The cart reference [%s] is not found.', $immutableQuoteId),
+                    sprintf('The cart reference [%s] cannot be found.', $immutableQuoteId),
                     404
                 );
                 return false;
@@ -131,11 +131,11 @@ abstract class UpdateCartCommon
             if(empty($parentQuoteId)) {
                 $this->bugsnag->notifyError(
                     BoltErrorResponse::ERR_INSUFFICIENT_INFORMATION,
-                    'Parent quote is not exist'
+                    'Parent quote does not exist'
                 );
                 $this->sendErrorResponse(
                     BoltErrorResponse::ERR_INSUFFICIENT_INFORMATION,
-                    'Parent quote is not exist',
+                    'Parent quote does not exist',
                     404
                 );
                 return false;
@@ -153,7 +153,7 @@ abstract class UpdateCartCommon
             if ($this->orderHelper->getExistingOrder(null, $parentQuoteId)) {
                 $this->sendErrorResponse(
                     BoltErrorResponse::ERR_INSUFFICIENT_INFORMATION,
-                    sprintf('The order by quote #%s has already been created ', $parentQuoteId),
+                    sprintf('The order with quote #%s has already been created ', $parentQuoteId),
                     422
                 );
                 return false;

--- a/Test/Unit/Model/Api/UpdateCartTest.php
+++ b/Test/Unit/Model/Api/UpdateCartTest.php
@@ -49,8 +49,6 @@ class UpdateCartTest extends TestCase
 {
     const PARENT_QUOTE_ID = "1000";
     const IMMUTABLE_QUOTE_ID = "1001";
-    const INCREMENT_ID = '100050001';
-    const DISPLAY_ID = self::INCREMENT_ID . ' / ' . self::IMMUTABLE_QUOTE_ID;
     const RULE_ID = 6;
     const COUPON_ID = 5;
     const WEBSITE_ID = 1;
@@ -319,8 +317,8 @@ class UpdateCartTest extends TestCase
     private function getRequestCart()
     {        
         $request_cart = [
-            'order_reference' => self::PARENT_QUOTE_ID,
-            'display_id'  => self::DISPLAY_ID,
+            'order_reference' => self::IMMUTABLE_QUOTE_ID,
+            'display_id'  => '',
             'shipments' => [
                 0 => $this->getShipments(),
             ],
@@ -338,7 +336,7 @@ class UpdateCartTest extends TestCase
     {
         return [
             'order_reference' => self::PARENT_QUOTE_ID,
-            'display_id' => self::DISPLAY_ID,
+            'display_id' => '',
             'currency' => 'USD',
             'total_amount' => 50500,
             'tax_amount' => 1000,            
@@ -421,7 +419,7 @@ class UpdateCartTest extends TestCase
         $this->initCurrentMock(['validateQuote']);
         
         $this->currentMock->expects(self::once())->method('validateQuote')
-            ->with(self::PARENT_QUOTE_ID, self::IMMUTABLE_QUOTE_ID, self::INCREMENT_ID)
+            ->with(self::IMMUTABLE_QUOTE_ID)
             ->willReturn(false);
         
         $requestCart = $this->getRequestCart();
@@ -463,7 +461,7 @@ class UpdateCartTest extends TestCase
         $immutableQuoteMock = $this->getQuoteMock();
         
         $this->currentMock->expects(self::once())->method('validateQuote')
-            ->with(self::PARENT_QUOTE_ID, self::IMMUTABLE_QUOTE_ID, self::INCREMENT_ID)
+            ->with(self::IMMUTABLE_QUOTE_ID)
             ->willReturn([$parentQuoteMock,$immutableQuoteMock]);
             
         $this->currentMock->expects(self::once())->method('preProcessWebhook')
@@ -557,7 +555,7 @@ class UpdateCartTest extends TestCase
         $immutableQuoteMock = $this->getQuoteMock();
         
         $this->currentMock->expects(self::once())->method('validateQuote')
-            ->with(self::PARENT_QUOTE_ID, self::IMMUTABLE_QUOTE_ID, self::INCREMENT_ID)
+            ->with(self::IMMUTABLE_QUOTE_ID)
             ->willReturn([$parentQuoteMock,$immutableQuoteMock]);
             
         $this->currentMock->expects(self::once())->method('preProcessWebhook')
@@ -628,7 +626,7 @@ class UpdateCartTest extends TestCase
         $this->currentMock->expects(self::never())->method('getQuoteCart');
             
         $this->currentMock->expects(self::once())->method('validateQuote')
-            ->with(self::PARENT_QUOTE_ID, self::IMMUTABLE_QUOTE_ID, self::INCREMENT_ID)
+            ->with(self::IMMUTABLE_QUOTE_ID)
             ->willReturn([$parentQuoteMock,$immutableQuoteMock]);
 
         $this->currentMock->expects(self::once())->method('preProcessWebhook')


### PR DESCRIPTION
Address changes we did with bolt cart:
- we can't use reserved order id anymore
- in update_order call bolt server sends immutable quote id as order_reference

Fixes: (link Jira ticket)

#changelog Fix update_order after display_id refactoring

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
