### PR TITLE
M2P-296 Change the return type annotation from array to mixed[] to fix the Swagger issue

### DIFF
--- a/Api/Data/CartDataInterface.php
+++ b/Api/Data/CartDataInterface.php
@@ -59,7 +59,7 @@ interface CartDataInterface
      * Get items.
      *
      * @api
-     * @return array
+     * @return mixed[]
      */
     public function getItems();
 
@@ -77,7 +77,7 @@ interface CartDataInterface
      * Get discounts.
      *
      * @api
-     * @return array
+     * @return mixed[]
      */
     public function getDiscounts();
 
@@ -149,7 +149,7 @@ interface CartDataInterface
      * Get shipments.
      *
      * @api
-     * @return array
+     * @return mixed[]
      */
     public function getShipments();
 
@@ -167,7 +167,7 @@ interface CartDataInterface
      * Get cart data.
      *
      * @api
-     * @return array
+     * @return mixed[]
      */
     public function getCartData();
 }

--- a/Api/Data/UpdateCartResultInterface.php
+++ b/Api/Data/UpdateCartResultInterface.php
@@ -74,7 +74,7 @@ interface UpdateCartResultInterface
      * Get result.
      *
      * @api
-     * @return array
+     * @return mixed[]
      */
     public function getCartResult();
 }


### PR DESCRIPTION
# Description
Currently, our Bolt module is breaking the Magento swagger UI. See here - https://prnt.sc/uuwdbm
This PR is to resolve the issue by changing the return type annotation from array to mixed[]
See the reference link here - https://github.com/mundipagg/magento2/issues/137

Fixes: 
https://boltpay.atlassian.net/browse/M2P-296
https://boltpay.atlassian.net/browse/EN-674

#changelog M2P-296 Change the return type annotation from array to mixed[] to fix the Swagger issue

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
