### PR TITLE
Remove final keyword

### DIFF
--- a/Model/Api/UpdateCart.php
+++ b/Model/Api/UpdateCart.php
@@ -66,7 +66,7 @@ class UpdateCart extends UpdateCartCommon implements UpdateCartInterface
      * @param CartDataInterfaceFactory $cartDataFactory
      * @param UpdateCartResultInterfaceFactory $updateCartResultFactory
      */
-    final public function __construct(
+    public function __construct(
         UpdateCartContext $updateCartContext,
         CartDataInterfaceFactory $cartDataFactory,
         UpdateCartResultInterfaceFactory $updateCartResultFactory

--- a/Model/Api/UpdateDiscountTrait.php
+++ b/Model/Api/UpdateDiscountTrait.php
@@ -99,7 +99,7 @@ trait UpdateDiscountTrait
      *
      * @param UpdateCartContext $updateCartContext
      */
-    final public function __construct(
+    public function __construct(
         UpdateCartContext $updateCartContext
     ) {        
         $this->ruleRepository = $updateCartContext->getRuleRepository();


### PR DESCRIPTION
# Description
Final keyword is prohibited in Magento. It decreases extensibility and is not compatible with plugins and proxies.

And we need to remove final keyword from plugin to pass the check of marketplace.magento.com

Fixes: (link Jira ticket)

#changelog Remove final keyword

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
