### PR TITLE
M2P-317 Fix issue with discounts in backend orders

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1946,48 +1946,64 @@ class Cart extends AbstractHelper
         // check if getCouponCode is not null
         /////////////////////////////////////////////////////////////////////////////////
         if (($amount = abs($address->getDiscountAmount())) || $quote->getCouponCode()) {
-            // The discount amount of each sale rule is stored in the checkout session, using rule id as key,
-            // Bolt\Boltpay\Plugin\SalesRuleActionDiscountPlugin
-            $boltCollectSaleRuleDiscounts = $this->checkoutSession->getBoltCollectSaleRuleDiscounts([]);
-            $salesruleIds = explode(',', $quote->getAppliedRuleIds());
-            foreach ($salesruleIds as $salesruleId) {
-                if (!isset($boltCollectSaleRuleDiscounts[$salesruleId])) {
-                    continue;
-                }
-                $rule = $this->ruleRepository->getById($salesruleId);
-                $ruleDiscountAmount = $boltCollectSaleRuleDiscounts[$salesruleId];
-                if ($rule && $ruleDiscountAmount) {
-                    $roundedAmount = CurrencyUtils::toMinor($ruleDiscountAmount, $currencyCode);
-                    switch ($rule->getCouponType()) {
-                        case RuleInterface::COUPON_TYPE_SPECIFIC_COUPON:
-                        case RuleInterface::COUPON_TYPE_AUTO:
-                            $couponCode = $quote->getCouponCode();
-                            $description = trim(__('Discount ') . $rule->getDescription());
-                            $discounts[] = [
-                                'description'       => $description,
-                                'amount'            => $roundedAmount,
-                                'reference'         => $couponCode,
-                                'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_COUPON,
-                                'discount_type'     => $this->discountHelper->convertToBoltDiscountType($couponCode), // For v1/discounts.code.apply and v2/cart.update
-                                'type'              => $this->discountHelper->convertToBoltDiscountType($couponCode), // For v1/merchant/order
-                            ];            
-                            $this->logEmptyDiscountCode($couponCode, $description);
-                            
-                            break;
-                        case RuleInterface::COUPON_TYPE_NO_COUPON:
-                        default:
-                            $discounts[] = [
-                                'description'       => trim(__('Discount ') . $rule->getDescription()),
-                                'amount'            => $roundedAmount,
-                                'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_AUTO_PROMO,
-                                'discount_type'     => $this->discountHelper->getBoltDiscountType($rule->getSimpleAction()), // For v1/discounts.code.apply and v2/cart.update
-                                'type'              => $this->discountHelper->getBoltDiscountType($rule->getSimpleAction()), // For v1/merchant/order
-                            ];
-                            
-                            break;
+            if ($paymentOnly) {
+                $roundedAmount = CurrencyUtils::toMinor($amount, $currencyCode);
+
+                $discounts[] = [
+                    'description'       => trim(__('Discount ') . $address->getDiscountDescription()),
+                    'amount'            => $roundedAmount,
+                    'reference'         => $quote->getCouponCode(),
+                    'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_COUPON,
+                    'discount_type'     => $this->discountHelper->convertToBoltDiscountType($quote->getCouponCode()), // For v1/discounts.code.apply and v2/cart.update
+                    'type'              => $this->discountHelper->convertToBoltDiscountType($quote->getCouponCode()), // For v1/merchant/order
+                ];
+
+                $diff -= CurrencyUtils::toMinorWithoutRounding($amount, $currencyCode) - $roundedAmount;
+                $totalAmount -= $roundedAmount;
+            } else {
+                // The discount amount of each sale rule is stored in the checkout session, using rule id as key,
+                // Bolt\Boltpay\Plugin\SalesRuleActionDiscountPlugin
+                $boltCollectSaleRuleDiscounts = $this->checkoutSession->getBoltCollectSaleRuleDiscounts([]);
+                $salesruleIds = explode(',', $quote->getAppliedRuleIds());
+                foreach ($salesruleIds as $salesruleId) {
+                    if (!isset($boltCollectSaleRuleDiscounts[$salesruleId])) {
+                        continue;
                     }
-                    $diff -= CurrencyUtils::toMinorWithoutRounding($ruleDiscountAmount, $currencyCode) - $roundedAmount;
-                    $totalAmount -= $roundedAmount;
+                    $rule = $this->ruleRepository->getById($salesruleId);
+                    $ruleDiscountAmount = $boltCollectSaleRuleDiscounts[$salesruleId];
+                    if ($rule && $ruleDiscountAmount) {
+                        $roundedAmount = CurrencyUtils::toMinor($ruleDiscountAmount, $currencyCode);
+                        switch ($rule->getCouponType()) {
+                            case RuleInterface::COUPON_TYPE_SPECIFIC_COUPON:
+                            case RuleInterface::COUPON_TYPE_AUTO:
+                                $couponCode = $quote->getCouponCode();
+                                $description = trim(__('Discount ') . $rule->getDescription());
+                                $discounts[] = [
+                                    'description'       => $description,
+                                    'amount'            => $roundedAmount,
+                                    'reference'         => $couponCode,
+                                    'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_COUPON,
+                                    'discount_type'     => $this->discountHelper->convertToBoltDiscountType($couponCode), // For v1/discounts.code.apply and v2/cart.update
+                                    'type'              => $this->discountHelper->convertToBoltDiscountType($couponCode), // For v1/merchant/order
+                                ];
+                                $this->logEmptyDiscountCode($couponCode, $description);
+
+                                break;
+                            case RuleInterface::COUPON_TYPE_NO_COUPON:
+                            default:
+                                $discounts[] = [
+                                    'description'       => trim(__('Discount ') . $rule->getDescription()),
+                                    'amount'            => $roundedAmount,
+                                    'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_AUTO_PROMO,
+                                    'discount_type'     => $this->discountHelper->getBoltDiscountType($rule->getSimpleAction()), // For v1/discounts.code.apply and v2/cart.update
+                                    'type'              => $this->discountHelper->getBoltDiscountType($rule->getSimpleAction()), // For v1/merchant/order
+                                ];
+
+                                break;
+                        }
+                        $diff -= CurrencyUtils::toMinorWithoutRounding($ruleDiscountAmount, $currencyCode) - $roundedAmount;
+                        $totalAmount -= $roundedAmount;
+                    }
                 }
             }
         }

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -4245,24 +4245,6 @@ ORDER
             [DiscountHelper::GIFT_VOUCHER => $this->quoteAddressTotal]
         );
 
-        $quote->method('getAppliedRuleIds')->willReturn('2');
-        $this->checkoutSession->expects(static::once())
-                              ->method('getBoltCollectSaleRuleDiscounts')
-                              ->willReturn([2 => ($discountAmount),]);
-        $rule2 = $this->getMockBuilder(DataObject::class)
-            ->setMethods(['getCouponType', 'getDescription'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $rule2->expects(static::once())->method('getCouponType')
-            ->willReturn('SPECIFIC_COUPON');
-        $rule2->expects(static::once())->method('getDescription')
-            ->willReturn(self::COUPON_DESCRIPTION);
-
-        $this->ruleRepository->expects(static::once())
-            ->method('getById')
-            ->with(2)
-            ->willReturn($rule2);
-
         $totalAmount = 10000; // cents
         $diff = 0;
         $paymentOnly = true;


### PR DESCRIPTION
In https://github.com/BoltApp/bolt-magento2/pull/942 we introduced code that split discounts in bolt modal in case when few discounts applied to cart.
PR942 saves intermediate results in checkout session, it doesn't work for backend orders.
Down the road we can find a solution for BO, but for now, I just fix the regression issue by applying PR942 to multistep orders only.

Fixes: [M2P-317](https://boltpay.atlassian.net/browse/M2P-317)

#changelog M2P-317 Fix issue with discounts in backend orders

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
