### PR TITLE
M2P-259 Re-add parentheses to discount display

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1968,7 +1968,7 @@ class Cart extends AbstractHelper
                         case RuleInterface::COUPON_TYPE_AUTO:
                             $couponCode = $quote->getCouponCode();
                             $ruleDescription = $rule->getDescription();
-                            $description = trim(__('Discount (') . ($ruleDescription !== '' ? $ruleDescription : $couponCode) . ')');
+                            $description = $ruleDescription !== '' ? $ruleDescription : 'Discount (' . $couponCode . ')';
                             $discounts[] = [
                                 'description'       => $description,
                                 'amount'            => $roundedAmount,

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1968,7 +1968,7 @@ class Cart extends AbstractHelper
                         case RuleInterface::COUPON_TYPE_AUTO:
                             $couponCode = $quote->getCouponCode();
                             $ruleDescription = $rule->getDescription();
-                            $description = trim(__('Discount ') . ($ruleDescription !== '' ? $ruleDescription : $couponCode));
+                            $description = trim(__('Discount ($1)', $ruleDescription !== '' ? $ruleDescription : $couponCode));
                             $discounts[] = [
                                 'description'       => $description,
                                 'amount'            => $roundedAmount,

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1968,7 +1968,7 @@ class Cart extends AbstractHelper
                         case RuleInterface::COUPON_TYPE_AUTO:
                             $couponCode = $quote->getCouponCode();
                             $ruleDescription = $rule->getDescription();
-                            $description = trim(__('Discount ($1)', $ruleDescription !== '' ? $ruleDescription : $couponCode));
+                            $description = trim(__('Discount (') . ($ruleDescription !== '' ? $ruleDescription : $couponCode) . ')');
                             $discounts[] = [
                                 'description'       => $description,
                                 'amount'            => $roundedAmount,

--- a/Model/Api/DiscountCodeValidation.php
+++ b/Model/Api/DiscountCodeValidation.php
@@ -398,7 +398,7 @@ class DiscountCodeValidation extends UpdateCartCommon implements DiscountCodeVal
             'status'          => 'success',
             'discount_code'   => $couponCode,
             'discount_amount' => abs(CurrencyUtils::toMinor($address->getDiscountAmount(), $parentQuote->getQuoteCurrencyCode())),
-            'description'     =>  __('Discount ($1)', $description !== '' ? $description : $couponCode),
+            'description'     =>  __('Discount (') . ($description !== '' ? $description : $couponCode),
             'discount_type'   => $this->discountHelper->convertToBoltDiscountType($couponCode),
         ];
     }

--- a/Model/Api/DiscountCodeValidation.php
+++ b/Model/Api/DiscountCodeValidation.php
@@ -393,12 +393,13 @@ class DiscountCodeValidation extends UpdateCartCommon implements DiscountCodeVal
 
         $address = $parentQuote->isVirtual() ? $parentQuote->getBillingAddress() : $parentQuote->getShippingAddress();
         $description = $address->getDiscountDescription();
+        $description = $description !== '' ? $description : 'Discount (' . $couponCode . ')';
 
         return $result = [
             'status'          => 'success',
             'discount_code'   => $couponCode,
             'discount_amount' => abs(CurrencyUtils::toMinor($address->getDiscountAmount(), $parentQuote->getQuoteCurrencyCode())),
-            'description'     =>  __('Discount (') . ($description !== '' ? $description : $couponCode),
+            'description'     => $description,
             'discount_type'   => $this->discountHelper->convertToBoltDiscountType($couponCode),
         ];
     }

--- a/Model/Api/DiscountCodeValidation.php
+++ b/Model/Api/DiscountCodeValidation.php
@@ -398,7 +398,7 @@ class DiscountCodeValidation extends UpdateCartCommon implements DiscountCodeVal
             'status'          => 'success',
             'discount_code'   => $couponCode,
             'discount_amount' => abs(CurrencyUtils::toMinor($address->getDiscountAmount(), $parentQuote->getQuoteCurrencyCode())),
-            'description'     =>  __('Discount ') . ($description !== '' ? $description : $couponCode),
+            'description'     =>  __('Discount ($1)', $description !== '' ? $description : $couponCode),
             'discount_type'   => $this->discountHelper->convertToBoltDiscountType($couponCode),
         ];
     }

