### PR TITLE
M2P-338 Bugfix: Tax mismatch if the available points balance of Mirasvit Rewards is larger than cart subtotal

### DIFF
--- a/Model/Api/CreateOrder.php
+++ b/Model/Api/CreateOrder.php
@@ -301,6 +301,7 @@ class CreateOrder implements CreateOrderInterface
         $createdOrder = $this->orderHelper->processExistingOrder($quote, $transaction);
 
         if (! $createdOrder) {
+            $this->eventsForThirdPartyModules->dispatchEvent("beforeValidateQuoteDataForProcessNewOrder", $quote);
             $this->validateQuoteData($quote, $transaction);
             $createdOrder = $this->orderHelper->processNewOrder($quote, $transaction);
         }
@@ -649,7 +650,8 @@ class CreateOrder implements CreateOrderInterface
     {
         // Skip validation if Mirasvit_Credit is used.
         // Rely on Model\Api\CreateOrder::validateTotalAmount which is called next.
-        if ($quote->getShippingAddress()->getCreditAmount()) {
+        if ($quote->getShippingAddress()->getCreditAmount()
+            || $this->eventsForThirdPartyModules->runFilter("filterSkipValidateShippingForProcessNewOrder", $quote, $transaction)) {
             return;
         }
         if ($quote->getShippingAddress() && !$quote->isVirtual()) {

--- a/Model/EventsForThirdPartyModules.php
+++ b/Model/EventsForThirdPartyModules.php
@@ -123,6 +123,19 @@ class EventsForThirdPartyModules
                 ],
             ]
         ],
+        'beforeValidateQuoteDataForProcessNewOrder' => [
+            "listeners" => [
+                [
+                    "module" => "Mirasvit_Rewards",
+                    "sendClasses" => ["Mirasvit\Rewards\Helper\Purchase",
+                                      "Mirasvit\Rewards\Helper\Balance",
+                                      "Mirasvit\Rewards\Helper\Balance\SpendRulesList",
+                                      "Mirasvit\Rewards\Model\Config",
+                                      "Mirasvit\Rewards\Helper\Checkout"],
+                    "boltClass" => Mirasvit_Rewards::class,
+                ],
+            ]
+        ],
     ];
 
     const filterListeners = [
@@ -187,7 +200,10 @@ class EventsForThirdPartyModules
                 ],
                 [
                     "module" => "Mirasvit_Rewards",
-                    "sendClasses" => ["Mirasvit\Rewards\Helper\Purchase"],
+                    "sendClasses" => ["Mirasvit\Rewards\Helper\Purchase",
+                                      "Mirasvit\Rewards\Helper\Balance",
+                                      "Mirasvit\Rewards\Helper\Balance\SpendRulesList",
+                                      "Mirasvit\Rewards\Model\Config"],
                     "boltClass" => Mirasvit_Rewards::class,
                 ],
                 [
@@ -308,7 +324,10 @@ class EventsForThirdPartyModules
             "listeners" => [
                 [
                     "module" => "Mirasvit_Rewards",
-                    "sendClasses" => ["Mirasvit\Rewards\Helper\Purchase"],
+                    "sendClasses" => ["Mirasvit\Rewards\Helper\Purchase",
+                                      "Mirasvit\Rewards\Helper\Balance",
+                                      "Mirasvit\Rewards\Helper\Balance\SpendRulesList",
+                                      "Mirasvit\Rewards\Model\Config"],
                     "boltClass" => Mirasvit_Rewards::class,
                 ],
             ],
@@ -339,6 +358,15 @@ class EventsForThirdPartyModules
                     "checkClasses" => ["Amasty\Rewards\Api\CheckoutRewardsManagementInterface"],
                     "boltClass" => Amasty_Rewards::class,
                 ],
+        ],
+        'filterSkipValidateShippingForProcessNewOrder' => [
+            "listeners" => [
+                [
+                    "module" => "Mirasvit_Rewards",
+                    "sendClasses" => ["Mirasvit\Rewards\Model\Config"],
+                    "boltClass" => Mirasvit_Rewards::class,
+                ],
+            ]
         ],
     ];
 

--- a/ThirdPartyModules/Mirasvit/Rewards.php
+++ b/ThirdPartyModules/Mirasvit/Rewards.php
@@ -21,6 +21,7 @@ use Bolt\Boltpay\Helper\Bugsnag;
 use Bolt\Boltpay\Helper\Shared\CurrencyUtils;
 use Bolt\Boltpay\Helper\Discount;
 use Magento\Store\Model\ScopeInterface;
+use Magento\Customer\Model\CustomerFactory;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 
 class Rewards
