### PR TITLE
M2P-357 - Show alternative payment type in order grid

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -113,6 +113,7 @@ class Order extends AbstractHelper
         'paypal' => 'PayPal',
         'afterpay' => 'Afterpay',
         'affirm' => 'Affirm',
+	    'braintree' => 'Braintree'
     ];
 
     /**

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -113,7 +113,7 @@ class Order extends AbstractHelper
         'paypal' => 'PayPal',
         'afterpay' => 'Afterpay',
         'affirm' => 'Affirm',
-	    'braintree' => 'Braintree'
+        'braintree' => 'Braintree'
     ];
 
     /**

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -113,7 +113,8 @@ class Order extends AbstractHelper
         'paypal' => 'PayPal',
         'afterpay' => 'Afterpay',
         'affirm' => 'Affirm',
-        'braintree' => 'Braintree'
+        'braintree' => 'Braintree',
+        'applepay' => 'ApplePay'
     ];
 
     /**

--- a/Plugin/Magento/Framework/View/Element/UiComponent/DataProvider/DataProviderPlugin.php
+++ b/Plugin/Magento/Framework/View/Element/UiComponent/DataProvider/DataProviderPlugin.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Plugin\Magento\Framework\View\Element\UiComponent\DataProvider;
+
+use Magento\Framework\View\Element\UiComponent\DataProvider\DataProvider;
+use Magento\Sales\Model\ResourceModel\Order\Payment\CollectionFactory;
+
+class DataProviderPlugin
+{
+    /**
+     * @var CollectionFactory
+     */
+    private $paymentCollectionFactory;
+
+    /**
+     * DataProviderPlugin constructor.
+     * @param CollectionFactory $paymentCollectionFactory
+     */
+    public function __construct(CollectionFactory $paymentCollectionFactory)
+    {
+        $this->paymentCollectionFactory = $paymentCollectionFactory;
+    }
+
+    /**
+     * Plugin for {@see \Magento\Framework\View\Element\UiComponent\DataProvider\DataProvider::getData}
+     * Appends payment processor to the Bolt orders payment method code for the following grids:
+     * 1. Sales Order Grid
+     * 2. Order Invoice Grid
+     * 3. Creditmemo Grid
+     * 4. Shipments Grid
+     *
+     * @param DataProvider $subject
+     * @param array        $result
+     *
+     * @return array
+     */
+    public function afterGetData(DataProvider $subject, $result)
+    {
+        if (!in_array(
+            $subject->getName(),
+            [
+                'sales_order_grid_data_source',
+                'sales_order_invoice_grid_data_source',
+                'sales_order_creditmemo_grid_data_source',
+                'sales_order_shipment_grid_data_source'
+            ]
+        )) {
+            return $result;
+        }
+        $ids = array_column(
+            array_filter(
+                $result['items'],
+                function ($item) {
+                    return $item['payment_method'] == \Bolt\Boltpay\Model\Payment::METHOD_CODE;
+                }
+            ),
+            key_exists('order_id', $result['items'][0]) ? 'order_id' : 'entity_id' //todo: both
+        );
+        $paymentCollection = $this->paymentCollectionFactory->create()
+            ->addFieldToFilter('parent_id', ['in' => $ids]);
+        foreach ($result['items'] as &$item) {
+            $payment = $paymentCollection->getItemByColumnValue(
+                'parent_id',
+                key_exists('order_id', $item) ? $item['order_id'] : $item['entity_id']
+            );
+            if (!$payment) {
+                continue;
+            }
+            $processor = $payment->getData('additional_information/processor');
+            if (key_exists($processor, \Bolt\Boltpay\Helper\Order::TP_METHOD_DISPLAY)) {
+                $item['payment_method'] .= '_' . $processor;
+            }
+        }
+        return $result;
+    }
+}

--- a/Plugin/Magento/Framework/View/Element/UiComponent/DataProvider/DataProviderPlugin.php
+++ b/Plugin/Magento/Framework/View/Element/UiComponent/DataProvider/DataProviderPlugin.php
@@ -69,7 +69,7 @@ class DataProviderPlugin
                     return $item['payment_method'] == \Bolt\Boltpay\Model\Payment::METHOD_CODE;
                 }
             ),
