### PR TITLE
M2P-375 Bugfix: Missing shipping option blocking checkout

### DIFF
--- a/Model/Api/Shipping.php
+++ b/Model/Api/Shipping.php
@@ -146,7 +146,7 @@ class Shipping extends ShippingTax implements ShippingInterface
      */
     public function getShippingOptions($addressData)
     {
-        $addressData = $this->reformatAddressData($addressData);
+        list(,$addressData) = $this->populateAddress($addressData);
 
         $estimateAddress = $this->estimateAddressFactory->create();
 

--- a/Model/Api/ShippingTax.php
+++ b/Model/Api/ShippingTax.php
@@ -394,7 +394,7 @@ abstract class ShippingTax
         $address = $this->quote->isVirtual() ? $this->quote->getBillingAddress() : $this->quote->getShippingAddress();
         $addressData = $this->reformatAddressData($addressData);
         $address->addData($addressData);
-        return $address;
+        return [$address, $addressData];
     }
 
     /**

--- a/Model/Api/Tax.php
+++ b/Model/Api/Tax.php
@@ -95,7 +95,7 @@ class Tax extends ShippingTax implements TaxInterface
      */
     public function setAddressInformation($addressData, $shipping_option)
     {
-        $address = $this->populateAddress($addressData);
+        list($address,) = $this->populateAddress($addressData);
         $this->addressInformation->setAddress($address);
 
         if (!$shipping_option) {

--- a/Test/Unit/Model/Api/ShippingTaxTest.php
+++ b/Test/Unit/Model/Api/ShippingTaxTest.php
@@ -816,7 +816,7 @@ class ShippingTaxTest extends TestCase
 
         $address->expects(self::once())->method('addData')->willReturnSelf();
 
-        $this->assertEquals($address, $this->currentMock->populateAddress($addressData));
+        $this->assertEquals([$address,$addressDataReformatted], $this->currentMock->populateAddress($addressData));
     }
 
 

--- a/Test/Unit/Model/Api/ShippingTest.php
+++ b/Test/Unit/Model/Api/ShippingTest.php
@@ -273,10 +273,10 @@ class ShippingTest extends TestCase
         $this->shippingTaxContext->method('getBugsnag')
             ->willReturn($bugsnag);
 
-        $this->initCurrentMock(['reformatAddressData', 'formatResult']);
+        $this->initCurrentMock(['populateAddress', 'formatResult']);
 
-        $this->currentMock->expects(self::once())->method('reformatAddressData')->with($addressData)
-            ->willReturn($reformattedAddressData);
+        $this->currentMock->expects(self::once())->method('populateAddress')->with($addressData)
+            ->willReturn([null,$reformattedAddressData]);
 
         $quote = $this->getQuoteMock();
 
@@ -365,10 +365,10 @@ class ShippingTest extends TestCase
         $this->shippingTaxContext->method('getBugsnag')
             ->willReturn($bugsnag);
 
-        $this->initCurrentMock(['reformatAddressData', 'formatResult']);
+        $this->initCurrentMock(['populateAddress', 'formatResult']);
 
-        $this->currentMock->expects(self::once())->method('reformatAddressData')->with($addressData)
-            ->willReturn($reformattedAddressData);
+        $this->currentMock->expects(self::once())->method('populateAddress')->with($addressData)
+            ->willReturn([null,$reformattedAddressData]);
 
         $quote = $this->getQuoteMock();
 

--- a/Test/Unit/Model/Api/TaxTest.php
+++ b/Test/Unit/Model/Api/TaxTest.php
@@ -177,6 +177,17 @@ class TaxTest extends TestCase
             'email' => 'integration@bolt.com',
             'company' => 'Bolt'
         ];
+        
+        $addressDataReformatted = [
+            'country_id' => 'US',
+            'postcode' => '90210',
+            'region' => 'California',
+            'region_id' => 12,
+            'city' => 'San Franciso',
+            'street' => '123 Sesame St.',
+            'email' => 'integration@bolt.com',
+            'company' => 'Bolt'
+        ];
 
         $shipping_option = [
             'reference' => $shippingReference
@@ -186,7 +197,7 @@ class TaxTest extends TestCase
 
         $address = $this->createMock(\Magento\Quote\Model\Quote\Address::class);
         $this->currentMock->expects(self::once())->method('populateAddress')
-            ->with($addressData)->willReturn($address);
+            ->with($addressData)->willReturn([$address,$addressDataReformatted]);
 
         $this->addressInformation->expects(self::once())->method('setAddress')
             ->with($address);
@@ -222,6 +233,17 @@ class TaxTest extends TestCase
             'email' => 'integration@bolt.com',
             'company' => 'Bolt'
         ];
+        
+        $addressDataReformatted = [
+            'country_id' => 'US',
+            'postcode' => '90210',
+            'region' => 'California',
+            'region_id' => 12,
+            'city' => 'San Franciso',
+            'street' => '123 Sesame St.',
+            'email' => 'integration@bolt.com',
+            'company' => 'Bolt'
+        ];
 
         $shipping_option = null;
 
@@ -229,7 +251,7 @@ class TaxTest extends TestCase
 
         $address = $this->createMock(\Magento\Quote\Model\Quote\Address::class);
         $this->currentMock->expects(self::once())->method('populateAddress')
-            ->with($addressData)->willReturn($address);
+            ->with($addressData)->willReturn([$address,$addressDataReformatted]);
 
         $this->addressInformation->expects(self::once())->method('setAddress')
             ->with($address);


### PR DESCRIPTION
# Description
This is a bug of v2 shipping endpoint, when calling $this->shippingMethodManagement->estimateByAddress, the address of quote is still empty.

Fixes: https://boltpay.atlassian.net/browse/M2P-375

#changelog Bugfix: Missing shipping option blocking checkout

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
