### PR TITLE
 M2P-242 - Discounts v2 fix - Unable to apply Amasty Gift Card via PPC

### DIFF
--- a/Model/Api/UpdateCart.php
+++ b/Model/Api/UpdateCart.php
@@ -28,6 +28,7 @@ use Bolt\Boltpay\Model\ErrorResponse as BoltErrorResponse;
 use Bolt\Boltpay\Api\Data\CartDataInterfaceFactory;
 use Bolt\Boltpay\Api\Data\UpdateCartResultInterfaceFactory;
 use Bolt\Boltpay\Helper\Session as SessionHelper;
+use Magento\Quote\Model\Quote;
 
 /**
  * Class UpdateCart
@@ -174,7 +175,7 @@ class UpdateCart extends UpdateCartCommon implements UpdateCartInterface
             }
 
             $this->cartHelper->replicateQuoteData($parentQuote, $immutableQuote);
-           
+
             $result = $this->generateResult($immutableQuote);
                 
             $this->sendSuccessResponse($result);
@@ -230,6 +231,8 @@ class UpdateCart extends UpdateCartCommon implements UpdateCartInterface
     protected function getQuoteCart($quote)
     {
         $has_shipment = !empty($this->cartRequest['shipments'][0]['reference']);
+        //make sure we recollect totals
+        $quote->setTotalsCollectedFlag(false);
         return $this->cartHelper->getCartData($has_shipment, null, $quote);
     }
     

--- a/Model/Api/UpdateDiscountTrait.php
+++ b/Model/Api/UpdateDiscountTrait.php
@@ -386,7 +386,7 @@ trait UpdateDiscountTrait
                 // Remove Amasty Gift Card if already applied
                 // to avoid errors on multiple calls to discount validation API
                 // from the Bolt checkout (changing the address, going back and forth)
-                $this->discountHelper->removeAmastyGiftCard($couponCode, $quote);
+                $this->discountHelper->removeAmastyGiftCard($giftCard->getCodeId(), $quote);
                 // Apply Amasty Gift Card to the parent quote
                 $giftAmount = $this->discountHelper->applyAmastyGiftCard($couponCode, $giftCard, $quote);
             } else {

--- a/Model/EventsForThirdPartyModules.php
+++ b/Model/EventsForThirdPartyModules.php
@@ -22,6 +22,7 @@ use Bolt\Boltpay\ThirdPartyModules\Mageplaza\ShippingRestriction as Mageplaza_Sh
 use Bolt\Boltpay\ThirdPartyModules\Mirasvit\Credit as Mirasvit_Credit;
 use Bolt\Boltpay\ThirdPartyModules\IDme\GroupVerification as IDme_GroupVerification;
 use Bolt\Boltpay\ThirdPartyModules\Amasty\Rewards as Amasty_Rewards;
+use Bolt\Boltpay\ThirdPartyModules\Amasty\GiftCardAccount as Amasty_GiftCardAccount;
 use Bolt\Boltpay\ThirdPartyModules\MageWorld\RewardPoints as MW_RewardPoints;
 use Bolt\Boltpay\ThirdPartyModules\Bss\StoreCredit as Bss_StoreCredit;
 use Bolt\Boltpay\ThirdPartyModules\Mageplaza\GiftCard as Mageplaza_GiftCard;
@@ -43,6 +44,14 @@ class EventsForThirdPartyModules
         ],
         "beforeDeleteOrder" => [
             "listeners" => [
+                [
+                    "module"      => "Amasty_GiftCardAccount",
+                    "sendClasses" => [
+                        '\Amasty\GiftCardAccount\Model\GiftCardAccount\Repository',
+                        '\Amasty\GiftCardAccount\Model\GiftCardExtension\Order\Repository',
+                    ],
+                    "boltClass"   => Amasty_GiftCardAccount::class,
+                ],
                 [
                     "module" => "Aheadworks_Giftcard",
                     "sendClasses" => ["\Aheadworks\Giftcard\Plugin\Model\Service\OrderServicePlugin"],

--- a/Test/Unit/Helper/DiscountTest.php
+++ b/Test/Unit/Helper/DiscountTest.php
@@ -73,48 +73,48 @@ class DiscountTest extends TestCase
     /**
      * @var MockObject|ResourceConnection mocked instance of the resource collection
      */
-    private $resource;    
-    
+    private $resource;
+
     /**
      * @var MockObject|ThirdPartyModuleFactory mocked instance of the legacy Amasty GiftCard model Account factory
      */
     private $amastyLegacyAccountFactory;
-    
+
     /**
      * @var MockObject|ThirdPartyModuleFactory mocked instance of the legacy Amasty GiftCard model GiftCardManagement
      */
     private $amastyLegacyGiftCardManagement;
-    
+
     /**
      * @var MockObject|ThirdPartyModuleFactory mocked instance of the legacy Amasty GiftCard model Quote factory
      */
     private $amastyLegacyQuoteFactory;
-    
+
     /**
      * @var MockObject|ThirdPartyModuleFactory mocked instance of the legacy Amasty GiftCard model ResourceModel\Quote
      */
     private $amastyLegacyQuoteResource;
-    
+
     /**
      * @var MockObject|ThirdPartyModuleFactory mocked instance of the legacy Amasty GiftCard model Repository\QuoteRepository
      */
     private $amastyLegacyQuoteRepository;
-    
+
     /**
      * @var MockObject|ThirdPartyModuleFactory mocked instance of the legacy Amasty GiftCard model ResourceModel\Account\Collection
      */
     private $amastyLegacyAccountCollection;
-    
+
     /**
      * @var MockObject|ThirdPartyModuleFactory mocked instance of the legacy Amasty GiftCardAccount model GiftCardAccount\Repository
      */
     private $amastyAccountFactory;