-            key_exists('order_id', $result['items'][0]) ? 'order_id' : 'entity_id' //todo: both
+            key_exists('order_id', $result['items'][0]) ? 'order_id' : 'entity_id'
         );
         $paymentCollection = $this->paymentCollectionFactory->create()
             ->addFieldToFilter('parent_id', ['in' => $ids]);
@@ -81,9 +81,11 @@ class DataProviderPlugin
             if (!$payment) {
                 continue;
             }
-            $processor = $payment->getData('additional_information/processor');
-            if (key_exists($processor, \Bolt\Boltpay\Helper\Order::TP_METHOD_DISPLAY)) {
-                $item['payment_method'] .= '_' . $processor;
+            if ($intersection = array_intersect(
+                [$payment->getData('additional_information/processor'), $payment->getAdditionalData()],
+                array_keys(\Bolt\Boltpay\Helper\Order::TP_METHOD_DISPLAY)
+            )) {
+                $item['payment_method'] .= '_' . reset($intersection);
             }
         }
         return $result;

--- a/Plugin/Magento/Ui/Component/Form/Element/SelectPlugin.php
+++ b/Plugin/Magento/Ui/Component/Form/Element/SelectPlugin.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Plugin\Magento\Ui\Component\Form\Element;
+
+class SelectPlugin
+{
+
+    /**
+     * Append individual Boltpay processors as payment method options to be rendered in order grid(s)
+     * @see \Bolt\Boltpay\Plugin\Magento\Framework\View\Element\UiComponent\DataProvider\DataProviderPlugin::afterGetData
+     *
+     * @param \Magento\Ui\Component\Form\Element\Select $subject
+     * @param                                           $result
+     * @return mixed
+     */
+    public function afterPrepare(\Magento\Ui\Component\Form\Element\Select $subject, $result)
+    {
+        if (in_array(
+            $subject->getContext()->getNamespace(),
+            [
+                    'sales_order_grid',
+                    'sales_order_invoice_grid',
+                    'sales_order_creditmemo_grid',
+                    'sales_order_shipment_grid',
+                ]
+        ) && $subject->getName() == 'payment_method') {
+            $config = $subject->getData('config');
+            foreach (\Bolt\Boltpay\Helper\Order::TP_METHOD_DISPLAY as $key => $suffix) {
+                $config['options'][] = [
+                    'value'         => \Bolt\Boltpay\Model\Payment::METHOD_CODE . '_' . $key,
+                    'label'         => 'Bolt-' . $suffix,
+                    '__disableTmpl' => true
+                ];
+            }
+            $subject->setData('config', $config);
+        }
+        return $result;
+    }
+}

