### PR TITLE
[WIP] Add return type declaration to PHPUnit test functions

### DIFF
--- a/Test/Unit/Block/Adminhtml/Customer/CreditCard/Tab/CreditCardTest.php
+++ b/Test/Unit/Block/Adminhtml/Customer/CreditCard/Tab/CreditCardTest.php
@@ -50,7 +50,7 @@ class CreditCardTest extends \PHPUnit\Framework\TestCase
     /**
      * @inheritdoc
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->initRequiredMocks();
         $this->initCurrentMock();

--- a/Test/Unit/Block/Adminhtml/Customer/CreditCard/Tab/View/CardNumberTest.php
+++ b/Test/Unit/Block/Adminhtml/Customer/CreditCard/Tab/View/CardNumberTest.php
@@ -30,7 +30,7 @@ class CardNumberTest extends \PHPUnit\Framework\TestCase
     /** @var CardNumber */
     private $block;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->block = $this->getMockBuilder(CardNumber::class)
             ->disableOriginalConstructor()

--- a/Test/Unit/Block/Adminhtml/Customer/CreditCard/Tab/View/CardTypeTest.php
+++ b/Test/Unit/Block/Adminhtml/Customer/CreditCard/Tab/View/CardTypeTest.php
@@ -26,7 +26,7 @@ class CardTypeTest extends \PHPUnit\Framework\TestCase
     /** @var CardType */
     private $block;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->block = $this->getMockBuilder(CardType::class)
             ->disableOriginalConstructor()

--- a/Test/Unit/Block/Adminhtml/Customer/CreditCard/Tab/View/CreditCardTest.php
+++ b/Test/Unit/Block/Adminhtml/Customer/CreditCard/Tab/View/CreditCardTest.php
@@ -26,7 +26,7 @@ class CreditCardTest extends \PHPUnit\Framework\TestCase
      */
     private $block;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->block = $this->createMock(CreditCard::class);
     }

--- a/Test/Unit/Block/Adminhtml/Customer/CreditCard/Tab/View/DeleteActionTest.php
+++ b/Test/Unit/Block/Adminhtml/Customer/CreditCard/Tab/View/DeleteActionTest.php
@@ -27,7 +27,7 @@ class DeleteActionTest extends \PHPUnit\Framework\TestCase
     /** @var DeleteAction */
     private $block;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->block = $this->getMockBuilder(DeleteAction::class)
             ->disableOriginalConstructor()

--- a/Test/Unit/Block/BlockTraitTest.php
+++ b/Test/Unit/Block/BlockTraitTest.php
@@ -47,7 +47,7 @@ class BlockTraitTest extends TestCase
     /** @var Decider */
     private $featureSwitches;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->currentMock = $this->getMockBuilder(BlockTrait::class)
             ->enableOriginalConstructor()

--- a/Test/Unit/Block/Checkout/Cart/ComponentSwitcherProcessorTest.php
+++ b/Test/Unit/Block/Checkout/Cart/ComponentSwitcherProcessorTest.php
@@ -68,7 +68,7 @@ class ComponentSwitcherProcessorTest extends TestCase
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->helperContextMock = $this->createMock(Context::class);
         $this->configHelper = $this->getMockBuilder(ConfigHelper::class)

--- a/Test/Unit/Block/Checkout/ComponentSwitcherProcessorTest.php
+++ b/Test/Unit/Block/Checkout/ComponentSwitcherProcessorTest.php
@@ -36,7 +36,7 @@ class ComponentSwitcherProcessorTest extends TestCase
      */
     private $componentSwitcherProcessor;
 
-    public function setup()
+    public function setUp(): void
     {
         $this->configHelper = $this->createPartialMock(ConfigHelper::class, ['isPaymentOnlyCheckoutEnabled']);
         $this->componentSwitcherProcessor = $this->getMockBuilder(ComponentSwitcherProcessor::class)

--- a/Test/Unit/Block/Checkout/LayoutProcessorTest.php
+++ b/Test/Unit/Block/Checkout/LayoutProcessorTest.php
@@ -36,7 +36,7 @@ class LayoutProcessorTest extends TestCase
     /**
      * Setup test dependencies, called before each test
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->configHelper = $this->createMock(ConfigHelper::class);
     }

--- a/Test/Unit/Block/Checkout/SuccessTest.php
+++ b/Test/Unit/Block/Checkout/SuccessTest.php
@@ -39,7 +39,7 @@ class SuccessTest extends \PHPUnit\Framework\TestCase
      */
     protected $block;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $helperContextMock = $this->createMock(\Magento\Framework\App\Helper\Context::class);
         $contextMock = $this->createMock(\Magento\Framework\View\Element\Template\Context::class);

--- a/Test/Unit/Block/Customer/CreditCardTest.php
+++ b/Test/Unit/Block/Customer/CreditCardTest.php
@@ -73,7 +73,7 @@ class CreditCardTest extends \PHPUnit\Framework\TestCase
     /**
      * @inheritdoc
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->initRequiredMocks();
         $this->initCurrentMock();

--- a/Test/Unit/Block/FormTest.php
+++ b/Test/Unit/Block/FormTest.php
@@ -81,7 +81,7 @@ class FormTest extends \PHPUnit\Framework\TestCase
     /**
      * @inheritdoc
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->initRequiredMocks();
         $this->initCurrentMock();

--- a/Test/Unit/Block/InfoTest.php
+++ b/Test/Unit/Block/InfoTest.php
@@ -29,7 +29,7 @@ class InfoTest extends \PHPUnit\Framework\TestCase
      */
     protected $mock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->mock = $this->createPartialMock(Info::class, ['getInfo', 'getMethod', 'getCcType', 'getCcLast4', 'getAdditionalInformation', 'getOrder', 'getAdditionalData']);
     }

