### PR TITLE
Increase memory limit for unit tests

### DIFF
--- a/Test/scripts/ci-unit.sh
+++ b/Test/scripts/ci-unit.sh
@@ -19,5 +19,5 @@ mkdir -p project
 cp magento/app/code/Bolt/Boltpay/composer.json project/composer.json
 cp magento/app/code/Bolt/Boltpay/Test/Unit/phpunit.xml magento/dev/tests/unit/bolt_phpunit.xml
 echo "Starting Bolt Unit Tests"
-php magento/vendor/phpunit/phpunit/phpunit --verbose -c magento/dev/tests/unit/bolt_phpunit.xml --coverage-clover=./artifacts/coverage.xml
+php magento/vendor/phpunit/phpunit/phpunit -dmemory_limit=5G --verbose -c magento/dev/tests/unit/bolt_phpunit.xml --coverage-clover=./artifacts/coverage.xml
 bash <(curl -s https://bolt-devops.s3-us-west-2.amazonaws.com/testing/codecov_uploader) -f ./artifacts/coverage.xml -F $TEST_ENV

--- a/Test/scripts/ci-unit.sh
+++ b/Test/scripts/ci-unit.sh
@@ -19,5 +19,5 @@ mkdir -p project
 cp magento/app/code/Bolt/Boltpay/composer.json project/composer.json
 cp magento/app/code/Bolt/Boltpay/Test/Unit/phpunit.xml magento/dev/tests/unit/bolt_phpunit.xml
 echo "Starting Bolt Unit Tests"
-php magento/vendor/phpunit/phpunit/phpunit -dmemory_limit=5G --verbose -c magento/dev/tests/unit/bolt_phpunit.xml --coverage-clover=./artifacts/coverage.xml
+php magento/vendor/phpunit/phpunit/phpunit -d memory_limit=5G --verbose -c magento/dev/tests/unit/bolt_phpunit.xml --coverage-clover=./artifacts/coverage.xml
 bash <(curl -s https://bolt-devops.s3-us-west-2.amazonaws.com/testing/codecov_uploader) -f ./artifacts/coverage.xml -F $TEST_ENV


### PR DESCRIPTION
# Description
For now memory limit for unit tests is 128MB. Consumed memory grows linearly with the number of tests and recently we crossed this threshold for PHP 7.2

Fixes: (link Jira ticket)

#changelog Increase memory limit for unit tests

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
