### PR TITLE
Add feature switch (default OFF) for disabling the redirect customers to the cart page after they log in

### DIFF
--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -269,4 +269,8 @@ class Decider extends AbstractHelper
     public function isPrefetchShippingEnabled() {
         return $this->isSwitchEnabled(Definitions::M2_PREFETCH_SHIPPING);
     }
+
+    public function ifShouldDisableRedirectCustomerToCartPageAfterTheyLogIn() {
+        return $this->isSwitchEnabled(Definitions::M2_IF_SHOULD_DISABLE_REDIRECT_CUSTOMER_TO_CART_PAGE_AFTER_THEY_LOG_IN);
+    }
 }

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -118,6 +118,11 @@ class Definitions
     const M2_IF_SHOULD_DISABLE_PREFILL_ADDRESS_FROM_BOLT_FOR_LOGGED_IN_CUSTOMER = "M2_IF_SHOULD_DISABLE_PREFILL_ADDRESS_FROM_BOLT_FOR_LOGGED_IN_CUSTOMER";
 
     /**
+     * Disable redirect customers to the cart page after they log in
+     */
+    const M2_IF_SHOULD_DISABLE_REDIRECT_CUSTOMER_TO_CART_PAGE_AFTER_THEY_LOG_IN = "M2_IF_SHOULD_DISABLE_REDIRECT_CUSTOMER_TO_CART_PAGE_AFTER_THEY_LOG_IN";
+
+    /**
      * Handle virtual cart as physical. Workarond for known issue with taxable virtual products.
      */
     const M2_HANDLE_VIRTUAL_PRODUCTS_AS_PHYSICAL = "M2_HANDLE_VIRTUAL_PRODUCTS_AS_PHYSICAL";
@@ -254,6 +259,12 @@ class Definitions
         ],
         self::M2_PREFETCH_SHIPPING =>  [
             self::NAME_KEY            => self::M2_PREFETCH_SHIPPING,
+            self::VAL_KEY             => true,
+            self::DEFAULT_VAL_KEY     => false,
+            self::ROLLOUT_KEY         => 0
+        ],
+        self::M2_IF_SHOULD_DISABLE_REDIRECT_CUSTOMER_TO_CART_PAGE_AFTER_THEY_LOG_IN =>  [
+            self::NAME_KEY            => self::M2_IF_SHOULD_DISABLE_REDIRECT_CUSTOMER_TO_CART_PAGE_AFTER_THEY_LOG_IN,
             self::VAL_KEY             => true,
             self::DEFAULT_VAL_KEY     => false,
             self::ROLLOUT_KEY         => 0

--- a/Plugin/AbstractLoginPlugin.php
+++ b/Plugin/AbstractLoginPlugin.php
@@ -17,6 +17,7 @@
 
 namespace Bolt\Boltpay\Plugin;
 
+use Bolt\Boltpay\Helper\FeatureSwitch\Decider;
 use Magento\Framework\App\Action\Action;
 use Magento\Framework\Controller\ResultInterface;
 use Magento\Framework\Controller\ResultFactory;
@@ -24,7 +25,8 @@ use Magento\Customer\Model\Session as CustomerSession;
 use Magento\Checkout\Model\Session as CheckoutSession;
 use Bolt\Boltpay\Helper\Bugsnag;
 
-abstract class AbstractLoginPlugin
+abstract class
+AbstractLoginPlugin
 {
     const SHOPPING_CART_PATH = 'checkout/cart';
 
@@ -49,23 +51,30 @@ abstract class AbstractLoginPlugin
     private $bugsnag;
 
     /**
+     * @var Decider
+     */
+    private $decider;
+
+    /**
      * AbstractLoginPlugin constructor.
-     *
      * @param CustomerSession $customerSession
      * @param CheckoutSession $checkoutSession
      * @param ResultFactory $resultFactory
      * @param Bugsnag $bugsnag
+     * @param Decider $decider
      */
     public function __construct(
         CustomerSession $customerSession,
         CheckoutSession $checkoutSession,
         ResultFactory $resultFactory,
-        Bugsnag $bugsnag
+        Bugsnag $bugsnag,
+        Decider $decider
     ) {
         $this->customerSession = $customerSession;
         $this->checkoutSession = $checkoutSession;
         $this->resultFactory = $resultFactory;
         $this->bugsnag = $bugsnag;
+        $this->decider = $decider;
     }
 
     /**
@@ -100,7 +109,9 @@ abstract class AbstractLoginPlugin
      */
     protected function shouldRedirectToCartPage()
     {
-        return $this->isCustomerLoggedIn() && $this->hasCart();
+        return $this->isCustomerLoggedIn()
+            && !$this->decider->ifShouldDisableRedirectCustomerToCartPageAfterTheyLogIn()
+            && $this->hasCart();
     }
 
     /**

--- a/Test/Unit/Plugin/LoginPostPluginTest.php
+++ b/Test/Unit/Plugin/LoginPostPluginTest.php
@@ -24,6 +24,7 @@ use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\Customer\Model\Session as CustomerSession;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Customer\Controller\Account\LoginPost;
+use Bolt\Boltpay\Helper\FeatureSwitch\Decider;
 
 /**
  * Class LoginPostPluginTest
@@ -52,10 +53,14 @@ class LoginPostPluginTest extends TestCase
     /** @var Bugsnag */
     protected $bugsnag;
 
+    /** @var @var Decider */
+    private $decider;
+
     public function setUp()
     {
         $this->customerSession = $this->createMock(CustomerSession::class);
         $this->checkoutSession = $this->createMock(CheckoutSession::class);
+        $this->decider = $this->createMock(CheckoutSession::class);
         $this->resultFactory = $this->createPartialMock(
             ResultFactory::class,
             [
@@ -65,6 +70,10 @@ class LoginPostPluginTest extends TestCase
         );
         $this->bugsnag = $this->createMock(Bugsnag::class);
         $this->loginPost = $this->createMock(LoginPost::class);
+        $this->decider = $this->createPartialMock(
+            Decider::class,
+            ['ifShouldDisableRedirectCustomerToCartPageAfterTheyLogIn']
+        );
         $this->plugin = $this->getMockBuilder(LoginPostPlugin::class)
             ->setMethods([
                 'shouldRedirectToCartPage',
@@ -74,7 +83,8 @@ class LoginPostPluginTest extends TestCase
                 $this->customerSession,
                 $this->checkoutSession,
                 $this->resultFactory,
-                $this->bugsnag
+                $this->bugsnag,
+                $this->decider
             ])
             ->getMock();
     }


### PR DESCRIPTION
# Description
EN-1297 Add feature switch for disabling the redirect customers to the cart page after they log in

Fixes: https://boltpay.atlassian.net/browse/EN-1297

#changelog Add feature switch for disabling the redirect customers to the cart page after they log in

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
