### PR TITLE
M2P-354 Bugfix: Bolt cart does not update after Mirasvit credits changes

### DIFF
--- a/Block/Js.php
+++ b/Block/Js.php
@@ -551,4 +551,14 @@ function($argName) {
     }
 }";
     }
+    
+    /**
+     * Get Additional Javascript to invalidate BoltCart.
+     *
+     * @return string
+     */
+    public function getAdditionalInvalidateBoltCartJavascript()
+    {
+        return $this->eventsForThirdPartyModules->runFilter("getAdditionalInvalidateBoltCartJavascript", null);
+    }
 }

--- a/Model/EventsForThirdPartyModules.php
+++ b/Model/EventsForThirdPartyModules.php
@@ -498,6 +498,15 @@ class EventsForThirdPartyModules
                 ],
             ]
         ],
+        "getAdditionalInvalidateBoltCartJavascript" => [
+            "listeners" => [
+                [
+                    "module" => "Mirasvit_Credit",
+                    "checkClasses" => ["Mirasvit\Credit\Helper\Data"],
+                    "boltClass" => Mirasvit_Credit::class,
+                ],
+            ],
+        ],
     ];
 
     /**

--- a/ThirdPartyModules/Mirasvit/Credit.php
+++ b/ThirdPartyModules/Mirasvit/Credit.php
@@ -257,4 +257,21 @@ class Credit
         $result -= $mirasvitStoreCreditShippingDiscountAmount;
         return $result;
     }
+    
+    /**
+     * Get Additional Javascript to invalidate BoltCart.
+     *
+     * @param $result
+     * @return string
+     */
+    public function getAdditionalInvalidateBoltCartJavascript($result)
+    {
+        $result .= 'var credit = customerData.get("credit")();
+                    if (credit.data_id >= boltCartDataID) {
+                        invalidateBoltCart();
+                        return;
+                    }';
+        
+        return $result;
+    }
 }

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -800,6 +800,8 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
                     invalidateBoltCart();
                 }
             }
+            
+            <?= /* @noEscape */ $block->getAdditionalInvalidateBoltCartJavascript(); ?>
         }
 
         var callConfigureAfterAddingNewButton = function() {


### PR DESCRIPTION
# Description
This is not a 100% reproducible issue, but it does exist. After investigation, it turned out that, in some contexts, neither the **boltcart** nor **cart** in the local storage do not update after Mirasvit credits changes. So we need to force to invalidate the Bolt cart if the script detect credit.data_id >= boltCartDataID

Fixes: https://boltpay.atlassian.net/browse/M2P-354

#changelog Bugfix: Bolt cart does not update after Mirasvit credits changes

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
