### PR TITLE
Allow running integration tests manually

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,3 +311,11 @@ workflows:
     jobs:
       - rebase-and-unit-test:
           name: "Rebase and Unit Test << pipeline.parameters.rebase_and_unit_test_branch_name >>"
+  hold:
+    type: approval # requires that an in-app button be clicked by an appropriate member of the project to continue.
+  integration-tests-manual:
+    requires:
+     - hold
+    jobs:
+      - integration-php72-magento23:
+          context: integration-tests-secrets

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,11 +311,11 @@ workflows:
     jobs:
       - rebase-and-unit-test:
           name: "Rebase and Unit Test << pipeline.parameters.rebase_and_unit_test_branch_name >>"
-  hold:
-    type: approval # requires that an in-app button be clicked by an appropriate member of the project to continue.
   integration-tests-manual:
-    requires:
-     - hold
     jobs:
+      - hold:
+          type: approval # requires that an in-app button be clicked by an appropriate member of the project to continue.
       - integration-php72-magento23:
+          requires:
+            - hold
           context: integration-tests-secrets


### PR DESCRIPTION
For now, we run integration tests once per day.
By this PR we add the opportunity to run integration tests manually for any PRs.

It can be helpful when we need to make sure that our change doesn't break tests.

#changelog Allow running integration tests manually

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
