### PR TITLE
M2P-233 Check if previous page updated bolt cart properly

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -201,6 +201,7 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
 
     var expectCartRendering = true;
     var waitingForResolvingPromises = false;
+    var skipNextBoltCartUpdate = false;
 
     ////////////////////////////////////////////////////
     // DI: Inserting required Magento objects
@@ -666,6 +667,12 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
         }
 
         var callConfigureWithPromises = function() {
+            // Set the flag in case bolt cart updating will not be finished
+            // because page loading breaks
+            // We check the flag when next page is loaded
+            if (localStorage) {
+                localStorage.setItem("bolt_cart_is_updating", "true");
+            }
             if (waitingForResolvingPromises) {
                 return;
             }
@@ -875,7 +882,19 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
                         boltCheckoutConfigure(cart, hintBarrier.promise, callbacks);
                 });
             } else {
+                // If flag set it means the previous page didn't update bolt cart properly
+                // Magento continue cart updating now and we know that bolt cart isn't actual
+                if (localStorage && localStorage.getItem("bolt_cart_is_updating") == "true") {
+                    skipNextBoltCartUpdate = true;
+                }
             customerData.get('boltcart').subscribe(function(data) {
+                if (localStorage) {
+                    localStorage.setItem("bolt_cart_is_updating", "false");
+                }
+                if (skipNextBoltCartUpdate) {
+                    skipNextBoltCartUpdate = false;
+                    return;
+                }
                 boltCartDataID = data.data_id;
 
                 cart = data.cart !== undefined ? data.cart : {};


### PR DESCRIPTION
Fix for version 2.13.0, the same as in https://github.com/BoltApp/bolt-magento2/pull/917

**Steps to reproduce a bug:**
- go to the product page
- click add to cart and go to cart page very fast (it happens if Magento redirects to the cart page or just user click very fast)
- on the cart page click bolt button right after it appears.

**Actual behavior**
User sees unactual cart on bolt modal (or even error if the cart was empty before adding to cart)

To fix this we need to set a flag in local storage when updating the cart is started and remove it when the new bolt cart is delivered.
 If we see the flag on the page loading it means the previous page didn't finish updating and current bolt cart is unactual.

Fixes: [M2P-233](https://boltpay.atlassian.net/browse/M2P-233)

#changelog M2P-233 Check if previous page updated bolt cart properly

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
