### PR TITLE
M2P-371 Remove zero discount text from shipping option label

### DIFF
--- a/Helper/Discount.php
+++ b/Helper/Discount.php
@@ -57,7 +57,7 @@ class Discount extends AbstractHelper
     const BOLT_DISCOUNT_CATEGORY_AUTO_PROMO = 'automatic_promotion';
     
     // In Magento 2, if the discount amount is less than 0.005, we can treat it as zero.
-    const ZERO_VALUE = 0.004;
+    const ZERO_VALUE = 0.00499999;
 
     /**
      * @var ResourceConnection $resource

--- a/Helper/Discount.php
+++ b/Helper/Discount.php
@@ -55,6 +55,9 @@ class Discount extends AbstractHelper
     const BOLT_DISCOUNT_CATEGORY_COUPON = 'coupon';
     const BOLT_DISCOUNT_CATEGORY_GIFTCARD = 'giftcard';
     const BOLT_DISCOUNT_CATEGORY_AUTO_PROMO = 'automatic_promotion';
+    
+    // In Magento 2, if the discount amount is less than 0.005, we can treat it as zero.
+    const ZERO_VALUE = 0.004;
 
     /**
      * @var ResourceConnection $resource

--- a/Helper/Discount.php
+++ b/Helper/Discount.php
@@ -56,8 +56,9 @@ class Discount extends AbstractHelper
     const BOLT_DISCOUNT_CATEGORY_GIFTCARD = 'giftcard';
     const BOLT_DISCOUNT_CATEGORY_AUTO_PROMO = 'automatic_promotion';
     
-    // In Magento 2, if the discount amount is less than 0.005, we can treat it as zero.
-    const ZERO_VALUE = 0.00499999;
+    // In Magento 2, 0.005 would be converted into 0.01 which is greater than 0 while 0.0049999 would be converted into 0,
+    // so we can treat 0.00499999 as the closest number to zero in M2.
+    const MIN_NONZERO_VALUE = 0.00499999;
 
     /**
      * @var ResourceConnection $resource

--- a/Helper/Discount.php
+++ b/Helper/Discount.php
@@ -57,8 +57,8 @@ class Discount extends AbstractHelper
     const BOLT_DISCOUNT_CATEGORY_AUTO_PROMO = 'automatic_promotion';
     
     // In Magento 2, 0.005 would be converted into 0.01 which is greater than 0 while 0.0049999 would be converted into 0,
-    // so we can treat 0.00499999 as the closest number to zero in M2.
-    const MIN_NONZERO_VALUE = 0.00499999;
+    // so we can treat 0.005 as the closest number to zero in M2.
+    const MIN_NONZERO_VALUE = 0.005;
 
     /**
      * @var ResourceConnection $resource

--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -780,7 +780,7 @@ class ShippingMethods implements ShippingMethodsInterface
 
             $taxAmount = round(CurrencyUtils::toMinorWithoutRounding($shippingAddress->getTaxAmount(), $currencyCode) + $diff);
 
-            if ($discountAmount) {
+            if ($discountAmount > DiscountHelper::ZERO_VALUE) {
                 if ($cost == 0) {
                     $service .= ' [free&nbsp;shipping&nbsp;discount]';
                 } else {

--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -780,7 +780,7 @@ class ShippingMethods implements ShippingMethodsInterface
 
             $taxAmount = round(CurrencyUtils::toMinorWithoutRounding($shippingAddress->getTaxAmount(), $currencyCode) + $diff);
 
-            if ($discountAmount > DiscountHelper::MIN_NONZERO_VALUE) {
+            if ($discountAmount >= DiscountHelper::MIN_NONZERO_VALUE) {
                 if ($cost == 0) {
                     $service .= ' [free&nbsp;shipping&nbsp;discount]';
                 } else {

--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -780,7 +780,7 @@ class ShippingMethods implements ShippingMethodsInterface
 
             $taxAmount = round(CurrencyUtils::toMinorWithoutRounding($shippingAddress->getTaxAmount(), $currencyCode) + $diff);
 
-            if ($discountAmount > DiscountHelper::ZERO_VALUE) {
+            if ($discountAmount > DiscountHelper::MIN_NONZERO_VALUE) {
                 if ($cost == 0) {
                     $service .= ' [free&nbsp;shipping&nbsp;discount]';
                 } else {


### PR DESCRIPTION
# Description
In some certain contexts, the shipping discounts amount could be some very small values like 0.00002, then the Bolt plugin collect it and covert it into [$0.00 discount], cause priceHelper->currency round 0.00002 into 0.00.

Actually in m2, if the number is less than 0.005, it can be treated as zero.

![image](https://user-images.githubusercontent.com/3198527/99535860-765caf00-29e4-11eb-860c-17b847687256.png)


Fixes: https://boltpay.atlassian.net/browse/M2P-371

#changelog Remove zero discount text from shipping option label

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
