### PR TITLE
M2P-326 Fix issue with discounts of backoffice order

### DIFF
--- a/Plugin/SalesRuleActionDiscountPlugin.php
+++ b/Plugin/SalesRuleActionDiscountPlugin.php
@@ -16,32 +16,35 @@
  */
 namespace Bolt\Boltpay\Plugin;
 
-use Magento\Checkout\Model\Session as CheckoutSession;
+use Bolt\Boltpay\Helper\Session as SessionHelper;
 
 class SalesRuleActionDiscountPlugin
-{
-    /** @var CheckoutSession */
-    private $checkoutSession;
+{    
+    /** @var SessionHelper */
+    private $sessionHelper;
     
     public function __construct(
-        CheckoutSession $checkoutSession
+        SessionHelper $sessionHelper
     ) {
-        $this->checkoutSession = $checkoutSession;
+        $this->sessionHelper = $sessionHelper;
     }
     
     public function afterCalculate(\Magento\SalesRule\Model\Rule\Action\Discount\AbstractDiscount $subject,
                                    $result, $rule, $item, $qty)
     {
+        $checkoutSession = $this->sessionHelper->getCheckoutSession();
+
         // If the sale rule has no coupon, its discount amount can not be retrieved directly,
         // so we store the discount amount in the checkout session with the rule id as key.
-        $boltCollectSaleRuleDiscounts = $this->checkoutSession->getBoltCollectSaleRuleDiscounts([]);
+        $boltCollectSaleRuleDiscounts = $checkoutSession->getBoltCollectSaleRuleDiscounts([]);
         $ruleId = $rule->getId();
         if (!isset($boltCollectSaleRuleDiscounts[$ruleId])) {
             $boltCollectSaleRuleDiscounts[$ruleId] = $result->getAmount();            
         } else {
             $boltCollectSaleRuleDiscounts[$ruleId] += $result->getAmount();
         }
-        $this->checkoutSession->setBoltCollectSaleRuleDiscounts($boltCollectSaleRuleDiscounts);      
+        $checkoutSession->setBoltCollectSaleRuleDiscounts($boltCollectSaleRuleDiscounts);
+
         return $result;
     }
 }

--- a/Plugin/SalesRuleQuoteDiscountPlugin.php
+++ b/Plugin/SalesRuleQuoteDiscountPlugin.php
@@ -16,24 +16,25 @@
  */
 namespace Bolt\Boltpay\Plugin;
 
-use Magento\Checkout\Model\Session as CheckoutSession;
+use Bolt\Boltpay\Helper\Session as SessionHelper;
 
 class SalesRuleQuoteDiscountPlugin
 {
-    /** @var CheckoutSession */
-    private $checkoutSession;
+    /** @var SessionHelper */
+    private $sessionHelper;
     
     public function __construct(
-        CheckoutSession $checkoutSession
+        SessionHelper $sessionHelper
     ) {
-        $this->checkoutSession = $checkoutSession;
+        $this->sessionHelper = $sessionHelper;
     }
     
     public function beforeCollect(\Magento\SalesRule\Model\Quote\Discount $subject, $quote, $shippingAssignment, $total)
     {
+        $checkoutSession = $this->sessionHelper->getCheckoutSession();
         // Each time when collecting address discount amount, the BoltCollectSaleRuleDiscounts session data would be reset,
         // then it can store the updated info of applied sale rules.
-        $this->checkoutSession->setBoltCollectSaleRuleDiscounts([]);
+        $checkoutSession->setBoltCollectSaleRuleDiscounts([]);
        
         return [$quote, $shippingAssignment, $total];
     }

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -4244,6 +4244,24 @@ ORDER
         $quote->expects(static::any())->method('getTotals')->willReturn(
             [DiscountHelper::GIFT_VOUCHER => $this->quoteAddressTotal]
         );
+        
+        $quote->method('getAppliedRuleIds')->willReturn('2');	
+        $this->checkoutSession->expects(static::once())	
+                              ->method('getBoltCollectSaleRuleDiscounts')	
+                              ->willReturn([2 => ($discountAmount),]);	
+        $rule2 = $this->getMockBuilder(DataObject::class)	
+            ->setMethods(['getCouponType', 'getDescription'])	
+            ->disableOriginalConstructor()	
+            ->getMock();	
+        $rule2->expects(static::once())->method('getCouponType')	
+            ->willReturn('SPECIFIC_COUPON');	
+        $rule2->expects(static::once())->method('getDescription')	
+            ->willReturn(self::COUPON_DESCRIPTION);	
+
+        $this->ruleRepository->expects(static::once())	
+            ->method('getById')	
+            ->with(2)	
+            ->willReturn($rule2);
 
         $totalAmount = 10000; // cents
         $diff = 0;

--- a/Test/Unit/Plugin/SalesRuleActionDiscountPluginTest.php
+++ b/Test/Unit/Plugin/SalesRuleActionDiscountPluginTest.php
@@ -58,7 +58,7 @@ class SalesRuleActionDiscountPluginTest extends TestCase
         $this->plugin = (new ObjectManager($this))->getObject(
             SalesRuleActionDiscountPlugin::class,
             [
-                'checkoutSession' => $this->checkoutSession
+                'sessionHelper' => $this->sessionHelper
             ]
         );
     }

--- a/Test/Unit/Plugin/SalesRuleActionDiscountPluginTest.php
+++ b/Test/Unit/Plugin/SalesRuleActionDiscountPluginTest.php
@@ -23,6 +23,7 @@ use Magento\Framework\DataObject;
 use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\SalesRule\Model\Rule\Action\Discount\AbstractDiscount;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Bolt\Boltpay\Helper\Session as SessionHelper;
 
 /**
  * Class SalesRuleActionDiscountPluginTest
@@ -35,9 +36,12 @@ class SalesRuleActionDiscountPluginTest extends TestCase
      * @var SalesRuleActionDiscountPlugin
      */
     protected $plugin;
-
+    
     /** @var CheckoutSession */
     protected $checkoutSession;
+
+    /** @var SessionHelper */
+    protected $sessionHelper;
     
     /** @var AbstractDiscount */
     protected $subject;
@@ -45,6 +49,9 @@ class SalesRuleActionDiscountPluginTest extends TestCase
     public function setUp()
     {
         $this->subject = $this->createMock(AbstractDiscount::class);
+        $this->sessionHelper = $this->createPartialMock(SessionHelper::class,
+            ['getCheckoutSession']
+        );
         $this->checkoutSession = $this->createPartialMock(CheckoutSession::class,
             ['getBoltCollectSaleRuleDiscounts', 'setBoltCollectSaleRuleDiscounts']
         );
@@ -82,7 +89,10 @@ class SalesRuleActionDiscountPluginTest extends TestCase
                             ->willReturn($boltCollectSaleRuleDiscounts);
         $this->checkoutSession->expects(self::once())
                             ->method('setBoltCollectSaleRuleDiscounts')
-                            ->with([2 => 126.0,]);                    
+                            ->with([2 => 126.0,]);
+        $this->sessionHelper->expects(self::once())
+                            ->method('getCheckoutSession')
+                            ->willReturn($this->checkoutSession);
         $this->plugin->afterCalculate($this->subject, $result, $rule, null, null);
     }
 
@@ -112,7 +122,10 @@ class SalesRuleActionDiscountPluginTest extends TestCase
                             ->willReturn($boltCollectSaleRuleDiscounts);
         $this->checkoutSession->expects(self::once())
                             ->method('setBoltCollectSaleRuleDiscounts')
-                            ->with([2 => 20.0,]);                    
+                            ->with([2 => 20.0,]);
+        $this->sessionHelper->expects(self::once())
+                            ->method('getCheckoutSession')
+                            ->willReturn($this->checkoutSession);
         $this->plugin->afterCalculate($this->subject, $result, $rule, null, null);
     }
 }

