### PR TITLE
M2P-359 Correct the total amount calculation logic when building Bolt cart

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1341,7 +1341,7 @@ class Cart extends AbstractHelper
                 $unitPrice   = $item->getCalculationPrice();
                 $itemTotalAmount = $unitPrice * $item->getQty();
 
-                $roundedTotalAmount = CurrencyUtils::toMinor($itemTotalAmount, $currencyCode);
+                $roundedTotalAmount = CurrencyUtils::toMinor($unitPrice, $currencyCode) * round($item->getQty());
 
                 // Aggregate eventual total differences if prices are stored with more than 2 decimal places
                 $diff += CurrencyUtils::toMinorWithoutRounding($itemTotalAmount, $currencyCode) -$roundedTotalAmount;


### PR DESCRIPTION
# Description
Currently, there are some rounding issues if the customer adds a product with a large qty. So this PR is to correct the total amount calculation logic when building Bolt cart

FYI, this is the same as the way that we handle on M1. See here: https://github.com/BoltApp/bolt-magento1/blob/master/app/code/community/Bolt/Boltpay/Model/BoltOrder.php#L150

Fixes: https://boltpay.atlassian.net/browse/ON-389

#changelog Correct the total amount calculation logic when building Bolt cart

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
