### PR TITLE
M2P-333 Use integration tests instead of unit tests for method getCartData in class Helper/Cart

### DIFF
--- a/Test/Unit/TestUtils.php
+++ b/Test/Unit/TestUtils.php
@@ -60,6 +60,32 @@ class TestUtils {
         return $product;
     }
 
+    /**
+     * @return mixed
+     */
+    public static function createVirtualProduct()
+    {
+        $product = Bootstrap::getObjectManager()->create(Product::class);
+        $product->setTypeId(\Magento\Catalog\Model\Product\Type::TYPE_VIRTUAL)
+            ->setAttributeSetId(4)
+            ->setWebsiteIds([1])
+            ->setName('Test Virtual Product')
+            ->setSku('TestProduct')
+            ->setPrice(100)
+            ->setDescription('Product Description')
+            ->setMetaTitle('meta title')
+            ->setMetaKeyword('meta keyword')
+            ->setMetaDescription('meta description')
+            ->setVisibility(\Magento\Catalog\Model\Product\Visibility::VISIBILITY_BOTH)
+            ->setStatus(\Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_ENABLED)
+            ->setCategoryIds([2])
+            ->setStockData(['use_config_manage_stock' => 0])
+            ->setCanSaveCustomOptions(true)
+            ->setHasOptions(true);
+        $product->save();
+        return $product;
+    }
+
     private static function setSecureAreaIfNeeded()
     {
         $registry = Bootstrap::getObjectManager()->get("\Magento\Framework\Registry");
@@ -90,5 +116,35 @@ class TestUtils {
                     throw new \Exception("Unexpected type for delete:".get_class($object));
             }
         }
+    }
+
+    /**
+     * @param $addressData
+     * @param $quote
+     * @param $addressType
+     */
+    public static function setAddressToQuote($addressData ,$quote, $addressType)
+    {
+        if ($addressType === 'billing') {
+            $address = $quote->getBillingAddress();
+        }
+
+        if ($addressType === 'shipping') {
+            $address = $quote->getShippingAddress();
+        }
+
+        $address->setFirstname($addressData['first_name']);
+        $address->setLastname($addressData['last_name']);
+        $address->setCompany($addressData['company']);
+        $address->setTelephone($addressData['phone']);
+        $address->setStreet([
+            $addressData['street_address1'],
+            $addressData['street_address2']
+        ]);
+        $address->setCity($addressData['locality']);
+        $address->setRegion($addressData['region']);
+        $address->setPostcode($addressData['postal_code']);
+        $address->setCountryId($addressData['country_code']);
+        $address->setEmail($addressData['email']);
     }
 }


### PR DESCRIPTION

# Description
Use integration tests instead of unit tests for method getCartData in class Helper/Cart

Fixes: https://boltpay.atlassian.net/browse/M2P-333

#changelog M2P-333 Use integration tests instead of unit tests for method getCartData in class Helper/Cart

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
