### PR TITLE
 M2P-333 Use integration tests instead of unit test for methods (processExistingOrder,tryDeclinedPaymentCancelation,getExistingOrder) in class Helper/Order

### DIFF
--- a/Test/Unit/TestUtils.php
+++ b/Test/Unit/TestUtils.php
@@ -45,6 +45,15 @@ class TestUtils {
     }
 
     /**
+     * @param $orderId
+     * @return mixed
+     */
+    public static function getOrderById($orderId)
+    {
+        return Bootstrap::getObjectManager()->get(Order::class)->load($orderId);
+    }
+
+    /**
      * @param $quote
      * @return mixed
      */
@@ -114,6 +123,7 @@ class TestUtils {
             ->setProductType('simple')
             ->setName($product->getName());
 
+
         /** @var Order $order */
         $order = $objectManager->create(Order::class);
         $order->setIncrementId('100000001')
@@ -123,6 +133,7 @@ class TestUtils {
             ->setGrandTotal(100)
             ->setBaseSubtotal(100)
             ->setBaseGrandTotal(100)
+            ->setOrderCurrencyCode('USD')
             ->setCustomerIsGuest(true)
             ->setCustomerEmail('johnmc@bolt.com')
             ->setBillingAddress($billingAddress)
@@ -130,6 +141,7 @@ class TestUtils {
             ->setStoreId($objectManager->get(StoreManagerInterface::class)->getStore()->getId())
             ->addItem($orderItem)
             ->setPayment($payment);
+
 
         if ($data){
             foreach ($data as $key => $value) {
@@ -227,6 +239,9 @@ class TestUtils {
         foreach ($objects as $object) {
             switch (get_class($object)) {
                 case "Magento\Catalog\Model\Product\Interceptor":
+                    $object->delete();
+                    break;
+                case "Magento\Sales\Model\Order\Interceptor":
                     $object->delete();
                     break;
                 default:


### PR DESCRIPTION
# Description
 Use integration tests instead of unit test for methods (processExistingOrder,tryDeclinedPaymentCancelation,getExistingOrder) in class Helper/Order

Fixes: https://boltpay.atlassian.net/browse/M2P-333

#changelog  M2P-333 Use integration tests instead of unit test for methods (processExistingOrder,tryDeclinedPaymentCancelation,getExistingOrder) in class Helper/Order

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
