### PR TITLE
Postpone setupReplacement() code until BoltState is initialized

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -861,6 +861,75 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
             return;
         }
 
+        /////////////////////////////////////////////////////
+        // Flag that is true if checkout buttons exists on the page
+        var checkout_buttons = false;
+
+        //////////////////////////////////////////////////////////
+        // loop through selectors array and set up the replacement
+        //////////////////////////////////////////////////////////
+        var setupReplacement = function() {
+            for (var i = 0, length = settings.selectors.length; i < length; i++) {
+                var selector = settings.selectors[i];
+                ! function(selector) {
+                    var parts = selector.split('|');
+                    // the CSS selector
+                    var identifier = parts[0].trim();
+                    // button placement regarding the selector element, prepend, append
+                    var position =  parts[1];
+                    /////////////////////////////////////////////////////
+                    // replace the selectors with bolt button identifiers
+                    // if / when selectors are in the DOM
+                    /////////////////////////////////////////////////////
+                    onElementReady(identifier, function(element) {
+                        if (getCheckoutKey() === '') return;
+                        var bolt_button = document.createElement('div');
+                        if(settings.is_instant_checkout_button){
+                            bolt_button.setAttribute('data-tid','instant-bolt-checkout-button');
+                            var button_object = document.createElement('object');
+                            var checkout_button_url = settings.cdn_url
+                                +'/v1/checkout_button?publishable_key='
+                                +settings.publishable_key_checkout
+                            button_object.setAttribute('data',checkout_button_url);
+                            bolt_button.appendChild(button_object);
+                        } else {
+                            bolt_button.setAttribute('class', bolt_button_css_class);
+                            if (bolt_button_css_styles.length) {
+                                bolt_button.setAttribute('style', bolt_button_css_styles);
+                            }
+                            if (getCheckoutType() === 'checkout') {
+                                bolt_button.classList.add(multi_step_css_class);
+                            }
+
+                            for (var attribute_name in additional_button_attributes) {
+                                if (additional_button_attributes.hasOwnProperty(attribute_name)) {
+                                    bolt_button.setAttribute(attribute_name, additional_button_attributes[attribute_name]);
+                                }
+                            }
+                        }
+                        // place the button before or after selector element
+                        if (position && position.trim().toLowerCase() === 'append') {
+                            element.parentNode.insertBefore(bolt_button, element.nextSibling);
+                        } else {
+                            element.parentNode.insertBefore(bolt_button, element);
+                        }
+                        // if no position is specified remove the selector element
+                        if (!position) {
+                            $(element).hide();
+                        }
+                        // if the replacement takes place after BoltCheckout.configure call
+                        // call it again to set up the button. Skip if BoltCheckout is not available,
+                        // ie. connect.js not loaded / executed yet,
+                        // the button will be processed after connect.js loads.
+                        if (window.BoltCheckout && !waitingForResolvingPromises) {
+                            boltCheckoutConfigure(cart, hints, callbacks, boltCheckoutConfig);
+                        }
+                    });
+                    /////////////////////////////////////////////////////
+                }(selector);
+            }
+        };
+
         var boltCheckoutSetup = function (el, dataChanged) {
             // Check if BoltCheckout is defined (connect.js executed).
             // If not, postpone processing until it is
@@ -875,6 +944,8 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
             BoltState.beforeConfigureBarrier = boltBarrier();
             // resolve promise for now, extensions can initialize it again
             BoltState.beforeConfigureBarrier.resolve(true);
+
+            setupReplacement();
 
             // check and set payment_only flag
             if (getCheckoutType() === 'payment') {
@@ -1131,76 +1202,6 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
             }
         });
         }
-
-        /////////////////////////////////////////////////////
-        // Flag that is true if checkout buttons exists on the page
-        var checkout_buttons = false;
-
-        //////////////////////////////////////////////////////////
-        // loop through selectors array and set up the replacement
-        //////////////////////////////////////////////////////////
-        var setupReplacement = function() {
-            for (var i = 0, length = settings.selectors.length; i < length; i++) {
-                var selector = settings.selectors[i];
-                ! function(selector) {
-                    var parts = selector.split('|');
-                    // the CSS selector
-                    var identifier = parts[0].trim();
-                    // button placement regarding the selector element, prepend, append
-                    var position =  parts[1];
-                    /////////////////////////////////////////////////////
-                    // replace the selectors with bolt button identifiers
-                    // if / when selectors are in the DOM
-                    /////////////////////////////////////////////////////
-                    onElementReady(identifier, function(element) {
-                        if (getCheckoutKey() === '') return;
-                        var bolt_button = document.createElement('div');
-                        if(settings.is_instant_checkout_button){
-                            bolt_button.setAttribute('data-tid','instant-bolt-checkout-button');
-                            var button_object = document.createElement('object');
-                            var checkout_button_url = settings.cdn_url
-                                +'/v1/checkout_button?publishable_key='
-                                +settings.publishable_key_checkout
-                            button_object.setAttribute('data',checkout_button_url);
-                            bolt_button.appendChild(button_object);
-                        } else {
-                            bolt_button.setAttribute('class', bolt_button_css_class);
-                            if (bolt_button_css_styles.length) {
-                                bolt_button.setAttribute('style', bolt_button_css_styles);
-                            }
-                            if (getCheckoutType() === 'checkout') {
-                                bolt_button.classList.add(multi_step_css_class);
-                            }
-
-                            for (var attribute_name in additional_button_attributes) {
-                                if (additional_button_attributes.hasOwnProperty(attribute_name)) {
-                                    bolt_button.setAttribute(attribute_name, additional_button_attributes[attribute_name]);
-                                }
-                            }
-                        }
-                        // place the button before or after selector element
-                        if (position && position.trim().toLowerCase() === 'append') {
-                            element.parentNode.insertBefore(bolt_button, element.nextSibling);
-                        } else {
-                            element.parentNode.insertBefore(bolt_button, element);
-                        }
-                        // if no position is specified remove the selector element
-                        if (!position) {
-                            $(element).hide();
-                        }
-                        // if the replacement takes place after BoltCheckout.configure call
-                        // call it again to set up the button. Skip if BoltCheckout is not available,
-                        // ie. connect.js not loaded / executed yet,
-                        // the button will be processed after connect.js loads.
-                        if (window.BoltCheckout && !waitingForResolvingPromises) {
-                            boltCheckoutConfigure(cart, hints, callbacks, boltCheckoutConfig);
-                        }
-                    });
-                    /////////////////////////////////////////////////////
-                }(selector);
-            }
-        };
-        setupReplacement();
 
         ///////////////////////////////////////////////////////////
         // Run function fn on element underlying data change


### PR DESCRIPTION
Under some condition possible that `setupReplacement()` run after bolt js script is initialized but before BoltState setup.
In version 2.14 this produces error
`Uncaught TypeError: Cannot read property 'isResolved' of null at callConfigure`

Solution: call setupReplacement() right after BoltState is initialized

Fixes: (link Jira ticket)

#changelog Postpone setupReplacement() code until BoltState is initialized

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
