### PR TITLE
M2P-339 Bugfix: the specified aheadworks Gift Card code already in the quote

### DIFF
--- a/ThirdPartyModules/Aheadworks/Giftcard.php
+++ b/ThirdPartyModules/Aheadworks/Giftcard.php
@@ -228,7 +228,8 @@ class Giftcard
      */
     public function replicateQuoteData($aheadworksGiftcardOrderServicePlugin, $sourceQuote, $destinationQuote)
     {
-        if ($sourceQuote->getExtensionAttributes() && $sourceQuote->getExtensionAttributes()->getAwGiftcardCodes()) {
+        if ($sourceQuote->getExtensionAttributes() && $sourceQuote->getExtensionAttributes()->getAwGiftcardCodes()
+            && (!$destinationQuote->getExtensionAttributes() || empty($destinationQuote->getExtensionAttributes()->getAwGiftcardCodes()))) {
             $giftcards = $sourceQuote->getExtensionAttributes()->getAwGiftcardCodes();
             /** @var GiftcardQuoteInterface $giftcard */
             foreach ($giftcards as $giftcard) {


### PR DESCRIPTION
# Description
In some contexts, if the cart has aheadworks Giftcard applied, there would be an error "The specified Gift Card code already in the quote" during order creation.

It is because when cloning quote data from the parent quote to the immutable quote, the immutable quote already has aheadworks Giftcard applied

Fixes: https://boltpay.atlassian.net/browse/M2P-339

#changelog Bugfix: the specified aheadworks Gift Card code already in the quote

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
