### PR TITLE
M2P-256 Add support to enable PPC only on specific products

### DIFF
--- a/Block/JsProductPage.php
+++ b/Block/JsProductPage.php
@@ -168,17 +168,27 @@ class JsProductPage extends Js
 
     public function isBoltProductPage()
     {
-        if ($this->configHelper->getSelectProductPageCheckoutFlag())
+        // If this flag is not enabled, we ignore this check and only use the parent check
+        if (!$this->configHelper->getSelectProductPageCheckoutFlag())
         {
-            $attributes = $this->getProduct()->getAttributes();
-            foreach ($attributes as $attribute) {
-                if ($attribute->getName() == 'bolt_ppc')
-                {
-                    return parent::isBoltProductPage();
-                }
-            }
+            return parent::isBoltProductPage();
+        }
+
+        // If the parent check is false, this check is automatically false
+        if (!parent::isBoltProductPage())
+        {
             return false;
         }
-        return parent::isBoltProductPage();
+
+        // By this point we know that the Select flag is true, the parent check is true, so
+        // all that remains is to check if this product has the ppc attribute or not.
+        $attributes = $this->getProduct()->getAttributes();
+        foreach ($attributes as $attribute) {
+            if ($attribute->getName() == 'bolt_ppc')
+            {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/Block/JsProductPage.php
+++ b/Block/JsProductPage.php
@@ -168,7 +168,13 @@ class JsProductPage extends Js
 
     public function isBoltProductPage()
     {
-        $specific = $this->configHelper->getSelectProductPageCheckoutFlag() && contains('bolt_pcc', $this->_product->getAttributes());
+        $attributes = $this->getProduct()->getAttributes();
+        $codes = [];
+        foreach ($attributes as $attribute) {
+            array_push($codes, $attribute->getName());
+        }
+        //note to self: getAttributes is returning an array that is not a string. Looking for the attribute code, not the attribute itself here.
+        $specific = $this->configHelper->getSelectProductPageCheckoutFlag() && in_array('bolt_ppc', $codes);
         return $specific && parent::isBoltProductPage();
     }
 }

--- a/Block/JsProductPage.php
+++ b/Block/JsProductPage.php
@@ -165,4 +165,9 @@ class JsProductPage extends Js
     {
         return $this->featureSwitches->isSaveHintsInSections();
     }
+
+    public function isBoltProductPage()
+    {
+        return contains('bolt_pcc', $this->_product->getAttributes()) && parent::isBoltProductPage();
+    }
 }

--- a/Block/JsProductPage.php
+++ b/Block/JsProductPage.php
@@ -168,6 +168,7 @@ class JsProductPage extends Js
 
     public function isBoltProductPage()
     {
-        return contains('bolt_pcc', $this->_product->getAttributes()) && parent::isBoltProductPage();
+        $specific = $this->configHelper->getSelectProductPageCheckoutFlag() && contains('bolt_pcc', $this->_product->getAttributes());
+        return $specific && parent::isBoltProductPage();
     }
 }

--- a/Block/JsProductPage.php
+++ b/Block/JsProductPage.php
@@ -168,13 +168,15 @@ class JsProductPage extends Js
 
     public function isBoltProductPage()
     {
-        $attributes = $this->getProduct()->getAttributes();
-        $codes = [];
-        foreach ($attributes as $attribute) {
-            array_push($codes, $attribute->getName());
+        if ($this->configHelper->getSelectProductPageCheckoutFlag())
+        {
+            $attributes = $this->getProduct()->getAttributes();
+            $codes = [];
+            foreach ($attributes as $attribute) {
+                array_push($codes, $attribute->getName());
+            }
+            return in_array('bolt_ppc', $codes) && parent::isBoltProductPage();
         }
-        //note to self: getAttributes is returning an array that is not a string. Looking for the attribute code, not the attribute itself here.
-        $specific = $this->configHelper->getSelectProductPageCheckoutFlag() && in_array('bolt_ppc', $codes);
-        return $specific && parent::isBoltProductPage();
+        return parent::isBoltProductPage();
     }
 }

--- a/Block/JsProductPage.php
+++ b/Block/JsProductPage.php
@@ -171,11 +171,13 @@ class JsProductPage extends Js
         if ($this->configHelper->getSelectProductPageCheckoutFlag())
         {
             $attributes = $this->getProduct()->getAttributes();
-            $codes = [];
             foreach ($attributes as $attribute) {
-                array_push($codes, $attribute->getName());
+                if ($attribute->getName() == 'bolt_ppc')
+                {
+                    return parent::isBoltProductPage();
+                }
             }
-            return in_array('bolt_ppc', $codes) && parent::isBoltProductPage();
+            return false;
         }
         return parent::isBoltProductPage();
     }

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -1654,6 +1654,10 @@ class Config extends AbstractHelper
         $boltSettings[] = $this->boltConfigSettingFactory->create()
                                                          ->setName('product_page_checkout')
                                                          ->setValue(var_export($this->getProductPageCheckoutFlag(), true));