--- a/Test/Unit/Plugin/Magento/Framework/View/Element/UiComponent/DataProvider/DataProviderPluginTest.php
+++ b/Test/Unit/Plugin/Magento/Framework/View/Element/UiComponent/DataProvider/DataProviderPluginTest.php
@@ -1,0 +1,288 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Test\Unit\Plugin\Magento\Framework\View\Element\UiComponent\DataProvider;
+
+use Bolt\Boltpay\Plugin\Magento\Framework\View\Element\UiComponent\DataProvider\DataProviderPlugin;
+
+/**
+ * @coversDefaultClass \Bolt\Boltpay\Plugin\Magento\Framework\View\Element\UiComponent\DataProvider\DataProviderPlugin
+ */
+class DataProviderPluginTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \Magento\Sales\Model\ResourceModel\Order\Payment\CollectionFactory|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $paymentCollectionFactoryMock;
+
+    /**
+     * @var DataProviderPlugin|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $currentMock;
+
+    /**
+     * @var \Magento\Framework\View\Element\UiComponent\DataProvider\DataProvider|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $subjectMock;
+
+    /**
+     * @var \Magento\Sales\Model\ResourceModel\Order\Payment\Collection|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $paymentCollectionMock;
+
+    /**
+     * @var \Magento\Sales\Model\Order\Payment|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $paymentMock;
+
+    protected function setUp()
+    {
+        $this->paymentCollectionFactoryMock = $this->createPartialMock(
+            \Magento\Sales\Model\ResourceModel\Order\Payment\CollectionFactory::class,
+            ['create']
+        );
+        $this->currentMock = $this->getMockBuilder(DataProviderPlugin::class)
+            ->setConstructorArgs([$this->paymentCollectionFactoryMock])
+            ->setMethods(null)
+            ->getMock();
+        $this->subjectMock = $this->createMock(
+            \Magento\Framework\View\Element\UiComponent\DataProvider\DataProvider::class
+        );
+        $this->paymentCollectionMock = $this->createMock(
+            \Magento\Sales\Model\ResourceModel\Order\Payment\Collection::class
+        );
+        $this->paymentMock = $this->createMock(\Magento\Sales\Model\Order\Payment::class);
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     */
+    public function __construct_always_setsProperty()
+    {
+        $instance = new DataProviderPlugin($this->paymentCollectionFactoryMock);
+        static::assertAttributeEquals(
+            $this->paymentCollectionFactoryMock,
+            'paymentCollectionFactory',
+            $instance
+        );
+    }
+
+    /**
+     * @test
+     * that afterGetData appends payment processor to the Bolt orders payment method code for the following grids:
+     * 1. Sales Order Grid
+     * 2. Order Invoice Grid
+     * 3. Creditmemo Grid
+     * 4. Shipments Grid
+     *
+     * @covers ::afterGetData
+     *
+     * @dataProvider afterGetDataProvider
+     *
+     * @param string $name
+     * @param array  $resultBefore
+     * @param array  $expectedIds
+     * @param array  $processors
+     * @param array  $resultAfter
+     */
+    public function afterGetData_withVariousOrderGridData_appendsProcessorToPaymentMethod(
+        $name,
+        $resultBefore,
+        $expectedIds,
+        $processors,
+        $resultAfter
+    ) {
+        $this->subjectMock->expects(static::once())->method('getName')->willReturn($name);
+        $this->paymentCollectionFactoryMock->method('create')
+            ->willReturn($this->paymentCollectionMock);
+        $this->paymentCollectionMock->method('addFieldToFilter')
+            ->with('parent_id', ['in' => $expectedIds])->willReturnSelf();
+        $this->paymentCollectionMock
+            ->method('getItemByColumnValue')->willReturnCallback(
+                function ($column, $value) use ($expectedIds) {
+                    return in_array($value, $expectedIds) ? $this->paymentMock : null;
+                }
+            );
+        $this->paymentMock->method('getData')->with('additional_information/processor')
+            ->willReturnOnConsecutiveCalls(...$processors);
+        $resultActual = $this->currentMock->afterGetData($this->subjectMock, $resultBefore);
+        static::assertEquals($resultAfter, $resultActual);
+    }
+
+    public function afterGetDataProvider()
+    {
+        return [
+            [
+                'dataSourceName' => 'sales_order_grid_data_source',
+                'resultBefore'   => [
+                    'items'        => [
+                        ['entity_id' => '1', 'payment_method' => 'checkmo'],
+                        ['entity_id' => '2', 'payment_method' => 'boltpay'],
+                        ['entity_id' => '3', 'payment_method' => 'boltpay'],
+                        ['entity_id' => '4', 'payment_method' => 'boltpay'],
+                        ['entity_id' => '5', 'payment_method' => 'boltpay'],
+                        ['entity_id' => '6', 'payment_method' => 'cashondelivery'],
+                    ],
+                    'totalRecords' => 170,
+                ],
+                'expectedIds'    => [2, 3, 4, 5],
+                'processors'     => [
+                    'paypal',
+                    'affirm',
+                    'afterpay',
+                    'paypal',
+                ],
+                'resultAfter'    => [
+                    'items'        => [
+                        ['entity_id' => '1', 'payment_method' => 'checkmo'],
+                        ['entity_id' => '2', 'payment_method' => 'boltpay_paypal'],
+                        ['entity_id' => '3', 'payment_method' => 'boltpay_affirm'],
+                        ['entity_id' => '4', 'payment_method' => 'boltpay_afterpay'],
+                        ['entity_id' => '5', 'payment_method' => 'boltpay_paypal'],
+                        ['entity_id' => '6', 'payment_method' => 'cashondelivery'],
+                    ],
+                    'totalRecords' => 170,
+                ]
+            ],
+            [
+                'dataSourceName' => 'sales_order_invoice_grid_data_source',
+                'resultBefore'   => [
+                    'items'        => [
+                        ['order_id' => '1', 'payment_method' => 'checkmo'],
+                        ['order_id' => '2', 'payment_method' => 'boltpay'],
+                        ['order_id' => '3', 'payment_method' => 'boltpay'],
+                        ['order_id' => '4', 'payment_method' => 'boltpay'],
+                        ['order_id' => '5', 'payment_method' => 'boltpay'],
+                        ['order_id' => '6', 'payment_method' => 'cashondelivery'],
+                    ],
+                    'totalRecords' => 170,
+                ],
+                'expectedIds'    => [2, 3, 4, 5],
+                'processors'     => [
+                    'paypal',
+                    'affirm',
+                    'afterpay',
+                    'paypal',
+                ],
+                'resultAfter'    => [
+                    'items'        => [
+                        ['order_id' => '1', 'payment_method' => 'checkmo'],
+                        ['order_id' => '2', 'payment_method' => 'boltpay_paypal'],
+                        ['order_id' => '3', 'payment_method' => 'boltpay_affirm'],
+                        ['order_id' => '4', 'payment_method' => 'boltpay_afterpay'],
+                        ['order_id' => '5', 'payment_method' => 'boltpay_paypal'],
+                        ['order_id' => '6', 'payment_method' => 'cashondelivery'],
+                    ],
+                    'totalRecords' => 170,
+                ]
+            ],
+            [
+                'dataSourceName' => 'sales_order_creditmemo_grid_data_source',
+                'resultBefore'   => [
+                    'items'        => [
+                        ['order_id' => '1', 'payment_method' => 'checkmo'],
+                        ['order_id' => '2', 'payment_method' => 'boltpay'],
+                        ['order_id' => '3', 'payment_method' => 'boltpay'],
+                        ['order_id' => '4', 'payment_method' => 'boltpay'],
+                        ['order_id' => '5', 'payment_method' => 'boltpay'],
+                        ['order_id' => '6', 'payment_method' => 'cashondelivery'],
+                    ],
+                    'totalRecords' => 170,
+                ],
+                'expectedIds'    => [2, 3, 4, 5],
+                'processors'     => [
+                    'paypal',
+                    'affirm',
+                    'afterpay',
+                    'paypal',
+                ],
+                'resultAfter'    => [
+                    'items'        => [
+                        ['order_id' => '1', 'payment_method' => 'checkmo'],
+                        ['order_id' => '2', 'payment_method' => 'boltpay_paypal'],
+                        ['order_id' => '3', 'payment_method' => 'boltpay_affirm'],
+                        ['order_id' => '4', 'payment_method' => 'boltpay_afterpay'],
+                        ['order_id' => '5', 'payment_method' => 'boltpay_paypal'],
+                        ['order_id' => '6', 'payment_method' => 'cashondelivery'],
+                    ],
+                    'totalRecords' => 170,
+                ]
+            ],
+            [
+                'dataSourceName' => 'sales_order_shipment_grid_data_source',
+                'resultBefore'   => [
+                    'items'        => [
+                        ['order_id' => '1', 'payment_method' => 'checkmo'],
+                        ['order_id' => '2', 'payment_method' => 'boltpay'],
+                        ['order_id' => '3', 'payment_method' => 'boltpay'],
+                        ['order_id' => '4', 'payment_method' => 'boltpay'],
+                        ['order_id' => '5', 'payment_method' => 'boltpay'],
+                        ['order_id' => '6', 'payment_method' => 'cashondelivery'],
+                    ],
+                    'totalRecords' => 170,
+                ],
+                'expectedIds'    => [2, 3, 4, 5],
+                'processors'     => [
+                    'paypal',
+                    'affirm',
+                    'afterpay',
+                    'paypal',
+                ],
+                'resultAfter'    => [
+                    'items'        => [
+                        ['order_id' => '1', 'payment_method' => 'checkmo'],
+                        ['order_id' => '2', 'payment_method' => 'boltpay_paypal'],
+                        ['order_id' => '3', 'payment_method' => 'boltpay_affirm'],
+                        ['order_id' => '4', 'payment_method' => 'boltpay_afterpay'],
+                        ['order_id' => '5', 'payment_method' => 'boltpay_paypal'],
+                        ['order_id' => '6', 'payment_method' => 'cashondelivery'],
+                    ],
+                    'totalRecords' => 170,
+                ]
+            ],
+            [
+                'dataSourceName' => 'sales_order_transaction_grid_data_source',
+                'resultBefore'   => [
+                    'items'        => [
+                        ['order_id' => '1', 'payment_method' => 'checkmo'],
+                        ['order_id' => '2', 'payment_method' => 'boltpay'],
+                        ['order_id' => '3', 'payment_method' => 'boltpay'],
+                        ['order_id' => '4', 'payment_method' => 'boltpay'],
+                        ['order_id' => '5', 'payment_method' => 'boltpay'],
+                        ['order_id' => '6', 'payment_method' => 'cashondelivery'],
+                    ],
+                    'totalRecords' => 170,
+                ],
+                'expectedIds'    => [],
+                'processors'     => [],
+                'resultAfter'    => [
+                    'items'        => [
+                        ['order_id' => '1', 'payment_method' => 'checkmo'],
+                        ['order_id' => '2', 'payment_method' => 'boltpay'],
+                        ['order_id' => '3', 'payment_method' => 'boltpay'],
+                        ['order_id' => '4', 'payment_method' => 'boltpay'],
+                        ['order_id' => '5', 'payment_method' => 'boltpay'],
+                        ['order_id' => '6', 'payment_method' => 'cashondelivery'],
+                    ],
+                    'totalRecords' => 170,
+                ]
+            ],
+        ];
+    }
+}

