### PR TITLE
Bugfix: collect Mirasvit store credit only if the quote has used credits

### DIFF
--- a/ThirdPartyModules/Mirasvit/Credit.php
+++ b/ThirdPartyModules/Mirasvit/Credit.php
@@ -17,12 +17,15 @@
 
 namespace Bolt\Boltpay\ThirdPartyModules\Mirasvit;
 
+use Bolt\Boltpay\Model\Payment;
 use Bolt\Boltpay\Helper\Bugsnag;
 use Bolt\Boltpay\Helper\Discount;
 use Bolt\Boltpay\Helper\Shared\CurrencyUtils;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Sales\Model\Service\OrderService;
 use Magento\Framework\App\State;
+use Magento\Backend\App\Area\FrontNameResolver;
+use Magento\Framework\Event\Observer;
 
 class Credit
 {


### PR DESCRIPTION
# Description
When creating the Bolt cart, it should collect Mirasvit store credit only if the quote has used credits.

Fixes: (link Jira ticket)

#changelog Bugfix: collect Mirasvit store credit only if the quote has used credits

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