-    
+
     /**
      * @var MockObject|ThirdPartyModuleFactory mocked instance of the legacy Amasty GiftCardAccount model GiftCardAccount\GiftCardAccountManagement
      */
     private $amastyGiftCardAccountManagement;
-    
+
     /**
      * @var MockObject|ThirdPartyModuleFactory mocked instance of the legacy Amasty GiftCardAccount model GiftCardAccount\ResourceModel\Collection
      */
@@ -124,7 +124,7 @@ class DiscountTest extends TestCase
      * @var MockObject|ThirdPartyModuleFactory mocked instance of the Unirgy Giftcert repository
      */
     private $unirgyCertRepository;
-    
+
     /**
      * @var MockObject|ThirdPartyModuleFactory mocked instance of the Unirgy Giftcert helper
      */
@@ -184,17 +184,17 @@ class DiscountTest extends TestCase
      * @var MockObject|Mysql mocked instance of Mysql adapter
      */
     private $connectionMock;
-    
+
     /**
      * @var MockObject|ThirdPartyModuleFactory
      */
     private $moduleGiftCardAccountMock;
-    
+
     /**
      * @var MockObject|ThirdPartyModuleFactory
      */
     private $moduleGiftCardAccountHelperMock;
-    
+
     /**
      * @var CouponFactory
      */
@@ -217,7 +217,7 @@ class DiscountTest extends TestCase
     protected function setUp()
     {
         $this->context = $this->createMock(Context::class);
-        $this->resource = $this->createMock(ResourceConnection::class);        
+        $this->resource = $this->createMock(ResourceConnection::class);
         $this->amastyLegacyAccountFactory = $this->createMock(ThirdPartyModuleFactory::class);
         $this->amastyLegacyGiftCardManagement = $this->createMock(ThirdPartyModuleFactory::class);
         $this->amastyLegacyQuoteFactory = $this->createMock(ThirdPartyModuleFactory::class);
@@ -353,7 +353,7 @@ class DiscountTest extends TestCase
         static::assertAttributeEquals($this->amastyLegacyAccountCollection, 'amastyLegacyAccountCollection', $instance);
         static::assertAttributeEquals($this->amastyAccountFactory, 'amastyAccountFactory', $instance);
         static::assertAttributeEquals($this->amastyGiftCardAccountManagement, 'amastyGiftCardAccountManagement', $instance);
-        static::assertAttributeEquals($this->amastyGiftCardAccountCollection, 'amastyGiftCardAccountCollection', $instance);        
+        static::assertAttributeEquals($this->amastyGiftCardAccountCollection, 'amastyGiftCardAccountCollection', $instance);
         static::assertAttributeEquals($this->unirgyCertRepository, 'unirgyCertRepository', $instance);
         static::assertAttributeEquals($this->unirgyGiftCertHelper, 'unirgyGiftCertHelper', $instance);
         static::assertAttributeEquals($this->mirasvitRewardsPurchaseHelper, 'mirasvitRewardsPurchaseHelper', $instance);
@@ -414,7 +414,7 @@ class DiscountTest extends TestCase
             ['amastyModuleAvailable' => false, 'amastyLegacyModuleAvailable' => false, 'expectedResult' => false],
         ];
     }