--- a/Test/Unit/Block/JsProductPageTest.php
+++ b/Test/Unit/Block/JsProductPageTest.php
@@ -112,7 +112,7 @@ class JsProductPageTest extends \PHPUnit\Framework\TestCase
     /**
      * @inheritdoc
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->helperContextMock = $this->createMock(\Magento\Framework\App\Helper\Context::class);
         $this->contextMock = $this->createMock(\Magento\Framework\View\Element\Template\Context::class);

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -127,7 +127,7 @@ class JsTest extends \PHPUnit\Framework\TestCase
      *
      * @throws ReflectionException if unable to create one of the required mocks
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
         $this->helperContextMock = $this->createMock(Context::class);

--- a/Test/Unit/Block/MinifiedJsTest.php
+++ b/Test/Unit/Block/MinifiedJsTest.php
@@ -37,7 +37,7 @@ class MinifiedJsTest extends \PHPUnit\Framework\TestCase
     /**
      * @inheritdoc
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->block = $this->createPartialMock(MinifiedJs::class, ['minifyJs']);
     }

--- a/Test/Unit/Controller/Adminhtml/Cart/DataTest.php
+++ b/Test/Unit/Controller/Adminhtml/Cart/DataTest.php
@@ -93,7 +93,7 @@ class DataTest extends TestCase
      */
     private $request;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->initData();
         $this->initRequiredMocks();

--- a/Test/Unit/Controller/Adminhtml/Customer/CreditCardTest.php
+++ b/Test/Unit/Controller/Adminhtml/Customer/CreditCardTest.php
@@ -178,7 +178,7 @@ class CreditCardTest extends TestCase
      */
     private $resultJsonFactoryMock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->contextMock = $this->createMock(Context::class);
         $this->coreRegistryMock = $this->createMock(Registry::class);

--- a/Test/Unit/Controller/Adminhtml/Customer/DeleteCreditCardTest.php
+++ b/Test/Unit/Controller/Adminhtml/Customer/DeleteCreditCardTest.php
@@ -65,7 +65,7 @@ class DeleteCreditCardTest extends TestCase
      */
     private $redirectMock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->contextMock = $this->createMock(Context::class);
 

--- a/Test/Unit/Controller/Adminhtml/Order/ReceivedUrlTest.php
+++ b/Test/Unit/Controller/Adminhtml/Order/ReceivedUrlTest.php
@@ -87,7 +87,7 @@ class ReceivedUrlTest extends TestCase
 
     private $order;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->context = $this->createMock(Context::class, ['getBackendUrl']);
         $this->backendUrl = $this->createMock(UrlInterface::class, ['getUrl']);

--- a/Test/Unit/Controller/Adminhtml/Order/SaveTest.php
+++ b/Test/Unit/Controller/Adminhtml/Order/SaveTest.php
@@ -84,7 +84,7 @@ class SaveTest extends TestCase
      */
     private $dataObjectFactory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->initRequiredMocks();
     }

--- a/Test/Unit/Controller/Cart/CheckoutConfigTest.php
+++ b/Test/Unit/Controller/Cart/CheckoutConfigTest.php
@@ -48,7 +48,7 @@ class CheckoutConfigTest extends TestCase
     /**
      * Setup method, called before each test
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $om = new ObjectManager($this);
         $this->context = $om->getObject(\Magento\Framework\App\Action\Context::class);

--- a/Test/Unit/Controller/Cart/DataTest.php
+++ b/Test/Unit/Controller/Cart/DataTest.php
@@ -74,7 +74,7 @@ class DataTest extends TestCase
      */
     private $resultJsonFactory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->initResponseData();
         $this->initRequiredMocks();

--- a/Test/Unit/Controller/Cart/EmailTest.php
+++ b/Test/Unit/Controller/Cart/EmailTest.php
@@ -76,7 +76,7 @@ class EmailTest extends TestCase
      */
     private $currentMock;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->initRequiredMocks();
         $this->initCurrentMock();

--- a/Test/Unit/Controller/Cart/HintsTest.php
+++ b/Test/Unit/Controller/Cart/HintsTest.php
@@ -47,7 +47,7 @@ class HintsTest extends TestCase
     /** @var Hints */
     private $currentMock;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->initRequiredMocks();
         $this->initCurrentMock();

--- a/Test/Unit/Controller/Customer/CreditCardTest.php
+++ b/Test/Unit/Controller/Customer/CreditCardTest.php
@@ -44,7 +44,7 @@ class CreditCardTest extends TestCase
      */
     protected $_view;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->_context = $this->createPartialMock(Context::class, ['getView']);
         $this->_view = $this->createPartialMock(

--- a/Test/Unit/Controller/Customer/DeleteCreditCardTest.php
+++ b/Test/Unit/Controller/Customer/DeleteCreditCardTest.php
@@ -78,7 +78,7 @@ class DeleteCreditCardTest extends TestCase
      */
     private $validatorMock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->contextMock = $this->createMock(Context::class);
 

--- a/Test/Unit/Controller/Order/ReceivedUrlTest.php
+++ b/Test/Unit/Controller/Order/ReceivedUrlTest.php
@@ -653,7 +653,7 @@ class ReceivedUrlTest extends TestCase
         $receivedUrl->execute();
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->initRequiredMocks();
         $this->initAuthentication();

--- a/Test/Unit/Controller/Order/SaveTest.php
+++ b/Test/Unit/Controller/Order/SaveTest.php
@@ -94,7 +94,7 @@ class SaveTest extends TestCase
      */
     private $resultJsonFactory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->initRequiredMocks();
     }

--- a/Test/Unit/Controller/ReceivedUrlTraitTest.php
+++ b/Test/Unit/Controller/ReceivedUrlTraitTest.php
@@ -75,7 +75,7 @@ class ReceivedUrlTraitTest extends TestCase
      */
     private $configHelper;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->currentMock = $this->getMockBuilder(ReceivedUrlTrait::class)
             ->enableOriginalConstructor()

--- a/Test/Unit/Controller/Shipping/PrefetchTest.php
+++ b/Test/Unit/Controller/Shipping/PrefetchTest.php
@@ -87,7 +87,7 @@ class PrefetchTest extends TestCase
      */
     private $currentMock;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->initRequiredMocks();
         $this->initCurrentMock();

