### PR TITLE
M2P-402 Bugfix: New lines break the api response

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1405,7 +1405,7 @@ class Cart extends AbstractHelper
                 ////////////////////////////////////
                 // Get product description and image
                 ////////////////////////////////////
-                $product['description'] = strip_tags($_product->getDescription());
+                $product['description'] = str_replace(array("\r\n", "\n", "\r"), ' ', strip_tags($_product->getDescription()));
                 $variantProductToGetImage = $_product;
 
                 // This will override the $_product with the variant product to get the variant image rather than the main product image.

--- a/Model/Api/UpdateCart.php
+++ b/Model/Api/UpdateCart.php
@@ -313,11 +313,12 @@ class UpdateCart extends UpdateCartCommon implements UpdateCartInterface
      */
     protected function sendSuccessResponse($result, $quote = null)
     {
+        $result = str_replace(array("\r\n", "\n", "\r"), ' ', json_encode($result));
         $this->logHelper->addInfoLog('### sendSuccessResponse');
-        $this->logHelper->addInfoLog(json_encode($result));
+        $this->logHelper->addInfoLog($result);
         $this->logHelper->addInfoLog('=== END ===');
 
-        $this->response->setBody(json_encode($result));
+        $this->response->setBody($result);
         $this->response->sendResponse();
     }
 

--- a/Model/ErrorResponse.php
+++ b/Model/ErrorResponse.php
@@ -92,6 +92,6 @@ class ErrorResponse
             $errResponse += $additionalData;
         }
 
-        return json_encode($errResponse);
+        return str_replace(array("\r\n", "\n", "\r"), ' ', json_encode($errResponse));
     }
 }

--- a/Test/Unit/Model/Api/UpdateCartTest.php
+++ b/Test/Unit/Model/Api/UpdateCartTest.php
@@ -403,7 +403,8 @@ class UpdateCartTest extends TestCase
 
     private function expectSuccessResponse($result)
     {
-        $this->response->expects(self::once())->method('setBody')->with(json_encode($result));
+        $result = str_replace(array("\r\n", "\n", "\r"), ' ', json_encode($result));
+        $this->response->expects(self::once())->method('setBody')->with($result);
         $this->response->expects(self::once())->method('sendResponse');
     }
 

--- a/Test/Unit/Model/ErrorResponseTest.php
+++ b/Test/Unit/Model/ErrorResponseTest.php
@@ -75,4 +75,71 @@ class ErrorResponseTest extends TestCase
             ],
         ];
     }
+    
+    /**
+     * @test
+     *
+     * @covers ::prepareUpdateCartErrorMessage
+     *
+     * @dataProvider providerPrepareUpdateCartErrorMessage
+     *
+     * @param  $errCode
+     * @param  $message
+     * @param  $additionalData
+     * @param  $expected
+     */
+    public function prepareUpdateCartErrorMessage($errCode, $message, $additionalData, $expected)
+    {
+        $result = $this->currentMock->prepareErrorMessage($errCode, $message, $additionalData);
+        $this->assertEquals($expected, $result);
+    }
+    
+    /**
+     * Data provider for {@see prepareUpdateCartErrorMessage}
+     */
+    public function providerPrepareUpdateCartErrorMessage()
+    {
+        return [
+            [
+                ErrorResponse::ERR_INSUFFICIENT_INFORMATION,
+                'The order reference is invalid.',
+                [],
+                '{"status":"failure","error":[{"code":6200,"message":"The order reference is invalid."}]}'
+            ],
+            [
+                ErrorResponse::ERR_INSUFFICIENT_INFORMATION,
+                'The order reference is invalid.',
+                [
+                    'order_reference' => 100010,
+                    'display_id' => '',
+                    'currency' => 'USD',
+                    'total_amount' => 50500,
+                    'tax_amount' => 1000,            
+                    'items' => [
+                        [
+                            'name'         => 'Beaded Long Dress',
+                            'description'  => 'Test
+                                               New
+                                               Lines',
+                            'reference'    => 101,
+                            'total_amount' => 50000,
+                            'unit_price'   => 50000,
+                            'quantity'     => 1,
+                            'image_url'    => 'https://images.example.com/dress.jpg',
+                            'type'         => 'physical',
+                            'properties'   =>
+                                [
+                                    [
+                                        'name'  => 'color',
+                                        'value' => 'blue',
+                                    ],
+                                ],
+                        ],
+                    ],
+                    'discounts' => [],
+                ],
+                '{"status":"failure","errors":[{"code":6200,"message":"The order reference is invalid."}],"order_reference":100010,"display_id":"","currency":"USD","total_amount":50500,"tax_amount":1000,"items":[{"name":"Beaded Long Dress","description":"Test\n New\n Lines","reference":101,"total_amount":50000,"unit_price":50000,"quantity":1,"image_url":"https:\/\/images.example.com\/dress.jpg","type":"physical","properties":[{"name":"color","value":"blue"}]}],"discounts":[]}'
+            ],
+        ];
+    }
 }

--- a/Test/Unit/Model/ErrorResponseTest.php
+++ b/Test/Unit/Model/ErrorResponseTest.php
@@ -104,7 +104,7 @@ class ErrorResponseTest extends TestCase
                 ErrorResponse::ERR_INSUFFICIENT_INFORMATION,
                 'The order reference is invalid.',
                 [],
-                '{"status":"failure","error":[{"code":6200,"message":"The order reference is invalid."}]}'
+                '{"status":"failure","error":{"code":6200,"message":"The order reference is invalid."}}'
             ],
             [
                 ErrorResponse::ERR_INSUFFICIENT_INFORMATION,
@@ -119,8 +119,8 @@ class ErrorResponseTest extends TestCase
                         [
                             'name'         => 'Beaded Long Dress',
                             'description'  => 'Test
-                                               New
-                                               Lines',
+New
+Lines',
                             'reference'    => 101,
                             'total_amount' => 50000,
                             'unit_price'   => 50000,
@@ -138,7 +138,7 @@ class ErrorResponseTest extends TestCase
                     ],
                     'discounts' => [],
                 ],
-                '{"status":"failure","errors":[{"code":6200,"message":"The order reference is invalid."}],"order_reference":100010,"display_id":"","currency":"USD","total_amount":50500,"tax_amount":1000,"items":[{"name":"Beaded Long Dress","description":"Test\n New\n Lines","reference":101,"total_amount":50000,"unit_price":50000,"quantity":1,"image_url":"https:\/\/images.example.com\/dress.jpg","type":"physical","properties":[{"name":"color","value":"blue"}]}],"discounts":[]}'
+                '{"status":"failure","error":{"code":6200,"message":"The order reference is invalid."},"order_reference":100010,"display_id":"","currency":"USD","total_amount":50500,"tax_amount":1000,"items":{"0":{"name":"Beaded Long Dress","description":"Test\nNew\nLines","reference":101,"total_amount":50000,"unit_price":50000,"quantity":1,"image_url":"https:\/\/images.example.com\/dress.jpg","type":"physical","properties":{"0":{"name":"color","value":"blue"}}}},"discounts":{}}'
             ],
         ];
     }


### PR DESCRIPTION
# Description
The description of product is HTML content ( or even some other HTML content in the fields ) and may have new lines. 
In some contexts (eg. https://boltpay.atlassian.net/browse/EN-2762) it would break the response of Bolt v2 update-cart API and result in a timeout error. So we need to escape the new lines before sending.

Fixes: https://boltpay.atlassian.net/browse/M2P-402

#changelog Bugfix: New lines break the api response

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