+        // Select Product Page Checkout
+        $boltSettings[] = $this->boltConfigSettingFactory->create()
+                                                         ->setName('select_product_page_checkout')
+                                                         ->setValue(var_export($this->getSelectProductPageCheckoutFlag(), true));
         // Geolocation API Key (obscured)
         $boltSettings[] = $this->boltConfigSettingFactory->create()
                                                          ->setName('geolocation_api_key')

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -403,6 +403,7 @@ class Config extends AbstractHelper
         "sandbox_mode" => self::XML_PATH_SANDBOX_MODE,
         "is_pre_auth" => self::XML_PATH_IS_PRE_AUTH,
         "product_page_checkout" => self::XML_PATH_PRODUCT_PAGE_CHECKOUT,
+        "select_product_page_checkout" => self::XML_PATH_SELECT_PRODUCT_PAGE_CHECKOUT,
         "geolocation_api_key" => self::XML_PATH_GEOLOCATION_API_KEY,
         "replace_selectors" => self::XML_PATH_REPLACE_SELECTORS,
         "totals_change_selectors" => self::XML_PATH_TOTALS_CHANGE_SELECTORS,

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -125,6 +125,11 @@ class Config extends AbstractHelper
     const XML_PATH_PRODUCT_PAGE_CHECKOUT = 'payment/boltpay/product_page_checkout';
 
     /**
+     * Enable product page checkout for select products.
+     */
+    const XML_PATH_SELECT_PRODUCT_PAGE_CHECKOUT = 'payment/boltpay/select_product_page_checkout';
+
+    /**
      * Enable Bolt order management
      */
     const XML_PATH_PRODUCT_ORDER_MANAGEMENT = 'payment/boltpay/order_management';
