### PR TITLE
M2P-276 Bugfix: Tax amount mismatch after applying discount via v2 update-cart api hook

### DIFF
--- a/Helper/Discount.php
+++ b/Helper/Discount.php
@@ -1084,6 +1084,11 @@ class Discount extends AbstractHelper
      */
     public function setCouponCode($quote, $couponCode)
     {
+        $address = $quote->isVirtual() ?
+                $quote->getBillingAddress() :
+                $quote->getShippingAddress();
+        $address->setAppliedRuleIds('');
+        $quote->setAppliedRuleIds('');
         $quote->setCouponCode($couponCode);
         $this->updateTotals($quote);
     }

--- a/Test/Unit/Helper/DiscountTest.php
+++ b/Test/Unit/Helper/DiscountTest.php
@@ -3053,7 +3053,19 @@ class DiscountTest extends TestCase
     {
         $this->initCurrentMock();
         
-         $couponCode = 'testcoupon';
+        $couponCode = 'testcoupon';
+        
+        $addressMock = $this->getMockBuilder(Quote\Address::class)
+            ->setMethods(
+                [
+                    'setAppliedRuleIds',
+                    'setCollectShippingRates'
+                ]
+            )
+            ->disableOriginalConstructor()
+            ->getMock();
+        $addressMock->expects(static::once())->method('setAppliedRuleIds')->with('')->willReturnSelf();
+        $addressMock->expects(static::once())->method('setCollectShippingRates')->with(true)->willReturnSelf();
         
         $quote = $this->createPartialMock(
             Quote::class,
@@ -3062,15 +3074,19 @@ class DiscountTest extends TestCase
                 'setTotalsCollectedFlag',
                 'collectTotals',
                 'setDataChanges',
-                'setCouponCode'
+                'setCouponCode',
+                'isVirtual',
+                'setAppliedRuleIds'
             ]
         );
-
-        $quote->expects(static::once())->method('getShippingAddress')->willReturnSelf();
+        
+        $quote->expects(static::once())->method('isVirtual')->willReturn(false);
+        $quote->expects(static::once())->method('getShippingAddress')->willReturn($addressMock);
         $quote->expects(static::once())->method('setTotalsCollectedFlag')->with(false)->willReturnSelf();
         $quote->expects(static::once())->method('collectTotals')->willReturnSelf();
         $quote->expects(static::once())->method('setDataChanges')->with(true)->willReturnSelf();
         $quote->expects(static::once())->method('setCouponCode')->with($couponCode)->willReturnSelf();
+        $quote->expects(static::once())->method('setAppliedRuleIds')->with('')->willReturnSelf();
 
         $this->quoteRepository->expects(static::once())->method('save')->with($quote)->willReturnSelf();
 

--- a/Test/Unit/Helper/DiscountTest.php
+++ b/Test/Unit/Helper/DiscountTest.php
@@ -3081,7 +3081,7 @@ class DiscountTest extends TestCase
         );
         
         $quote->expects(static::once())->method('isVirtual')->willReturn(false);
-        $quote->expects(static::once())->method('getShippingAddress')->willReturn($addressMock);
+        $quote->expects(static::exactly(2))->method('getShippingAddress')->willReturn($addressMock);
         $quote->expects(static::once())->method('setTotalsCollectedFlag')->with(false)->willReturnSelf();
         $quote->expects(static::once())->method('collectTotals')->willReturnSelf();
         $quote->expects(static::once())->method('setDataChanges')->with(true)->willReturnSelf();


### PR DESCRIPTION
# Description
When collecting quote totals, by default it only reset the applied coupon rules once (https://github.com/magento/magento2/blob/2.4/app/code/Magento/SalesRule/Model/Validator.php#L248).

But in our plugin, especially when applying/removing the coupon code, we may collect quote totals for several times. And in current logic, the applied coupon rules are not updated properly after updating the coupon, as a result, the discount amount is wrong in some context and cause the discount/tax mismatch.

So we need to maunally reset the applied coupon rules every time set coupon code.

Fixes: https://boltpay.atlassian.net/browse/M2P-276

#changelog Bugfix: Tax amount mismatch after applying discount via v2 update-cart api hook

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