--- a/Test/Unit/Plugin/Magento/Framework/View/Element/UiComponent/DataProvider/DataProviderPluginTest.php
+++ b/Test/Unit/Plugin/Magento/Framework/View/Element/UiComponent/DataProvider/DataProviderPluginTest.php
@@ -93,12 +93,13 @@ class DataProviderPluginTest extends \PHPUnit\Framework\TestCase
      *
      * @covers ::afterGetData
      *
-     * @dataProvider afterGetDataProvider
+     * @dataProvider afterGetData_withVariousOrderGridDataProvider
      *
      * @param string $name
      * @param array  $resultBefore
      * @param array  $expectedIds
      * @param array  $processors
+     * @param array  $additionalData
      * @param array  $resultAfter
      */
     public function afterGetData_withVariousOrderGridData_appendsProcessorToPaymentMethod(
@@ -106,6 +107,7 @@ class DataProviderPluginTest extends \PHPUnit\Framework\TestCase
         $resultBefore,
         $expectedIds,
         $processors,
+        $additionalData,
         $resultAfter
     ) {
         $this->subjectMock->expects(static::once())->method('getName')->willReturn($name);
@@ -121,11 +123,18 @@ class DataProviderPluginTest extends \PHPUnit\Framework\TestCase
             );
         $this->paymentMock->method('getData')->with('additional_information/processor')
             ->willReturnOnConsecutiveCalls(...$processors);
