### PR TITLE
M2P-233 Don't call configure if we have more fresh Magento cart

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -1019,6 +1019,10 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
                         return;
                     }
                     boltCartDataID = data.data_id;
+                    if (BoltState.magentoCart.data_id > boltCartDataID) {
+                        // bolt cart is unactual
+                        return;
+                    }
 
                     cart = data.cart !== undefined ? data.cart : {};
                     if ((JSON.stringify(cart) === oldBoltCartValue) && !waitingForResolvingPromises) {


### PR DESCRIPTION
Under some condition, it's possible that we observe Bolt cart at the moment when we already have a more fresh Magento cart.
Don't call configure because we will have a new bolt cart in the next second or so.
This continues the fix from https://github.com/BoltApp/bolt-magento2/pull/943

Fixes: [M2P-233](https://boltpay.atlassian.net/browse/M2P-233)

#changelog M2P-233 Don't call configure if we have more fresh Magento cart

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
