### PR TITLE
ON-429 Show cart type and last four digits for all payment processors

### DIFF
--- a/Block/Info.php
+++ b/Block/Info.php
@@ -33,14 +33,12 @@ class Info extends \Magento\Payment\Block\Info
         $boltProcessor = $info->getAdditionalInformation('processor');
         $data = [];
         
-        if (empty($boltProcessor) || $boltProcessor == \Bolt\Boltpay\Helper\Order::TP_VANTIV) {
-            if ($ccType = $info->getCcType()) {
-                $data[(string)__('Credit Card Type')] = strtoupper($ccType);
-            }
+        if ($ccType = $info->getCcType()) {
+            $data[(string)__('Credit Card Type')] = strtoupper($ccType);
+        }
     
-            if ($ccLast4 = $info->getCcLast4()) {
-                $data[(string)__('Credit Card Number')] = sprintf('xxxx-%s', $ccLast4);
-            }
+        if ($ccLast4 = $info->getCcLast4()) {
+            $data[(string)__('Credit Card Number')] = sprintf('xxxx-%s', $ccLast4);
         }
 
         if ($data) {

--- a/Block/Info.php
+++ b/Block/Info.php
@@ -30,7 +30,6 @@ class Info extends \Magento\Payment\Block\Info
     {
         $transport = parent::_prepareSpecificInformation($transport);
         $info = $this->getInfo();
-        $boltProcessor = $info->getAdditionalInformation('processor');
         $data = [];
         
         if ($ccType = $info->getCcType()) {

--- a/Test/Unit/Block/InfoTest.php
+++ b/Test/Unit/Block/InfoTest.php
@@ -42,7 +42,6 @@ class InfoTest extends \PHPUnit\Framework\TestCase
         $this->mock->expects(self::once())->method('getInfo')->willReturnSelf();
         $this->mock->expects(self::once())->method('getCcType')->willReturn('visa');
         $this->mock->expects(self::once())->method('getCcLast4')->willReturn('1111');
-        $this->mock->expects(self::once())->method('getAdditionalInformation')->willReturn('vantiv');
         $data = TestHelper::invokeMethod($this->mock, '_prepareSpecificInformation', [null]);
         $this->assertEquals(
             [
@@ -59,7 +58,8 @@ class InfoTest extends \PHPUnit\Framework\TestCase
     public function prepareSpecificInformationPaypal()
     {
         $this->mock->expects(self::once())->method('getInfo')->willReturnSelf();
-        $this->mock->expects(self::once())->method('getAdditionalInformation')->willReturn('paypal');
+        $this->mock->expects(self::once())->method('getCcType')->willReturn('');
+        $this->mock->expects(self::once())->method('getCcLast4')->willReturn('');
         $data = TestHelper::invokeMethod($this->mock, '_prepareSpecificInformation', [null]);
         $this->assertEquals(
             [],


### PR DESCRIPTION
Now we show the last four cart digits for vantiv only.
But we have this info for adyen, alliance, braintree, nmi, and stripe as well.

After this fix, we show last4 for each case when we have it.

Fixes: [ON-429](https://boltpay.atlassian.net/browse/ON-429)

#changelog ON-429 Show cart type and last four digits for all payment processors

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