-    
+
     /**
      * @test
      * that isAmastyGiftCardLegacyVersion returns if the Amasty Gift Card module is a legacy version or not
@@ -435,7 +435,7 @@ class DiscountTest extends TestCase
 
         static::assertEquals($expectedResult, $this->currentMock->isAmastyGiftCardLegacyVersion());
     }
-    
+
     /**
      * Data provider for {@see isAmastyGiftCardLegacyVersion__withVariousAmastyModuleVersion_returnsProperResult}
      *
@@ -533,7 +533,7 @@ class DiscountTest extends TestCase
 
         static::assertEquals($accountModelMock, $this->currentMock->loadAmastyGiftCard($couponCode, $websiteId));
     }
-    
+
     /**
      * @test
      * that loadAmastyGiftCard returns Amasty Gift Card legacy Account object
@@ -606,7 +606,7 @@ class DiscountTest extends TestCase
 
         static::assertNull($this->currentMock->loadAmastyGiftCard($couponCode, $websiteId));
     }
-    
+
     /**
      * @test
      * that loadAmastyGiftCard returns null if an exception occurs during gift card loading
@@ -640,7 +640,7 @@ class DiscountTest extends TestCase
 
         static::assertNull($this->currentMock->loadAmastyGiftCard($couponCode, $websiteId));
     }
-    
+
     /**
      * @test
      * that applyAmastyGiftCard throws a localized exception if one of the following is true:
@@ -680,7 +680,7 @@ class DiscountTest extends TestCase
         $this->initCurrentMock(['isAmastyGiftCardAvailable', 'isAmastyGiftCardLegacyVersion', 'getAmastyPayForEverything']);
         $this->currentMock->expects(static::once())->method('isAmastyGiftCardAvailable')->willReturn(true);
         $this->currentMock->expects(static::once())->method('isAmastyGiftCardLegacyVersion')->willReturn(true);
-        
+
         $giftTestAmount = 1322;
         $quoteId = 2;
 
@@ -708,7 +708,7 @@ class DiscountTest extends TestCase
             ->setMethods(['getInstance', 'validateCode'])
             ->disableOriginalConstructor()
             ->getMock();
-                                                     
+
         TestHelper::setProperty($this->currentMock, 'amastyLegacyGiftCardManagement', $amastyGiftCardMock);
 
         $amastyGiftCardMock->expects(static::once())->method('getInstance')->willReturnSelf();
@@ -843,7 +843,7 @@ class DiscountTest extends TestCase
             ],
         ];
     }
-    
+
     /**
      * @test
      * that applyAmastyGiftCard returns pay items everything or pay for items only after meeting the following conditions:
@@ -875,7 +875,7 @@ class DiscountTest extends TestCase
         );
         $code = 321312;
         $quoteId = 2;
-        
+
         $this->currentMock->expects(static::once())->method('isAmastyGiftCardAvailable')->willReturn(true);
         $this->currentMock->expects(static::once())->method('isAmastyGiftCardLegacyVersion')->willReturn(false);
 
@@ -911,6 +911,7 @@ class DiscountTest extends TestCase
         $amastyGiftCardAccountQuoteExtensionRepositoryMock = $this->getMockBuilder('\Amasty\GiftCardAccount\Model\GiftCardExtension\Quote\Repository')
             ->setMethods(['getByQuoteId'])
             ->disableOriginalConstructor()
+            ->disableAutoload()
             ->getMock();
         $this->amastyGiftCardAccountQuoteExtensionRepositoryFactory->expects(static::once())->method('getInstance')
             ->willReturn($amastyGiftCardAccountQuoteExtensionRepositoryMock);
@@ -932,7 +933,7 @@ class DiscountTest extends TestCase
         $quoteMock->expects(!$amastyPayForEverything ? static::once() : static::never())
             ->method('getTotals')
             ->willReturn([Discount::AMASTY_GIFTCARD => new DataObject(['value' => $totalsAmastyGiftCard])]);
-            
+
         $this->quoteRepository->expects(!$amastyPayForEverything ? static::once() : static::never())
             ->method('getActive')->with($quoteId)->willReturn($quoteMock);
 
@@ -968,7 +969,7 @@ class DiscountTest extends TestCase
         $this->initCurrentMock(['isAmastyGiftCardAvailable', 'isAmastyGiftCardLegacyVersion', 'getAmastyPayForEverything']);
         $code = 321312;
         $quoteId = 2;
-        
+
         $this->currentMock->expects(static::once())->method('isAmastyGiftCardAvailable')->willReturn(true);
         $this->currentMock->expects(static::once())->method('isAmastyGiftCardLegacyVersion')->willReturn(true);
 
@@ -1152,7 +1153,7 @@ class DiscountTest extends TestCase
      */
     public function cloneAmastyGiftCards_ifAmastyGiftCardIsAvailable_commitsTheQuery()
     {
-        $this->initCurrentMock(['isAmastyGiftCardAvailable', 'isAmastyGiftCardLegacyVersion']);        
+        $this->initCurrentMock(['isAmastyGiftCardAvailable', 'isAmastyGiftCardLegacyVersion']);
         $this->currentMock->expects(static::once())->method('isAmastyGiftCardAvailable')->willReturn(true);
         $this->currentMock->expects(static::once())->method('isAmastyGiftCardLegacyVersion')->willReturn(false);
         $sourceQuoteId = 232;
@@ -1200,7 +1201,7 @@ class DiscountTest extends TestCase
         $this->connectionMock->expects(static::never())->method('commit');
         $this->currentMock->cloneAmastyGiftCards($sourceQuoteId, $destinationQuoteId);
     }
-    
+
     /**
      * @test
      * that cloneAmastyGiftCards:
@@ -1213,7 +1214,7 @@ class DiscountTest extends TestCase
      */
     public function cloneAmastyGiftCards_legacyVersion_ifAmastyGiftCardIsAvailable_commitsTheQuery()
     {
-        $this->initCurrentMock(['isAmastyGiftCardAvailable', 'isAmastyGiftCardLegacyVersion']);        
+        $this->initCurrentMock(['isAmastyGiftCardAvailable', 'isAmastyGiftCardLegacyVersion']);
         $this->currentMock->expects(static::once())->method('isAmastyGiftCardAvailable')->willReturn(true);
         $this->currentMock->expects(static::once())->method('isAmastyGiftCardLegacyVersion')->willReturn(true);
         $sourceQuoteId = 232;
@@ -1239,7 +1240,7 @@ class DiscountTest extends TestCase
 
         $this->currentMock->cloneAmastyGiftCards($sourceQuoteId, $destinationQuoteId);
     }
