### PR TITLE
M2P-299 Use Collection to cache feature switches data

### DIFF
--- a/Model/FeatureSwitch.php
+++ b/Model/FeatureSwitch.php
@@ -44,7 +44,7 @@ class FeatureSwitch extends AbstractModel implements \Bolt\Boltpay\Api\Data\Feat
 
     public function getValue()
     {
-        return $this->_getData(self::VALUE);
+        return boolval($this->_getData(self::VALUE));
     }
 
     public function setValue($value)
@@ -54,7 +54,7 @@ class FeatureSwitch extends AbstractModel implements \Bolt\Boltpay\Api\Data\Feat
 
     public function getDefaultValue()
     {
-        return $this->_getData(self::DEFAULT_VALUE);
+        return boolval($this->_getData(self::DEFAULT_VALUE));
     }
 
     public function setDefaultValue($defaultValue)

--- a/Model/FeatureSwitchRepository.php
+++ b/Model/FeatureSwitchRepository.php
@@ -22,6 +22,11 @@ use Magento\Framework\Exception\NoSuchEntityException;
 class FeatureSwitchRepository implements \Bolt\Boltpay\Api\FeatureSwitchRepositoryInterface
 {
     /**
+     * @var FeatureSwitch[]
+     */
+    private $cache;
+
+    /**
      * @var FeatureSwitchFactory
      */
     private $featureSwitchFactory;
@@ -32,14 +37,23 @@ class FeatureSwitchRepository implements \Bolt\Boltpay\Api\FeatureSwitchReposito
         $this->featureSwitchFactory = $featureSwitchFactory;
     }
 
