### PR TITLE
[MA-85] Move core logic of split shipping/tax to helper fn

### DIFF
--- a/Model/Api/ShippingTax.php
+++ b/Model/Api/ShippingTax.php
@@ -333,7 +333,7 @@ abstract class ShippingTax
      * @return ShippingTaxDataInterface
      * @throws BoltException
      */
-    public function handleRequest($cart, $shipping_address, $shipping_option)
+    public function handleRequest($cart = null, $shipping_address = null, $shipping_option = null)
     {
         // get immutable quote id stored with transaction
         $immutableQuoteId = $this->cartHelper->getImmutableQuoteIdFromBoltCartArray($cart);


### PR DESCRIPTION
# Description

Move core logic of split shipping/tax to helper fn. This will be useful when we implement the UniveralMerchantAPI. 

Fixes: https://boltpay.atlassian.net/browse/MA-85?atlOrigin=eyJpIjoiMzRhZTE3Y2UxYzEwNGE1NGI3MTUwZjdiZDFmMGQyZDIiLCJwIjoiaiJ9

#changelog [MA-85] Move core logic of split shipping/tax to helper fn

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