-    
+
     /**
      * @test
      * that cloneAmastyGiftCards will rollback the SQL query and notify the Bugsnag if
@@ -1351,7 +1352,7 @@ class DiscountTest extends TestCase
         $this->connectionMock->expects(static::once())->method('query')->with($sql, $bind)->willReturnSelf();
         $this->currentMock->clearAmastyGiftCard($quoteMock);
     }
-    
+
     /**
      * @test
      * that clearAmastyGiftCard removes Amasty Gift Card from the provided quote using a custom SQL query
@@ -1410,7 +1411,7 @@ class DiscountTest extends TestCase
         $this->bugsnag->expects(static::once())->method('notifyException')->with($exception)->willReturnSelf();
         $this->currentMock->clearAmastyGiftCard($quoteMock);
     }
-    
+
     /**
      * @test
      * that clearAmastyGiftCard only notifies the Bugsnag if the SQL query throws an exception
@@ -1494,7 +1495,7 @@ class DiscountTest extends TestCase
 
         $this->currentMock->deleteRedundantAmastyGiftCards($quoteMock);
     }
-    
+
     /**
      * @test
      * that deleteRedundantAmastyGiftCards deletes redundant Amasty Giftcards for the provided quote
@@ -1573,7 +1574,7 @@ class DiscountTest extends TestCase
         $this->bugsnag->expects(static::once())->method('notifyException')->with($exception)->willReturnSelf();
         $this->currentMock->deleteRedundantAmastyGiftCards($quoteMock);
     }
-    
+
     /**
      * @test
      * that deleteRedundantAmastyGiftCards only notifies Bugsnag if the SQL query throws an exception
@@ -1628,7 +1629,7 @@ class DiscountTest extends TestCase
 
         static::assertNull($this->currentMock->removeAmastyGiftCard($testCodeId, $this->quote));
     }
-    
+
     /**
      * @test
      * that removeAmastyGiftCard collects totals and saves the quote if the Amasty Gift Card module is available
@@ -1660,13 +1661,13 @@ class DiscountTest extends TestCase
         );
         $extensionAttributes = $this->createPartialMock(CartExtension::class, ['getAmGiftcardQuote']);
         $gCardQuote = $this->createPartialMock(GiftCardQuote::class, ['getGiftCards']);
-        
+
         $gCardQuote->expects($this->atLeastOnce())->method('getGiftCards')
             ->willReturn($cardInfo);
-        
+
         $extensionAttributes->expects($this->atLeastOnce())->method('getAmGiftcardQuote')
-            ->willReturn($gCardQuote);        
-        
+            ->willReturn($gCardQuote);
+
         $quoteMock->expects(static::once())->method('getId')->willReturn($quoteId);
         $quoteMock->expects($this->atLeastOnce())->method('getExtensionAttributes')
             ->willReturn($extensionAttributes);
@@ -1834,7 +1835,7 @@ class DiscountTest extends TestCase
             )
         );
     }
-    
+
     /**
      * @test
      * that getAmastyGiftCardCodesCurrentValue returns accumulated unused balances
@@ -1849,7 +1850,7 @@ class DiscountTest extends TestCase
         $this->initCurrentMock(['isAmastyGiftCardAvailable', 'isAmastyGiftCardLegacyVersion']);
         $this->currentMock->expects(static::once())->method('isAmastyGiftCardAvailable')->willReturn(true);
         $this->currentMock->expects(static::once())->method('isAmastyGiftCardLegacyVersion')->willReturn(false);
-        
+
         $giftCardCodes = [22, 33, 44, 55];
 
         $amastyAccountMock = $this->getMockBuilder(ThirdPartyModuleFactory::class)
@@ -1893,7 +1894,7 @@ class DiscountTest extends TestCase
         $this->initCurrentMock(['isAmastyGiftCardAvailable', 'isAmastyGiftCardLegacyVersion']);
         $this->currentMock->expects(static::once())->method('isAmastyGiftCardAvailable')->willReturn(true);
         $this->currentMock->expects(static::once())->method('isAmastyGiftCardLegacyVersion')->willReturn(true);
-        
+
         $giftCardCodes = [22, 33, 44, 55];
 
         $amastyAccountMock = $this->getMockBuilder(ThirdPartyModuleFactory::class)
@@ -1922,7 +1923,7 @@ class DiscountTest extends TestCase
             $this->currentMock->getAmastyGiftCardCodesCurrentValue($giftCardCodes)
         );
     }
-    
+
     /**
      * @test
      * @covers ::loadUnirgyGiftCertData
@@ -2788,7 +2789,7 @@ class DiscountTest extends TestCase
 
         static::assertNull($this->currentMock->applyMiravistRewardPoint($immutableQuote));
     }
-    
+
     /**
      * @test
      * that isMagentoGiftCardAccountAvailable returns availability of Magento Gift Card module
@@ -2824,7 +2825,7 @@ class DiscountTest extends TestCase
             ['magentoGiftCardAccountAvailable' => false, 'expectedResult' => false],
         ];
     }
-    
+
     /**
      * @test
      * that loadMagentoGiftCardAccount returns null if the Magento Gift Card is unavailable
@@ -2840,7 +2841,7 @@ class DiscountTest extends TestCase
 
         static::assertNull($this->currentMock->loadMagentoGiftCardAccount($code, $storeId));
     }
-    
+
     /**
      * @test
      * that loadMagentoGiftCardAccount returns null if the Magento Gift Card is unavailable
@@ -2853,14 +2854,14 @@ class DiscountTest extends TestCase
         $code = 'testCouponCode';
         $storeId = 23;
         $this->currentMock->method('isMagentoGiftCardAccountAvailable')->willReturn(true);
-        
+
         $this->moduleGiftCardAccountMock->expects(static::once())
             ->method('getInstance')
             ->willReturn(null);
-            
+
         static::assertNull($this->currentMock->loadMagentoGiftCardAccount($code, $storeId));
     }
-    
+
     /**
      * @test
      * that loadMagentoGiftCardAccount returns \Magento\GiftCardAccount\Model\Giftcardaccount object
@@ -2891,20 +2892,20 @@ class DiscountTest extends TestCase
         $accountModelMock->expects(static::once())->method('getInstance')->willReturnSelf();
         $accountModelMock->expects(static::once())->method('addFieldToFilter')->with('code', ['eq' => $couponCode])->willReturnSelf();
         $accountModelMock->expects(static::once())->method('addWebsiteFilter')->with([0, $websiteId])->willReturnSelf();
-        
+
         $giftcardMock = $this->getMockBuilder('\Magento\GiftCardAccount\Model\Giftcardaccount')
             ->disableOriginalConstructor()
             ->setMethods(['isEmpty', 'isValid'])
             ->getMock();
         $giftcardMock->method('isEmpty')->willReturn(false);
         $giftcardMock->method('isValid')->willReturn(true);
-        
+
         $accountModelMock->expects(self::once())->method('getFirstItem')
             ->willReturn($giftcardMock);
 
         static::assertEquals($giftcardMock, $this->currentMock->loadMagentoGiftCardAccount($couponCode, $websiteId));
     }
-    
+
     /**
      * @test
      * that loadCouponCodeData returns \Magento\SalesRule\Model\Coupon object
@@ -2934,7 +2935,7 @@ class DiscountTest extends TestCase
 
         static::assertEquals($couponMock, $this->currentMock->loadCouponCodeData($couponCode));
     }
-    
+
     /**
      * @test
      * that convertToBoltDiscountType returns empty string if the coupon code is empty
@@ -2947,7 +2948,7 @@ class DiscountTest extends TestCase
         $this->initCurrentMock();
         static::assertEquals('fixed_amount', $this->currentMock->convertToBoltDiscountType(''));
     }
-    
+
     /**
      * @test
      * that convertToBoltDiscountType returns empty string if the coupon code is empty
@@ -2958,7 +2959,7 @@ class DiscountTest extends TestCase
     public function convertToBoltDiscountType_loadCouponCodeDataThrowsException_notifyException()
     {
         $this->initCurrentMock(['loadCouponCodeData']);
-        
+
         $exceptionMock = $this->createMock(\Exception::class);
         $this->currentMock->expects(static::once())->method('loadCouponCodeData')->willThrowException($exceptionMock);
         $this->bugsnag->expects(static::once())->method('notifyException')->with($exceptionMock)->willReturnSelf();
@@ -3005,7 +3006,7 @@ class DiscountTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $couponMock->expects(static::once())->method('getRuleId')->willReturn(6);
-        
+
         $this->currentMock->expects(static::once())->method('loadCouponCodeData')->with($couponCode)->willReturn($couponMock);
 
         $ruleMock = $this->getMockBuilder(Rule::class)
@@ -3065,7 +3066,7 @@ class DiscountTest extends TestCase
 
         static::assertNull($this->currentMock->setCouponCode($quoteMock,$couponCode));
     }
-    
+
     /**
      * @test
      * that getMagentoGiftCardAccountGiftCardData returns empty array if the MagentoGiftCardAccount is unavailable
@@ -3080,10 +3081,10 @@ class DiscountTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $this->currentMock->method('isMagentoGiftCardAccountAvailable')->willReturn(false);
-        
+
         static::assertEquals([], $this->currentMock->getMagentoGiftCardAccountGiftCardData($quote));
     }
-    
+
     /**
      * @test
      * that getMagentoGiftCardAccountGiftCardData returns empty array if the GiftCardAccountHelper is unavailable
@@ -3097,12 +3098,12 @@ class DiscountTest extends TestCase
         $quote = $this->getMockBuilder(Quote::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->currentMock->method('isMagentoGiftCardAccountAvailable')->willReturn(true);        
+        $this->currentMock->method('isMagentoGiftCardAccountAvailable')->willReturn(true);
         $this->moduleGiftCardAccountHelperMock->expects(static::once())->method('getInstance')->willReturn(null);
-        
+
         static::assertEquals([], $this->currentMock->getMagentoGiftCardAccountGiftCardData($quote));
     }
-    
+
     /**
      * @test
      * that getMagentoGiftCardAccountGiftCardData returns empty array if the no gift card in the quote
@@ -3117,18 +3118,18 @@ class DiscountTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $this->currentMock->method('isMagentoGiftCardAccountAvailable')->willReturn(true);
-        
+
         $moduleGiftCardAccountHelperMock = $this->getMockBuilder(ThirdPartyModuleFactory::class)
             ->setMethods(['getInstance', 'getCards'])
             ->disableOriginalConstructor()
             ->getMock();
         $moduleGiftCardAccountHelperMock->expects(static::once())->method('getInstance')->willReturnSelf();
         $moduleGiftCardAccountHelperMock->expects(static::once())->method('getCards')->with($quote)->willReturn([]);
-        TestHelper::setProperty($this->currentMock, 'moduleGiftCardAccountHelper', $moduleGiftCardAccountHelperMock);   
-        
+        TestHelper::setProperty($this->currentMock, 'moduleGiftCardAccountHelper', $moduleGiftCardAccountHelperMock);
+
         static::assertEquals([], $this->currentMock->getMagentoGiftCardAccountGiftCardData($quote));
     }
-    
+
     /**
      * @test
      * that getMagentoGiftCardAccountGiftCardData returns gift card array
@@ -3143,11 +3144,11 @@ class DiscountTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $this->currentMock->method('isMagentoGiftCardAccountAvailable')->willReturn(true);
-        
+
         $cards = [
             [
                 'a' => 50,
-                'c' => '1234' 
+                'c' => '1234'
             ],
             [
                 'a' => 50,
@@ -3161,7 +3162,7 @@ class DiscountTest extends TestCase
         $moduleGiftCardAccountHelperMock->expects(static::once())->method('getInstance')->willReturnSelf();
         $moduleGiftCardAccountHelperMock->expects(static::once())->method('getCards')->with($quote)->willReturn($cards);
         TestHelper::setProperty($this->currentMock, 'moduleGiftCardAccountHelper', $moduleGiftCardAccountHelperMock);
-        
+
         static::assertEquals(['1234'=>50, '5678'=>50], $this->currentMock->getMagentoGiftCardAccountGiftCardData($quote));
     }
 }

--- a/Test/Unit/Model/Api/UpdateDiscountTraitTest.php
+++ b/Test/Unit/Model/Api/UpdateDiscountTraitTest.php
@@ -40,7 +40,7 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Class UpdateDiscountTraitTest
- * @coversDefaultClass \Bolt\Boltpay\Controller\UpdateDiscountTrait
+ * @coversDefaultClass \Bolt\Boltpay\Model\Api\UpdateDiscountTrait
  */
 class UpdateDiscountTraitTest extends TestCase
 {
@@ -971,23 +971,26 @@ class UpdateDiscountTraitTest extends TestCase
         
         $this->assertFalse($result);
     }
