### PR TITLE
M2P-275 Bugfix: fail to add coupon via update-cart v2 api hook

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -2498,4 +2498,14 @@ class Cart extends AbstractHelper
             return $result;
         }
     }
+    
+    /**
+     * Reset checkout session
+     *
+     * @param $checkoutSession
+     */
+    public function resetCheckoutSession($checkoutSession)
+    {
+        $this->checkoutSession = $checkoutSession;
+    }
 }

--- a/Helper/Discount.php
+++ b/Helper/Discount.php
@@ -1067,7 +1067,7 @@ class Discount extends AbstractHelper
      */
     public function setCouponCode($quote, $couponCode)
     {
-        $quote->getShippingAddress()->setCollectShippingRates(true);
-        $quote->setCouponCode($couponCode)->collectTotals()->save();
+        $quote->setCouponCode($couponCode);
+        $this->updateTotals($quote);
     }
 }

--- a/Model/Api/UpdateCart.php
+++ b/Model/Api/UpdateCart.php
@@ -116,6 +116,7 @@ class UpdateCart extends UpdateCartCommon implements UpdateCartInterface
             // Load logged in customer checkout and customer sessions from cached session id.
             // Replace the quote with $parentQuote in checkout session.
             $this->sessionHelper->loadSession($parentQuote);
