### PR TITLE
M2P-269 Update bolt cart when Amasty rewards applied or removed

### DIFF
--- a/Model/EventsForThirdPartyModules.php
+++ b/Model/EventsForThirdPartyModules.php
@@ -229,6 +229,10 @@ class EventsForThirdPartyModules
                     "checkClasses" => ["MW\RewardPoints\Helper\Data"],
                     "boltClass" => MW_RewardPoints::class,
                 ],
+                [
+                    "module" => "Amasty_Rewards",
+                    "boltClass" => Amasty_Rewards::class,
+                ],
             ],
         ],
         "filterApplyingGiftCardCode" => [

--- a/ThirdPartyModules/Amasty/Rewards.php
+++ b/ThirdPartyModules/Amasty/Rewards.php
@@ -87,4 +87,20 @@ class Rewards
             return [$discounts, $totalAmount, $diff];
         }
     }
+
+    public function getAdditionalJS($result)
+    {
+        $result .= 'var selectorsForInvalidate = ["apply-amreward","cancel-amreward"];
+        for (var i = 0; i < selectorsForInvalidate.length; i++) {
+            var button = document.getElementById(selectorsForInvalidate[i]);
+            if (button) {
+                button.addEventListener("click", function() {
+                    if (localStorage) {
+                        localStorage.setItem("bolt_cart_is_invalid", "true");
+                    }
+                }, false);
+            }
+        }';
+        return $result;
+    }
 }

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -1085,6 +1085,12 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
                 }
 
                 boltCartDataListener = function(data) {
+                    if (localStorage && localStorage.getItem("bolt_cart_is_invalid") == "true") {
+                        localStorage.setItem("bolt_cart_is_invalid", "false");
+                        invalidateBoltCart();
+                        return;
+                    }
+
                     if (BoltState.magentoCart === null) {
                         // We haven't seen magento cart yet. If Magento cart isn't set it means that bolt cart is unactual
                         return;


### PR DESCRIPTION
When users click on Amasty reward button "apply" or "remove" the module sends form data to the server, get 302 answer and reload cart page.
When the user clicks the button we know that the bolt cart will be unactual soon and we persist flag to update the bolt cart during the next page load.

We need to implement the same for all modules that reload cart page after discount applying. For 3p modules that works via jQuery AJAX we have another solution: https://github.com/BoltApp/bolt-magento2/pull/929

Fixes: [M2P-269](https://boltpay.atlassian.net/browse/M2P-269)

#changelog M2P-269 Update bolt cart when Amasty rewards applied or removed

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
