### PR TITLE
Split shipping_and_tax logic into helper [MA-85]

### DIFF
--- a/Test/Unit/Model/Api/ShippingMethodsTest.php
+++ b/Test/Unit/Model/Api/ShippingMethodsTest.php
@@ -348,7 +348,9 @@ class ShippingMethodsTest extends TestCase
         $this->initCurrentMock(['catchExceptionAndSendError']);
 
         $exception =  new BoltException(
-            __('Unknown quote id: %1.', self::IMMUTABLE_QUOTE_ID)
+            __('Unknown quote id: %1.', self::IMMUTABLE_QUOTE_ID),
+            null,
+            6103
         );
 
         $this->currentMock->expects(self::once())->method('catchExceptionAndSendError')


### PR DESCRIPTION
# Description
Move the core logic to get the shipping_and_tax information into a helper function. This will be useful when we we switch over to the Universal API. 

Fixes: https://boltpay.atlassian.net/browse/MA-85?atlOrigin=eyJpIjoiNTkyYTM1NTYwN2Q2NGRlMDhmMTAzMGM1OWIyNzU1YjEiLCJwIjoiaiJ9

#changelog Split shipping_and_tax logic into helper

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