+            $this->cartHelper->resetCheckoutSession($this->sessionHelper->getCheckoutSession());
             
             if (!empty($cart['shipments'][0]['reference'])) {
                 $this->setShipment($cart['shipments'][0], $immutableQuote);
@@ -151,7 +152,8 @@ class UpdateCart extends UpdateCartCommon implements UpdateCartInterface
                 $discount_code = $discount_codes_to_remove[0];
                 $couponCode = trim($discount_code);
 
-                $discounts = $this->getQuoteDiscounts($parentQuote);
+                $quoteCart = $this->getQuoteCart($parentQuote);
+                $discounts = $quoteCart['discounts'];
 
                 if(empty($discounts)){
                     $this->sendErrorResponse(
@@ -208,18 +210,6 @@ class UpdateCart extends UpdateCartCommon implements UpdateCartInterface
         }
 
         return true;
-    }
-    
-    /**
-     * @param Quote $quote
-     * @return array
-     * @throws \Exception
-     */
-    protected function getQuoteDiscounts($quote)
-    {
-        $is_has_shipment = !empty($this->cartRequest['shipments'][0]['reference']);
-        list ($discounts, ,) = $this->cartHelper->collectDiscounts(0, 0, $is_has_shipment, $quote);
-        return $discounts;
     }
     
     /**

--- a/Model/Api/UpdateDiscountTrait.php
+++ b/Model/Api/UpdateDiscountTrait.php
@@ -352,7 +352,6 @@ trait UpdateDiscountTrait
         $address = $quote->isVirtual() ?
             $quote->getBillingAddress() :
             $quote->getShippingAddress();
-        $this->totalsCollector->collectAddressTotals($quote, $address);
 
         $result = [
             'status'          => 'success',

--- a/Test/Unit/Helper/DiscountTest.php
+++ b/Test/Unit/Helper/DiscountTest.php
@@ -2998,15 +2998,28 @@ class DiscountTest extends TestCase
      */
     public function setCouponCode_savesProperly()
     {
-        $this->initCurrentMock(['updateTotals']);
-        $quoteMock = $this->getMockBuilder(Quote::class)
-            ->setMethods(['setCouponCode'])
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->initCurrentMock();
+        
+         $couponCode = 'testcoupon';
+        
+        $quote = $this->createPartialMock(
+            Quote::class,
+            [
+                'getShippingAddress',
+                'setTotalsCollectedFlag',
+                'collectTotals',
+                'setDataChanges',
+                'setCouponCode'
+            ]
+        );
 
-        $couponCode = 'testcoupon';
-        $quoteMock->expects(static::once())->method('setCouponCode')->with($couponCode)->willReturnSelf();
-        $this->currentMock->expects(static::once())->method('updateTotals')->with($quoteMock);
+        $quote->expects(static::once())->method('getShippingAddress')->willReturnSelf();
+        $quote->expects(static::once())->method('setTotalsCollectedFlag')->with(false)->willReturnSelf();
+        $quote->expects(static::once())->method('collectTotals')->willReturnSelf();
+        $quote->expects(static::once())->method('setDataChanges')->with(true)->willReturnSelf();
+        $quote->expects(static::once())->method('setCouponCode')->with($couponCode)->willReturnSelf();
+
+        $this->quoteRepository->expects(static::once())->method('save')->with($quote)->willReturnSelf();
 
         static::assertNull($this->currentMock->setCouponCode($quoteMock,$couponCode));
     }

--- a/Test/Unit/Helper/DiscountTest.php
+++ b/Test/Unit/Helper/DiscountTest.php
@@ -2998,18 +2998,15 @@ class DiscountTest extends TestCase
      */
     public function setCouponCode_savesProperly()
     {
-        $this->initCurrentMock();
+        $this->initCurrentMock(['updateTotals']);
         $quoteMock = $this->getMockBuilder(Quote::class)
-            ->setMethods(['getShippingAddress','setCollectShippingRates','setCouponCode','collectTotals','save'])
+            ->setMethods(['setCouponCode'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $couponCode = 'testcoupon';
-        $quoteMock->expects(static::once())->method('getShippingAddress')->willReturnSelf();
-        $quoteMock->expects(static::once())->method('setCollectShippingRates')->with(true)->willReturnSelf();
         $quoteMock->expects(static::once())->method('setCouponCode')->with($couponCode)->willReturnSelf();
-        $quoteMock->expects(static::once())->method('collectTotals')->willReturnSelf();
-        $quoteMock->expects(static::once())->method('save')->willReturnSelf();
+        $this->currentMock->expects(static::once())->method('updateTotals')->with($quoteMock);
 
         static::assertNull($this->currentMock->setCouponCode($quoteMock,$couponCode));
     }

--- a/Test/Unit/Helper/DiscountTest.php
+++ b/Test/Unit/Helper/DiscountTest.php
@@ -3021,7 +3021,7 @@ class DiscountTest extends TestCase
 
         $this->quoteRepository->expects(static::once())->method('save')->with($quote)->willReturnSelf();
 
-        static::assertNull($this->currentMock->setCouponCode($quoteMock,$couponCode));
+        static::assertNull($this->currentMock->setCouponCode($quote,$couponCode));
     }
     
     /**

--- a/Test/Unit/Model/Api/UpdateCartTest.php
+++ b/Test/Unit/Model/Api/UpdateCartTest.php
@@ -21,6 +21,7 @@ use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Webapi\Exception as WebApiException;
 use Magento\Framework\Webapi\Rest\Response;
+use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\SalesRule\Model\Coupon;
 use Bolt\Boltpay\Api\UpdateCartInterface;
 use Bolt\Boltpay\Api\Data\CartDataInterface;
@@ -188,6 +189,7 @@ class UpdateCartTest extends TestCase
             ->setMethods(
                 [
                     'replicateQuoteData',
+                    'resetCheckoutSession',
                 ]
             )
             ->disableOriginalConstructor()
@@ -441,10 +443,17 @@ class UpdateCartTest extends TestCase
         );
         
         $sessionHelper = $this->getMockBuilder(SessionHelper::class)
-            ->setMethods(['loadSession'])
+            ->setMethods(['loadSession','getCheckoutSession'])
             ->disableOriginalConstructor()
             ->getMock();
         $sessionHelper->expects(self::once())->method('loadSession')->with($parentQuoteMock);
+        
+        $checkoutSession = $this->createMock(CheckoutSession::class);
+        $sessionHelper->expects(self::once())->method('getCheckoutSession')
+            ->willReturn($checkoutSession);
+        
+        $this->cartHelper->expects(self::once())->method('resetCheckoutSession')
+            ->with($checkoutSession);
 
         $this->initCurrentMock([
             'validateQuote',
@@ -535,17 +544,24 @@ class UpdateCartTest extends TestCase
         );
         
         $sessionHelper = $this->getMockBuilder(SessionHelper::class)
-            ->setMethods(['loadSession'])
+            ->setMethods(['loadSession','getCheckoutSession'])
             ->disableOriginalConstructor()
             ->getMock();
         $sessionHelper->expects(self::once())->method('loadSession')->with($parentQuoteMock);
+        
+        $checkoutSession = $this->createMock(CheckoutSession::class);
+        $sessionHelper->expects(self::once())->method('getCheckoutSession')
+            ->willReturn($checkoutSession);
+        
+        $this->cartHelper->expects(self::once())->method('resetCheckoutSession')
+            ->with($checkoutSession);
             
         $this->initCurrentMock([
             'validateQuote',
             'preProcessWebhook',
             'setShipment',
             'generateResult',
-            'getQuoteDiscounts',
+            'getQuoteCart',
             'removeDiscount'
         ], $sessionHelper);        
         
@@ -574,9 +590,9 @@ class UpdateCartTest extends TestCase
                 'discount_type'   => 'fixed_amount',
             ]
         ];
-        $this->currentMock->expects(self::once())->method('getQuoteDiscounts')
+        $this->currentMock->expects(self::once())->method('getQuoteCart')
             ->with($parentQuoteMock)
-            ->willReturn($quoteDiscount);
+            ->willReturn(['discounts' => $quoteDiscount]);
         
         $this->currentMock->expects(self::once())->method('removeDiscount')
             ->with(self::COUPON_CODE, [self::COUPON_CODE => 'coupon'], $parentQuoteMock, self::WEBSITE_ID, self::STORE_ID)

--- a/Test/Unit/Model/Api/UpdateCartTest.php
+++ b/Test/Unit/Model/Api/UpdateCartTest.php
@@ -451,9 +451,6 @@ class UpdateCartTest extends TestCase
         $checkoutSession = $this->createMock(CheckoutSession::class);
         $sessionHelper->expects(self::once())->method('getCheckoutSession')
             ->willReturn($checkoutSession);
-        
-        $this->cartHelper->expects(self::once())->method('resetCheckoutSession')
-            ->with($checkoutSession);
 
         $this->initCurrentMock([
             'validateQuote',
@@ -488,6 +485,8 @@ class UpdateCartTest extends TestCase
             ->with(self::COUPON_CODE, $this->couponMock, null, $parentQuoteMock)
             ->willReturn(true);
         
+        $this->cartHelper->expects(self::once())->method('resetCheckoutSession')
+            ->with($checkoutSession);
         $this->cartHelper->expects(self::once())->method('replicateQuoteData')
             ->with($parentQuoteMock, $immutableQuoteMock);
 
@@ -552,9 +551,6 @@ class UpdateCartTest extends TestCase
         $checkoutSession = $this->createMock(CheckoutSession::class);
         $sessionHelper->expects(self::once())->method('getCheckoutSession')
             ->willReturn($checkoutSession);
-        
-        $this->cartHelper->expects(self::once())->method('resetCheckoutSession')
-            ->with($checkoutSession);
             
         $this->initCurrentMock([
             'validateQuote',
@@ -598,6 +594,8 @@ class UpdateCartTest extends TestCase
             ->with(self::COUPON_CODE, [self::COUPON_CODE => 'coupon'], $parentQuoteMock, self::WEBSITE_ID, self::STORE_ID)
             ->willReturn(true);
         
+        $this->cartHelper->expects(self::once())->method('resetCheckoutSession')
+            ->with($checkoutSession);
         $this->cartHelper->expects(self::once())->method('replicateQuoteData')
             ->with($parentQuoteMock, $immutableQuoteMock);
 

--- a/Test/Unit/Model/Api/UpdateDiscountTraitTest.php
+++ b/Test/Unit/Model/Api/UpdateDiscountTraitTest.php
@@ -174,14 +174,6 @@ class UpdateDiscountTraitTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->totalsCollector = $this->getMockBuilder(TotalsCollector::class)
-            ->setMethods(['collectAddressTotals'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->totalsCollector->method('collectAddressTotals')
-            ->withAnyParameters()
-            ->willReturnSelf();
-
         $this->eventsForThirdPartyModules = $this->createPartialMock(EventsForThirdPartyModules::class, ['runFilter','dispatchEvent']);
         $this->eventsForThirdPartyModules
             ->method('runFilter')

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -297,5 +297,17 @@
                 type="Bolt\Boltpay\Plugin\Magento\TogglePaymentMethodsPlugin"
                 sortOrder="1"/>
     </type>
+    
+    <type name="Magento\SalesRule\Model\Rule\Action\Discount\AbstractDiscount">
+        <plugin name="Bolt_Boltpay_SalesRule_Action_Discount_Plugin"
+                type="Bolt\Boltpay\Plugin\SalesRuleActionDiscountPlugin"
+                sortOrder="20"/>
+    </type>
+    
+    <type name="Magento\SalesRule\Model\Quote\Discount">
+        <plugin name="Bolt_Boltpay_SalesRule_Quote_Discount_Plugin"
+                type="Bolt\Boltpay\Plugin\SalesRuleQuoteDiscountPlugin"
+                sortOrder="1"/>
+    </type>
 
 </config>

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -44,17 +44,6 @@
     <type name="Amasty\GiftCard\Controller\Cart\Remove">
         <plugin name="Bolt_Boltpay_Amasty_GiftCard_Remove_Plugin" type="Bolt\Boltpay\Plugin\AmastyGiftCardRemovePlugin" sortOrder="1" />
     </type>
-    <type name="Magento\SalesRule\Model\Rule\Action\Discount\AbstractDiscount">
-        <plugin name="Bolt_Boltpay_SalesRule_Action_Discount_Plugin"
-                type="Bolt\Boltpay\Plugin\SalesRuleActionDiscountPlugin"
-                sortOrder="20"/>
-    </type>
-    
-    <type name="Magento\SalesRule\Model\Quote\Discount">
-        <plugin name="Bolt_Boltpay_SalesRule_Quote_Discount_Plugin"
-                type="Bolt\Boltpay\Plugin\SalesRuleQuoteDiscountPlugin"
-                sortOrder="1"/>
-    </type>
 
     <type name="Magento\Checkout\Block\Cart\Totals">
         <arguments>


### PR DESCRIPTION
# Description
Currently the coupon can not be added via update-cart v2 api hook, something is broken. This PR is to fix it.

Fixes: https://boltpay.atlassian.net/browse/M2P-275

#changelog Bugfix: fail to add coupon via update-cart v2 api hook

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