@@ -802,6 +807,22 @@ class Config extends AbstractHelper
     {
         return $this->getScopeConfig()->isSetFlag(
             self::XML_PATH_PRODUCT_PAGE_CHECKOUT,
+            ScopeInterface::SCOPE_STORE,
+            $store
+        );
+    }
+
+    /**
+     * Get select product page checkout flag from config.
+     * Used to specify if product page is only enabled for specific products.
+     * @param int|string|Store $store
+     * @return boolean
+     */
+
+    public function getSelectProductPageCheckoutFlag($store = null)
+    {
+        return $this->getScopeConfig()->isSetFlag(
+            self::XML_PATH_SELECT_PRODUCT_PAGE_CHECKOUT,
             ScopeInterface::SCOPE_STORE,
             $store
         );

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -52,7 +52,7 @@ class JsTest extends \PHPUnit\Framework\TestCase
 {
 
     /** @var int expected number of settings returned by {@see \Bolt\Boltpay\Block\Js::getSettings} */
-    const SETTINGS_NUMBER = 26;
+    const SETTINGS_NUMBER = 27;
 
     /** @var int expeced number of tracking callback returned by {@see \Bolt\Boltpay\Block\Js::getTrackCallbacks} */
     const TRACK_CALLBACK_NUMBER = 7;
@@ -176,6 +176,7 @@ class JsTest extends \PHPUnit\Framework\TestCase
             'getModuleVersion',
             'shouldMinifyJavascript',
             'getProductPageCheckoutFlag',
+            'getSelectProductPageCheckoutFlag',
             'isOrderManagementEnabled',
             'isAlwaysPresentCheckoutEnabled',
             'isShowTermsPaymentButton',

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -52,7 +52,7 @@ class JsTest extends \PHPUnit\Framework\TestCase
 {
 
     /** @var int expected number of settings returned by {@see \Bolt\Boltpay\Block\Js::getSettings} */
-    const SETTINGS_NUMBER = 27;
+    const SETTINGS_NUMBER = 26;
 
     /** @var int expeced number of tracking callback returned by {@see \Bolt\Boltpay\Block\Js::getTrackCallbacks} */
     const TRACK_CALLBACK_NUMBER = 7;

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -780,7 +780,7 @@ JSON;
                           ->with(BoltConfig::XML_PATH_SELECT_PRODUCT_PAGE_CHECKOUT)
                           ->will($this->returnValue(false));
         $this->assertFalse(
-            $this->currentMock->getProductPageCheckoutFlag(),
+            $this->currentMock->getSelectProductPageCheckoutFlag(),
             'getSelectProductPageCheckoutFlag() method: not working properly'
         );
     }

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -771,6 +771,22 @@ JSON;
 
     /**
      * @test
+     *
+     */
+
+    public function testGetSelectProductPageCheckoutFlag()
+    {
+        $this->scopeConfig->method('isSetFlag')
+                          ->with(BoltConfig::XML_PATH_SELECT_PRODUCT_PAGE_CHECKOUT)
+                          ->will($this->returnValue(false));
+        $this->assertFalse(
+            $this->currentMock->getProductPageCheckoutFlag(),
+            'getSelectProductPageCheckoutFlag() method: not working properly'
+        );
+    }
+
+    /**
+     * @test
      * @covers ::getScopeConfig
      */
     public function getScopeConfig()
@@ -1076,6 +1092,7 @@ JSON;
             'isSandboxModeSet',
             'getIsPreAuth',
             'getProductPageCheckoutFlag',
+            'getSelectProductPageCheckoutFlag',
             'getGeolocationApiKey',
             'getReplaceSelectors',
             'getTotalsChangeSelectors',
@@ -1119,6 +1136,7 @@ JSON;
         $this->currentMock->method('isSandboxModeSet')->willReturn(true);
         $this->currentMock->method('getIsPreAuth')->willReturn(true);
         $this->currentMock->method('getProductPageCheckoutFlag')->willReturn(true);
+        $this->currentMock->method('getSelectProductPageCheckoutFlag')->willReturn(true);
         $this->currentMock->method('getGeolocationApiKey')->willReturn('geolocation api key');
         $this->currentMock->method('getReplaceSelectors')->willReturn('#replace');
         $this->currentMock->method('getTotalsChangeSelectors')->willReturn('.totals');

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -1181,6 +1181,7 @@ JSON;
             ['sandbox_mode', 'true'],
             ['is_pre_auth', 'true'],
             ['product_page_checkout', 'true'],
+            ['select_product_page_checkout', 'true'],
             ['geolocation_api_key', 'geo***key'],
             ['replace_selectors', '#replace'],
             ['totals_change_selectors', '.totals'],
@@ -1214,7 +1215,7 @@ JSON;
             ['track_checkout_funnel', 'false'],
         ];
         $actual = $this->currentMock->getAllConfigSettings();
-        $this->assertEquals(41, count($actual));
+        $this->assertEquals(42, count($actual));
         for ($i = 0; $i < 2; $i ++) {
             $this->assertEquals($expected[$i][0], $actual[$i]->getName());
             $this->assertEquals($expected[$i][1], $actual[$i]->getValue(), 'actual value for ' . $expected[$i][0] . ' is not equals to expected');

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -91,6 +91,7 @@
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     </field>
                     <field id="select_product_page_checkout" translate="label" type="select" sortOrder="81" showInDefault="1" showInWebsite="1" showInStore="0">
+                        <depends><field id="product_page_checkout">1</field></depends>
                         <label>Limited product page checkout</label>
                         <comment>Enable Bolt Checkout only for products with "bolt_ppc" attribute</comment>
                         <config_path>payment/boltpay/select_product_page_checkout</config_path>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -91,7 +91,6 @@
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     </field>
                     <field id="select_product_page_checkout" translate="label" type="select" sortOrder="81" showInDefault="1" showInWebsite="1" showInStore="0">
-                        <depends><field id="product_page_checkout">1</field></depends>
                         <label>Limited product page checkout</label>
                         <comment>Enable Bolt Checkout only for products with "bolt_ppc" attribute</comment>
                         <config_path>payment/boltpay/select_product_page_checkout</config_path>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -90,6 +90,13 @@
                         <config_path>payment/boltpay/product_page_checkout</config_path>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     </field>
+                    <field id="select_product_page_checkout" translate="label" type="select" sortOrder="81" showInDefault="1" showInWebsite="1" showInStore="0">
+                        <depends><field id="product_page_checkout">1</field></depends>
+                        <label>Limited product page checkout</label>
+                        <comment>Enable Bolt Checkout only for products with "bolt_ppc" attribute</comment>
+                        <config_path>payment/boltpay/select_product_page_checkout</config_path>
+                        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    </field>
                     <field id="order_management" translate="label" type="select" sortOrder="82" showInDefault="1" showInWebsite="1" showInStore="0">
                         <label>(BETA) Enable Bolt order management</label>
                         <config_path>payment/boltpay/order_management</config_path>


### PR DESCRIPTION
# Description
Adds a configuration field to allow merchants to enable PPC only on products with the `bolt_ppc` attribute.


Fixes: [M2P-256](https://boltpay.atlassian.net/browse/M2P-256)

#changelog Add support to enable PPC only on specific products

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
