### PR TITLE
M2P-263 Allow the retry auth hook to authorize order if its status is payment review

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -1839,7 +1839,8 @@ class Order extends AbstractHelper
         if ($transactionState == $prevTransactionState &&
             $reference == $prevTransactionReference &&
             !$newCapture &&
-            !($hookType == Hook::HT_PENDING && $order->getState() == OrderModel::STATE_PENDING_PAYMENT)
+            !($hookType == Hook::HT_PENDING && $order->getState() == OrderModel::STATE_PENDING_PAYMENT) &&
+            !($hookType == Hook::HT_AUTH && $order->getState() == OrderModel::STATE_PAYMENT_REVIEW)
         ) {
             if ($this->isAnAllowedUpdateFromAdminPanel($order, $transactionState)) {
                 $payment->setIsTransactionApproved(true);


### PR DESCRIPTION
# Description
This PR resolves the following case:

1. The customer clicked the Pay button in the Bolt modal and the order was created on both Bolt and Magento.
2. The first auth hook was sent to Magento and the exception “Unprocessable Entity: SQLSTATE[40001]: Serialization failure: 1213 Deadlock found when trying to get lock“ was thrown ( See here: https://prnt.sc/uz8olh). The deadlock exception is an edge case exception.
3. Since the first auth hook failed, Bolt re-sent the second auth hook to Magento to re-authorize the order. But the odd thing here is that it skipped because of this code http://prntscr.com/sb7lgg so it put order status to payment review

=> So I create the PR to allow the retry auth hook to authorize the order and update status to processing if it's status is payment review so the #3 above won’t occur.

Fixes: https://boltpay.atlassian.net/browse/M2P-263

#changelog M2P-263 Allow the retry auth hook to authorize order if its status is payment review

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
