### PR TITLE
Refactor validate Quote

### DIFF
--- a/Model/Api/UpdateCart.php
+++ b/Model/Api/UpdateCart.php
@@ -226,7 +226,7 @@ class UpdateCart extends UpdateCartCommon implements UpdateCartInterface
             $this->sendErrorResponse(
                 $e->getCode(),
                 $e->getMessage(),
-                $e->getHttpCode()
+                422
             );
 
             return false;

--- a/Model/Api/UpdateCart.php
+++ b/Model/Api/UpdateCart.php
@@ -30,6 +30,7 @@ use Bolt\Boltpay\Api\Data\CartDataInterfaceFactory;
 use Bolt\Boltpay\Api\Data\UpdateCartResultInterfaceFactory;
 use Bolt\Boltpay\Helper\Session as SessionHelper;
 use Magento\Quote\Model\Quote;
+use Bolt\Boltpay\Exception\BoltException;
 
 /**
  * Class UpdateCart
@@ -103,11 +104,6 @@ class UpdateCart extends UpdateCartCommon implements UpdateCartInterface
             $immutableQuoteId = $cart['order_reference'];
             
             $result = $this->validateQuote($immutableQuoteId);
-            
-            if(!$result){
-                // Already sent a response with error, so just return.
-                return false;
-            }
             
             list($parentQuote, $immutableQuote) = $result;
             
@@ -226,6 +222,14 @@ class UpdateCart extends UpdateCartCommon implements UpdateCartInterface
                 
             $this->sendSuccessResponse($result);
             
+        } catch (BoltException $e) {
+            $this->sendErrorResponse(
+                $e->getCode(),
+                $e->getMessage(),
+                $e->getHttpCode()
+            );
+
+            return false;
         } catch (WebApiException $e) {
             $this->sendErrorResponse(
                 BoltErrorResponse::ERR_SERVICE,

--- a/Test/Unit/Model/Api/UpdateCartTest.php
+++ b/Test/Unit/Model/Api/UpdateCartTest.php
@@ -17,6 +17,7 @@
 
 namespace Bolt\Boltpay\Test\Unit\Model\Api;
 
+use Bolt\Boltpay\Exception\BoltException;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Webapi\Exception as WebApiException;
@@ -434,10 +435,14 @@ class UpdateCartTest extends TestCase
     public function execute_validateQuoteFail_returnFalse()
     {            
         $this->initCurrentMock(['validateQuote']);
-        
+        $exception = new BoltException(
+            __(sprintf('The cart reference [%s] cannot be found.', SELF::IMMUTABLE_QUOTE_ID)),
+            null,
+            BoltErrorResponse::ERR_INSUFFICIENT_INFORMATION
+        );
         $this->currentMock->expects(self::once())->method('validateQuote')
             ->with(self::IMMUTABLE_QUOTE_ID)
-            ->willReturn(false);
+            ->willThrowException($exception);
         
         $requestCart = $this->getRequestCart();
 


### PR DESCRIPTION
# Description

Refactor validate quote so that it throws an exception instead of sending an error response to the client. 
I moved the sending of the error response to the api entry point (`UpdateCart::execute` and `DiscountCountValidation::validate`). 

This allows us to reuse the validateQuote function and not have to worry about the format of the error response (i.e. universalAPI will have a different error response format).

Fixes: (link Jira ticket)

#changelog Refactor validate Quote

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