-    
+
     /**
      * @test
      *
+     * @covers \Bolt\Boltpay\Model\Api\UpdateDiscountTrait::applyingGiftCardCode
      */
     public function applyingGiftCardCode_amastyGiftCard()
     {
         $quote = $this->getQuoteMock();
-        
+
         $giftcardMock = $this->getMockBuilder('\Amasty\GiftCard\Model\Account')
+            ->setMethods(['getCodeId'])
             ->disableOriginalConstructor()
-            ->getMock();        
-        $this->discountHelper->expects(static::once())->method('removeAmastyGiftCard')->with(self::COUPON_CODE, $quote);            
+            ->getMock();
+        $giftcardMock->expects(static::once())->method('getCodeId')->willReturn(self::COUPON_ID);
+        $this->discountHelper->expects(static::once())->method('removeAmastyGiftCard')->with(self::COUPON_ID, $quote);
         $this->discountHelper->expects(static::once())->method('applyAmastyGiftCard')->with(self::COUPON_CODE, $giftcardMock, $quote);
-        
+
         $result = TestHelper::invokeMethod($this->currentMock, 'applyingGiftCardCode', [self::COUPON_CODE, $giftcardMock, $quote]);
-        
+
         $this->assertTrue($result);
     }
     

--- a/Test/Unit/ThirdPartyModules/Amasty/GiftCardAccountTest.php
+++ b/Test/Unit/ThirdPartyModules/Amasty/GiftCardAccountTest.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Test\Unit\ThirdPartyModules\Amasty;
+
+use Bolt\Boltpay\ThirdPartyModules\Amasty\GiftCardAccount;
+use Magento\Framework\Exception\NoSuchEntityException;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Bolt\Boltpay\ThirdPartyModules\Amasty\GiftCardAccount
+ */
+class GiftCardAccountTest extends TestCase
+{
+    /** @var int Test order id */
+    const ORDER_ID = 10001;
+
+    /**
+     * @var \Bolt\Boltpay\Helper\Bugsnag|MockObject mocked instance of the Bolt Bugsnag helper
+     */
+    private $bugsnagHelperMock;
+
+    /**
+     * @var \Amasty\GiftCardAccount\Model\GiftCardAccount\Repository|MockObject
+     * mocked instance of the Amasty Giftcard repository
+     */
+    private $giftcardRepositoryMock;
+
+    /**
+     * @var \Amasty\GiftCardAccount\Model\GiftCardExtension\Order\Repository|MockObject
+     */
+    private $giftcardOrderRepositoryMock;
+
+    /**
+     * @var \Magento\Sales\Model\Order|MockObject mocked instance of the Magento Order model
+     */
+    private $orderMock;
+
+    /**
+     * @var \Amasty\GiftCardAccount\Api\Data\GiftCardOrderInterface|MockObject
+     * mocked instance of the Order Extension Attribute added by Amasty Giftcard
+     */
+    private $giftcardOrderExtensionMock;
+
+    /**
+     * @var GiftCardAccount|MockObject mocked instance of the class tested
+     */
+    private $currentMock;
+
+    /**
+     * Setup test dependencies, called before each test
+     */
+    protected function setUp()
+    {
+        $this->bugsnagHelperMock = $this->createMock(\Bolt\Boltpay\Helper\Bugsnag::class);
+        $this->giftcardRepositoryMock = $this->getMockBuilder(
+            '\Amasty\GiftCardAccount\Model\GiftCardAccount\Repository'
+        )->setMethods([])->disableOriginalConstructor()->getMock();
+        $this->giftcardOrderRepositoryMock = $this->getMockBuilder(
+            '\Amasty\GiftCardAccount\Model\GiftCardExtension\Order\Repository'
+        )->setMethods([])->disableOriginalConstructor()->getMock();
+        $this->orderMock = $this->createMock(\Magento\Sales\Model\Order::class);
+        $this->orderMock->method('getId')->willReturn(self::ORDER_ID);
+        $this->currentMock = $this->getMockBuilder(GiftCardAccount::class)
+            ->setMethods(null)->setConstructorArgs([$this->bugsnagHelperMock])->getMock();
+        $this->giftcardOrderExtensionMock = $this->getMockBuilder(
+            '\Amasty\GiftCardAccount\Api\Data\GiftCardOrderInterface'
+        )->setMethods([])->disableOriginalConstructor()->getMock();
+    }
+
+    /**
+     * @test
+     * that constructor sets provided arguments to properties
+     *
+     * @covers ::__construct
+     */
+    public function __construct_always_setsProperties()
+    {
+        $instance = new GiftCardAccount($this->bugsnagHelperMock);
+        static::assertAttributeEquals($this->bugsnagHelperMock, 'bugsnagHelper', $instance);
+    }
+
+    /**
+     * @test
+     * that beforeDeleteOrder doesn't affect any giftcards if non are applied to the order
+     *
+     * @covers ::beforeDeleteOrder
+     */
+    public function beforeDeleteOrder_withNoGiftcardsOnOrder_doesNotRestoreBalance()
+    {
+        $this->giftcardOrderRepositoryMock->expects(static::once())->method('getByOrderId')
+            ->with(self::ORDER_ID)->willThrowException(new NoSuchEntityException(__('Gift Card Order not found.')));
+        $this->giftcardRepositoryMock->expects(static::never())->method('save');
+        $this->currentMock->beforeDeleteOrder(
+            $this->giftcardRepositoryMock,
+            $this->giftcardOrderRepositoryMock,
+            $this->orderMock
+        );
+    }
+
+    /**
+     * @test
+     * that beforeDeleteOrder doesn't affect any giftcards if non are applied to the order
+     *
+     * @covers ::beforeDeleteOrder
+     */
+    public function beforeDeleteOrder_withGiftcardsAppliedToOrder_restoresGiftcardBalance()
+    {
+        $this->giftcardOrderRepositoryMock->expects(static::once())->method('getByOrderId')
+            ->with(self::ORDER_ID)->willReturn($this->giftcardOrderExtensionMock);
+        $this->giftcardOrderExtensionMock->expects(static::once())->method('getGiftCards')->willReturn(
+            [
+                ['id' => 3, 'b_amount' => 123.45],
+                ['id' => 5, 'b_amount' => 456.78],
+                ['id' => 15, 'b_amount' => 232.23],
+            ]
+        );
+        $giftcard1 = $this->createGiftcardMock();
+        $giftcard2 = $this->createGiftcardMock();
+        $giftcard3 = $this->createGiftcardMock();
+        $this->giftcardRepositoryMock->expects(static::exactly(3))->method('getById')
+            ->withConsecutive([3], [5])->willReturnMap(
+                [
+                    [3, $giftcard1],
+                    [5, $giftcard2],
+                    [15, $giftcard3],
+                ]
+            );
+        $giftcard1->expects(static::once())->method('setCurrentValue')
+            ->with((float)(123.45 + 234.23));
+        $giftcard1->expects(static::once())->method('getCurrentValue')->willReturn(234.23);
+        $giftcard1->expects(static::once())->method('setStatus')->with(1);
+        $giftcard2->expects(static::once())->method('setCurrentValue')
+            ->with((float)(456.78 + 321.54));
+        $giftcard2->expects(static::once())->method('getCurrentValue')->willReturn(321.54);
+        $giftcard2->expects(static::once())->method('setStatus')->with(1);
+        $exception = new \Magento\Framework\Exception\LocalizedException(__(''));
+        $giftcard3->expects(static::once())->method('setCurrentValue')
+            ->with((float)(232.23 + 521.23))->willThrowException($exception);
+        $giftcard3->expects(static::once())->method('getCurrentValue')->willReturn(521.23);
+        $this->giftcardRepositoryMock->expects(static::exactly(2))->method('save')
+            ->withConsecutive([$giftcard1], [$giftcard3]);
+        $this->bugsnagHelperMock->expects(static::once())->method('notifyException')->with($exception);
+        $this->currentMock->beforeDeleteOrder(
+            $this->giftcardRepositoryMock,
+            $this->giftcardOrderRepositoryMock,
+            $this->orderMock
+        );
+    }
+
+    /**
+     * Creates a mocked instance of the Amasty Giftcard Account
+     * @return \Amasty\GiftCardAccount\Api\Data\GiftCardAccountInterface|MockObject
+     */
+    private function createGiftcardMock()
+    {
+        return $this->getMockBuilder('Amasty\GiftCardAccount\Api\Data\GiftCardAccountInterface')
+            ->setMethods(['setCurrentValue', 'getCurrentValue', 'setStatus'])
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->getMockForAbstractClass();
+    }
+}

