### PR TITLE
 M2P-233 Don't use bolt cart if we have no Magento cart

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -262,12 +262,6 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
          */
         cartRestricted: false,
 
-        /**
-         * @var bool true if we know that next bolt cart update is already unactual
-         *           and we need to skip it
-         */
-        skipNextBoltCartUpdate: false,
-
     };
 
     ////////////////////////////////////////////////////
@@ -751,12 +745,6 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
         }
 
         var callConfigureWithPromises = function() {
-            // Set the flag in case bolt cart updating will not be finished
-            // because page loading breaks
-            // We check the flag when next page is loaded
-            if (localStorage) {
-                localStorage.setItem("bolt_cart_is_updating", "true");
-            }
             if (waitingForResolvingPromises) {
                 return;
             }
@@ -816,7 +804,7 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
             // we rely on current bolt cart
             if (waitingForResolvingPromises) {
                 // if bolt checkout is opened we can't show new button now
-                // and will show it only if user closes bolt checkout
+                // and will show it only if user close bolt checkout
                 if (popUpOpen) {
                     return;
                 }
@@ -999,11 +987,6 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
                         boltCheckoutConfigure(cart, hintBarrier.promise, callbacks);
                 });
             } else {
-                // If flag set it means the previous page didn't update bolt cart properly
-                // Magento continue cart updating now and we know that bolt cart isn't actual
-                if (localStorage && localStorage.getItem("bolt_cart_is_updating") == "true") {
-                    BoltState.skipNextBoltCartUpdate = true;
-                }
                 callConfigureWithPromises();
 
                 magentoCartDataListener = function(data) {
@@ -1023,13 +1006,6 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
                 }
 
                 boltCartDataListener = function(data) {
-                    if (localStorage) {
-                        localStorage.setItem("bolt_cart_is_updating", "false");
-                    }
-                    if (BoltState.skipNextBoltCartUpdate) {
-                        BoltState.skipNextBoltCartUpdate = false;
-                        return;
-                    }
                     boltCartDataID = data.data_id;
 
                     cart = data.cart !== undefined ? data.cart : {};

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -991,6 +991,14 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
 
                 magentoCartDataListener = function(data) {
                     BoltState.magentoCart = data;
+                    if (boltCartDataID === undefined) {
+                        var boltCart = customerData.get('boltcart')();
+                        if (boltCart !== undefined && boltCart.data_id !== undefined && data.data_id<=boltCart.data_id) {
+                            // If we have bolt cart, haven't processed it before and timestamp is actual
+                            // we need process it now. We haven't done it before because wanted to check if bolt cart is present
+                            boltCartDataListener(boltCart);
+                        }
+                    }
                     resolveCheckPromise();
                     // Call invalidateBoltCartIfOutdated with zero delay
                     // to make sure that it is added into the end of event loop.
@@ -1006,6 +1014,10 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
                 }
 
                 boltCartDataListener = function(data) {
+                    if (BoltState.magentoCart === null) {
+                        // We haven't see magento cart yet. If Magento cart isn't set it means that bolt cart is unactual
+                        return;
+                    }
                     boltCartDataID = data.data_id;
 
                     cart = data.cart !== undefined ? data.cart : {};

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -804,7 +804,7 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
             // we rely on current bolt cart
             if (waitingForResolvingPromises) {
                 // if bolt checkout is opened we can't show new button now
-                // and will show it only if user close bolt checkout
+                // and will show it only if user closes bolt checkout
                 if (popUpOpen) {
                     return;
                 }
@@ -1015,7 +1015,7 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
 
                 boltCartDataListener = function(data) {
                     if (BoltState.magentoCart === null) {
-                        // We haven't see magento cart yet. If Magento cart isn't set it means that bolt cart is unactual
+                        // We haven't seen magento cart yet. If Magento cart isn't set it means that bolt cart is unactual
                         return;
                     }
                     boltCartDataID = data.data_id;


### PR DESCRIPTION
If settings "redirect to cart after add to cart" enabled we have an issue during a couple of seconds after cart page loading: Magento cart wasn't loaded on the previous page so we called configure() with an unactual bolt cart.

In https://github.com/BoltApp/bolt-magento2/pull/917 we saved flag in local storage when the updating process was started, but it doesn't work if users clicks add to cart on the category page, because Magento doesn't trigger the event.

I found a more robust solution: when Magento started the update process, it deletes Magento cart from local storage.
So if we have bolt cart in local storage and do not have Magento cart it means the bolt cart is unactual and we shouldn't use it.

I reverted PR917 because new solution covers all cases.

Fixes: [M2P-233](https://boltpay.atlassian.net/browse/M2P-233)

#changelog  M2P-233 Don't use bolt cart if we have no Magento cart

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