@@ -29,6 +30,21 @@ class Rewards
      * @var \Mirasvit\Rewards\Helper\Purchase
      */
     private $mirasvitRewardsPurchaseHelper;
+    
+    /**
+     * @var ThirdPartyModuleFactory
+     */
+    private $mirasvitRewardsSpendRulesListHelper;
+    
+    /**
+     * @var ThirdPartyModuleFactory
+     */
+    private $mirasvitRewardsModelConfig;
+    
+    /**
+     * @var ThirdPartyModuleFactory
+     */
+    private $mirasvitRewardsBalanceHelper;
 
     /**
      * @var Bugsnag
@@ -44,22 +60,30 @@ class Rewards
      * @var ScopeConfigInterface
      */
     private $scopeConfigInterface;
+    
+    /**
+     * @var CustomerFactory
+     */
+    private $customerFactory;
 
     /**
      * Rewards constructor.
      * @param Bugsnag $bugsnagHelper
      * @param Discount $discountHelper
      * @param ScopeInterface $scopeConfigInterface
+     * @param CustomerFactory $customerFactory
      */
     public function __construct(
         Bugsnag $bugsnagHelper,
         Discount $discountHelper,
-        ScopeConfigInterface $scopeConfigInterface
+        ScopeConfigInterface $scopeConfigInterface,
+        CustomerFactory $customerFactory
     )
     {
         $this->bugsnagHelper = $bugsnagHelper;
         $this->discountHelper = $discountHelper;
         $this->scopeConfigInterface = $scopeConfigInterface;
+        $this->customerFactory = $customerFactory;
     }
 
     /**
@@ -75,6 +99,9 @@ class Rewards
     /**
      * @param $result
      * @param $mirasvitRewardsPurchaseHelper
+     * @param $mirasvitRewardsBalanceHelper
+     * @param $mirasvitRewardsSpendRulesListHelper
+     * @param $mirasvitRewardsModelConfig
      * @param $quote
      * @param $parentQuote
      * @param $paymentOnly
@@ -83,12 +110,18 @@ class Rewards
     public function collectDiscounts(
         $result,
         $mirasvitRewardsPurchaseHelper,
+        $mirasvitRewardsBalanceHelper,
+        $mirasvitRewardsSpendRulesListHelper,
+        $mirasvitRewardsModelConfig,
         $quote,
         $parentQuote,
         $paymentOnly
     )
     {
         $this->mirasvitRewardsPurchaseHelper = $mirasvitRewardsPurchaseHelper;
+        $this->mirasvitRewardsBalanceHelper = $mirasvitRewardsBalanceHelper;
+        $this->mirasvitRewardsSpendRulesListHelper = $mirasvitRewardsSpendRulesListHelper;
+        $this->mirasvitRewardsModelConfig = $mirasvitRewardsModelConfig;
         list ($discounts, $totalAmount, $diff) = $result;
         $discountType = $this->discountHelper->getBoltDiscountType('by_fixed');
         try {
@@ -123,12 +156,24 @@ class Rewards
      * @param $quote
      * @return string
      */
-    public function filterApplyExternalQuoteData($result, $mirasvitRewardsPurchaseHelper, $quote)
+    public function filterApplyExternalQuoteData(
+        $result,
+        $mirasvitRewardsPurchaseHelper,
+        $mirasvitRewardsBalanceHelper,
+        $mirasvitRewardsSpendRulesListHelper,
+        $mirasvitRewardsModelConfig,
+        $quote
+    )
     {
         $this->mirasvitRewardsPurchaseHelper = $mirasvitRewardsPurchaseHelper;
+        $this->mirasvitRewardsBalanceHelper = $mirasvitRewardsBalanceHelper;
+        $this->mirasvitRewardsSpendRulesListHelper = $mirasvitRewardsSpendRulesListHelper;
+        $this->mirasvitRewardsModelConfig = $mirasvitRewardsModelConfig;
+
         if ($rewardsAmount = $this->getMirasvitRewardsAmount($quote)) {
             $result .= $rewardsAmount;
         }
+
         return $result;
     }
 
@@ -174,15 +219,83 @@ class Rewards
      * @return float  If enabled, the currency amount used in the order, otherwise 0
      */
     private function getMirasvitRewardsAmount($quote)
