### PR TITLE
M2P-331 Fix issue with deleting PPC orders

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -1278,7 +1278,7 @@ class Order extends AbstractHelper
         }
         // reset PPC quote checkout type so it can be treated as active
         if ($parentQuote->getBoltCheckoutType() == CartHelper::BOLT_CHECKOUT_TYPE_PPC_COMPLETE) {
-            $parentQuote->SetBoltCheckoutType(CartHelper::BOLT_CHECKOUT_TYPE_PPC);
+            $parentQuote->setBoltCheckoutType(CartHelper::BOLT_CHECKOUT_TYPE_PPC);
             $this->cartHelper->quoteResourceSave($parentQuote->setIsActive(false));
         }
     }

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -2253,7 +2253,7 @@ class OrderTest extends TestCase
         $this->currentMock->expects(static::once())->method('deleteOrder')->with($this->orderMock);
         $quoteMock->expects(static::once())->method('getBoltCheckoutType')
             ->willReturn(CartHelper::BOLT_CHECKOUT_TYPE_PPC_COMPLETE);
-        $quoteMock->expects(static::once())->method('SetBoltCheckoutType')
+        $quoteMock->expects(static::once())->method('setBoltCheckoutType')
             ->with(CartHelper::BOLT_CHECKOUT_TYPE_PPC);
         $quoteMock->expects(static::once())->method('setIsActive')->with(false)->WillReturnSelf();
         $this->cartHelper->expects(static::once())->method('quoteResourceSave')->with($quoteMock);
@@ -2291,7 +2291,7 @@ class OrderTest extends TestCase
         $this->cartHelper->expects(static::once())->method('quoteResourceSave')->with($this->quoteMock);
         $this->quoteMock->expects(static::once())->method('getBoltCheckoutType')
             ->willReturn(CartHelper::BOLT_CHECKOUT_TYPE_PPC_COMPLETE);
-        $this->quoteMock->expects(static::once())->method('SetBoltCheckoutType')
+        $this->quoteMock->expects(static::once())->method('setBoltCheckoutType')
             ->willReturn(CartHelper::BOLT_CHECKOUT_TYPE_PPC);
         $this->currentMock->deleteOrderByIncrementId(self::INCREMENT_ID, self::IMMUTABLE_QUOTE_ID);
     }


### PR DESCRIPTION
When PPC order isn't paid and we try to delete it PHP throws an exception because of the wrong method name.

Fixes: [M2P-331](https://boltpay.atlassian.net/browse/M2P-331)

#changelog M2P-331Fix issue with deleting PPC orders

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
