### PR TITLE
[MA-87] Move cart_create logic to helper fn

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -2295,18 +2295,31 @@ class Cart extends AbstractHelper
      */
     public function createCartByRequest($request)
     {
+        return $this->createCart($request['items'], $request['metadata']);
+    }
+
+
+    /**
+     * Create a cart with the provided items
+     * @param $items - cart items
+     * @param $metadata - cart metadata
+     * @return array cart_data in bolt format
+     * @throws BoltException
+     */
+    public function createCart($items, $metadata = null)
+    {
         $quoteId = $this->quoteManagement->createEmptyCart();
         $quote = $this->quoteFactory->create()->load($quoteId);
 
         $quote->setBoltParentQuoteId($quoteId);
         $quote->setBoltCheckoutType(self::BOLT_CHECKOUT_TYPE_PPC);
 
-        if (isset($request['metadata']['encrypted_user_id'])) {
-            $this->assignQuoteCustomerByEncryptedUserId($quote, $request['metadata']['encrypted_user_id']);
+        if (isset($metadata['encrypted_user_id'])) {
+            $this->assignQuoteCustomerByEncryptedUserId($quote, $metadata['encrypted_user_id']);
         }
 
         //add item to quote
-        foreach ($request['items'] as $item) {
+        foreach ($items as $item) {
             $product = $this->productRepository->getbyId($item['reference']);
 
             $options = json_decode($item['options'], true);
@@ -2342,9 +2355,9 @@ class Cart extends AbstractHelper
 
         $cart_data = $this->getCartData(false, '', $quote);
         $this->quoteResourceSave($quote);
-
         return $cart_data;
     }
+
 
     /**
      * Assign customer to Quote by encrypted user id

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -2292,12 +2292,12 @@ class Cart extends AbstractHelper
      *
      * @return array cart_data in bolt format
      * @throws \Exception
+     * @throws BoltException
      */
     public function createCartByRequest($request)
     {
         return $this->createCart($request['items'], $request['metadata']);
     }
-
 
     /**
      * Create a cart with the provided items

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -2358,7 +2358,6 @@ class Cart extends AbstractHelper
         return $cart_data;
     }
 
-
     /**
      * Assign customer to Quote by encrypted user id
      *

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -5523,6 +5523,353 @@ ORDER
         static::assertEquals($expectedCartData, $currentMock->createCartByRequest($request));
         }
 
+    /**
+     * @test
+     * that createCart creates cart with simple product and returns expected cart data using
+     * @see \Bolt\Boltpay\Helper\Cart::getCartData
+     *
+     * @covers ::createCart
+     *
+     * @throws Exception from tested method
+     */
+    public function createCart_withGuestUserAndSimpleProduct_returnsExpectedCartData()
+    {
+        $items = [
+            [
+                'reference'    => CartTest::PRODUCT_ID,
+                'name'         => 'Product name',
+                'description'  => null,
+                'options'      => json_encode(['storeId' => CartTest::STORE_ID]),
+                'total_amount' => CartTest::PRODUCT_PRICE,
+                'unit_price'   => CartTest::PRODUCT_PRICE,
+                'tax_amount'   => 0,
+                'quantity'     => 1,
+                'uom'          => null,
+                'upc'          => null,
+                'sku'          => null,
+                'isbn'         => null,
+                'brand'        => null,
+                'manufacturer' => null,
+                'category'     => null,
+                'tags'         => null,
+                'properties'   => null,
+                'color'        => null,
+                'size'         => null,
+                'weight'       => null,
+                'weight_unit'  => null,
+                'image_url'    => null,
+                'details_url'  => null,
+                'tax_code'     => null,
+                'type'         => 'unknown'
+            ]
+        ];
+
+        $expectedCartData = [
+            'order_reference' => self::IMMUTABLE_QUOTE_ID,
+            'display_id'      => '',
+            'currency'        => self::CURRENCY_CODE,
+            'items'           => [
+                [
+                    'reference'    => self::PRODUCT_ID,
+                    'name'         => 'Affirm Water Bottle ',
+                    'total_amount' => self::PRODUCT_PRICE,
+                    'unit_price'   => self::PRODUCT_PRICE,
+                    'quantity'     => 1,
+                    'sku'          => self::PRODUCT_SKU,
+                    'type'         => 'physical',
+                    'description'  => 'Product description',
+                ],
+            ],
+            'discounts'       => [],
+            'total_amount'    => self::PRODUCT_PRICE,
+            'tax_amount'      => 0,
+            'metadata'        => [
+                'immutable_quote_id' => self::IMMUTABLE_QUOTE_ID,
+            ],
+        ];
+
+        $cartMock = $this->getCurrentMock(['getCartData']);
+        $cartMock->expects(static::once())->method('getCartData')->with(false, '', $this->quoteMock)
+            ->willReturn($expectedCartData);
+        $this->quoteManagement->expects(static::once())->method('createEmptyCart')
+            ->willReturn(self::QUOTE_ID);
+        $this->quoteFactory->method('create')->withAnyParameters()->willReturnSelf();
+        $this->quoteFactory->method('load')->with(self::QUOTE_ID)->willReturn($this->quoteMock);
+        $this->productRepository->expects(static::once())->method('getById')->with(self::PRODUCT_ID)
+            ->willReturn($this->productMock);
+        $this->quoteMock->expects(static::once())->method('setIsActive')->with(false);
+
+        static::assertEquals($expectedCartData, $cartMock->createCart($items));
+    }
+
+
+    /**
+     * @test
+     * that that createCart creates cart with grouped product's children and returns expected cart data using
+     * @see \Bolt\Boltpay\Helper\Cart::getCartData
+     *
+     * @covers ::createCart
+     *
+     * @throws Exception from tested method
+     */
+    public function createCart_withGroupedProductChildren_returnsExpectedCartData()
+    {
+        $items = [
+            [
+                'reference'    => CartTest::PRODUCT_ID,
+                'name'         => 'Affirm Water Bottle 1',
+                'description'  => null,
+                'options'      => json_encode(['storeId' => CartTest::STORE_ID]),
+                'total_amount' => CartTest::PRODUCT_PRICE,
+                'unit_price'   => CartTest::PRODUCT_PRICE,
+                'tax_amount'   => 0,
+                'quantity'     => 1,
+                'uom'          => null,
+                'upc'          => null,
+                'sku'          => null,
+                'isbn'         => null,
+                'brand'        => null,
+                'manufacturer' => null,
+                'category'     => null,
+                'tags'         => null,
+                'properties'   => null,
+                'color'        => null,
+                'size'         => null,
+                'weight'       => null,
+                'weight_unit'  => null,
+                'image_url'    => null,
+                'details_url'  => null,
+                'tax_code'     => null,
+                'type'         => 'unknown'
+            ],
+            [
+                'reference'    => CartTest::PRODUCT_ID,
+                'name'         => 'Affirm Water Bottle 1',
+                'description'  => null,
+                'options'      => json_encode(['storeId' => CartTest::STORE_ID]),
+                'total_amount' => CartTest::PRODUCT_PRICE,
+                'unit_price'   => CartTest::PRODUCT_PRICE,
+                'tax_amount'   => 0,
+                'quantity'     => 1,
+                'uom'          => null,
+                'upc'          => null,
+                'sku'          => null,
+                'isbn'         => null,
+                'brand'        => null,
+                'manufacturer' => null,
+                'category'     => null,
+                'tags'         => null,
+                'properties'   => null,
+                'color'        => null,
+                'size'         => null,
+                'weight'       => null,
+                'weight_unit'  => null,
+                'image_url'    => null,
+                'details_url'  => null,
+                'tax_code'     => null,
+                'type'         => 'unknown'
+            ]
+        ];
+
+        $expectedCartData = [
+            'order_reference' => self::IMMUTABLE_QUOTE_ID,
+            'display_id'      => self::ORDER_INCREMENT_ID . ' / ' . self::IMMUTABLE_QUOTE_ID,
+            'currency'        => self::CURRENCY_CODE,
+            'items'           => [
+                [
+                    'reference'    => self::PRODUCT_ID,
+                    'name'         => 'Affirm Water Bottle 1',
+                    'total_amount' => self::PRODUCT_PRICE,
+                    'unit_price'   => self::PRODUCT_PRICE,
+                    'quantity'     => 1,
+                    'sku'          => self::PRODUCT_SKU,
+                    'type'         => 'physical',
+                    'description'  => 'Product description',
+                ],
+                [
+                    'reference'    => self::PRODUCT_ID,
+                    'name'         => 'Affirm Water Bottle 2',
+                    'total_amount' => self::PRODUCT_PRICE,
+                    'unit_price'   => self::PRODUCT_PRICE,
+                    'quantity'     => 1,
+                    'sku'          => self::PRODUCT_SKU,
+                    'type'         => 'physical',
+                    'description'  => 'Product description',
+                ],
+            ],
+            'discounts'       => [],
+            'total_amount'    => self::PRODUCT_PRICE,
+            'tax_amount'      => 0,
+        ];
+
+        $cartMock = $this->getCurrentMock(['getCartData']);
+        $cartMock->expects(static::once())->method('getCartData')->with(false, '', $this->quoteMock)
+            ->willReturn($expectedCartData);
+        $this->quoteManagement->expects(static::once())->method('createEmptyCart')
+            ->willReturn(self::QUOTE_ID);
+        $this->quoteFactory->method('create')->withAnyParameters()->willReturnSelf();
+        $this->quoteFactory->method('load')->with(self::QUOTE_ID)->willReturn($this->quoteMock);
+        $this->productRepository->expects(static::exactly(2))->method('getById')->with(self::PRODUCT_ID)
+            ->willReturn($this->productMock);
+        $this->quoteMock->expects(static::once())->method('setIsActive')->with(false);
+
+        static::assertEquals($expectedCartData, $cartMock->createCart($items));
+    }
+
+    /**
+     * @test
+     * that createCart creates cart with configurable product and returns expected cart data using
+     * @see \Bolt\Boltpay\Helper\Cart::getCartData
+     *
+     * @covers ::createCart
+     *
+     * @throws Exception from tested method
+     */
+    public function createCart_withGuestUserAndConfigurableProduct_returnsExpectedCartData()
+    {
+        $items = [
+            [
+                    'reference'    => CartTest::PRODUCT_ID,
+                    'name'         => 'Product name',
+                    'description'  => null,
+                    'options'      => json_encode(['storeId' => CartTest::STORE_ID]),
+                    'total_amount' => CartTest::PRODUCT_PRICE,
+                    'unit_price'   => CartTest::PRODUCT_PRICE,
+                    'tax_amount'   => 0,
+                    'quantity'     => 1,
+                    'type'         => 'unknown'
+            ]
+        ];
+
+        $items[0]['options'] = json_encode(
+            [
+                "product"                      => self::PRODUCT_ID,
+                "selected_configurable_option" => "",
+                "item"                         => self::PRODUCT_ID,
+                "related_product"              => "",
+                "form_key"                     => "8xaF8eKXVaiRVM53",
+                "super_attribute"              => self::SUPER_ATTRIBUTE,
+                "qty"                          => "1",
+                'storeId'                      => self::STORE_ID
+            ],
+            JSON_FORCE_OBJECT
+        );
+
+        $expectedCartData = [
+            'order_reference' => self::IMMUTABLE_QUOTE_ID,
+            'display_id'      => self::ORDER_INCREMENT_ID,
+            'currency'        => self::CURRENCY_CODE,
+            'items'           => [
+                [
+                    'reference'    => self::PRODUCT_ID,
+                    'name'         => 'Affirm Water Bottle ',
+                    'total_amount' => self::PRODUCT_PRICE,
+                    'unit_price'   => self::PRODUCT_PRICE,
+                    'quantity'     => 1,
+                    'sku'          => self::PRODUCT_SKU,
+                    'type'         => 'physical',
+                    'description'  => 'Product description',
+                ],
+            ],
+            'discounts'       => [],
+            'total_amount'    => self::PRODUCT_PRICE,
+            'tax_amount'      => 0,
+            'metadata'        => [
+                'immutable_quote_id' => self::IMMUTABLE_QUOTE_ID,
+            ],
+        ];
+
+        $cartMock = $this->getCurrentMock(['getCartData']);
+        $cartMock->expects(static::once())->method('getCartData')->with(false, '', $this->quoteMock)
+            ->willReturn($expectedCartData);
+        $this->quoteManagement->expects(static::once())->method('createEmptyCart')
+            ->willReturn(self::QUOTE_ID);
+        $this->quoteFactory->method('create')->withAnyParameters()->willReturnSelf();
+        $this->quoteFactory->method('load')->with(self::QUOTE_ID)->willReturn($this->quoteMock);
+        $this->productRepository->expects(static::once())->method('getById')->with(self::PRODUCT_ID)
+            ->willReturn($this->productMock);
+        $this->quoteMock->expects(static::once())->method('setIsActive')->with(false);
+
+        static::assertEquals($expectedCartData, $cartMock->createCart($items));
+    }
+
+    /**
+     * @test
+     * that createCart assigns customer to quote by calling
+     * @see \Bolt\Boltpay\Helper\Cart::assignQuoteCustomerByEncryptedUserId
+     *
+     * @covers ::createCart
+     *
+     * @throws Exception from tested method
+     */
+    public function createCart_withEncryptedUserIdInRequest_assignsCustomerToQuote()
+    {
+        list($request, $payload, $expectedCartData, $currentMock) = $this->createCartByRequestSetUp();
+        $this->quoteMock->expects(static::once())->method('setIsActive')->with(false);
+        $currentMock->expects(static::once())->method('getCartData')->with(false, '', $this->quoteMock)
+            ->willReturn($expectedCartData);
+
+        $items = $request['items'];
+        $metadata = [
+            'encrypted_user_id' =>  json_encode($payload + ['signature' => 'correct_signature']),
+        ];
+
+        $customer = $this->createMock(CustomerInterface::class);
+        $this->customerRepository->method('getById')->willReturn($customer);
+        $this->quoteMock->expects(static::once())->method('assignCustomer')->with($customer);
+
+        static::assertEquals($expectedCartData, $currentMock->createCart($items, $metadata));
+    }
+
+    /**
+     * @test
+     * that createCart throws BoltException with if a stock exception occurs when adding product to cart
+     * @see \Bolt\Boltpay\Model\ErrorResponse::ERR_PPC_OUT_OF_STOCK used as exception code
+     *
+     * @covers ::createCart
+     *
+     * @throws Exception from tested method
+     */
+    public function createCart_withOutOfStockException_throwsBoltExceptionWithOutOfStockCode()
+    {
+        list($request, $payload, $expectedCartData, $currentMock) = $this->createCartByRequestSetUp();
+        $items = $request['items'];
+        $this->quoteMock->expects(static::once())->method('addProduct')
+            ->with($this->productMock, new DataObject(['qty' => 1]))
+            ->willThrowException(new Exception('Product that you are trying to add is not available.'));
+
+        $this->expectException(BoltException::class);
+        $this->expectExceptionCode(BoltErrorResponse::ERR_PPC_OUT_OF_STOCK);
+        $this->expectExceptionMessage('Product that you are trying to add is not available.');
+
+        static::assertEquals($expectedCartData, $currentMock->createCart($items));
+    }
+
+    /**
+     * @test
+     * that createCart throws BoltException with if a non-stock exception occurs when adding product to cart
+     * @see \Bolt\Boltpay\Model\ErrorResponse::ERR_PPC_INVALID_QUANTITY used as exception code
+     *
+     * @covers ::createCart
+     *
+     * @throws Exception from tested method
+     */
+    public function createCart_withExceptionWhenAddingProductToCart_throwsBoltException()
+    {
+        list($request, $payload, $expectedCartData, $currentMock) = $this->createCartByRequestSetUp();
+
+        $items = $request['items'];
+        $this->quoteMock->expects(static::once())->method('addProduct')
+            ->with($this->productMock, new DataObject(['qty' => 1]))
+            ->willThrowException(new Exception('Product unavailable.'));
+
+        $this->expectException(BoltException::class);
+        $this->expectExceptionCode(BoltErrorResponse::ERR_PPC_INVALID_QUANTITY);
+        $this->expectExceptionMessage('The requested qty is not available');
+
+        static::assertEquals($expectedCartData, $currentMock->createCart($items));
+    }
+
         /**
         * @test
         * that getHints returns virtual_terminal_mode set to true when provided checkout type is admin


### PR DESCRIPTION
# Description
Move the core logic of create_cart to a helper function. This will be useful when we implement the universal endpoint and we have to handle the `cart.create` call - it allows us to call the new fn without having to worry about how the request is formatted.

Fixes: https://boltpay.atlassian.net/browse/MA-87?atlOrigin=eyJpIjoiZjA5YWRhZDBhZmYxNDQ0YTk3MWZiZDEzOGQwMjhkYzIiLCJwIjoiaiJ9

#changelog Move cart_create logic to helper fn

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
