### PR TITLE
M2P-384 - Pre auth double check if order was created

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -1140,6 +1140,39 @@ class Order extends AbstractHelper
 
     /**
      * @param Quote $quote
+     * @return false|OrderModel|null
+     * @throws \Exception
+     */
+    public function submitQuote($quote)
+    {
+        /** @var OrderModel $order */
+        try {
+            $order = $this->quoteManagement->submit($quote);
+        } catch (\Exception $e) {
+            $order = $this->getOrderByQuoteId($quote->getId());
+            if ($order && $order->getPayment() && $order->getPayment()->getMethod() === Payment::METHOD_CODE) {
+                $this->bugsnag->registerCallback(
+                    function ($report) use ($order) {
+                        $report->setMetaData(
+                            [
+                                'CREATE ORDER' => [
+                                    'order_id' => $order->getId(),
+                                    'order_increment_id' => $order->getIncrementId(),
+                                ]
+                            ]
+                        );
+                    }
+                );
+                $this->bugsnag->notifyException($e);
+            } else {
+                throw $e;
+            }
+        }
+        return $order;
+    }
+
+    /**
+     * @param Quote $quote
      * @param \stdClass $transaction
      * @return OrderModel
      * @throws BoltException
@@ -1147,8 +1180,7 @@ class Order extends AbstractHelper
      */
     public function processNewOrder($quote, $transaction)
     {
-        /** @var OrderModel $order */
-        $order = $this->quoteManagement->submit($quote);
+        $order = $this->submitQuote($quote);
 
         if (!$order) {
             $this->bugsnag->registerCallback(function ($report) use ($quote) {


### PR DESCRIPTION
# Description
It's possible that Magento throws an exception during pre-auth call when order is already created.It's better for us to check if the order looks good and return a success answer to not block checkout for users

Fixes: https://boltpay.atlassian.net/browse/M2P-384

#changelog Pre auth double check if order was created

# Type of change

- [x] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [x] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