+        $this->paymentMock->method('getAdditionalData')
+            ->willReturnOnConsecutiveCalls(...$additionalData);
         $resultActual = $this->currentMock->afterGetData($this->subjectMock, $resultBefore);
         static::assertEquals($resultAfter, $resultActual);
     }
 
-    public function afterGetDataProvider()
+    /**
+     * Data provider for {@see afterGetData_withVariousOrderGridData}
+     *
+     * @return array[]
+     */
+    public function afterGetData_withVariousOrderGridDataProvider()
     {
         return [
             [
@@ -137,16 +146,25 @@ class DataProviderPluginTest extends \PHPUnit\Framework\TestCase
                         ['entity_id' => '3', 'payment_method' => 'boltpay'],
                         ['entity_id' => '4', 'payment_method' => 'boltpay'],
                         ['entity_id' => '5', 'payment_method' => 'boltpay'],
-                        ['entity_id' => '6', 'payment_method' => 'cashondelivery'],
+                        ['entity_id' => '6', 'payment_method' => 'boltpay'],
+                        ['entity_id' => '7', 'payment_method' => 'cashondelivery'],
                     ],
                     'totalRecords' => 170,
                 ],
-                'expectedIds'    => [2, 3, 4, 5],
+                'expectedIds'    => [2, 3, 4, 5, 6],
                 'processors'     => [
                     'paypal',
                     'affirm',
                     'afterpay',
+                    null,
                     'paypal',
+                ],
+                'additionalData' => [
+                    null,
+                    null,
+                    null,
+                    'applepay',
+                    null
                 ],
                 'resultAfter'    => [
                     'items'        => [
@@ -154,8 +172,9 @@ class DataProviderPluginTest extends \PHPUnit\Framework\TestCase
                         ['entity_id' => '2', 'payment_method' => 'boltpay_paypal'],
                         ['entity_id' => '3', 'payment_method' => 'boltpay_affirm'],
                         ['entity_id' => '4', 'payment_method' => 'boltpay_afterpay'],
-                        ['entity_id' => '5', 'payment_method' => 'boltpay_paypal'],
-                        ['entity_id' => '6', 'payment_method' => 'cashondelivery'],
+                        ['entity_id' => '5', 'payment_method' => 'boltpay_applepay'],
+                        ['entity_id' => '6', 'payment_method' => 'boltpay_paypal'],
+                        ['entity_id' => '7', 'payment_method' => 'cashondelivery'],
                     ],
                     'totalRecords' => 170,
                 ]
@@ -180,6 +199,7 @@ class DataProviderPluginTest extends \PHPUnit\Framework\TestCase
                     'afterpay',
                     'paypal',
                 ],
