### PR TITLE
M2P-389 Fix exception: Call to member function getMethod() on boolean

### DIFF
--- a/Plugin/Magento/GiftCard/GenerateGiftCardAccountsOrderPlugin.php
+++ b/Plugin/Magento/GiftCard/GenerateGiftCardAccountsOrderPlugin.php
@@ -30,7 +30,7 @@ class GenerateGiftCardAccountsOrderPlugin
         $event = $observer->getEvent();
         /** @var Order $order */
         $order =  $event->getOrder();
-        if ($order->getPayment()->getMethod() === BoltPayment::METHOD_CODE &&
+        if ($order->getPayment() && $order->getPayment()->getMethod() === BoltPayment::METHOD_CODE &&
             in_array($order->getStatus(), [Order::STATE_PENDING_PAYMENT, Order::STATE_CANCELED])) {
             return;
         }

--- a/Test/Unit/Plugin/Magento/GiftCard/GenerateGiftCardAccountsOrderPluginTest.php
+++ b/Test/Unit/Plugin/Magento/GiftCard/GenerateGiftCardAccountsOrderPluginTest.php
@@ -84,9 +84,7 @@ class GenerateGiftCardAccountsOrderPluginTest extends TestCase
         };
 
         $this->payment = $this->createMock(OrderPaymentInterface::class);
-
         $this->order = $this->createMock(Order::class);
-        $this->order->method('getPayment')->willReturn($this->payment);
 
         $this->event = $this->getMockBuilder(Event::class)->setMethods(['getOrder'])->getMock();
         $this->event->method('getOrder')->willReturn($this->order);
@@ -101,11 +99,22 @@ class GenerateGiftCardAccountsOrderPluginTest extends TestCase
      */
     public function aroundExecute($paymentMethod, $orderStatus, $expects)
     {
+        $this->order->method('getPayment')->willReturn($this->payment);
         $this->payment->method('getMethod')->willReturn($paymentMethod);
         $this->order->method('getStatus')->willReturn($orderStatus);
 
         $this->callback->expects($this->$expects())->method('__invoke')->with($this->observer);
 
+        $this->plugin->aroundExecute($this->subject, $this->proceed, $this->observer);
+    }
+
+    /**
+     * @test
+     */
+    public function aroundExecute_withoutPayment()
+    {
+        $this->order->method('getPayment')->willReturn(null);
+        $this->callback->expects(self::once())->method('__invoke')->with($this->observer);
         $this->plugin->aroundExecute($this->subject, $this->proceed, $this->observer);
     }
 


### PR DESCRIPTION
# Description
Fix exception: Call to member function getMethod() on boolean

Fixes: https://boltpay.atlassian.net/browse/M2P-389

#changelog Fix exception: Call to member function getMethod() on boolean

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