--- a/Test/Unit/ThirdPartyModules/Amasty/GiftCardAccountTest.php
+++ b/Test/Unit/ThirdPartyModules/Amasty/GiftCardAccountTest.php
@@ -70,17 +70,17 @@ class GiftCardAccountTest extends TestCase
         $this->bugsnagHelperMock = $this->createMock(\Bolt\Boltpay\Helper\Bugsnag::class);
         $this->giftcardRepositoryMock = $this->getMockBuilder(
             '\Amasty\GiftCardAccount\Model\GiftCardAccount\Repository'
-        )->setMethods([])->disableOriginalConstructor()->getMock();
+        )->setMethods(['save', 'getById'])->disableOriginalConstructor()->getMock();
         $this->giftcardOrderRepositoryMock = $this->getMockBuilder(
             '\Amasty\GiftCardAccount\Model\GiftCardExtension\Order\Repository'
-        )->setMethods([])->disableOriginalConstructor()->getMock();
+        )->setMethods(['getByOrderId'])->disableOriginalConstructor()->getMock();
         $this->orderMock = $this->createMock(\Magento\Sales\Model\Order::class);
         $this->orderMock->method('getId')->willReturn(self::ORDER_ID);
         $this->currentMock = $this->getMockBuilder(GiftCardAccount::class)
             ->setMethods(null)->setConstructorArgs([$this->bugsnagHelperMock])->getMock();
         $this->giftcardOrderExtensionMock = $this->getMockBuilder(
-            '\Amasty\GiftCardAccount\Api\Data\GiftCardOrderInterface'
-        )->setMethods([])->disableOriginalConstructor()->getMock();
+            '\Amasty\GiftCardAccount\Model\GiftCardExtension\Order\Order'
+        )->setMethods(['getGiftCards'])->disableOriginalConstructor()->getMock();
     }
 
     /**
@@ -165,14 +165,14 @@ class GiftCardAccountTest extends TestCase
 
     /**
      * Creates a mocked instance of the Amasty Giftcard Account
-     * @return \Amasty\GiftCardAccount\Api\Data\GiftCardAccountInterface|MockObject
+     * @return MockObject|\Amasty\GiftCardAccount\Model\GiftCardAccount\Account
      */
     private function createGiftcardMock()
     {
-        return $this->getMockBuilder('Amasty\GiftCardAccount\Api\Data\GiftCardAccountInterface')
+        return $this->getMockBuilder('\Amasty\GiftCardAccount\Model\GiftCardAccount\Account')
             ->setMethods(['setCurrentValue', 'getCurrentValue', 'setStatus'])
             ->disableOriginalConstructor()
             ->disableOriginalClone()
-            ->getMockForAbstractClass();
+            ->getMock();
     }
 }