--- a/Test/Unit/Plugin/SalesRuleQuoteDiscountPluginTest.php
+++ b/Test/Unit/Plugin/SalesRuleQuoteDiscountPluginTest.php
@@ -22,6 +22,7 @@ use Bolt\Boltpay\Plugin\SalesRuleQuoteDiscountPlugin;
 use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\SalesRule\Model\Quote\Discount;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Bolt\Boltpay\Helper\Session as SessionHelper;
 
 /**
  * Class SalesRuleQuoteDiscountPluginTest
@@ -38,12 +39,18 @@ class SalesRuleQuoteDiscountPluginTest extends TestCase
     /** @var CheckoutSession */
     protected $checkoutSession;
     
+    /** @var SessionHelper */
+    protected $sessionHelper;
+    
     /** @var Discount */
     protected $subject;
 
     public function setUp()
     {
         $this->subject = $this->createMock(Discount::class);
+        $this->sessionHelper = $this->createPartialMock(SessionHelper::class,
+            ['getCheckoutSession']
+        );
         $this->checkoutSession = $this->createPartialMock(CheckoutSession::class,
             ['setBoltCollectSaleRuleDiscounts']
         );
@@ -63,7 +70,10 @@ class SalesRuleQuoteDiscountPluginTest extends TestCase
     {
         $this->checkoutSession->expects(self::once())
                             ->method('setBoltCollectSaleRuleDiscounts')
-                            ->with([]);                    
+                            ->with([]);
+        $this->sessionHelper->expects(self::once())
+                            ->method('getCheckoutSession')
+                            ->willReturn($this->checkoutSession);
         $this->plugin->beforeCollect($this->subject, null, null, null);
     }
 }

--- a/Test/Unit/Plugin/SalesRuleQuoteDiscountPluginTest.php
+++ b/Test/Unit/Plugin/SalesRuleQuoteDiscountPluginTest.php
@@ -57,7 +57,7 @@ class SalesRuleQuoteDiscountPluginTest extends TestCase
         $this->plugin = (new ObjectManager($this))->getObject(
             SalesRuleQuoteDiscountPlugin::class,
             [
-                'checkoutSession' => $this->checkoutSession
+                'sessionHelper' => $this->sessionHelper
             ]
         );
     }


### PR DESCRIPTION
# Description
This bug is caused by the PR https://github.com/BoltApp/bolt-magento2/pull/997 , then the Bolt plugin can not distinguish between M2 discount rules and custom discount rule of 3rd-party plugins.

And after investigation, the root cause of the bug mentioned in the task https://boltpay.atlassian.net/browse/M2P-317 is that, for backoffice order, the default session type in SalesRuleActionDiscountPlugin and SalesRuleQuoteDiscountPlugin is Magento\\Backend\\Model\\Session, while the one in CartHelper is Magento\\Backend\\Model\\Session\\Quote, so the data of discount rules are not saved properly.

Solution: make all the sessions same type.


![image](https://user-images.githubusercontent.com/3198527/96262513-75ef8380-0ff4-11eb-9aed-ce507980822a.png)


Fixes: https://boltpay.atlassian.net/browse/M2P-326

#changelog Fix issue with discounts of backoffice order

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
