### PR TITLE
M2P-219 Check if interface exists in legacy 3p support flow

### DIFF
--- a/Model/ThirdPartyModuleFactory.php
+++ b/Model/ThirdPartyModuleFactory.php
@@ -84,7 +84,11 @@ class ThirdPartyModuleFactory
         // Return false instead if any uncaught exceptions.
         ///////////////////////////////////////////////////////////////
         try {
-            return class_exists($this->className);
+            if (substr($this->className, -9) === "Interface") {
+                return interface_exists($this->className);
+            } else {
+                return class_exists($this->className);
+            }
         } catch (\Exception $e) {
             return false;
         }

--- a/Test/Unit/Model/ThirdPartyModuleFactoryTest.php
+++ b/Test/Unit/Model/ThirdPartyModuleFactoryTest.php
@@ -133,8 +133,28 @@ class ThirdPartyModuleFactoryTest extends TestCase
      * @test
      * @covers ::isExists
      */
-    public function isExists()
+    public function isExists_withClass_returnTrue()
     {
+        $this->assertTrue($this->currentMock->isExists());
+    }
+
+    /**
+     * @test
+     * @covers ::isExists
+     */
+    public function isExists_withInterface_returnTrue()
+    {
+        $this->currentMock = $this->getMockBuilder(ThirdPartyModuleFactory::class)
+        ->setConstructorArgs([
+            $this->_moduleManager,
+            $this->_objectManager,
+            $this->logHelper,
+            "Bolt\Boltpay\Api\CreateOrderInterface",
+            $this->className
+        ])
+        ->enableProxyingToOriginalMethods()
+        ->getMock();
+
         $this->assertTrue($this->currentMock->isExists());
     }
 }


### PR DESCRIPTION
In legacy flow for support third party modules call **interface_exists** in necessary cases.
This fix makes module Aheadworks Store Credit work
We already have the same in new 3p support flow - https://github.com/BoltApp/bolt-magento2/blob/67c717b6a6aa7dd3e3ae1e073c6bb3bc9d194d1f/Model/EventsForThirdPartyModules.php#L332

Fixes: [M2P-219](https://boltpay.atlassian.net/browse/M2P-219)

#changelog M2P-219 Check if interface exists in legacy 3p support flow

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
