### PR TITLE
M2P-262 - Resolve issue with Aheadworkds_Sarp2

### DIFF
--- a/Model/EventsForThirdPartyModules.php
+++ b/Model/EventsForThirdPartyModules.php
@@ -33,6 +33,14 @@ use Exception;
 class EventsForThirdPartyModules
 {
     const eventListeners = [
+        'adminhtmlControllerActionPredispatchSalesOrderCreateIndex' => [
+            "listeners" => [
+                [
+                    "module" => "Aheadworks_Sarp2",
+                    "boltClass" => \Bolt\Boltpay\ThirdPartyModules\Aheadworks\Sarp2::class,
+                ],
+            ]
+        ],
         "afterLoadSession" => [
             "listeners" => [
                 [

--- a/Observer/Adminhtml/ActionPredispatch.php
+++ b/Observer/Adminhtml/ActionPredispatch.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Observer\Adminhtml;
+
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Event\Observer;
+
+/**
+ * Observer for controller_action_predispatch
+ * @see \Magento\Framework\App\Action\Action::dispatch
+ */
+class ActionPredispatch implements ObserverInterface
+{
+    /**
+     * @var \Bolt\Boltpay\Model\EventsForThirdPartyModules
+     */
+    private $eventsForThirdPartyModules;
+
+    /**
+     * ActionPredispatch constructor.
+     * @param \Bolt\Boltpay\Model\EventsForThirdPartyModules $eventsForThirdPartyModules
+     */
+    public function __construct(\Bolt\Boltpay\Model\EventsForThirdPartyModules $eventsForThirdPartyModules)
+    {
+        $this->eventsForThirdPartyModules = $eventsForThirdPartyModules;
+    }
+
+    /**
+     * Redirects the predispatch event to the {@see \Bolt\Boltpay\Model\EventsForThirdPartyModules}
+     *
+     * @param Observer $observer
+     * @return void
+     */
+    public function execute(Observer $observer)
+    {
+        /** @var \Magento\Framework\App\RequestInterface $request */
+        $request = $observer->getData('request');
+        $this->eventsForThirdPartyModules->dispatchEvent(
+            $this->convertEventName('adminhtml_controller_action_predispatch'),
+            $observer
+        );
+        $this->eventsForThirdPartyModules->dispatchEvent(
+            $this->convertEventName('adminhtml_controller_action_predispatch_' . $request->getRouteName()),
+            $observer
+        );
+        $this->eventsForThirdPartyModules->dispatchEvent(
+            $this->convertEventName('adminhtml_controller_action_predispatch_' . $request->getFullActionName()),
+            $observer
+        );
+    }
+
+    /**
+     * Converts Magento format event name to the Boltpay format used in
+     * @see \Bolt\Boltpay\Model\EventsForThirdPartyModules
+     *
+     * @param string $eventName in Magento format
+     * @return string event name in Boltpay third party modules event format
+     */
+    private function convertEventName($eventName)
+    {
+        return lcfirst(str_replace('_', '', ucwords($eventName, '_')));
+    }
+}

--- a/Test/Unit/Observer/Adminhtml/ActionPredispatchTest.php
+++ b/Test/Unit/Observer/Adminhtml/ActionPredispatchTest.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Test\Unit\Observer\Adminhtml;
+
+use Bolt\Boltpay\Observer\Adminhtml\ActionPredispatch;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Bolt\Boltpay\Observer\Adminhtml\ActionPredispatch
+ */
+class ActionPredispatchTest extends TestCase
+{
+    /**
+     * @var \Bolt\Boltpay\Model\EventsForThirdPartyModules|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $eventsForThirdPartyModulesMock;
+
+    /**
+     * @var ActionPredispatch|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $currentMock;
+
+    /**
+     * Setup test dependencies, called before each test
+     */
+    protected function setUp()
+    {
+        $this->eventsForThirdPartyModulesMock = $this->createMock(
+            \Bolt\Boltpay\Model\EventsForThirdPartyModules::class
+        );
+        $this->currentMock = $this->getMockBuilder(ActionPredispatch::class)
+            ->setMethods(null)
+            ->setConstructorArgs([$this->eventsForThirdPartyModulesMock])
+            ->getMock();
+    }
+
+    /**
+     * @test
+     * that constructor sets provided arguments to expected properties
+     *
+     * @covers ::__construct
+     */
+    public function __construct_always_setsInternalProperty()
+    {
+        $instance = new ActionPredispatch($this->eventsForThirdPartyModulesMock);
+        static::assertAttributeEquals($this->eventsForThirdPartyModulesMock, 'eventsForThirdPartyModules', $instance);
+    }
+
+    /**
+     * @test
+     * that excute redirects the predispatch event to the Events for Third Party Modules
+     *
+     * @dataProvider executeDataProvider
+     *
+     * @covers ::execute
+     * @covers ::convertEventName
+     *
+     * @param string $route
+     * @param string $controller
+     * @param string $action
+     * @param array  $expectedThirdPartyEvents
+     */
+    public function execute_withVariousActions_dispatchesThirdPartyEvents(
+        $route,
+        $controller,
+        $action,
+        $expectedThirdPartyEvents
+    ) {
+        $request = $this->createMock(\Magento\Framework\App\Request\Http::class);
+        $request->expects(static::once())->method('getRouteName')->willReturn($route);
+        $request->expects(static::once())->method('getFullActionName')->willReturn(
+            implode('_', [$route, $controller, $action])
+        );
+        $observer = new \Magento\Framework\Event\Observer(['request' => $request]);
+        $this->eventsForThirdPartyModulesMock->expects(static::exactly(count($expectedThirdPartyEvents)))
+            ->method('dispatchEvent')
+            ->withConsecutive(
+                ...array_chunk($expectedThirdPartyEvents, 1)
+            );
+        $this->currentMock->execute($observer);
+    }
+
+    /**
+     * Data provider for {@see execute_withVariousAction}
+     */
+    public function execute_withVariousActionProvider()
+    {
+        return [
+            [
+                'route'                    => 'sales',
+                'controller'               => 'order_create',
+                'action'                   => 'index',
+                'expectedThirdPartyEvents' => [
+                    'adminhtmlControllerActionPredispatch',
+                    'adminhtmlControllerActionPredispatchSales',
+                    'adminhtmlControllerActionPredispatchSalesOrderCreateIndex',
+                ]
+            ],
+            [
+                'route'                    => 'sales',
+                'controller'               => 'order_create',
+                'action'                   => 'start',
+                'expectedThirdPartyEvents' => [
+                    'adminhtmlControllerActionPredispatch',
+                    'adminhtmlControllerActionPredispatchSales',
+                    'adminhtmlControllerActionPredispatchSalesOrderCreateStart',
+                ]
+            ],
+            [
+                'route'                    => 'catalog',
+                'controller'               => 'product',
+                'action'                   => 'edit',
+                'expectedThirdPartyEvents' => [
+                    'adminhtmlControllerActionPredispatch',
+                    'adminhtmlControllerActionPredispatchCatalog',
+                    'adminhtmlControllerActionPredispatchCatalogProductEdit',
+                ]
+            ],
+        ];
+    }
+
+}

--- a/Test/Unit/Observer/Adminhtml/ActionPredispatchTest.php
+++ b/Test/Unit/Observer/Adminhtml/ActionPredispatchTest.php
@@ -65,7 +65,7 @@ class ActionPredispatchTest extends TestCase
      * @test
      * that excute redirects the predispatch event to the Events for Third Party Modules
      *
-     * @dataProvider executeDataProvider
+     * @dataProvider execute_withVariousActionProvider
      *
      * @covers ::execute
      * @covers ::convertEventName
@@ -96,7 +96,7 @@ class ActionPredispatchTest extends TestCase
     }
 
     /**
-     * Data provider for {@see execute_withVariousAction}
+     * Data provider for {@see execute_withVariousActions_dispatchesThirdPartyEvents}
      */
     public function execute_withVariousActionProvider()
     {

--- a/Test/Unit/ThirdPartyModules/Aheadworks/Sarp2Test.php
+++ b/Test/Unit/ThirdPartyModules/Aheadworks/Sarp2Test.php
@@ -1,0 +1,225 @@
+<?php
+
+namespace Bolt\Boltpay\Test\Unit\ThirdPartyModules\Aheadworks;
+
+use Bolt\Boltpay\ThirdPartyModules\Aheadworks\Sarp2;
+use Magento\Framework\ObjectManager\ConfigLoaderInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class Sarp2Test extends TestCase
+{
+    const CHECK_SPECIFICATION_FACTORY_CLASS = 'Magento\Payment\Model\Checks\SpecificationFactory';
+
+    /**
+     * @var \Magento\Framework\ObjectManager\ObjectManager|MockObject
+     */
+    private $objectManagerMock;
+
+    /**
+     * @var \Magento\Framework\App\ObjectManager\ConfigLoader\Compiled|MockObject
+     */
+    private $compiledConfigLoaderMock;
+
+    /**
+     * @var \Magento\Framework\App\ObjectManager\ConfigLoader|MockObject
+     */
+    private $configLoaderMock;
+
+    /**
+     * @var Sarp2|MockObject
+     */
+    private $currentMock;
+
+    /**
+     * Setup test dependencies, called before each test
+     */
+    protected function setUp()
+    {
+        $this->objectManagerMock = $this->createMock(\Magento\Framework\ObjectManager\ObjectManager::class);
+        $this->configLoaderMock = $this->createMock(\Magento\Framework\App\ObjectManager\ConfigLoader::class);
+        $this->compiledConfigLoaderMock = $this->createMock(
+            \Magento\Framework\App\ObjectManager\ConfigLoader\Compiled::class
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function __construct_always_setsInternalProperties()
+    {
+        $instance = new Sarp2($this->objectManagerMock, $this->configLoaderMock);
+        static::assertAttributeEquals($this->objectManagerMock, 'objectManager', $instance);
+        static::assertAttributeEquals($this->configLoaderMock, 'configLoader', $instance);
+    }
+
+    /**
+     * @param ConfigLoaderInterface|MockObject $configLoader
+     * @param array                            $globalConfig
+     * @param array                            $adminConfig
+     */
+    private function adminhtmlControllerActionPredispatchSalesOrderCreateIndexSetUp(
+        ConfigLoaderInterface $configLoader,
+        $globalConfig,
+        $adminConfig
+    ) {
+        $configLoader->method('load')->willReturnMap(
+            [
+                [\Magento\Framework\App\Area::AREA_GLOBAL, $globalConfig],
+                [\Magento\Framework\App\Area::AREA_ADMINHTML, $adminConfig],
+            ]
+        );
+        $this->currentMock = $this->getMockBuilder(Sarp2::class)
+            ->setConstructorArgs([$this->objectManagerMock, $configLoader])
+            ->setMethods(null)
+            ->getMock();
+    }
+
+    /**
+     * @test
+     * that adminhtmlControllerActionPredispatchSalesOrderCreateIndex reconfigures DI configuration to resolve issue
+     * with Aheadworks_Sarp2 module
+     *
+     * @dataProvider adminhtmlControllerActionPredispatchSalesOrderCreateIndexProvider
+     *
+     * @param array $globalConfig
+     * @param array $adminConfig
+     * @param bool  $isProductionMode
+     * @param array $mergedConfiguration
+     */
+    public function adminhtmlControllerActionPredispatchSalesOrderCreateIndex_withVariousModesAndConfigurations_reconfiguresDI(
+        $globalConfig,
+        $adminConfig,
+        $isProductionMode,
+        $mergedConfiguration
+    ) {
+        $this->adminhtmlControllerActionPredispatchSalesOrderCreateIndexSetUp(
+            $isProductionMode ? $this->compiledConfigLoaderMock : $this->configLoaderMock,
+            $globalConfig,
+            $adminConfig
+        );
+        $this->objectManagerMock->expects(static::once())->method('configure')->with($mergedConfiguration);
+        $this->currentMock->adminhtmlControllerActionPredispatchSalesOrderCreateIndex();
+    }
+
+    /**
+     * Data provider for {@see adminhtmlControllerActionPredispatchSalesOrderCreateIndex_withVariousModesAndConfigurations_reconfiguresOM}
+     *
+     * @return array[] containing global and admin DI config arrays, whether the production mode is set
+     * and the expected result
+     */
+    public function adminhtmlControllerActionPredispatchSalesOrderCreateIndexProvider()
+    {
+        return [
+            [
+                'globalConfig'        => [
+                    self::CHECK_SPECIFICATION_FACTORY_CLASS => [
+                        'arguments' => [
+                            'mapping' => [
+                                'country'    => ['instance' => 'Magento\\Payment\\Model\\Checks\\CanUseForCountry',],
+                                'currency'   => ['instance' => 'Magento\\Payment\\Model\\Checks\\CanUseForCurrency',],
+                                'checkout'   => ['instance' => 'Magento\\Payment\\Model\\Checks\\CanUseCheckout',],
+                                'internal'   => ['instance' => 'Magento\\Payment\\Model\\Checks\\CanUseInternal',],
+                                'total'      => ['instance' => 'Magento\\Payment\\Model\\Checks\\TotalMinMax',],
+                                'zero_total' => ['instance' => 'Magento\\Payment\\Model\\Checks\\ZeroTotal',],
+                            ],
+                        ],
+                    ]
+                ],
+                'adminConfig'         => [
+                    self::CHECK_SPECIFICATION_FACTORY_CLASS => [
+                        'arguments' => [
+                            'mapping' => [
+                                'check_recurring' => [
+                                    'instance' => 'Aheadworks\\Sarp2\\Model\\Payment\\Checks\\Recurring',
+                                ],
+                            ],
+                        ],
+                    ]
+                ],
+                'isProductionMode'    => false,
+                'mergedConfiguration' => [
+                    self::CHECK_SPECIFICATION_FACTORY_CLASS => [
+                        'arguments' => [
+                            'mapping' => [
+                                'country'         => [
+                                    'instance' => 'Magento\\Payment\\Model\\Checks\\CanUseForCountry'
+                                ],
+                                'currency'        => [
+                                    'instance' => 'Magento\\Payment\\Model\\Checks\\CanUseForCurrency'
+                                ],
+                                'checkout'        => [
+                                    'instance' => 'Magento\\Payment\\Model\\Checks\\CanUseCheckout'
+                                ],
+                                'internal'        => [
+                                    'instance' => 'Magento\\Payment\\Model\\Checks\\CanUseInternal'
+                                ],
+                                'total'           => [
+                                    'instance' => 'Magento\\Payment\\Model\\Checks\\TotalMinMax'
+                                ],
+                                'zero_total'      => [
+                                    'instance' => 'Magento\\Payment\\Model\\Checks\\ZeroTotal'
+                                ],
+                                'check_recurring' => [
+                                    'instance' => 'Aheadworks\\Sarp2\\Model\\Payment\\Checks\\Recurring'
+                                ],
+                            ],
+                        ],
+                    ],
+                ]
+            ],
+            [
+                'globalConfig'        => [
+                    'arguments' => [
+                        self::CHECK_SPECIFICATION_FACTORY_CLASS => [
+                            'compositeFactory' => ['_i_' => 'Magento\\Payment\\Model\\Checks\\CompositeFactory',],
+                            'mapping'          => [
+                                '_vac_' => [
+                                    'country'    => ['_i_' => 'Magento\\Payment\\Model\\Checks\\CanUseForCountry',],
+                                    'currency'   => ['_i_' => 'Magento\\Payment\\Model\\Checks\\CanUseForCurrency',],
+                                    'checkout'   => ['_i_' => 'Magento\\Payment\\Model\\Checks\\CanUseCheckout',],
+                                    'internal'   => ['_i_' => 'Magento\\Payment\\Model\\Checks\\CanUseInternal',],
+                                    'total'      => ['_i_' => 'Magento\\Payment\\Model\\Checks\\TotalMinMax\\Interceptor',],
+                                    'zero_total' => ['_i_' => 'Magento\\Payment\\Model\\Checks\\ZeroTotal\\Interceptor',],
+                                ],
+                            ],
+                        ],
+                    ]
+                ],
+                'adminConfig'         => [
+                    'arguments' => [
+                        self::CHECK_SPECIFICATION_FACTORY_CLASS => [
+                            'compositeFactory' => ['_i_' => 'Magento\\Payment\\Model\\Checks\\CompositeFactory',],
+                            'mapping'          => [
+                                '_vac_' => [
+                                    'check_recurring' => [
+                                        '_i_' => 'Aheadworks\\Sarp2\\Model\\Payment\\Checks\\Recurring',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ]
+                ],
+                'isProductionMode'    => true,
+                'mergedConfiguration' => [
+                    'arguments' => [
+                        self::CHECK_SPECIFICATION_FACTORY_CLASS => [
+                            'compositeFactory' => ['_i_' => 'Magento\\Payment\\Model\\Checks\\CompositeFactory',],
+                            'mapping'          => [
+                                '_vac_' => [
+                                    'country'         => ['_i_' => 'Magento\\Payment\\Model\\Checks\\CanUseForCountry',],
+                                    'currency'        => ['_i_' => 'Magento\\Payment\\Model\\Checks\\CanUseForCurrency',],
+                                    'checkout'        => ['_i_' => 'Magento\\Payment\\Model\\Checks\\CanUseCheckout',],
+                                    'internal'        => ['_i_' => 'Magento\\Payment\\Model\\Checks\\CanUseInternal',],
+                                    'total'           => ['_i_' => 'Magento\\Payment\\Model\\Checks\\TotalMinMax\\Interceptor',],
+                                    'zero_total'      => ['_i_' => 'Magento\\Payment\\Model\\Checks\\ZeroTotal\\Interceptor',],
+                                    'check_recurring' => ['_i_' => 'Aheadworks\\Sarp2\\Model\\Payment\\Checks\\Recurring',],
+                                ],
+                            ],
+                        ],
+                    ],
+                ]
+            ]
+        ];
+    }
+}

--- a/ThirdPartyModules/Aheadworks/Sarp2.php
+++ b/ThirdPartyModules/Aheadworks/Sarp2.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\ThirdPartyModules\Aheadworks;
+
+/**
+ * Adds compatibility between Boltpay and Aheadworks_Sarp2 modules
+ */
+class Sarp2
+{
+    /**
+     * @var \Magento\Framework\App\ObjectManager Object Manager instance
+     */
+    private $objectManager;
+
+    /**
+     * @var \Magento\Framework\ObjectManager\ConfigLoaderInterface DI configuration loader
+     */
+    private $configLoader;
+
+    /**
+     * @param \Magento\Framework\ObjectManagerInterface              $objectManager Object Manager instance
+     * @param \Magento\Framework\ObjectManager\ConfigLoaderInterface $configLoader DI configuration loader
+     */
+    public function __construct(
+        \Magento\Framework\ObjectManagerInterface $objectManager,
+        \Magento\Framework\ObjectManager\ConfigLoaderInterface $configLoader
+    ) {
+        $this->objectManager = $objectManager;
+        $this->configLoader = $configLoader;
+    }
+
+    /**
+     * Aheadworks_Sarp2 adds a check for recurring payments when rendering payment methods,
+     * unfortunately it is added in the adminhtml area as opposed to global, where Magento has defined the default ones.
+     * This will, instead of adding, completely replace the default checks with Aheadworks’.
+     * This is defined in {@see https://devdocs.magento.com/guides/v2.4/extension-dev-guide/build/di-xml-file.html}
+     * “When Magento loads a new configuration at a later time, either by a more specific scope or through code,
+     * then any array definitions in the new configuration will replace the loaded config instead of merging.”.
+     *
+     * To resolve this, we merge those configurations in predispatch for the admin order create action.
+     */
+    public function adminhtmlControllerActionPredispatchSalesOrderCreateIndex()
+    {
+        $class = 'Magento\Payment\Model\Checks\SpecificationFactory';
+        $globalConfig = $this->configLoader->load(\Magento\Framework\App\Area::AREA_GLOBAL);
+        $adminConfig = $this->configLoader->load(\Magento\Framework\App\Area::AREA_ADMINHTML);
+
+        if ($this->configLoader instanceof \Magento\Framework\App\ObjectManager\ConfigLoader\Compiled) {
+            //PRODUCTION MODE
+            $merged['arguments'][$class] = array_merge(
+                $globalConfig['arguments'][$class],
+                $adminConfig['arguments'][$class]
+            );
+            $merged['arguments'][$class]['mapping'] = array_merge_recursive(
+                $globalConfig['arguments'][$class]['mapping'],
+                $adminConfig['arguments'][$class]['mapping']
+            );
+        } else {
+            // DEVELOPER MODE
+            $merged = [$class => array_merge_recursive($globalConfig[$class], $adminConfig[$class])];
+        }
+        $this->objectManager->configure($merged);
+    }
+}

--- a/etc/adminhtml/events.xml
+++ b/etc/adminhtml/events.xml
@@ -13,4 +13,8 @@
     <event name="admin_system_config_changed_section_carriers" >
         <observer name="clearBoltCache" instance="Bolt\Boltpay\Observer\ClearBoltShippingTaxCacheObserver" />
     </event>
+    <event name="controller_action_predispatch">
+        <observer name="bolt_boltpay_adminhtml_controller_predispatch"
+                  instance="Bolt\Boltpay\Observer\Adminhtml\ActionPredispatch"/>
+    </event>
 </config>


### PR DESCRIPTION
# Description
Backoffice key is dynamically loaded on Bolt order create [here](https://github.com/BoltApp/bolt-magento2/blob/a396f7342eff78e44aef056f4c866b506f603059/view/adminhtml/templates/boltpay/js/replacejs.phtml#L395). It is expected that, at the time of the order creation, an appropriate store is already chosen.

This was not the case for this client’s (Andrew Christian) store for the following reason: Magento 2, by default, performs some checks for each payment method before it can be rendered. These checks are defined [here](https://github.com/magento/magento2/blob/7ddd47e87e217ba20b883e9ee22e5e3ef618e6df/app/code/Magento/Sales/etc/di.xml#L154). Aheadworks_Sarp2 attempted to add a check for recurring payments, unfortunately they added it in the adminhtml area as opposed to global, where Magento has defined the default ones.

This will, instead of adding, completely replace the default checks with Aheadworks’. This behavior is defined [here](https://devdocs.magento.com/guides/v2.4/extension-dev-guide/build/di-xml-file.html): “When Magento loads a new configuration at a later time, either by a more specific scope or through code, then any array definitions in the new configuration will replace the loaded config instead of merging.”.

This means that the Bolt checkout button was present on the order create page long before we expected (on creation page load), and triggered order creation.

Fixes: [M2P-262](https://boltpay.atlassian.net/browse/M2P-262)

#changelog M2P-262 - Resolve issue with Aheadworkds_Sarp2

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
