### PR TITLE
M2P-290 Bugfix: Amasty Reward points are not applied to the order in Back Office

### DIFF
--- a/Model/EventsForThirdPartyModules.php
+++ b/Model/EventsForThirdPartyModules.php
@@ -124,7 +124,8 @@ class EventsForThirdPartyModules
                 ],
                 [
                     "module" => "Amasty_Rewards",
-                    "sendClasses" => ["Amasty\Rewards\Helper\Data"],
+                    "sendClasses" => ["Amasty\Rewards\Helper\Data",
+                                      "Amasty\Rewards\Model\ResourceModel\Quote"],
                     "boltClass" => Amasty_Rewards::class,
                 ],
                 [

--- a/ThirdPartyModules/Amasty/Rewards.php
+++ b/ThirdPartyModules/Amasty/Rewards.php
@@ -54,6 +54,7 @@ class Rewards
      */
     public function collectDiscounts($result,
                                      $amastyRewardsHelperData,
+                                     $amastyRewardsResourceModelQuote,
                                      $quote,
                                      $parentQuote,
                                      $paymentOnly)
@@ -63,7 +64,7 @@ class Rewards
         try {
             if ($quote->getData('amrewards_point')) {
                 $rewardData = $amastyRewardsHelperData->getRewardsData();
-                $pointsUsed = $rewardData['pointsUsed'];
+                $pointsUsed = $amastyRewardsResourceModelQuote->getUsedRewards($quote->getId());
                 $pointsRate = $rewardData['rateForCurrency'];
                 $amount = $pointsUsed / $pointsRate;
                 $currencyCode = $quote->getQuoteCurrencyCode();


### PR DESCRIPTION
# Description
Amasty\Rewards\Helper\Data->getRewardsData(); does not get applied reward points of backoffice order, and Amasty\Rewards\Model\ResourceModel\Quote->getUsedRewards($quoteId) works for both backoffice order and front store oder, so we use it instead.

Fixes: https://boltpay.atlassian.net/browse/M2P-290

#changelog Bugfix: Amasty Reward points are not applied to the order in Back Office

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