+    private function getSwitchesToCache() {
+        $switch = $this->featureSwitchFactory->create();
+        $collection = $switch->getCollection();
+        foreach ($collection as $item) {
+            $this->cache[$item->getName()] = $item;
+        }
+    }
+
     public function getByName($name)
     {
-        $switch = $this->featureSwitchFactory->create();
-        $switch->getResource()->load($switch, $name, FeatureSwitch::NAME);
-        if (! $switch->getName()) {
+        if (!$this->cache) {
+            $this->getSwitchesToCache();
+        }
+        if (!isset($this->cache[$name])) {
             throw new NoSuchEntityException(__('Unable to find switch with name "%1"', $name));
         }
-        return $switch;
+        return $this->cache[$name];
     }
 
     /**

--- a/Model/ResourceModel/FeatureSwitch/Collection.php
+++ b/Model/ResourceModel/FeatureSwitch/Collection.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Model\ResourceModel\FeatureSwitch;
+
+use \Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
+
+/**
+ * Class Collection
+ * @package Bolt\Boltpay\Model\ResourceModel\FeatureSwitch
+ */
+class Collection extends AbstractCollection
+{
+    protected function _construct()
+    {
+        $this->_init(
+            'Bolt\Boltpay\Model\FeatureSwitch',
+            'Bolt\Boltpay\Model\ResourceModel\FeatureSwitch'
+        );
+    }
+}

--- a/Setup/Recurring.php
+++ b/Setup/Recurring.php
@@ -58,13 +58,13 @@ class Recurring implements InstallSchemaInterface
                 'switch_value',
                 \Magento\Framework\DB\Ddl\Table::TYPE_BOOLEAN,
                 null,
-                ['nullable' => false, 'default' => '0'],
+                ['nullable' => false, 'default' => false],
                 'switch value'
             )->addColumn(
                 'default_value',
                 \Magento\Framework\DB\Ddl\Table::TYPE_BOOLEAN,
                 null,
-                ['nullable' => false, 'default' => '0'],
+                ['nullable' => false, 'default' => false],
                 'default value'
             )->addColumn(
                 'rollout_percentage',

--- a/Setup/Recurring.php
+++ b/Setup/Recurring.php
@@ -58,13 +58,13 @@ class Recurring implements InstallSchemaInterface
                 'switch_value',
                 \Magento\Framework\DB\Ddl\Table::TYPE_BOOLEAN,
                 null,
-                ['nullable' => false, 'default' => false],
+                ['nullable' => false, 'default' => '0'],
                 'switch value'
             )->addColumn(
                 'default_value',
                 \Magento\Framework\DB\Ddl\Table::TYPE_BOOLEAN,
                 null,
-                ['nullable' => false, 'default' => false],
+                ['nullable' => false, 'default' => '0'],
                 'default value'
             )->addColumn(
                 'rollout_percentage',

--- a/Test/Unit/Model/FeatureSwitchRepositoryTest.php
+++ b/Test/Unit/Model/FeatureSwitchRepositoryTest.php
@@ -27,10 +27,10 @@ class FeatureSwitchRepositoryTest extends BoltTestCase
 {
     private function checkSwitch($switch, $name, $value, $defaultValue, $rolloutPercentage)
     {
-        $this->assertEquals($switch->getName(),$name);
-        $this->assertEquals($switch->getValue(),$value);
-        $this->assertEquals($switch->getDefaultValue(),$defaultValue);
-        $this->assertEquals($switch->getRolloutPercentage(),$rolloutPercentage);
+        $this->assertEquals($name,$switch->getName());
+        $this->assertEquals($value,$switch->getValue());
+        $this->assertEquals($defaultValue,$switch->getDefaultValue());
+        $this->assertEquals($rolloutPercentage,$switch->getRolloutPercentage());
     }
 
     /**

--- a/Test/Unit/Model/FeatureSwitchRepositoryTest.php
+++ b/Test/Unit/Model/FeatureSwitchRepositoryTest.php
@@ -17,194 +17,60 @@
 
 namespace Bolt\Boltpay\Test\Unit\Model;
 
-use Bolt\Boltpay\Api\Data\FeatureSwitchInterface;
 use Bolt\Boltpay\Model\FeatureSwitchRepository;
-use Bolt\Boltpay\Model\FeatureSwitchFactory;
 use Bolt\Boltpay\Model\FeatureSwitch;
-use Magento\Framework\App\Helper\Context;
-use Magento\Framework\Registry;
-use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\Framework\Exception\NoSuchEntityException;
 
-class FeatureSwitchRepositoryTest extends TestCase
+class FeatureSwitchRepositoryTest extends BoltTestCase
 {
-    /**
-     * @var FeatureSwitch|\PHPUnit_Framework_MockObject_MockObject
-     */
-    private $mockSwitch;
-
-    /**
-     * @var FeatureSwitchRepository
-     */
-    private $switchRepo;
-
-    /**
-     * Setup for FeatureSwitchRepositoryTest Class
-     */
-    public function setUp()
+    private function checkSwitch($switch, $name, $value, $defaultValue, $rolloutPercentage)
     {
-        $context = $this->createMock(Context::class);
-        $registry = $this->createMock(Registry::class);
-        $this->mockSwitch = $this
-            ->getMockBuilder(FeatureSwitch::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $factory = $this->createMock(FeatureSwitchFactory::class);
-        $factory
-            ->method('create')
-            ->willReturn($this->mockSwitch);
-
-        $this->switchRepo = (new ObjectManager($this))->getObject(
-            FeatureSwitchRepository::class,
-            [
-                'featureSwitchFactory' => $factory,
-            ]
-        );
-    }
-
-    /**
-     * @test
-     * Test that getByName() works as expected.
-     */
-    public function getByName()
-    {
-        $foundSwitch = $this
-            ->getMockBuilder(FeatureSwitchInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $foundSwitch
-            ->method('getName')
-            ->willReturn("SOME_SWITCH");
-
-        $this->mockSwitch
-            ->expects($this->once())
-            ->method('getResource')
-            ->willReturn($this->mockSwitch);
-        $this->mockSwitch
-            ->expects($this->once())
-            ->method('load')
-            ->with($this->anything(), "SOME_SWITCH", FeatureSwitch::NAME)
-            ->willReturn($foundSwitch);
-
-        $this->mockSwitch
-            ->method('getName')
-            ->willReturn("SOME_SWITCH");
-
-        $this->assertEquals(
-            $foundSwitch->getName(),
-            $this->switchRepo->getByName("SOME_SWITCH")->getName()
-        );
+        $this->assertEquals($switch->getName(),$name);
+        $this->assertEquals($switch->getValue(),$value);
+        $this->assertEquals($switch->getDefaultValue(),$defaultValue);
+        $this->assertEquals($switch->getRolloutPercentage(),$rolloutPercentage);
     }
 
     /**
      * @test
      */
-    public function upsertByName_switchFound()
+    public function getByName_switchExists()
     {
-        $foundSwitch = $this
-            ->getMockBuilder(FeatureSwitchInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $foundSwitch
-            ->method('getName')
-            ->willReturn("SOME_SWITCH");
-
-        $this->mockSwitch
-            ->expects($this->exactly(2))
-            ->method('getResource')
-            ->willReturn($this->mockSwitch);
-        $this->mockSwitch
-            ->expects($this->once())
-            ->method('load')
-            ->with($this->anything(), "SOME_SWITCH", FeatureSwitch::NAME)
-            ->willReturn($foundSwitch);
-
-        $this->mockSwitch
-            ->method('getName')
-            ->willReturn("SOME_SWITCH");
-
-        $this->mockSwitch
-            ->expects($this->once())
-            ->method('save')
-            ->with(
-                $this->isInstanceOf('Bolt\BoltPay\Api\Data\FeatureSwitchInterface')
-            );
-
-        $this->mockSwitch->expects($this->once())->method('setValue')->with(true);
-        $this->mockSwitch->expects($this->once())
-            ->method('setDefaultValue')->with(false);
-        $this->mockSwitch->expects($this->once())
-            ->method('setRolloutPercentage')->with(10);
-
-        $this->switchRepo->upsertByName("SOME_SWITCH", true, false, 10);
+        $this->skipTestInUnitTestsFlow();
+        $featureSwitchRepository = Bootstrap::getObjectManager()->create(FeatureSwitchRepository::class);
+        $featureSwitchRepository->upsertByName("test_switch", true, false, 100);
+        $switch = $featureSwitchRepository->getByName("test_switch");
+        $this->checkSwitch($switch,"test_switch", true, false, 100);
     }
 
     /**
      * @test
      */
-    public function upsertByName_switchNotFound()
+    public function getByName_switchDoesNotExists()
     {
-        $this->mockSwitch
-            ->expects($this->exactly(2))
-            ->method('getResource')
-            ->willReturn($this->mockSwitch);
-        $this->mockSwitch
-            ->expects($this->once())
-            ->method('load')
-            ->with($this->anything(), "SOME_SWITCH", FeatureSwitch::NAME)
-            ->willReturn(null);
-
-        $this->mockSwitch
-            ->expects($this->once())
-            ->method('save')
-            ->with(
-                $this->isInstanceOf('Bolt\BoltPay\Api\Data\FeatureSwitchInterface')
-            );
-
-        $this->mockSwitch->expects($this->once())->method('setValue')->with(true);
-        $this->mockSwitch->expects($this->once())
-            ->method('setDefaultValue')->with(false);
-        $this->mockSwitch->expects($this->once())
-            ->method('setRolloutPercentage')->with(10);
-
-        $this->switchRepo->upsertByName("SOME_SWITCH", true, false, 10);
+        $this->skipTestInUnitTestsFlow();
+        $featureSwitchRepository = Bootstrap::getObjectManager()->create(FeatureSwitchRepository::class);
+        $exception_thrown = false;
+        try {
+            $switch = $featureSwitchRepository->getByName("wrong_name");
+        } catch (NoSuchEntityException $e) {
+            $exception_thrown = true;
+        }
+        $this->assertTrue($exception_thrown);
     }
 
     /**
      * @test
      */
-    public function save()
+    public function upsertByName_shouldOverrideData()
     {
-        $this->mockSwitch
-            ->expects($this->once())
-            ->method('getResource')
-            ->willReturn($this->mockSwitch);
-        $this->mockSwitch
-            ->expects($this->once())
-            ->method('save')
-            ->with(
-                $this->isInstanceOf('Bolt\BoltPay\Api\Data\FeatureSwitchInterface')
-            );
-
-        $this->switchRepo->save($this->mockSwitch);
-    }
-
-    /**
-     * @test
-     */
-    public function delete()
-    {
-        $this->mockSwitch
-            ->expects($this->once())
-            ->method('getResource')
-            ->willReturn($this->mockSwitch);
-        $this->mockSwitch
-            ->expects($this->once())
-            ->method('delete')
-            ->with(
-                $this->isInstanceOf('Bolt\BoltPay\Api\Data\FeatureSwitchInterface')
-            );
-
-        $this->switchRepo->delete($this->mockSwitch);
+        $this->skipTestInUnitTestsFlow();
+        $featureSwitchRepository = Bootstrap::getObjectManager()->create(FeatureSwitchRepository::class);
+        $featureSwitchRepository->upsertByName("test_switch", true, false, 100);
+        $featureSwitchRepository->upsertByName("test_switch", false, true, 90);
+        $switch = $featureSwitchRepository->getByName("test_switch");
+        $this->checkSwitch($switch,"test_switch", false, true, 90);
     }
 }

--- a/Test/Unit/Model/FeatureSwitchTest.php
+++ b/Test/Unit/Model/FeatureSwitchTest.php
@@ -66,8 +66,8 @@ class FeatureSwitchTest extends TestCase
      */
     public function setAndGetValue()
     {
-        $this->mockFeatureSwitch->setValue('value');
-        $this->assertEquals('value', $this->mockFeatureSwitch->getValue());
+        $this->mockFeatureSwitch->setValue(true);
+        $this->assertEquals(true, $this->mockFeatureSwitch->getValue());
     }
 
     /**
@@ -75,8 +75,8 @@ class FeatureSwitchTest extends TestCase
      */
     public function setAndGetDefaultValue()
     {
-        $this->mockFeatureSwitch->setDefaultValue('defaultValue');
-        $this->assertEquals('defaultValue', $this->mockFeatureSwitch->getDefaultValue());
+        $this->mockFeatureSwitch->setDefaultValue(false);
+        $this->assertEquals(false, $this->mockFeatureSwitch->getDefaultValue());
     }
 
     /**


### PR DESCRIPTION
# Description
Now we run sql query like
`SELECT `bolt_feature_switches`.* FROM `bolt_feature_switches` WHERE (`bolt_feature_switches`.`switch_name`='M2_MERCHANT_METRICS')
` few dozens time per request.

After this fix we use magento collection to retrieve all feature data by one request and save it into cache
Fixes: [M2P-299](https://boltpay.atlassian.net/browse/M2P-299
)
#changelog M2P-299 Use Collection to cache feature switches data

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Refactoring

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
-  x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
