### PR TITLE
M2P-343 Bugfix: duplicate shipping discount from Mirasvit rewards

### DIFF
--- a/Model/EventsForThirdPartyModules.php
+++ b/Model/EventsForThirdPartyModules.php
@@ -320,6 +320,11 @@ class EventsForThirdPartyModules
                     "checkClasses" => ["Mirasvit\Credit\Helper\Data"],
                     "boltClass" => Mirasvit_Credit::class,
                 ],
+                [
+                    "module" => "Mirasvit_Rewards",
+                    "checkClasses" => ["Mirasvit\Rewards\Model\Config"],
+                    "boltClass" => Mirasvit_Rewards::class,
+                ],
             ],
         ],
         "checkMirasvitCreditAdminQuoteUsed" => [
@@ -331,7 +336,6 @@ class EventsForThirdPartyModules
                 ],
             ],
         ],
-
         "checkMirasvitCreditIsShippingTaxIncluded" => [
             "listeners" => [
                 [
@@ -340,9 +344,17 @@ class EventsForThirdPartyModules
                                       "Mirasvit\Credit\Service\Config\CalculationConfig"]],
                     "boltClass" => Mirasvit_Credit::class,
                 ],
-             ],
-         ],
-
+            ],
+        ],
+        "checkMirasvitRewardsIsShippingIncluded" => [
+            "listeners" => [
+                [
+                    "module" => "Mirasvit_Rewards",
+                    "sendClasses" => ["Mirasvit\Rewards\Model\Config"],
+                    "boltClass" => Mirasvit_Rewards::class,
+                ],
+            ],
+        ],
         "getAdditionalJS" => [
             "listeners" => [
                 [

--- a/Plugin/Mirasvit/Rewards/Model/Total/Quote/DiscountPlugin.php
+++ b/Plugin/Mirasvit/Rewards/Model/Total/Quote/DiscountPlugin.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Plugin\Mirasvit\Rewards\Model\Total\Quote;
+
+use Bolt\Boltpay\Helper\Session as SessionHelper;
+use Bolt\Boltpay\Model\EventsForThirdPartyModules;
+
+/**
+ * Class DiscountPlugin
+ *
+ * @package Bolt\Boltpay\Plugin
+ */
+class DiscountPlugin
+{
+    /**
+     * @var SessionHelper
+     */
+    private $sessionHelper;
+    
+    /**
+     * @var EventsForThirdPartyModules
+     */
+    private $eventsForThirdPartyModules;
+
+    /**
+     * DiscountPlugin constructor.
+     *
+     * @param CheckoutSession $checkoutSession
+     * @param EventsForThirdPartyModules $eventsForThirdPartyModules
+     */
+    public function __construct(
+        SessionHelper $sessionHelper,
+        EventsForThirdPartyModules $eventsForThirdPartyModules
+    ) {
+        $this->sessionHelper = $sessionHelper;
+        $this->eventsForThirdPartyModules = $eventsForThirdPartyModules;
+    }
+
+    /**
+     * Save the shipping discount amount into checkout session before collecting discount from Mirasvit rewards,
+     * so we can restore the shipping discount amount later.
+     *
+     * @return mixed
+     */
+    public function beforeCollect(
+        \Mirasvit\Rewards\Model\Total\Quote\Discount $subject,
+        $quote,
+        $shippingAssignment,
+        $total   
+    ) {
+        if ($this->eventsForThirdPartyModules->runFilter("checkMirasvitRewardsIsShippingIncluded", false)) {
+            $address = $shippingAssignment->getShipping()->getAddress();
+            $beforeShippingDiscountAmount = $address->getShippingDiscountAmount();
+            $checkoutSession = $this->sessionHelper->getCheckoutSession();
+            $checkoutSession->setBeforeMirasvitRewardsShippingDiscountAmount($beforeShippingDiscountAmount);
+            $checkoutSession->setMirasvitRewardsShippingDiscountAmount(0);
+        }
+
+        return [$quote, $shippingAssignment, $total];
+    }
+    
+    /**
+     * Exclude the Mirasvit rewards points from shipping discount, so the Bolt can apply Mirasvit rewards points to shipping properly.
+     *
+     * @return mixed
+     */
+    public function afterCollect(
+        \Mirasvit\Rewards\Model\Total\Quote\Discount $subject,
+        $result,
+        $quote,
+        $shippingAssignment,
+        $total   
+    ) {
+        if ($this->eventsForThirdPartyModules->runFilter("checkMirasvitRewardsIsShippingIncluded", false)) {
+            $address = $shippingAssignment->getShipping()->getAddress();
+            $afterShippingDiscountAmount = $address->getShippingDiscountAmount();
+            $checkoutSession = $this->sessionHelper->getCheckoutSession();
+            $beforeShippingDiscountAmount = $checkoutSession->getBeforeMirasvitRewardsShippingDiscountAmount();
+            $mirasvitRewardsShippingDiscountAmount = $afterShippingDiscountAmount - $beforeShippingDiscountAmount;
+            if($mirasvitRewardsShippingDiscountAmount > 0) {
+                $checkoutSession->setMirasvitRewardsShippingDiscountAmount($mirasvitRewardsShippingDiscountAmount);
+            }            
+        }
+
+        return $result;
+    }
+}

--- a/ThirdPartyModules/Mirasvit/Rewards.php
+++ b/ThirdPartyModules/Mirasvit/Rewards.php
@@ -20,6 +20,7 @@ namespace Bolt\Boltpay\ThirdPartyModules\Mirasvit;
 use Bolt\Boltpay\Helper\Bugsnag;
 use Bolt\Boltpay\Helper\Shared\CurrencyUtils;
 use Bolt\Boltpay\Helper\Discount;
+use Bolt\Boltpay\Helper\Session as SessionHelper;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Customer\Model\CustomerFactory;
 use Magento\Framework\App\Config\ScopeConfigInterface;
@@ -65,6 +66,11 @@ class Rewards
      * @var CustomerFactory
      */
     private $customerFactory;
+    
+    /**
+     * @var SessionHelper
+     */
+    private $sessionHelper;
 
     /**
      * Rewards constructor.
@@ -72,18 +78,21 @@ class Rewards
      * @param Discount $discountHelper
      * @param ScopeInterface $scopeConfigInterface
      * @param CustomerFactory $customerFactory
+     * @param SessionHelper $sessionHelper
      */
     public function __construct(
         Bugsnag $bugsnagHelper,
         Discount $discountHelper,
         ScopeConfigInterface $scopeConfigInterface,
-        CustomerFactory $customerFactory
+        CustomerFactory $customerFactory,
+        SessionHelper $sessionHelper
     )
     {
         $this->bugsnagHelper = $bugsnagHelper;
         $this->discountHelper = $discountHelper;
         $this->scopeConfigInterface = $scopeConfigInterface;
         $this->customerFactory = $customerFactory;
+        $this->sessionHelper   = $sessionHelper;
     }
 
     /**

--- a/ThirdPartyModules/Mirasvit/Rewards.php
+++ b/ThirdPartyModules/Mirasvit/Rewards.php
@@ -298,4 +298,35 @@ class Rewards
         return $result || $mirasvitRewardsModelConfig->getGeneralIsSpendShipping();
     }
     
+    /**
+     * To run filter to check if the Mirasvit rewards can be applied to shipping.
+     *
+     * @param boolean $result
+     * @param Mirasvit\Rewards\Model\Config $mirasvitRewardsModelConfig
+     * 
+     * @return boolean
+     */
+    public function checkMirasvitRewardsIsShippingIncluded($result, $mirasvitRewardsModelConfig)
+    {
+        return $mirasvitRewardsModelConfig->getGeneralIsSpendShipping();
+    }
+    
+    /**
+     * Exclude the Mirasvit rewards points from shipping discount, so the Bolt can apply Mirasvit rewards points to shipping properly.
+     *
+     * @param float $result
+     * @param Quote|object $quote
+     * @param Address|object $shippingAddress
+     * 
+     * @return float
+     */
+    public function collectShippingDiscounts($result,
+                                     $quote,
+                                     $shippingAddress)
+    {
+        $mirasvitRewardsShippingDiscountAmount = $this->sessionHelper->getCheckoutSession()->getMirasvitRewardsShippingDiscountAmount(0);
+        $result -= $mirasvitRewardsShippingDiscountAmount;
+        return $result;
+    }
+    
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -181,6 +181,10 @@
         <plugin name="Bolt_Boltpay_Mirasvit_Rewards_Model_PurchasePlugin" type="Bolt\Boltpay\Plugin\Mirasvit\Rewards\Model\PurchasePlugin" sortOrder="1" />
     </type>
     
+    <type name="Mirasvit\Rewards\Model\Total\Quote\Discount">
+        <plugin name="Bolt_Boltpay_Mirasvit_Rewards_Model_Total_Quote_DiscountPlugin" type="Bolt\Boltpay\Plugin\Mirasvit\Rewards\Model\Total\Quote\DiscountPlugin" sortOrder="1" />
+    </type>
+    
     <type name="Mirasvit\Credit\Model\Total\Quote\Credit">
         <plugin name="Bolt_Boltpay_Mirasvit_Store_Credit_Model_Total_Quote_CreditPlugin" type="Bolt\Boltpay\Plugin\Mirasvit\Credit\Model\Total\Quote\CreditPlugin" sortOrder="1" />
     </type>


### PR DESCRIPTION
# Description
When the cart has Mirasvit rewards applied, if  subtotal < balance of Mirasvit rewards < subtotal +shipping cost , then the related quote has duplicate shipping discount from Mirasvit rewards, cause Bolt already count the Mirasvit rewards points in the totals.

Fixes: https://boltpay.atlassian.net/browse/M2P-343

#changelog Bugfix: duplicate shipping discount from Mirasvit rewards

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