--- a/Test/Unit/Cron/DeactivateQuoteTest.php
+++ b/Test/Unit/Cron/DeactivateQuoteTest.php
@@ -50,7 +50,7 @@ class DeactivateQuoteTest extends TestCase
      */
     private $connection;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->resourceConnection = $this->createPartialMock(
             ResourceConnection::class,

--- a/Test/Unit/Cron/DeleteOldWebHookLogsTest.php
+++ b/Test/Unit/Cron/DeleteOldWebHookLogsTest.php
@@ -38,7 +38,7 @@ class DeleteOldWebHookLogsTest extends TestCase
      */
     private $webhookLogFactory;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->webhookLogFactory = $this->createPartialMock(
             WebhookLogFactory::class,

--- a/Test/Unit/Helper/ApiTest.php
+++ b/Test/Unit/Helper/ApiTest.php
@@ -83,7 +83,7 @@ class ApiTest extends TestCase
     /**
      * @inheritdoc
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->initRequiredMocks();
         $this->currentMock = $this->getMockBuilder(ApiHelper::class)

--- a/Test/Unit/Helper/BugsnagTest.php
+++ b/Test/Unit/Helper/BugsnagTest.php
@@ -64,7 +64,7 @@ class BugsnagTest extends TestCase
      *
      * @throws ReflectionException if unable to set internal mock properties
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->contextMock = $this->createMock(Context::class);
         $this->configHelperMock = $this->createPartialMock(Config::class, ['getComposerVersion','isSandboxModeSet','isTestEnvSet','getModuleVersion']);

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -312,7 +312,7 @@ class CartTest extends BoltTestCase
     /**
      * Setup test dependencies, called before each test
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->originalObjectManager = ObjectManager::getInstance();
         $this->testAddressData = [
@@ -455,7 +455,7 @@ class CartTest extends BoltTestCase
         $this->objectsToClean = array();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         TestUtils::cleanupSharedFixtures($this->objectsToClean);
         ObjectManager::setInstance($this->originalObjectManager);

--- a/Test/Unit/Helper/CheckboxesHandlerTest.php
+++ b/Test/Unit/Helper/CheckboxesHandlerTest.php
@@ -52,7 +52,7 @@ class CheckboxesHandlerTest extends TestCase
     private $subscriber;
 
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->context = $this->getMockBuilder(Context::class)
             ->disableOriginalConstructor()

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -148,7 +148,7 @@ JSON;
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->encryptor = $this->createMock(EncryptorInterface::class);
         $this->moduleResource = $this->createMock(ModuleResource::class);

--- a/Test/Unit/Helper/DiscountTest.php
+++ b/Test/Unit/Helper/DiscountTest.php
@@ -206,7 +206,7 @@ class DiscountTest extends TestCase
     /**
      * Setup test dependencies, called before each test
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->context = $this->createMock(Context::class);
         $this->resource = $this->createMock(ResourceConnection::class);

--- a/Test/Unit/Helper/FeatureSwitch/DeciderTest.php
+++ b/Test/Unit/Helper/FeatureSwitch/DeciderTest.php
@@ -82,7 +82,7 @@ class DeciderTest  extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUp(): void
     {
 
         $this->context = $this->createMock(Context::class);

--- a/Test/Unit/Helper/FeatureSwitch/ManagerTest.php
+++ b/Test/Unit/Helper/FeatureSwitch/ManagerTest.php
@@ -55,7 +55,7 @@ class ManagerTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUp(): void
     {
 
         $this->context = $this->createMock(Context::class);

--- a/Test/Unit/Helper/GeolocationTest.php
+++ b/Test/Unit/Helper/GeolocationTest.php
@@ -69,7 +69,7 @@ class GeolocationTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->context = $this->createPartialMock(Context::class, ['getMpGiftCards']);
         $this->configHelper = $this->createPartialMock(ConfigHelper::class, ['getGeolocationApiKey', 'getClientIp']);

--- a/Test/Unit/Helper/GraphQL/ClientTest.php
+++ b/Test/Unit/Helper/GraphQL/ClientTest.php
@@ -82,7 +82,7 @@ class ClientTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUp(): void
     {
 
         $this->context = $this->createMock(Context::class);

--- a/Test/Unit/Helper/HookTest.php
+++ b/Test/Unit/Helper/HookTest.php
@@ -80,7 +80,7 @@ class HookTest extends TestCase
     /**
      * Setup test dependencies, called before each test
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->context = $this->createMock(Context::class);
         $this->request = $this->createMock(Request::class);

--- a/Test/Unit/Helper/LogRetrieverTest.php
+++ b/Test/Unit/Helper/LogRetrieverTest.php
@@ -48,7 +48,7 @@ class LogRetrieverTest extends TestCase
     private $bugsnag;
     private $file;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $structure = [
             'log' => [

--- a/Test/Unit/Helper/LogTest.php
+++ b/Test/Unit/Helper/LogTest.php
@@ -55,7 +55,7 @@ class LogTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->context = $this->createMock(Context::class);
         $this->boltLoger = $this->createPartialMock(

--- a/Test/Unit/Helper/MetricTest.php
+++ b/Test/Unit/Helper/MetricTest.php
@@ -30,7 +30,7 @@ class MetricTest extends TestCase
      */
     protected $metric;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->metric = new Metric(self::KEY, self::DATA);
     }

--- a/Test/Unit/Helper/MetricsClientTest.php
+++ b/Test/Unit/Helper/MetricsClientTest.php
@@ -127,7 +127,7 @@ class MetricsClientTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUp(): void
     {
         // common values
         $this->timeStamp = 1567541470604;

--- a/Test/Unit/Helper/ModuleRetrieverTest.php
+++ b/Test/Unit/Helper/ModuleRetrieverTest.php
@@ -62,7 +62,7 @@ class ModuleRetrieverTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->dbResult = [
             [

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -264,7 +264,7 @@ class OrderTest extends BoltTestCase
      *
      * @throws ReflectionException from initRequiredMocks and initCurrentMock methods
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->initRequiredMocks();
         $this->initCurrentMock(
@@ -287,7 +287,7 @@ class OrderTest extends BoltTestCase
     /**
      * Cleanup changes made by tests
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Hook::$fromBolt = false;
     }

--- a/Test/Unit/Helper/SessionTest.php
+++ b/Test/Unit/Helper/SessionTest.php
@@ -110,7 +110,7 @@ class SessionTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->initRequiredMocks();
         $this->initCurrentMock();

--- a/Test/Unit/Model/Api/CreateOrderTest.php
+++ b/Test/Unit/Model/Api/CreateOrderTest.php
@@ -153,7 +153,7 @@ class CreateOrderTest extends TestCase
     /**
      * @inheritdoc
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->initRequiredMocks();
         $this->initCurrentMock();

--- a/Test/Unit/Model/Api/Data/BoltConfigSettingTest.php
+++ b/Test/Unit/Model/Api/Data/BoltConfigSettingTest.php
@@ -31,7 +31,7 @@ class BoltConfigSettingTest extends TestCase
      */
     protected $boltConfigSetting;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->boltConfigSetting = new BoltConfigSetting();
     }

--- a/Test/Unit/Model/Api/Data/CartDataTest.php
+++ b/Test/Unit/Model/Api/Data/CartDataTest.php
@@ -49,7 +49,7 @@ class CartDataTest extends TestCase
      */
     private $typeProcessor;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->cartData = new CartData;
         $this->cartData->setDisplayId(self::DISPLAYID);

--- a/Test/Unit/Model/Api/Data/DebugInfoTest.php
+++ b/Test/Unit/Model/Api/Data/DebugInfoTest.php
@@ -31,7 +31,7 @@ class DebugInfoTest extends TestCase
      */
     protected $debugInfo;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->debugInfo = new DebugInfo();
         $this->debugInfo->setPhpVersion('7.1');

--- a/Test/Unit/Model/Api/Data/PluginVersionTest.php
+++ b/Test/Unit/Model/Api/Data/PluginVersionTest.php
@@ -31,7 +31,7 @@ class PluginVersionTest extends TestCase
      */
     protected $pluginVersion;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->pluginVersion = new PluginVersion();
     }

--- a/Test/Unit/Model/Api/Data/ShippingDataTest.php
+++ b/Test/Unit/Model/Api/Data/ShippingDataTest.php
@@ -39,7 +39,7 @@ class ShippingDataTest extends TestCase
      */
     private $shippingOptions;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->shippingOptions = [new ShippingOption];
         $this->shippingData = new ShippingData;

--- a/Test/Unit/Model/Api/Data/ShippingOptionTest.php
+++ b/Test/Unit/Model/Api/Data/ShippingOptionTest.php
@@ -37,7 +37,7 @@ class ShippingOptionTest extends TestCase
      */
     protected $shippingOption;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->shippingOption = new ShippingOption();
         $this->shippingOption->setReference(self::REFERENCE);

--- a/Test/Unit/Model/Api/Data/ShippingOptionsTest.php
+++ b/Test/Unit/Model/Api/Data/ShippingOptionsTest.php
@@ -37,7 +37,7 @@ class ShippingOptionsTest extends TestCase
      */
     protected $shippingOptions;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->shippingOptions = new \Bolt\Boltpay\Model\Api\Data\ShippingOptions();
     }

--- a/Test/Unit/Model/Api/Data/ShippingTaxTest.php
+++ b/Test/Unit/Model/Api/Data/ShippingTaxTest.php
@@ -32,7 +32,7 @@ class ShippingTaxTest extends TestCase
      */
     protected $shippingTax;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->shippingTax = new \Bolt\Boltpay\Model\Api\Data\ShippingTax;
     }

--- a/Test/Unit/Model/Api/Data/TaxDataTest.php
+++ b/Test/Unit/Model/Api/Data/TaxDataTest.php
@@ -45,7 +45,7 @@ class TaxDataTest extends TestCase
      */
     private $shippingOption;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->taxResult = new TaxResult;
         $this->shippingOption = new ShippingOption;

--- a/Test/Unit/Model/Api/Data/TaxResultTest.php
+++ b/Test/Unit/Model/Api/Data/TaxResultTest.php
@@ -35,7 +35,7 @@ class TaxResultTest extends TestCase
      */
     private $taxResult;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->taxResult = new TaxResult;
         $this->taxResult->setSubtotalAmount(self::SUBTOTAL_AMOUNT);

--- a/Test/Unit/Model/Api/Data/UpdateCartResultTest.php
+++ b/Test/Unit/Model/Api/Data/UpdateCartResultTest.php
@@ -57,7 +57,7 @@ class UpdateCartResultTest extends TestCase
      */
     private $typeProcessor;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->updateCartResult = new UpdateCartResult;
         $this->orderCreate = new CartData;
@@ -106,7 +106,7 @@ class UpdateCartResultTest extends TestCase
      *
      * @covers ::getStatus
      */
-    public function getStatus()
+    public function getStatus(): int
     {
         $this->assertEquals(self::STATUS, $this->updateCartResult->getStatus());
     }

--- a/Test/Unit/Model/Api/DebugTest.php
+++ b/Test/Unit/Model/Api/DebugTest.php
@@ -95,7 +95,7 @@ class DebugTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUp(): void
     {
         // prepare response
         $this->responseMock = $this->createMock(Response::class);

--- a/Test/Unit/Model/Api/DiscountCodeValidationTest.php
+++ b/Test/Unit/Model/Api/DiscountCodeValidationTest.php
@@ -227,7 +227,7 @@ class DiscountCodeValidationTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->initRequiredMocks();        
     }

--- a/Test/Unit/Model/Api/FeatureSwitchesHookTest.php
+++ b/Test/Unit/Model/Api/FeatureSwitchesHookTest.php
@@ -79,7 +79,7 @@ class FeatureSwitchesHookTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUp(): void
     {
         $rendererFactory = $this->createMock(RendererFactory::class);
         $errorProcessor = $this->createMock(ErrorProcessor::class);

--- a/Test/Unit/Model/Api/OrderManagementTest.php
+++ b/Test/Unit/Model/Api/OrderManagementTest.php
@@ -103,7 +103,7 @@ class OrderManagementTest extends TestCase
     /**
      * @inheritdoc
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->initRequiredMocks();
         $this->initCurrentMock([]);

--- a/Test/Unit/Model/Api/ShippingMethodsTest.php
+++ b/Test/Unit/Model/Api/ShippingMethodsTest.php
@@ -195,7 +195,7 @@ class ShippingMethodsTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->createFactoryMocks();
 

--- a/Test/Unit/Model/Api/ShippingTaxContextTest.php
+++ b/Test/Unit/Model/Api/ShippingTaxContextTest.php
@@ -105,7 +105,7 @@ class ShippingTaxContextTest extends TestCase
      */
     private $currentMock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->hookHelper = $this->createMock(HookHelper::class);
         $this->cartHelper = $this->createMock(CartHelper::class);

--- a/Test/Unit/Model/Api/ShippingTaxTest.php
+++ b/Test/Unit/Model/Api/ShippingTaxTest.php
@@ -130,7 +130,7 @@ class ShippingTaxTest extends TestCase
      */
     private $currentMock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->hookHelper = $this->createMock(HookHelper::class);
         $this->cartHelper = $this->createMock(CartHelper::class);

--- a/Test/Unit/Model/Api/ShippingTest.php
+++ b/Test/Unit/Model/Api/ShippingTest.php
@@ -72,7 +72,7 @@ class ShippingTest extends TestCase
      */
     private $currentMock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->shippingTaxContext = $this->createMock(ShippingTaxContext::class);
         $this->shippingDataFactory = $this->createMock(ShippingDataInterfaceFactory::class);

--- a/Test/Unit/Model/Api/TaxTest.php
+++ b/Test/Unit/Model/Api/TaxTest.php
@@ -76,7 +76,7 @@ class TaxTest extends TestCase
      */
     private $currentMock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->shippingTaxContext = $this->createMock(ShippingTaxContext::class);
 

--- a/Test/Unit/Model/Api/UpdateCartCommonTest.php
+++ b/Test/Unit/Model/Api/UpdateCartCommonTest.php
@@ -195,7 +195,7 @@ class UpdateCartCommonTest extends TestCase
     protected $stockStateInterface;
 
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->request = $this->createMock(Request::class);
         $this->response = $this->createMock(Response::class);

--- a/Test/Unit/Model/Api/UpdateCartContextTest.php
+++ b/Test/Unit/Model/Api/UpdateCartContextTest.php
@@ -177,7 +177,7 @@ class UpdateCartContextTest extends TestCase
      */
     private $currentMock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->request = $this->createMock(Request::class);
         $this->response = $this->createMock(Response::class);

--- a/Test/Unit/Model/Api/UpdateCartItemTraitTest.php
+++ b/Test/Unit/Model/Api/UpdateCartItemTraitTest.php
@@ -53,7 +53,7 @@ class UpdateCartItemTraitTest extends TestCase
     private $currentMock;
 
 
-    public function setUp()
+    public function setUp(): void
     {            
         $this->currentMock = $this->getMockBuilder(UpdateCartItemTrait::class)
             ->setMethods(['sendErrorResponse'])

--- a/Test/Unit/Model/Api/UpdateCartTest.php
+++ b/Test/Unit/Model/Api/UpdateCartTest.php
@@ -126,7 +126,7 @@ class UpdateCartTest extends TestCase
      */
     private $cacheMock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->updateCartContext = $this->getMockBuilder(UpdateCartContext::class)
             ->setMethods(['getSessionHelper', 'getCache'])

--- a/Test/Unit/Model/Api/UpdateDiscountTraitTest.php
+++ b/Test/Unit/Model/Api/UpdateDiscountTraitTest.php
@@ -138,7 +138,7 @@ class UpdateDiscountTraitTest extends TestCase
     private $currentMock;
 
 
-    public function setUp()
+    public function setUp(): void
     {
         global $ifRunFilter;
         $ifRunFilter = false;
@@ -216,7 +216,7 @@ class UpdateDiscountTraitTest extends TestCase
         $this->initRequiredMocks();
     }
 
-    public function tearDown() {
+    public function tearDown(): void {
 		parent::tearDown();
 		global $ifRunFilter;
         $ifRunFilter = false;

--- a/Test/Unit/Model/Api/UpdateSettingsTest.php
+++ b/Test/Unit/Model/Api/UpdateSettingsTest.php
@@ -80,7 +80,7 @@ class UpdateTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUp(): void
     {
         // prepare bolt config setting factory
         $this->boltConfigSettingFactoryMock = $this->createMock(BoltConfigSettingFactory::class);

--- a/Test/Unit/Model/CustomerCreditCardTest.php
+++ b/Test/Unit/Model/CustomerCreditCardTest.php
@@ -101,7 +101,7 @@ class CustomerCreditCardTest extends TestCase
     /**
      * Setup for CustomerCreditCardTest Class
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->dataObjectFactory = $this->getMockBuilder(DataObjectFactory::class)
             ->disableOriginalConstructor()

--- a/Test/Unit/Model/ErrorResponseTest.php
+++ b/Test/Unit/Model/ErrorResponseTest.php
@@ -32,7 +32,7 @@ class ErrorResponseTest extends TestCase
      */
     private $currentMock;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->currentMock = new ErrorResponse();
     }

--- a/Test/Unit/Model/FeatureSwitchTest.php
+++ b/Test/Unit/Model/FeatureSwitchTest.php
@@ -32,7 +32,7 @@ class FeatureSwitchTest extends TestCase
     /**
      * Setup for FeatureSwitchTest Class
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->mockFeatureSwitch = $this->getMockBuilder(FeatureSwitch::class)
             ->disableOriginalConstructor()

--- a/Test/Unit/Model/PaymentTest.php
+++ b/Test/Unit/Model/PaymentTest.php
@@ -172,7 +172,7 @@ class PaymentTest extends TestCase
     /** @var MockObject|Manager */
     private $eventManager;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         global $boltPaymentTestActive;
         $this->initRequiredMocks();

--- a/Test/Unit/Model/ResourceModel/CustomerCreditCard/CollectionTest.php
+++ b/Test/Unit/Model/ResourceModel/CustomerCreditCard/CollectionTest.php
@@ -42,7 +42,7 @@ class CollectionTest extends TestCase
     /**
      * Setup for CollectionTest Class
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->mockCustomerCreditCardCollection = $this->getMockBuilder(Collection::class)
             ->disableOriginalConstructor()

--- a/Test/Unit/Model/ResourceModel/CustomerCreditCardTest.php
+++ b/Test/Unit/Model/ResourceModel/CustomerCreditCardTest.php
@@ -30,7 +30,7 @@ class CustomerCreditCardTest extends TestCase
     /**
      * Setup for CustomerCreditCardTest Class
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->mockCustomerCreditCard = $this->getMockBuilder(CustomerCreditCard::class)
             ->disableOriginalConstructor()

--- a/Test/Unit/Model/ResourceModel/FeatureSwitchTest.php
+++ b/Test/Unit/Model/ResourceModel/FeatureSwitchTest.php
@@ -31,7 +31,7 @@ class FeatureSwitchTest extends TestCase
     /**
      * Setup for CustomerCreditCardTest Class
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->mockFeatureSwitch = $this->getMockBuilder(FeatureSwitch::class)
             ->disableOriginalConstructor()

--- a/Test/Unit/Model/ResourceModel/WebhookLog/CollectionTest.php
+++ b/Test/Unit/Model/ResourceModel/WebhookLog/CollectionTest.php
@@ -34,7 +34,7 @@ class CollectionTest extends TestCase
     /**
      * Setup for CollectionTest Class
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->webhookLogCollectionMock = $this->getMockBuilder(Collection::class)
             ->disableOriginalConstructor()

--- a/Test/Unit/Model/ResourceModel/WebhookLogTest.php
+++ b/Test/Unit/Model/ResourceModel/WebhookLogTest.php
@@ -31,7 +31,7 @@ class WebhookLogTest extends TestCase
     /**
      * Setup for CustomerCreditCardTest Class
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->wehookLogMock = $this->getMockBuilder(WebhookLog::class)
             ->disableOriginalConstructor()

--- a/Test/Unit/Model/Service/InvoiceServiceTest.php
+++ b/Test/Unit/Model/Service/InvoiceServiceTest.php
@@ -100,7 +100,7 @@ class InvoiceServiceTest extends TestCase
      */
     private $currentMock;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->repository = $this->createMock(InvoiceRepositoryInterface::class);
         $this->commentRepository = $this->createMock(InvoiceCommentRepositoryInterface::class);

--- a/Test/Unit/Model/ThirdPartyModuleFactoryTest.php
+++ b/Test/Unit/Model/ThirdPartyModuleFactoryTest.php
@@ -57,7 +57,7 @@ class ThirdPartyModuleFactoryTest extends TestCase
      */
     private $currentMock;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->_moduleManager = $this->createPartialMock(
             Manager::class,

--- a/Test/Unit/Model/WebhookLogTest.php
+++ b/Test/Unit/Model/WebhookLogTest.php
@@ -61,7 +61,7 @@ class WebhookLogTest extends TestCase
      */
     private $resourceCollection;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->coreDate = $this->createPartialMock(DateTime::class, ['gmtDate']);
         $this->context = $this->createMock(Context::class);

--- a/Test/Unit/Observer/Adminhtml/ActionPredispatchTest.php
+++ b/Test/Unit/Observer/Adminhtml/ActionPredispatchTest.php
@@ -38,7 +38,7 @@ class ActionPredispatchTest extends TestCase
     /**
      * Setup test dependencies, called before each test
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->eventsForThirdPartyModulesMock = $this->createMock(
             \Bolt\Boltpay\Model\EventsForThirdPartyModules::class

--- a/Test/Unit/Observer/Adminhtml/Sales/CreatingInvoiceForRechargeOrderTest.php
+++ b/Test/Unit/Observer/Adminhtml/Sales/CreatingInvoiceForRechargeOrderTest.php
@@ -66,7 +66,7 @@ class CreateInvoiceForRechargedOrderTest extends TestCase
      */
     protected $invoice;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->invoiceService = $this->createPartialMock(InvoiceService::class, ['prepareInvoice']);
         $this->invoiceSender = $this->createPartialMock(InvoiceSender::class, ['send']);

--- a/Test/Unit/Observer/Adminhtml/Sales/OrderCreateProcessDataObserverTest.php
+++ b/Test/Unit/Observer/Adminhtml/Sales/OrderCreateProcessDataObserverTest.php
@@ -55,7 +55,7 @@ class OrderCreateProcessDataObserverTest extends TestCase
      */
     protected $quote;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->observer = $this->createPartialMock(
             Observer::class,

--- a/Test/Unit/Observer/Adminhtml/Sales/RechargeCustomerTest.php
+++ b/Test/Unit/Observer/Adminhtml/Sales/RechargeCustomerTest.php
@@ -77,7 +77,7 @@ class RechargeCustomerTest extends TestCase
      */
     private $customerCreditCardFactoryMock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->initRequiredMocks();
         $this->initCurrentMock();

--- a/Test/Unit/Observer/ClearBoltShippingTaxCacheObserverTest.php
+++ b/Test/Unit/Observer/ClearBoltShippingTaxCacheObserverTest.php
@@ -40,7 +40,7 @@ class ClearBoltShippingTaxCacheObserverTest extends TestCase
      */
     private $cache;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->cache = $this->createPartialMock(CacheInterface::class, ['clean', 'remove', 'save', 'load', 'getFrontend']);
         $this->currentMock = new ClearBoltShippingTaxCacheObserver($this->cache);

--- a/Test/Unit/Observer/TrackingSaveObserverTest.php
+++ b/Test/Unit/Observer/TrackingSaveObserverTest.php
@@ -77,7 +77,7 @@ class TrackingSaveObserverTest extends TestCase
      */
     protected $observer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->initRequiredMocks();
     }

--- a/Test/Unit/Plugin/AbstractLoginPluginTest.php
+++ b/Test/Unit/Plugin/AbstractLoginPluginTest.php
@@ -71,7 +71,7 @@ class AbstractLoginPluginTest extends TestCase
      */
     private $decider;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->customerSession = $this->createPartialMock(
             CustomerSession::class,

--- a/Test/Unit/Plugin/CheckSettingsUpdateTest.php
+++ b/Test/Unit/Plugin/CheckSettingsUpdateTest.php
@@ -64,7 +64,7 @@ class CheckSettingsUpdateTest extends TestCase
      */
     private $bugsnag;
 
-    public function setUp()
+    public function setUp(): void
     {
         /*
         $this->context = $this->getMockBuilder(Context::class)

--- a/Test/Unit/Plugin/ClearQuoteTest.php
+++ b/Test/Unit/Plugin/ClearQuoteTest.php
@@ -45,7 +45,7 @@ class ClearQuoteTest extends TestCase
      */
     protected $plugin;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->cartHelper = $this->getMockBuilder(CartHelper::class)
             ->setMethods(['getIsActive', 'getQuoteById'])

--- a/Test/Unit/Plugin/LoginPostPluginTest.php
+++ b/Test/Unit/Plugin/LoginPostPluginTest.php
@@ -56,7 +56,7 @@ class LoginPostPluginTest extends TestCase
     /** @var @var Decider */
     private $decider;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->customerSession = $this->createMock(CustomerSession::class);
         $this->checkoutSession = $this->createMock(CheckoutSession::class);

--- a/Test/Unit/Plugin/MageVision/FreeShippingAdmin/MethodPluginTest.php
+++ b/Test/Unit/Plugin/MageVision/FreeShippingAdmin/MethodPluginTest.php
@@ -57,7 +57,7 @@ class MethodPluginTest extends TestCase
 
     private $subject;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->rateResultFactory = $this->createPartialMock(ResultFactory::class, ['create', 'append']);
         $this->resultMethodFactory = $this->createPartialMock(MethodFactory::class, [

--- a/Test/Unit/Plugin/Magento/Framework/View/Element/UiComponent/DataProvider/DataProviderPluginTest.php
+++ b/Test/Unit/Plugin/Magento/Framework/View/Element/UiComponent/DataProvider/DataProviderPluginTest.php
@@ -49,7 +49,7 @@ class DataProviderPluginTest extends \PHPUnit\Framework\TestCase
      */
     private $paymentMock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->paymentCollectionFactoryMock = $this->createPartialMock(
             \Magento\Sales\Model\ResourceModel\Order\Payment\CollectionFactory::class,

--- a/Test/Unit/Plugin/Magento/GiftCard/GenerateGiftCardAccountsOrderPluginTest.php
+++ b/Test/Unit/Plugin/Magento/GiftCard/GenerateGiftCardAccountsOrderPluginTest.php
@@ -62,7 +62,7 @@ class GenerateGiftCardAccountsOrderPluginTest extends TestCase
     /** @var GenerateGiftCardAccountsOrderPlugin  */
     protected $plugin;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $objectManager = new ObjectManager($this);
         $this->plugin = $objectManager->getObject(

--- a/Test/Unit/Plugin/Magento/Rewards/Controller/Cart/RemoveActionPluginTest.php
+++ b/Test/Unit/Plugin/Magento/Rewards/Controller/Cart/RemoveActionPluginTest.php
@@ -52,7 +52,7 @@ class RemoveActionPluginTest extends TestCase
     /**
      * Setup method, called before each test
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->configHelper = $this->createMock(\Bolt\Boltpay\Helper\Config::class);
         $this->subject = $this->getMockBuilder('\Magento\Reward\Controller\Cart\Remove')

--- a/Test/Unit/Plugin/Magento/Sales/Model/AdminOrder/CreatePluginTest.php
+++ b/Test/Unit/Plugin/Magento/Sales/Model/AdminOrder/CreatePluginTest.php
@@ -69,7 +69,7 @@ Room 1111',
     /** @var CreatePlugin */
     protected $plugin;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->configHelper = $this->createPartialMock(ConfigHelper::class, ['isStorePickupFeatureEnabled', 'isPickupInStoreShippingMethodCode', 'getPickupAddressData']);
         $this->adminCheckoutSession = $this->createPartialMock(AdminCheckoutSession::class, ['setData', 'getData', 'unsetData']);

--- a/Test/Unit/Plugin/Magento/TogglePaymentMethodsPluginTest.php
+++ b/Test/Unit/Plugin/Magento/TogglePaymentMethodsPluginTest.php
@@ -58,7 +58,7 @@ class TogglePaymentMethodsPluginTest extends TestCase
     /** @var DataObject|MockObject  */
     protected $result;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->plugin = (new ObjectManager($this))->getObject(TogglePaymentMethodsPlugin::class);
         $this->subject = $this->createMock(

--- a/Test/Unit/Plugin/Magento/Ui/Component/Form/Element/SelectPluginTest.php
+++ b/Test/Unit/Plugin/Magento/Ui/Component/Form/Element/SelectPluginTest.php
@@ -37,7 +37,7 @@ class SelectPluginTest extends \PHPUnit\Framework\TestCase
      */
     private $contextMock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->subjectMock = $this->createMock(\Magento\Ui\Component\Form\Element\Select::class);
         $this->contextMock = $this->createMock(\Magento\Framework\View\Element\UiComponent\Context::class);

--- a/Test/Unit/Plugin/Mirasvit/Rewards/Model/PurchasePluginTest.php
+++ b/Test/Unit/Plugin/Mirasvit/Rewards/Model/PurchasePluginTest.php
@@ -56,7 +56,7 @@ class PurchasePluginTest extends TestCase
     /** @var callable */
     private $callback;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->urlInterface = $this->getMockBuilder(UrlInterface::class)
             ->getMock();

--- a/Test/Unit/Plugin/NonBoltOrderObserverTest.php
+++ b/Test/Unit/Plugin/NonBoltOrderObserverTest.php
@@ -112,7 +112,7 @@ class NonBoltOrderObserverTest extends TestCase
      */
     protected $orderManagementInterface;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->initRequiredMocks();
     }

--- a/Test/Unit/Plugin/OrderPluginTest.php
+++ b/Test/Unit/Plugin/OrderPluginTest.php
@@ -53,7 +53,7 @@ class OrderPluginTest extends TestCase
     /** @var callable|MockObject */
     protected $callback;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->plugin = (new ObjectManager($this))->getObject(OrderPlugin::class);
         $this->subject = $this->createPartialMock(Order::class, [

--- a/Test/Unit/Plugin/OrderSenderPluginTest.php
+++ b/Test/Unit/Plugin/OrderSenderPluginTest.php
@@ -52,7 +52,7 @@ class OrderSenderPluginTest extends TestCase
     /** @var callable */
     private $callback;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->order = $this->createPartialMock(Order::class, ['getPayment', 'getMethod', 'getState']);
         $this->subject = $this->createPartialMock(OrderSender::class, ['getPayment', 'getMethod']);

--- a/Test/Unit/Plugin/QuotePluginTest.php
+++ b/Test/Unit/Plugin/QuotePluginTest.php
@@ -48,7 +48,7 @@ class QuotePluginTest extends TestCase
     /** @var callable|MockObject */
     protected $callback;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->subject = $this->getMockBuilder(Quote::class)
             ->setMethods(['getBoltParentQuoteId', 'getId', 'getIsActive', 'getBoltCheckoutType', 'getPayment', 'getMethod'])

--- a/Test/Unit/Plugin/RestoreQuotePluginTest.php
+++ b/Test/Unit/Plugin/RestoreQuotePluginTest.php
@@ -69,7 +69,7 @@ class RestoreQuotePluginTest extends TestCase
     /** @var callable|MockObject */
     protected $callback;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->checkoutSession = $this->createPartialMock(
             CheckoutSession::class,

--- a/Test/Unit/Plugin/SalesRuleActionDiscountPluginTest.php
+++ b/Test/Unit/Plugin/SalesRuleActionDiscountPluginTest.php
@@ -46,7 +46,7 @@ class SalesRuleActionDiscountPluginTest extends TestCase
     /** @var AbstractDiscount */
     protected $subject;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->subject = $this->createMock(AbstractDiscount::class);
         $this->sessionHelper = $this->createPartialMock(SessionHelper::class,

--- a/Test/Unit/Plugin/SalesRuleQuoteDiscountPluginTest.php
+++ b/Test/Unit/Plugin/SalesRuleQuoteDiscountPluginTest.php
@@ -45,7 +45,7 @@ class SalesRuleQuoteDiscountPluginTest extends TestCase
     /** @var Discount */
     protected $subject;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->subject = $this->createMock(Discount::class);
         $this->sessionHelper = $this->createPartialMock(SessionHelper::class,

--- a/Test/Unit/Section/CustomerData/BoltCartTest.php
+++ b/Test/Unit/Section/CustomerData/BoltCartTest.php
@@ -42,7 +42,7 @@ class BoltCartTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->cartHelper = $this->createPartialMock(CartHelper::class, ['calculateCartAndHints']);
         $this->boltCart = (new ObjectManager($this))->getObject(

--- a/Test/Unit/Section/CustomerData/BoltHintsTest.php
+++ b/Test/Unit/Section/CustomerData/BoltHintsTest.php
@@ -29,7 +29,7 @@ class BoltHintsTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUp(): void
     {
 
         $this->cartHelper = $this->createMock(CartHelper::class);

--- a/Test/Unit/Setup/RecurringDataTest.php
+++ b/Test/Unit/Setup/RecurringDataTest.php
@@ -68,7 +68,7 @@ class RecurringDataTest extends TestCase
      */
     private $currentMock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->fsManager = $this->createPartialMock(Manager::class, ['updateSwitchesFromBolt']);
         $this->logHelper = $this->createPartialMock(LogHelper::class, ['addInfoLog']);

--- a/Test/Unit/Setup/RecurringTest.php
+++ b/Test/Unit/Setup/RecurringTest.php
@@ -56,7 +56,7 @@ class RecurringTest extends TestCase
      */
     private $customTable;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->setup = $this->createMock(ModuleDataSetupInterface::class);
         $this->context = $this->createMock(ModuleContextInterface::class);

--- a/Test/Unit/Setup/UpgradeSchemaTest.php
+++ b/Test/Unit/Setup/UpgradeSchemaTest.php
@@ -51,7 +51,7 @@ class UpgradeSchemaTest extends TestCase
     /**
      * Setup test dependencies, called before each test
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->dbAdapter = $this->getMockBuilder(AdapterInterface::class)
             ->disableOriginalConstructor()

--- a/Test/Unit/ThirdPartyModules/Aheadworks/Sarp2Test.php
+++ b/Test/Unit/ThirdPartyModules/Aheadworks/Sarp2Test.php
@@ -34,7 +34,7 @@ class Sarp2Test extends TestCase
     /**
      * Setup test dependencies, called before each test
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->objectManagerMock = $this->createMock(\Magento\Framework\ObjectManager\ObjectManager::class);
         $this->configLoaderMock = $this->createMock(\Magento\Framework\App\ObjectManager\ConfigLoader::class);

--- a/Test/Unit/ThirdPartyModules/Amasty/GiftCardAccountTest.php
+++ b/Test/Unit/ThirdPartyModules/Amasty/GiftCardAccountTest.php
@@ -157,7 +157,7 @@ class GiftCardAccountTest extends TestCase
     /**
      * Setup test dependencies, called before each test
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->giftcardAccountRepositoryMock = $this->getMockBuilder(
             '\Amasty\GiftCardAccount\Api\GiftCardAccountRepositoryInterface'

--- a/Test/Unit/ThirdPartyModules/IDme/GroupVerificationTest.php
+++ b/Test/Unit/ThirdPartyModules/IDme/GroupVerificationTest.php
@@ -52,7 +52,7 @@ class GroupVerificationTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->customerSession = $this->quote = $this->createPartialMock(Session::class, [
             'setIdmeUuid',

--- a/Test/Unit/ViewModel/MinicartAddonsTest.php
+++ b/Test/Unit/ViewModel/MinicartAddonsTest.php
@@ -62,7 +62,7 @@ class MinicartAddonsTest extends TestCase
     /**
      * Setup test dependencies, called before each test
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->configHelper = $this->createMock(\Bolt\Boltpay\Helper\Config::class);
         $this->serializer = (new ObjectManager($this))


### PR DESCRIPTION
# Description
To make the PHPUnit test functions compatible with PHPUnit 9 for Magento 2.4.x, we need to add return type declaration to functions. 
And PHP 7.0 starts to support Return type declarations
https://www.php.net/manual/en/migration70.new-features.php#migration70.new-features.return-type-declarations, then from Magento 2 v2.2.x it drops the support for php5. So it is safe to add return type declaration to our test functions, it would work both with PHPUnit 6 (for M2 v2.3.x) and PHPUnit 9 (for M2 v2.4.x)

Fixes: (link Jira ticket)

#changelog Add return type declaration to PHPUnit test functions

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
