### PR TITLE
M2P-313 Remove Aheadworks StoreCredit by API hooks

### DIFF
--- a/Model/EventsForThirdPartyModules.php
+++ b/Model/EventsForThirdPartyModules.php
@@ -106,6 +106,11 @@ class EventsForThirdPartyModules
                     "sendClasses" => ["Amasty\StoreCredit\Model\StoreCredit\ApplyStoreCreditToQuote"],
                     "boltClass" => Amasty_StoreCredit::class,
                 ],
+                [
+                    "module" => "Aheadworks_StoreCredit",
+                    "checkClasses" => ["Aheadworks\StoreCredit\Model\TransactionRepository"],
+                    "boltClass" => Aheadworks_StoreCredit::class,
+                ],
             ]
         ],
     ];
@@ -312,7 +317,12 @@ class EventsForThirdPartyModules
                     "module" => "Amasty_StoreCredit",
                     "checkClasses" => ["Amasty\StoreCredit\Api\Data\SalesFieldInterface"],
                     "boltClass" => Amasty_StoreCredit::class,
-                ]
+                ],
+                [
+                    "module" => "Aheadworks_StoreCredit",
+                    "checkClasses" => ["Aheadworks\StoreCredit\Model\TransactionRepository"],
+                    "boltClass" => Aheadworks_StoreCredit::class,
+                ],
             ],
         ],
     ];

--- a/ThirdPartyModules/Aheadworks/StoreCredit.php
+++ b/ThirdPartyModules/Aheadworks/StoreCredit.php
@@ -92,6 +92,7 @@ class StoreCredit
                 $discounts[] = [
                     'description' => 'Store Credit',
                     'amount' => $roundedAmount,
+                    'reference' => self::AHEADWORKS_STORE_CREDIT,
                     'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_STORE_CREDIT,
                     'discount_type' => $discountType, // For v1/discounts.code.apply and v2/cart.update
                     'type' => $discountType, // For v1/merchant/order


### PR DESCRIPTION
# Description
Add support to remove Aheadworks StoreCredit by v2 update_cart api hook

Fixes: https://boltpay.atlassian.net/browse/M2P-313

#changelog Remove Aheadworks StoreCredit by API hooks

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