+                'additionalData' => [],
                 'resultAfter'    => [
                     'items'        => [
                         ['order_id' => '1', 'payment_method' => 'checkmo'],
@@ -212,6 +232,7 @@ class DataProviderPluginTest extends \PHPUnit\Framework\TestCase
                     'afterpay',
                     'paypal',
                 ],
+                'additionalData' => [],
                 'resultAfter'    => [
                     'items'        => [
                         ['order_id' => '1', 'payment_method' => 'checkmo'],
@@ -244,6 +265,7 @@ class DataProviderPluginTest extends \PHPUnit\Framework\TestCase
                     'afterpay',
                     'paypal',
                 ],
+                'additionalData' => [],
                 'resultAfter'    => [
                     'items'        => [
                         ['order_id' => '1', 'payment_method' => 'checkmo'],
@@ -271,6 +293,7 @@ class DataProviderPluginTest extends \PHPUnit\Framework\TestCase
                 ],
                 'expectedIds'    => [],
                 'processors'     => [],
+                'additionalData' => [],
                 'resultAfter'    => [
                     'items'        => [
                         ['order_id' => '1', 'payment_method' => 'checkmo'],

--- a/Test/Unit/Plugin/Magento/Ui/Component/Form/Element/SelectPluginTest.php
+++ b/Test/Unit/Plugin/Magento/Ui/Component/Form/Element/SelectPluginTest.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Test\Unit\Plugin\Magento\Ui\Component\Form\Element;
+
+/**
+ * @coversDefaultClass \Bolt\Boltpay\Plugin\Magento\Ui\Component\Form\Element\SelectPlugin
+ */
+class SelectPluginTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \Bolt\Boltpay\Plugin\Magento\Ui\Component\Form\Element\SelectPlugin|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $currentMock;
+
+    /**
+     * @var \Magento\Ui\Component\Form\Element\Select|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $subjectMock;
+
+    /**
+     * @var \Magento\Framework\View\Element\UiComponent\Context|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $contextMock;
+
+    protected function setUp()
+    {
+        $this->subjectMock = $this->createMock(\Magento\Ui\Component\Form\Element\Select::class);
+        $this->contextMock = $this->createMock(\Magento\Framework\View\Element\UiComponent\Context::class);
+        $this->currentMock = $this->createPartialMock(
+            \Bolt\Boltpay\Plugin\Magento\Ui\Component\Form\Element\SelectPlugin::class,
+            []
+        );
+    }
+
+    /**
+     * @test
+     * that afterPrepare appends individual Boltpay processors as payment method options
+     *
+     * @dataProvider afterPrepareDataProvider
+     *
+     * @covers ::afterPrepare
+     *
+     * @param string $namespace
+     * @param string $name
+     * @param array $configBefore
+     * @param array $configAfter
+     */
+    public function afterPrepare($namespace, $name, $configBefore, $configAfter)
+    {
+        $this->subjectMock->expects(static::once())->method('getContext')->willReturn($this->contextMock);
+        $this->contextMock->expects(static::once())->method('getNamespace')->willReturn($namespace);
+        $this->subjectMock->expects(static::once())->method('getName')->willReturn($name);
+        $this->subjectMock->expects($configBefore != $configAfter ? static::once() : static::never())
+            ->method('getData')->with('config')->willReturn($configBefore);
+        $this->subjectMock->expects($configBefore != $configAfter ? static::once() : static::never())
+            ->method('setData')->with('config', $configAfter);
+        static::assertNull($this->currentMock->afterPrepare($this->subjectMock, null));
+    }
+
+    /**
+     * Data provider for @see afterPrepare
+     */
+    public function afterPrepareDataProvider()
+    {
+        $appendedOptions = [
+            [
+                'value'         => 'boltpay_paypal',
+                'label'         => 'Bolt-PayPal',
+                '__disableTmpl' => true,
+            ],
+            [
+                'value'         => 'boltpay_afterpay',
+                'label'         => 'Bolt-Afterpay',
+                '__disableTmpl' => true,
+            ],
+	        [
+		        'value'         => 'boltpay_affirm',
+		        'label'         => 'Bolt-Affirm',
+		        '__disableTmpl' => true,
+	        ],
+	        [
+		        'value'         => 'boltpay_braintree',
+		        'label'         => 'Bolt-Braintree',
+		        '__disableTmpl' => true,
+	        ],
+        ];
+        return [
+            'Order grid, payment method column - appends options' => [
+                'namespace'    => 'sales_order_grid',
+                'name'         => 'payment_method',
+                'configBefore' => [],
+                'configAfter'  => [
+                    'options' => $appendedOptions,
+                ]
+            ],
+            'Invoice grid, payment method column - appends options' => [
+                'namespace'    => 'sales_order_invoice_grid',
+                'name'         => 'payment_method',
+                'configBefore' => [],
+                'configAfter'  => [
+                    'options' => $appendedOptions,
+                ]
+            ],
+            'Order grid, status column - does not append options' => [
+                'namespace'    => 'sales_order_grid',
+                'name'         => 'status',
+                'configBefore' => [],
+                'configAfter'  => []
+            ],
+        ];
+    }
+}

--- a/Test/Unit/Plugin/Magento/Ui/Component/Form/Element/SelectPluginTest.php
+++ b/Test/Unit/Plugin/Magento/Ui/Component/Form/Element/SelectPluginTest.php
@@ -88,16 +88,21 @@ class SelectPluginTest extends \PHPUnit\Framework\TestCase
                 'label'         => 'Bolt-Afterpay',
                 '__disableTmpl' => true,
             ],
-	        [
+            [
 		        'value'         => 'boltpay_affirm',
 		        'label'         => 'Bolt-Affirm',
 		        '__disableTmpl' => true,
-	        ],
+            ],
 	        [
 		        'value'         => 'boltpay_braintree',
 		        'label'         => 'Bolt-Braintree',
 		        '__disableTmpl' => true,
-	        ],
+            ],
+            [
+                'value'         => 'boltpay_applepay',
+                'label'         => 'Bolt-ApplePay',
+                '__disableTmpl' => true,
+            ],
         ];
         return [
             'Order grid, payment method column - appends options' => [

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -29,4 +29,12 @@
     <type name="Magento\Sales\Model\AdminOrder\Create">
         <plugin name="BoltBoltpayCreatePlugin" type="Bolt\Boltpay\Plugin\Magento\Sales\Model\AdminOrder\CreatePlugin" sortOrder="1"/>
     </type>
+    <type name="Magento\Framework\View\Element\UiComponent\DataProvider\DataProvider">
+        <plugin sortOrder="1"
+                name="bolt_boltpay_ui_dataprovider"
+                type="Bolt\Boltpay\Plugin\Magento\Framework\View\Element\UiComponent\DataProvider\DataProviderPlugin"/>
+    </type>
+    <type name="Magento\Ui\Component\Form\Element\Select">
+        <plugin sortOrder="1" name="bolt_boltpay_ui_form_element_select" type="Bolt\Boltpay\Plugin\Magento\Ui\Component\Form\Element\SelectPlugin"/>
+    </type>
 </config>


### PR DESCRIPTION
# Description
Show payment type (such as Paypal) it in order grid as well, as done on order details page.

Fixes: https://boltpay.atlassian.net/browse/M2P-357

#changelog M2P-357 - Show alternative payment type in order grid

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
