### PR TITLE
M2P-301 Disable prefetch shipping by default

### DIFF
--- a/Block/Js.php
+++ b/Block/Js.php
@@ -130,6 +130,13 @@ class Js extends Template
             && $this->featureSwitches->isAlwaysPresentCheckoutEnabled();
     }
 
+    public function getPrefetchShipping()
+    {
+        $storeId = $this->getStoreId();
+        return $this->configHelper->getPrefetchShipping($storeId)
+            && $this->featureSwitches->isPrefetchShippingEnabled();
+    }
+
     /**
      * Get account js url
      *
@@ -266,7 +273,7 @@ class Js extends Template
             'get_hints_url' => $this->getUrl(Config::GET_HINTS_ACTION),
             'selectors' => $this->getReplaceSelectors(),
             'shipping_prefetch_url' => $this->getUrl(Config::SHIPPING_PREFETCH_ACTION),
-            'prefetch_shipping' => $this->configHelper->getPrefetchShipping(),
+            'prefetch_shipping' => $this->getPrefetchShipping(),
             'save_email_url' => $this->getUrl(Config::SAVE_EMAIL_ACTION),
             'pay_by_link_url' => $this->featureSwitches->isPayByLinkEnabled() ? $this->getPayByLinkUrl() : null,
             'quote_is_virtual' => $this->getQuoteIsVirtual(),

--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -265,4 +265,8 @@ class Decider extends AbstractHelper
     public function isCaptureEmailToListrakEnabled() {
         return $this->isSwitchEnabled(Definitions::M2_CAPTURE_EMAIL_TO_LISTRAK_ENABLED);
     }
+
+    public function isPrefetchShippingEnabled() {
+        return $this->isSwitchEnabled(Definitions::M2_PREFETCH_SHIPPING);
+    }
 }

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -132,6 +132,11 @@ class Definitions
      */
     const M2_CAPTURE_EMAIL_TO_LISTRAK_ENABLED = "M2_CAPTURE_EMAIL_TO_LISTRAK_ENABLED";
 
+    /**
+     * Enable shipping prefetch option
+     */
+    const M2_PREFETCH_SHIPPING = "M2_PREFETCH_SHIPPING";
+
     const DEFAULT_SWITCH_VALUES = [
         self::M2_SAMPLE_SWITCH_NAME =>  [
           self::NAME_KEY            => self::M2_SAMPLE_SWITCH_NAME,
@@ -246,6 +251,12 @@ class Definitions
             self::VAL_KEY             => true,
             self::DEFAULT_VAL_KEY     => false,
             self::ROLLOUT_KEY         => 100
+        ],
+        self::M2_PREFETCH_SHIPPING =>  [
+            self::NAME_KEY            => self::M2_PREFETCH_SHIPPING,
+            self::VAL_KEY             => true,
+            self::DEFAULT_VAL_KEY     => false,
+            self::ROLLOUT_KEY         => 0
         ],
     ];
 }

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -1705,6 +1705,68 @@ JS;
         ];
     }
 
+
+    /**
+     * @test
+     * that getPrefetchShipping returns true only if both:
+     * 1. prefetch shipping is enabled for the current store in the configuration
+     * {@see \Bolt\Boltpay\Helper\Config::getPrefetchShipping returns true}
+     * 2. feature switch M2_PREFETCH_SHIPPING is enabled
+     * {@see \Bolt\Boltpay\Helper\FeatureSwitch\Decider::isPrefetchShippingEnabled returns true}
+     *
+     * @covers ::getPrefetchShipping
+     *
+     * @dataProvider getPrefetchShipping_withVariousConfigAndDeciderStatesProvider
+     *
+     * @param bool $isAlwaysPresentCheckoutConfigurationEnabled flag
+     * @param bool $isAlwaysPresentCheckoutFeatureSwitchEnabled flag
+     * @param bool $expectedResult of the tested method call
+     */
+    public function getPrefetchShipping_withVariousConfigAndDeciderStates_returnsPluginSettings(
+        $isPrefetchShippingConfigurationEnabled,
+        $isPrefetchShippingFeatureSwitchEnabled,
+        $expectedResult
+    ) {
+        $this->currentMock->expects(static::once())->method('getStoreId')->willReturn(static::STORE_ID);
+        $this->configHelper->expects(static::once())
+            ->method('getPrefetchShipping')
+            ->with(static::STORE_ID)
+            ->willReturn($isPrefetchShippingConfigurationEnabled);
+
+        $this->deciderMock->expects($isPrefetchShippingConfigurationEnabled ? static::once() : static::never())
+            ->method('isPrefetchShippingEnabled')
+            ->willReturn($isPrefetchShippingFeatureSwitchEnabled);
+
+        static::assertEquals($expectedResult, $this->currentMock->getPrefetchShipping());
+    }
+
+    /**
+     * Data provider for {@see getPrefetchShipping_withVariousConfigAndDeciderStates_returnsPluginSettings}
+     *
+     * @return array[] containing flags is config checkout enabled, is decider switch enabled and
+     * expected result of the tested method call
+     */
+    public function getPrefetchShipping_withVariousConfigAndDeciderStatesProvider()
+    {
+        return [
+            [
+                'isPrefetchShippingConfigurationEnabled' => true,
+                'isPrefetchShippingFeatureSwitchEnabled' => true,
+                'expectedResult'                         => true
+            ],
+            [
+                'isPrefetchShippingConfigurationEnabled' => false,
+                'isPrefetchShippingFeatureSwitchEnabled' => true,
+                'expectedResult'                         => false
+            ],
+            [
+                'isPrefetchShippingConfigurationEnabled' => true,
+                'isPrefetchShippingFeatureSwitchEnabled' => false,
+                'expectedResult'                         => false
+            ],
+        ];
+    }
+
     /**
      * @test
      * that getButtonCssStyles returns CSS style for Bolt button according to config button color

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -54,7 +54,7 @@ tr.shipping.totals td.amount span.price,
 .payment-method-boltpay .payment-method-title img.payment-icon {padding: 8px; border: 1px solid #cccccc; width: 200px;}</global_css>
                 <additional_checkout_button_class>with-cards</additional_checkout_button_class>
                 <success_page>checkout/onepage/success</success_page>
-                <prefetch_shipping>1</prefetch_shipping>
+                <prefetch_shipping>0</prefetch_shipping>
                 <reset_shipping_calculation>0</reset_shipping_calculation>
                 <minicart_support>1</minicart_support>
                 <store_credit>0</store_credit>


### PR DESCRIPTION
The prefetch option doesn't work with new shipping flow, adds load for merchants servers and additional calls to paid services such as avalara.
We need to disable it by default, but still can use for merchants who need it via feature switches.

Fixes: [M2P-301](https://boltpay.atlassian.net/browse/M2P-301)

#changelog M2P-301 Disable prefetch shipping by default

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
