### PR TITLE
M2P-409 Fix PHPUnit tests errors

### DIFF
--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -419,7 +419,7 @@ JSON;
     /**
      * @test
      * @dataProvider dataProvider_getCdnUrl_devModeSet
-     * @covers::getCdnUrl
+     * @covers ::getCdnUrl
      *
      * @param $validateCustomUrl
      * @param $expected
@@ -510,7 +510,7 @@ JSON;
     /**
      * @test
      * @dataProvider dataProvider_getAccountUrl_devModeSet
-     * @covers::getAccountUrl
+     * @covers ::getAccountUrl
      *
      * @param $validateCustomUrl
      * @param $expected
@@ -639,7 +639,7 @@ JSON;
     /**
      * @test
      * @dataProvider dataProvider_getApiUrl_devMode
-     * @covers::getApiUrl
+     * @covers ::getApiUrl
      *
      * @param $validateCustomUrl
      * @param $expected

--- a/Test/Unit/Observer/Adminhtml/Sales/CreatingInvoiceForRechargeOrderTest.php
+++ b/Test/Unit/Observer/Adminhtml/Sales/CreatingInvoiceForRechargeOrderTest.php
@@ -24,7 +24,6 @@ use Bolt\Boltpay\Observer\Adminhtml\Sales\CreateInvoiceForRechargedOrder;
 use Magento\Sales\Model\Service\InvoiceService;
 use Magento\Sales\Model\Order\Email\Sender\InvoiceSender;
 use Bolt\Boltpay\Helper\Bugsnag;
-use Magento\Sales\Api\Data\InvoiceInterface;
 
 /**
  * Class OrderCreateProcessDataObserverTest
@@ -66,11 +65,6 @@ class CreateInvoiceForRechargedOrderTest extends TestCase
      * @var Order\Invoice
      */
     protected $invoice;
-    
-    /**
-     * @var InvoiceInterface
-     */
-    private $invoiceInterface;
 
     protected function setUp()
     {
@@ -89,7 +83,7 @@ class CreateInvoiceForRechargedOrderTest extends TestCase
 
         $this->invoice = $this->createPartialMock(
             Order\Invoice::class,
-            ['getEmailSent']
+            ['getEmailSent', 'setRequestedCaptureCase', 'register']
         );
         $this->creatingInvoiceForRechargeOrderObserverTest = $this->getMockBuilder(CreateInvoiceForRechargedOrder::class)
             ->setConstructorArgs([
@@ -99,9 +93,6 @@ class CreateInvoiceForRechargedOrderTest extends TestCase
             ])
             ->setMethods(['_init'])
             ->getMock();
-        $this->invoiceInterface = $this->getMockBuilder(InvoiceInterface::class)
-            ->disableOriginalConstructor()
-            ->getMockForAbstractClass();
     }
 
     /**
@@ -116,9 +107,9 @@ class CreateInvoiceForRechargedOrderTest extends TestCase
         $this->order->expects(self::once())->method('setIsCustomerNotified')->willReturnSelf();
         $this->observer->expects(self::once())->method('getEvent')->willReturnSelf();
         $this->observer->expects(self::once())->method('getOrder')->willReturn($this->order);
-        $this->invoiceService->expects(self::once())->method('prepareInvoice')->with($this->order)->willReturn($this->invoiceInterface);
-        $this->invoiceInterface->expects(self::once())->method('setRequestedCaptureCase')->with(\Magento\Sales\Model\Order\Invoice::CAPTURE_OFFLINE)->willReturnSelf();
-        $this->invoiceInterface->expects(self::once())->method('register')->willReturnSelf();
+        $this->invoiceService->expects(self::once())->method('prepareInvoice')->with($this->order)->willReturn($this->invoice);
+        $this->invoice->expects(self::once())->method('setRequestedCaptureCase')->with(\Magento\Sales\Model\Order\Invoice::CAPTURE_OFFLINE)->willReturnSelf();
+        $this->invoice->expects(self::once())->method('register')->willReturnSelf();
 
         $this->order->expects(self::once())->method('addRelatedObject')->willReturnSelf();
         $this->invoice->expects(self::once())->method('getEmailSent')->willReturn(false);

--- a/Test/Unit/Observer/Adminhtml/Sales/CreatingInvoiceForRechargeOrderTest.php
+++ b/Test/Unit/Observer/Adminhtml/Sales/CreatingInvoiceForRechargeOrderTest.php
@@ -24,6 +24,7 @@ use Bolt\Boltpay\Observer\Adminhtml\Sales\CreateInvoiceForRechargedOrder;
 use Magento\Sales\Model\Service\InvoiceService;
 use Magento\Sales\Model\Order\Email\Sender\InvoiceSender;
 use Bolt\Boltpay\Helper\Bugsnag;
+use Magento\Sales\Api\Data\InvoiceInterface;
 
 /**
  * Class OrderCreateProcessDataObserverTest
@@ -65,6 +66,11 @@ class CreateInvoiceForRechargedOrderTest extends TestCase
      * @var Order\Invoice
      */
     protected $invoice;
