### PR TITLE
M2P-278 Exclude zero discount from the Bolt cart

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1957,8 +1957,8 @@ class Cart extends AbstractHelper
                     continue;
                 }
                 $rule = $this->ruleRepository->getById($salesruleId);
-                if ($rule) {
-                    $ruleDiscountAmount = $boltCollectSaleRuleDiscounts[$salesruleId];
+                $ruleDiscountAmount = $boltCollectSaleRuleDiscounts[$salesruleId];
+                if ($rule && $ruleDiscountAmount) {
                     $roundedAmount = CurrencyUtils::toMinor($ruleDiscountAmount, $currencyCode);
                     switch ($rule->getCouponType()) {
                         case RuleInterface::COUPON_TYPE_SPECIFIC_COUPON:

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -3653,7 +3653,7 @@ ORDER
         static::assertEquals(10000, $totalAmountResult);
         static::assertEquals([], $discounts);
         }
-
+        
         /**
         * @test
         * that collectDiscounts handles default coupon code discount
@@ -3684,10 +3684,10 @@ ORDER
         $appliedDiscountNoCoupon = 15; // $
         $shippingAddress->expects(static::once())->method('getDiscountAmount')->willReturn($appliedDiscount);
         
-        $quote->method('getAppliedRuleIds')->willReturn('2,3');
+        $quote->method('getAppliedRuleIds')->willReturn('2,3,4');
         $this->checkoutSession->expects(static::once())
                               ->method('getBoltCollectSaleRuleDiscounts')
-                              ->willReturn([2 => $appliedDiscount, 3 => $appliedDiscountNoCoupon]);
+                              ->willReturn([2 => $appliedDiscount, 3 => $appliedDiscountNoCoupon, 4 => 0]);
         $rule2 = $this->getMockBuilder(DataObject::class)
             ->setMethods(['getCouponType', 'getDescription'])
             ->disableOriginalConstructor()
@@ -3708,13 +3708,18 @@ ORDER
         $rule3->expects(static::exactly(2))->method('getSimpleAction')
             ->willReturn('by_fixed');
         
+        $rule4 = $this->getMockBuilder(DataObject::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+            
         $this->ruleRepository->expects(static::exactly(2))
             ->method('getById')
             ->withConsecutive(
                 [2],
-                [3]
+                [3],
+                [4]
             )
-            ->willReturnOnConsecutiveCalls($rule2, $rule3);
+            ->willReturnOnConsecutiveCalls($rule2, $rule3, $rule4);
         
         $this->discountHelper->expects(static::exactly(2))->method('getBoltDiscountType')->with('by_fixed')->willReturn('fixed_amount');
             

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -3712,7 +3712,7 @@ ORDER
             ->disableOriginalConstructor()
             ->getMock();
             
-        $this->ruleRepository->expects(static::exactly(2))
+        $this->ruleRepository->expects(static::exactly(3))
             ->method('getById')
             ->withConsecutive(
                 [2],


### PR DESCRIPTION
# Description
$quote->getAppliedRuleIds() would return all the available rules for the quote, and some of them (especially the no coupon type) actually does not match the conditions at that point and still have zero discount amount, so we need to exclude them from the cart data sent to Bolt

Fixes: https://boltpay.atlassian.net/browse/M2P-278

#changelog Exclude zero discount from the Bolt cart

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
