### PR TITLE
M2P-239 Create the missing Bugsnag property for class Bolt\Boltpay\ThirdPartyModules\Aheadworks\Giftcard

### DIFF
--- a/ThirdPartyModules/Aheadworks/Giftcard.php
+++ b/ThirdPartyModules/Aheadworks/Giftcard.php
@@ -17,6 +17,7 @@
 
 namespace Bolt\Boltpay\ThirdPartyModules\Aheadworks;
 
+use Bolt\Boltpay\Helper\Bugsnag;
 use Bolt\Boltpay\Helper\Shared\CurrencyUtils;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Sales\Model\Service\OrderService;
@@ -29,14 +30,28 @@ class Giftcard
     private $orderService;
 
     /**
+     * @var Bugsnag
+     */
+    private $bugsnagHelper;
+
+    /**
      * @param OrderService $orderService Magento order service instance
+     * @param Bugsnag $bugsnagHelper Bugsnag helper instance
      */
     public function __construct(
-        OrderService $orderService
+        OrderService $orderService,
+        Bugsnag $bugsnagHelper
     ) {
         $this->orderService = $orderService;
+        $this->bugsnagHelper = $bugsnagHelper;
     }
 
+    /**
+     * @param $result
+     * @param $aheadworksGiftcardManagement
+     * @param $quote
+     * @return array
+     */
     public function collectDiscounts($result, $aheadworksGiftcardManagement, $quote)
     {
         list ($discounts, $totalAmount, $diff) = $result;
@@ -59,6 +74,13 @@ class Giftcard
         }
     }
 
+    /**
+     * @param $result
+     * @param $aheadworksGiftcardRepository
+     * @param $code
+     * @param $storeId
+     * @return null
+     */
     public function loadGiftcard($result, $aheadworksGiftcardRepository, $code, $storeId)
     {
         if (!empty($result)) {
@@ -72,6 +94,15 @@ class Giftcard
         return null;
     }
 
+    /**
+     * @param $result
+     * @param $aheadworksGiftcardManagement
+     * @param $code
+     * @param $giftCard
+     * @param $immutableQuote
+     * @param $parentQuote
+     * @return array|null
+     */
     public function applyGiftcard($result, $aheadworksGiftcardManagement, $code, $giftCard, $immutableQuote, $parentQuote)
     {
         if (!empty($result)) {


### PR DESCRIPTION


# Description
Current, the Bugsnag property is missing in class Bolt\Boltpay\ThirdPartyModules\Aheadworks\Giftcard and it's not logging the exception to Bugsnag. See here - https://prnt.sc/udu0cv

This PR creates the missing Bugsnag property for class Bolt\Boltpay\ThirdPartyModules\Aheadworks\Giftcard

Fixes: https://boltpay.atlassian.net/browse/M2P-239

#changelog M2P-239 Create the missing Bugsnag property for class Bolt\Boltpay\ThirdPartyModules\Aheadworks\Giftcard

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