+    
+    /**
+     * @var InvoiceInterface
+     */
+    private $invoiceInterface;
 
     protected function setUp()
     {
@@ -93,6 +99,9 @@ class CreateInvoiceForRechargedOrderTest extends TestCase
             ])
             ->setMethods(['_init'])
             ->getMock();
+        $this->invoiceInterface = $this->getMockBuilder(InvoiceInterface::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
     }
 
     /**
@@ -107,9 +116,9 @@ class CreateInvoiceForRechargedOrderTest extends TestCase
         $this->order->expects(self::once())->method('setIsCustomerNotified')->willReturnSelf();
         $this->observer->expects(self::once())->method('getEvent')->willReturnSelf();
         $this->observer->expects(self::once())->method('getOrder')->willReturn($this->order);
-        $this->invoiceService->expects(self::once())->method('prepareInvoice')->with($this->order)->willReturnSelf();
-        $this->invoiceService->expects(self::once())->method('setRequestedCaptureCase')->with(\Magento\Sales\Model\Order\Invoice::CAPTURE_OFFLINE)->willReturnSelf();
-        $this->invoiceService->expects(self::once())->method('register')->willReturnSelf();
+        $this->invoiceService->expects(self::once())->method('prepareInvoice')->with($this->order)->willReturn($this->invoiceInterface);
+        $this->invoiceInterface->expects(self::once())->method('setRequestedCaptureCase')->with(\Magento\Sales\Model\Order\Invoice::CAPTURE_OFFLINE)->willReturnSelf();
+        $this->invoiceInterface->expects(self::once())->method('register')->willReturnSelf();
 
         $this->order->expects(self::once())->method('addRelatedObject')->willReturnSelf();
         $this->invoice->expects(self::once())->method('getEmailSent')->willReturn(false);

--- a/Test/Unit/Observer/Adminhtml/Sales/CreatingInvoiceForRechargeOrderTest.php
+++ b/Test/Unit/Observer/Adminhtml/Sales/CreatingInvoiceForRechargeOrderTest.php
@@ -68,7 +68,7 @@ class CreateInvoiceForRechargedOrderTest extends TestCase
 
     protected function setUp()
     {
-        $this->invoiceService = $this->createPartialMock(InvoiceService::class, ['prepareInvoice', 'setRequestedCaptureCase', 'register', 'save']);
+        $this->invoiceService = $this->createPartialMock(InvoiceService::class, ['prepareInvoice']);
         $this->invoiceSender = $this->createPartialMock(InvoiceSender::class, ['send']);
         $this->bugsnag = $this->createPartialMock(Bugsnag::class, ['notifyException']);
         $this->observer = $this->createPartialMock(
@@ -83,7 +83,7 @@ class CreateInvoiceForRechargedOrderTest extends TestCase
 
         $this->invoice = $this->createPartialMock(
             Order\Invoice::class,
-            ['getEmailSent', 'setRequestedCaptureCase', 'register']
+            ['getEmailSent', 'setRequestedCaptureCase', 'register', 'save']
         );
         $this->creatingInvoiceForRechargeOrderObserverTest = $this->getMockBuilder(CreateInvoiceForRechargedOrder::class)
             ->setConstructorArgs([
@@ -115,7 +115,7 @@ class CreateInvoiceForRechargedOrderTest extends TestCase
         $this->invoice->expects(self::once())->method('getEmailSent')->willReturn(false);
         $this->invoiceSender->expects(self::once())->method('send')->with($this->invoice)->willReturnSelf();
 
-        $this->invoiceService->expects(self::once())->method('save')->willReturn($this->invoice);
+        $this->invoice->expects(self::once())->method('save')->willReturn($this->invoice);
         $this->creatingInvoiceForRechargeOrderObserverTest->execute($this->observer);
     }
 


### PR DESCRIPTION
# Description
1. @covers::methodname is wrong, the correct syntax is @covers ::methodname 

2. Fix the error `Bolt\Boltpay\Test\Unit\Observer\Adminhtml\Sales\CreateInvoiceForRechargedOrderTest::execute_withRechargeOrder
TypeError: Return value of Mock_InvoiceService_490102db::prepareInvoice() must implement interface Magento\Sales\Api\Data\InvoiceInterface, instance of Mock_InvoiceService_490102db returned`

Fixes: https://boltpay.atlassian.net/browse/M2P-409

#changelog Fix PHPUnit tests errors

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