--- a/Test/Unit/ThirdPartyModules/Amasty/GiftCardAccountTest.php
+++ b/Test/Unit/ThirdPartyModules/Amasty/GiftCardAccountTest.php
@@ -70,17 +70,17 @@ class GiftCardAccountTest extends TestCase
         $this->bugsnagHelperMock = $this->createMock(\Bolt\Boltpay\Helper\Bugsnag::class);
         $this->giftcardRepositoryMock = $this->getMockBuilder(
             '\Amasty\GiftCardAccount\Model\GiftCardAccount\Repository'
-        )->setMethods(['save', 'getById'])->disableOriginalConstructor()->getMock();
+        )->setMethods(['save', 'getById'])->disableOriginalConstructor()->disableAutoload()->getMock();
         $this->giftcardOrderRepositoryMock = $this->getMockBuilder(
             '\Amasty\GiftCardAccount\Model\GiftCardExtension\Order\Repository'
-        )->setMethods(['getByOrderId'])->disableOriginalConstructor()->getMock();
+        )->setMethods(['getByOrderId'])->disableOriginalConstructor()->disableAutoload()->getMock();
         $this->orderMock = $this->createMock(\Magento\Sales\Model\Order::class);
         $this->orderMock->method('getId')->willReturn(self::ORDER_ID);
         $this->currentMock = $this->getMockBuilder(GiftCardAccount::class)
             ->setMethods(null)->setConstructorArgs([$this->bugsnagHelperMock])->getMock();
         $this->giftcardOrderExtensionMock = $this->getMockBuilder(
             '\Amasty\GiftCardAccount\Model\GiftCardExtension\Order\Order'
-        )->setMethods(['getGiftCards'])->disableOriginalConstructor()->getMock();
+        )->setMethods(['getGiftCards'])->disableOriginalConstructor()->disableAutoload()->getMock();
     }
 
     /**
@@ -172,6 +172,7 @@ class GiftCardAccountTest extends TestCase
         return $this->getMockBuilder('\Amasty\GiftCardAccount\Model\GiftCardAccount\Account')
             ->setMethods(['setCurrentValue', 'getCurrentValue', 'setStatus'])
             ->disableOriginalConstructor()
+            ->disableAutoload()
             ->disableOriginalClone()
             ->getMock();
     }

--- a/ThirdPartyModules/Amasty/GiftCardAccount.php
+++ b/ThirdPartyModules/Amasty/GiftCardAccount.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\ThirdPartyModules\Amasty;
+
+use Amasty\GiftCardAccount\Model\GiftCardAccount\GiftCardCartProcessor;
+use Amasty\GiftCardAccount\Model\OptionSource\AccountStatus;
+use Bolt\Boltpay\Helper\Bugsnag;
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Service\OrderService;
+
+class GiftCardAccount
+{
+
+    /**
+     * @var Bugsnag Bugsnag helper instance
+     */
+    private $bugsnagHelper;
+
+    /**
+     * @param Bugsnag $bugsnagHelper Bugsnag helper instance
+     */
+    public function __construct(Bugsnag $bugsnagHelper)
+    {
+        $this->bugsnagHelper = $bugsnagHelper;
+    }
+
+    /**
+     * Restores Amasty Giftcard balances used in an order that is going to be deleted
+     *
+     * @param \Amasty\GiftCardAccount\Model\GiftCardAccount\Repository         $giftcardRepository
+     * @param \Amasty\GiftCardAccount\Model\GiftCardExtension\Order\Repository $giftcardOrderRepository
+     * @param Order                                                            $order
+     */
+    public function beforeDeleteOrder($giftcardRepository, $giftcardOrderRepository, $order)
+    {
+        try {
+            $giftcardOrderExtension = $giftcardOrderRepository->getByOrderId($order->getId());
+            foreach ($giftcardOrderExtension->getGiftCards() as $orderGiftcard) {
+                try {
+                    /** @see GiftCardCartProcessor::GIFT_CARD_ID */
+                    $giftcard = $giftcardRepository->getById($orderGiftcard['id']);
+                    $giftcard->setCurrentValue(
+                        /** @see GiftCardCartProcessor::GIFT_CARD_BASE_AMOUNT */
+                        (float)($giftcard->getCurrentValue() + $orderGiftcard['b_amount'])
+                    );
+                    /** @see \Amasty\GiftCardAccount\Model\OptionSource\AccountStatus::STATUS_ACTIVE */
+                    $giftcard->setStatus(1);
+                    $giftcardRepository->save($giftcard);
+                } catch (\Magento\Framework\Exception\LocalizedException $e) {
+                    $this->bugsnagHelper->notifyException($e);
+                }
+            }
+        } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
+            //no giftcards applied on order, safe to ignore
+        }
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -166,6 +166,13 @@
             <argument name="className" xsi:type="string">Amasty\GiftCardAccount\Model\GiftCardAccount\ResourceModel\Collection</argument>
         </arguments>
     </virtualType>