-    {
-        /** @var \Mirasvit\Rewards\Helper\Purchase $mirasvitRewardsPurchaseHelper */
-        $mirasvitRewardsPurchaseHelper = $this->mirasvitRewardsPurchaseHelper;
-
-        if (!$mirasvitRewardsPurchaseHelper) {
+    {        
+        try{
+            $miravitRewardsPurchase = $this->mirasvitRewardsPurchaseHelper->getByQuote($quote);
+            $spendAmount = $miravitRewardsPurchase->getSpendAmount();
+            // If the setting "Allow to spend points for shipping charges" is set to Yes,
+            // we need to send full balance to the Bolt server.
+            if(($spendAmount > \Mirasvit\Rewards\Helper\Calculation::ZERO_VALUE) && $this->mirasvitRewardsModelConfig->getGeneralIsSpendShipping()) {
+                $balancePoints = $this->mirasvitRewardsBalanceHelper->getBalancePoints($quote->getCustomerId());
+                $customer = $this->customerFactory->create()->load($quote->getCustomer()->getId());
+                $points = 0;
+                $websiteId = $quote->getStore()->getWebsiteId();
+                $rules = $this->mirasvitRewardsSpendRulesListHelper->getRuleCollection($websiteId, $customer->getGroupId());
+                if ($rules->count()) {
+                    $pointsMoney = [0];
+                    /** @var \Mirasvit\Rewards\Model\Spending\Rule $rule */
+                    foreach ($rules as $rule) {
+                        $tier = $rule->getTier($customer);
+                        $spendPoints = $tier->getSpendPoints(); 
+                        if ($spendPoints <= \Mirasvit\Rewards\Helper\Calculation::ZERO_VALUE) {
+                            continue;
+                        }
+                        $pointsMoney[] = ($balancePoints / $spendPoints) * $tier->getMonetaryStep($spendAmount);  
+                    } 
+                    $points = max($pointsMoney);
+                }                
+                $spendAmount = max($points, $spendAmount);
+            }
+           
+            return $spendAmount;
+        } catch (\Exception $e) {
+            $this->bugsnagHelper->notifyException($e);
             return 0;
-        }
-
-        $miravitRewardsPurchase = $mirasvitRewardsPurchaseHelper->getByQuote($quote);
-        return $miravitRewardsPurchase->getSpendAmount();
+        }        
     }
+    
+    /**
+     * @param $mirasvitRewardsPurchaseHelper
+     * @param $mirasvitRewardsBalanceHelper
+     * @param $mirasvitRewardsSpendRulesListHelper
+     * @param $mirasvitRewardsModelConfig
+     * @param $quote
+     */
+    public function beforeValidateQuoteDataForProcessNewOrder(
+        $mirasvitRewardsPurchaseHelper,
+        $mirasvitRewardsBalanceHelper,
+        $mirasvitRewardsSpendRulesListHelper,
+        $mirasvitRewardsModelConfig,
+        $mirasvitRewardsCheckoutHelper,
+        $quote
+    )
+    {
+        $this->mirasvitRewardsPurchaseHelper = $mirasvitRewardsPurchaseHelper;
+        $this->mirasvitRewardsBalanceHelper = $mirasvitRewardsBalanceHelper;
+        $this->mirasvitRewardsSpendRulesListHelper = $mirasvitRewardsSpendRulesListHelper;
+        $this->mirasvitRewardsModelConfig = $mirasvitRewardsModelConfig;
+        
+        try{           
+            if($this->mirasvitRewardsModelConfig->getGeneralIsSpendShipping() && $this->getMirasvitRewardsAmount($quote)) {
+                $balancePoints = $this->mirasvitRewardsBalanceHelper->getBalancePoints($quote->getCustomerId());
+                $miravitRewardsPurchase = $this->mirasvitRewardsPurchaseHelper->getByQuote($quote);
+                $mirasvitRewardsCheckoutHelper->updatePurchase($miravitRewardsPurchase, $balancePoints);
+            }
+        } catch (\Exception $e) {
+            $this->bugsnagHelper->notifyException($e);
+        }
+    }
+    
+    /**
+     * @param $result
+     * @param $mirasvitRewardsModelConfig
+     * @param $quote
+     * @param $transaction
+     * @return boolean
+     */
+    public function filterSkipValidateShippingForProcessNewOrder($result, $mirasvitRewardsModelConfig, $quote, $transaction)
+    {
+        return $result || $mirasvitRewardsModelConfig->getGeneralIsSpendShipping();
+    }
+    
 }


### PR DESCRIPTION
# Description
We need to send all the available points balance of Mirasvit Rewards to the Bolt server side when necessary, so Bolt can calculate the totals properly.

Fixes: https://boltpay.atlassian.net/browse/M2P-338

#changelog Bugfix: Tax mismatch if the available points balance of Mirasvit Rewards is larger than cart subtotal

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
