### PR TITLE
M2P-250 Don't generate notice if display_id does not contain "/"

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -712,7 +712,10 @@ class Cart extends AbstractHelper
             } else {
                 // check if cart was created in plugin version before 2.14.0
                 if (isset($response->cart->display_id)) {
-                 list(, $immutableQuoteId) = explode(' / ', $response->cart->display_id);
+                    $result = explode(' / ', $response->cart->display_id);
+                    if (count($result) == 2) {
+                        list(, $immutableQuoteId) = $result;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Steps to reproduce:
- add product to cart with bolt version 2.13.0
- finish checkout with version 2.14.0-rc2

Actual behavior:
Order is created but stuck in pending status

Fixes: [M2P-250](https://boltpay.atlassian.net/browse/M2P-250)

#changelog M2P-250 Don't generate notice if display_id does not contain "/"

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