+    <!-- For Amasty Gift Card v2.0.0 and later -->
+    <virtualType name="boltAmastyGiftCardAccountQuoteExtensionRepository" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
+        <arguments>
+            <argument name="moduleName" xsi:type="string">Amasty_GiftCardAccount</argument>
+            <argument name="className" xsi:type="string">Amasty\GiftCardAccount\Model\GiftCardExtension\Quote\Repository</argument>
+        </arguments>
+    </virtualType>
 
     <virtualType name="boltMirasvitRewardsPurchaseHelper" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
         <arguments>
@@ -216,6 +223,8 @@
             <argument name="amastyAccountFactory" xsi:type="object">boltAmastyAccountFactory</argument>
             <argument name="amastyGiftCardAccountManagement" xsi:type="object">boltAmastyGiftCardAccountManagement</argument>
             <argument name="amastyGiftCardAccountCollection" xsi:type="object">boltAmastyGiftCardAccountCollection</argument>
+            <argument name="amastyGiftCardAccountQuoteExtensionRepository" xsi:type="object">boltAmastyGiftCardAccountQuoteExtensionRepository</argument>
+
             <argument name="mirasvitRewardsPurchaseHelper" xsi:type="object">boltMirasvitRewardsPurchaseHelper</argument>
             <argument name="amastyRewardsResourceQuote" xsi:type="object">boltAmastyRewardsResourceQuote</argument>
             <argument name="amastyRewardsQuote" xsi:type="object">boltAmastyRewardsQuote</argument>


### PR DESCRIPTION
# Description
Resolves issues when applying both new and legacy Amasty Giftcards via discount/v2.
Adds support for failed payments for the new Amasty Giftcards by restoring gift card balance on failed payment.
Resolves issue with PPC and discount/v2 where Giftcards would get removed by the cloneAmastyGiftCards because of the same source and destination quote ID.

Fixes: [M2P-242](https://boltpay.atlassian.net/browse/M2P-242)

#changelog Discounts v2 fix - Unable to apply Amasty Gift Card via PPC

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