--- a/Model/Api/UpdateDiscountTrait.php
+++ b/Model/Api/UpdateDiscountTrait.php
@@ -379,7 +379,7 @@ trait UpdateDiscountTrait
         }
 
         $description = $rule->getDescription();
-        $display = trim(__('Discount (' . ($description != '' ? $description : $couponCode) . ')')); 
+        $display = $description != '' ? $description : 'Discount (' . $couponCode . ')'; 
 
         $result = [
             'status'          => 'success',

--- a/Model/Api/UpdateDiscountTrait.php
+++ b/Model/Api/UpdateDiscountTrait.php
@@ -379,7 +379,7 @@ trait UpdateDiscountTrait
         }
 
         $description = $rule->getDescription();
-        $display = trim(__('Discount ') . ($description != '' ? $description : $couponCode));
+        $display = trim(__('Discount ($1)', $description != '' ? $description : $couponCode)); 
 
         $result = [
             'status'          => 'success',

--- a/Model/Api/UpdateDiscountTrait.php
+++ b/Model/Api/UpdateDiscountTrait.php
@@ -379,7 +379,7 @@ trait UpdateDiscountTrait
         }
 
         $description = $rule->getDescription();
-        $display = trim(__('Discount ($1)', $description != '' ? $description : $couponCode)); 
+        $display = trim(__('Discount (' . ($description != '' ? $description : $couponCode) . ')')); 
 
         $result = [
             'status'          => 'success',

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -3678,7 +3678,7 @@ ORDER
         $expectedTotalAmount = $totalAmount - (2 * $expectedDiscountAmount) - $expectedDiscountAmountNoCoupon;
         $expectedDiscount = [
             [
-                'description' => trim(__('Discount ') . self::COUPON_DESCRIPTION),
+                'description' => self::COUPON_DESCRIPTION,
                 'amount'      => $expectedDiscountAmount,
                 'reference'   => self::COUPON_CODE,
                 'discount_category' => 'coupon',
@@ -3693,7 +3693,7 @@ ORDER
                 'type'   => 'fixed_amount',
             ],
             [
-                'description' => trim(__('Discount ' . self::COUPON_CODE)),
+                'description' => trim(__('Discount (' . self::COUPON_CODE . ')')),
                 'amount'      => $expectedDiscountAmount,
                 'reference'   => self::COUPON_CODE,
                 'discount_category' => 'coupon',
@@ -4141,7 +4141,7 @@ ORDER
         $expectedTotalAmount = $totalAmount - $expectedRegularDiscountAmount - $expectedGiftVoucherAmount;
         $expectedDiscount = [
             [
-                'description' => trim(__('Discount ') . self::COUPON_DESCRIPTION),
+                'description' => self::COUPON_DESCRIPTION,
                 'amount'      => $expectedRegularDiscountAmount,
                 'reference'   => $giftVoucher,
                 'discount_category' => 'coupon',

--- a/Test/Unit/Model/Api/DiscountCodeValidationTest.php
+++ b/Test/Unit/Model/Api/DiscountCodeValidationTest.php
@@ -616,7 +616,7 @@ class DiscountCodeValidationTest extends TestCase
             'status'          => 'success',
             'discount_code'   => self::COUPON_CODE,
             'discount_amount' => $shippingDiscountAmount * 100,
-            'description'     => 'Discount Test Shipping Discount Description',
+            'description'     => 'Test Shipping Discount Description',
             'discount_type'   => 'fixed_amount',
             'cart'            => [
                 'total_amount' => 10000,


### PR DESCRIPTION
# Description
Re-adds parentheses to discount display when displaying the discount code.

Fixes: [M2P-259](https://boltpay.atlassian.net/browse/M2P-259?atlOrigin=eyJpIjoiYjlmNWFjZDQxNTZjNDVlNmJjY2I2N2Y0ZGU3NmI1NjEiLCJwIjoiaiJ9)

Discount description "Test description":
![image](https://user-images.githubusercontent.com/3057698/102114208-f0c3f780-3e07-11eb-9964-2bd1647fe593.png)


No description, discount code "NODES":
![image](https://user-images.githubusercontent.com/3057698/102114157-e1dd4500-3e07-11eb-898b-21decf979080.png)


#changelog M2P-259 Re-add parentheses to discount display

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
