### PR TITLE
M2P-331 Allow to create order on the second payment attempt

### DIFF
--- a/Model/Api/OrderManagement.php
+++ b/Model/Api/OrderManagement.php
@@ -239,14 +239,8 @@ class OrderManagement implements OrderManagementInterface
             $immutableQuoteId = $this->cartHelper->getImmutableQuoteIdFromBoltOrder($transaction->order);
 
             if ($type === 'failed_payment' || $type === 'failed') {
-                if ($this->decider->isCancelFailedPaymentOrderInsteadOfDeleting()) {
-                    /** @see \Bolt\Boltpay\Helper\Order::deleteOrderByIncrementId */
-                    $this->orderHelper->cancelFailedPaymentOrder($display_id, $immutableQuoteId);
-                    $this->setSuccessResponse('Order was canceled: ' . $display_id);
-                } else {
-                    $this->orderHelper->deleteOrderByIncrementId($display_id, $immutableQuoteId);
-                    $this->setSuccessResponse('Order was deleted: ' . $display_id);
-                }
+                $responseMessage = $this->orderHelper->deleteOrCancelFailedPaymentOrder($display_id, $immutableQuoteId);
+                $this->setSuccessResponse($responseMessage);
                 return;
             }
 


### PR DESCRIPTION
If users try to pay a second time after an unsuccessful attempt Magento plugin can return an error "Order is in pending payment. Waiting for the hook update.".It happens if Magento didn't receive failed payment hook yet.

It happens quite often (few times per day) because hooks work asynchronously, use the queue. We can't expect hook work instantly.

Order in pending payment status can mean another thing: the order was irreversibly rejected before auth (blacklist e.g.) but the hook wasn't sent yet.
In this case, we will delete the order as well. This is not the best behavior, but it's not an issue: eventually, the merchant will have an order with canceled status, the same as before this PR.
Down the road, we are going to change behavior on the server side and don't create orders in the cart if payment rejected before auth.

**Solution:**
If we see created order in pending payment status we can delete it and create a new one

Fixes: [M2P-331](https://boltpay.atlassian.net/browse/M2P-331)

#changelog M2P-331 Allow to create order on the second payment attempt

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
