### PR TITLE
M2P-412 Make phpunit green on Magento 2.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -288,7 +288,7 @@ workflows:
   build:
     when: << pipeline.parameters.run_default_workflow >>
     jobs:
-      #- unit-php74-magento24
+      - unit-php74-magento24
       - unit-php72-magento23
       - unit-php71-magento22
       - unit-php70-magento22

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -436,6 +436,13 @@ class Config extends AbstractHelper
         "capture_merchant_metrics" => self::XML_PATH_CAPTURE_MERCHANT_METRICS,
         "track_checkout_funnel" => self::XML_PATH_TRACK_CHECKOUT_FUNNEL
     ];
+    
+    /**
+     *  Xml path to disable checkout
+     *  From Magento 2.4.1, it makes Magento\Downloadable\Observer\IsAllowedGuestCheckoutObserver::XML_PATH_DISABLE_GUEST_CHECKOUT as private,
+     *  so we need to define this const in class.
+     */
+    const XML_PATH_DISABLE_GUEST_CHECKOUT = 'catalog/downloadable/disable_guest_checkout';
 
     /**
      * @var ResourceInterface
@@ -1659,7 +1666,7 @@ class Config extends AbstractHelper
     public function isGuestCheckoutForDownloadableProductDisabled()
     {
         return $this->getScopeConfig()->isSetFlag(
-            \Magento\Downloadable\Observer\IsAllowedGuestCheckoutObserver::XML_PATH_DISABLE_GUEST_CHECKOUT,
+            self::XML_PATH_DISABLE_GUEST_CHECKOUT,
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
         );
     }

--- a/Test/Unit/Block/Adminhtml/Customer/CreditCard/Tab/CreditCardTest.php
+++ b/Test/Unit/Block/Adminhtml/Customer/CreditCard/Tab/CreditCardTest.php
@@ -21,13 +21,14 @@ use Bolt\Boltpay\Block\Adminhtml\Customer\CreditCard\Tab\CreditCard;
 use Magento\Customer\Controller\RegistryConstants;
 use Magento\Backend\Block\Template\Context;
 use Magento\Framework\Registry;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
 /**
  * Class CreditCardTest
  *
  * @package Bolt\Boltpay\Test\Unit\Block
  */
-class CreditCardTest extends \PHPUnit\Framework\TestCase
+class CreditCardTest extends BoltTestCase
 {
     const CUSTOMER_ID = '11111';
     const URL = 'https://www.bolt.com/boltpay/customer/creditcard';
@@ -50,7 +51,7 @@ class CreditCardTest extends \PHPUnit\Framework\TestCase
     /**
      * @inheritdoc
      */
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->initRequiredMocks();
         $this->initCurrentMock();

--- a/Test/Unit/Block/Adminhtml/Customer/CreditCard/Tab/View/CardNumberTest.php
+++ b/Test/Unit/Block/Adminhtml/Customer/CreditCard/Tab/View/CardNumberTest.php
@@ -18,19 +18,20 @@
 namespace Bolt\Boltpay\Test\Unit\Block\Adminhtml\Customer\CreditCard\Tab\View;
 
 use Bolt\Boltpay\Block\Adminhtml\Customer\CreditCard\Tab\View\CardNumber;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
 /**
  * Class CardNumber
  * @package Bolt\Boltpay\Block\Adminhtml\Customer\CreditCard\Tab\View
  */
-class CardNumberTest extends \PHPUnit\Framework\TestCase
+class CardNumberTest extends BoltTestCase
 {
     const LAST_4_DIGIT_CARD = 'XXXX-4444';
 
     /** @var CardNumber */
     private $block;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->block = $this->getMockBuilder(CardNumber::class)
             ->disableOriginalConstructor()

--- a/Test/Unit/Block/Adminhtml/Customer/CreditCard/Tab/View/CardTypeTest.php
+++ b/Test/Unit/Block/Adminhtml/Customer/CreditCard/Tab/View/CardTypeTest.php
@@ -18,15 +18,16 @@
 namespace Bolt\Boltpay\Test\Unit\Block\Adminhtml\Customer\CreditCard\Tab\View;
 
 use Bolt\Boltpay\Block\Adminhtml\Customer\CreditCard\Tab\View\CardType;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
-class CardTypeTest extends \PHPUnit\Framework\TestCase
+class CardTypeTest extends BoltTestCase
 {
     const CARD_TYPE = 'Visa';
 
     /** @var CardType */
     private $block;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->block = $this->getMockBuilder(CardType::class)
             ->disableOriginalConstructor()

--- a/Test/Unit/Block/Adminhtml/Customer/CreditCard/Tab/View/CreditCardTest.php
+++ b/Test/Unit/Block/Adminhtml/Customer/CreditCard/Tab/View/CreditCardTest.php
@@ -18,15 +18,16 @@
 namespace Bolt\Boltpay\Test\Unit\Block\Adminhtml\Customer\CreditCard\Tab\View;
 
 use Bolt\Boltpay\Block\Adminhtml\Customer\CreditCard\Tab\View\CreditCard;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
-class CreditCardTest extends \PHPUnit\Framework\TestCase
+class CreditCardTest extends BoltTestCase
 {
     /**
      * @var CreditCard
      */
     private $block;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->block = $this->createMock(CreditCard::class);
     }

--- a/Test/Unit/Block/Adminhtml/Customer/CreditCard/Tab/View/DeleteActionTest.php
+++ b/Test/Unit/Block/Adminhtml/Customer/CreditCard/Tab/View/DeleteActionTest.php
@@ -18,8 +18,9 @@
 namespace Bolt\Boltpay\Test\Unit\Block\Adminhtml\Customer\CreditCard\Tab\View;
 
 use Bolt\Boltpay\Block\Adminhtml\Customer\CreditCard\Tab\View\DeleteAction;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
-class DeleteActionTest extends \PHPUnit\Framework\TestCase
+class DeleteActionTest extends BoltTestCase
 {
     const ID = '1';
     const DELETE_BUTTON_HTML = '<a href="https://www.bolt.com/admin/boltpay/customer/deletecreditcard/id/1/">Delete</a>';
@@ -27,7 +28,7 @@ class DeleteActionTest extends \PHPUnit\Framework\TestCase
     /** @var DeleteAction */
     private $block;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->block = $this->getMockBuilder(DeleteAction::class)
             ->disableOriginalConstructor()

--- a/Test/Unit/Block/BlockTraitTest.php
+++ b/Test/Unit/Block/BlockTraitTest.php
@@ -17,7 +17,7 @@
 
 namespace Bolt\Boltpay\Test\Unit\Block;
 
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Block\BlockTrait;
 use Bolt\Boltpay\Test\Unit\TestHelper;
 use Bolt\Boltpay\Helper\Config;
@@ -27,7 +27,7 @@ use Bolt\Boltpay\Helper\FeatureSwitch\Decider;
  * Class BlockTraitTest
  * @coversDefaultClass \Bolt\Boltpay\Block\BlockTrait
  */
-class BlockTraitTest extends TestCase
+class BlockTraitTest extends BoltTestCase
 {
     const CDN_URL = 'https://bolt-cdn.com';
     const STORE_ID = '1';
@@ -47,7 +47,7 @@ class BlockTraitTest extends TestCase
     /** @var Decider */
     private $featureSwitches;
 
-    public function setUp()
+    public function setUpInternal()
     {
         $this->currentMock = $this->getMockBuilder(BlockTrait::class)
             ->enableOriginalConstructor()

--- a/Test/Unit/Block/Checkout/Cart/ComponentSwitcherProcessorTest.php
+++ b/Test/Unit/Block/Checkout/Cart/ComponentSwitcherProcessorTest.php
@@ -24,7 +24,7 @@ use Magento\Framework\App\Helper\Context;
 use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\Encryption\EncryptorInterface;
 use Magento\Framework\Module\ResourceInterface;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use PHPUnit_Framework_MockObject_MockObject;
 use Magento\Directory\Model\RegionFactory;
 use Magento\Framework\Composer\ComposerFactory;
@@ -33,7 +33,7 @@ use Bolt\Boltpay\Model\EventsForThirdPartyModules;
 /**
  * @coversDefaultClass \Bolt\Boltpay\Block\Checkout\Cart\ComponentSwitcherProcessor
  */
-class ComponentSwitcherProcessorTest extends TestCase
+class ComponentSwitcherProcessorTest extends BoltTestCase
 {
     /**
      * Mocked instance of config helper
@@ -68,7 +68,7 @@ class ComponentSwitcherProcessorTest extends TestCase
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->helperContextMock = $this->createMock(Context::class);
         $this->configHelper = $this->getMockBuilder(ConfigHelper::class)

--- a/Test/Unit/Block/Checkout/ComponentSwitcherProcessorTest.php
+++ b/Test/Unit/Block/Checkout/ComponentSwitcherProcessorTest.php
@@ -18,13 +18,13 @@
 namespace Bolt\Boltpay\Test\Unit\Block\Checkout;
 
 use Bolt\Boltpay\Helper\Config as ConfigHelper;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Block\Checkout\ComponentSwitcherProcessor;
 
 /**
  * @coversDefaultClass \Bolt\Boltpay\Block\Checkout\ComponentSwitcherProcessor
  */
-class ComponentSwitcherProcessorTest extends TestCase
+class ComponentSwitcherProcessorTest extends BoltTestCase
 {
     /**
      * @var ConfigHelper
@@ -36,7 +36,7 @@ class ComponentSwitcherProcessorTest extends TestCase
      */
     private $componentSwitcherProcessor;
 
-    public function setup()
+    public function setUpInternal()
     {
         $this->configHelper = $this->createPartialMock(ConfigHelper::class, ['isPaymentOnlyCheckoutEnabled']);
         $this->componentSwitcherProcessor = $this->getMockBuilder(ComponentSwitcherProcessor::class)

--- a/Test/Unit/Block/Checkout/LayoutProcessorTest.php
+++ b/Test/Unit/Block/Checkout/LayoutProcessorTest.php
@@ -19,14 +19,14 @@ namespace Bolt\Boltpay\Test\Unit\Block\Checkout;
 
 use Bolt\Boltpay\Helper\Config as ConfigHelper;
 use Bolt\Boltpay\Block\Checkout\LayoutProcessor;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
 /**
  * Class LayoutProcessorTest
  * @package Bolt\Boltpay\Test\Unit\Block\Checkout
  * @coversDefaultClass \Bolt\Boltpay\Block\Checkout\LayoutProcessor
  */
-class LayoutProcessorTest extends TestCase
+class LayoutProcessorTest extends BoltTestCase
 {
      /**
      * @var MockObject|ConfigHelper mocked instance of Config helper
@@ -36,7 +36,7 @@ class LayoutProcessorTest extends TestCase
     /**
      * Setup test dependencies, called before each test
      */
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->configHelper = $this->createMock(ConfigHelper::class);
     }
@@ -54,6 +54,6 @@ class LayoutProcessorTest extends TestCase
             ->enableOriginalConstructor()
             ->getMockForAbstractClass();
 
-        $this->assertAttributeEquals($this->configHelper, 'configHelper', $instance);
+        static::assertAttributeEquals($this->configHelper, 'configHelper', $instance);
     }
 }

--- a/Test/Unit/Block/Checkout/SuccessTest.php
+++ b/Test/Unit/Block/Checkout/SuccessTest.php
@@ -21,13 +21,14 @@ use Bolt\Boltpay\Block\Checkout\Success;
 use Bolt\Boltpay\Helper\Config as HelperConfig;
 use Bolt\Boltpay\Helper\FeatureSwitch\Decider;
 use Bolt\Boltpay\Model\Api\Data\BoltConfigSettingFactory;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
 /**
  * Class SuccessTest
  *
  * @package Bolt\Boltpay\Test\Unit\Block\Checkout
  */
-class SuccessTest extends \PHPUnit\Framework\TestCase
+class SuccessTest extends BoltTestCase
 {
     /**
      * @var HelperConfig
@@ -39,7 +40,7 @@ class SuccessTest extends \PHPUnit\Framework\TestCase
      */
     protected $block;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $helperContextMock = $this->createMock(\Magento\Framework\App\Helper\Context::class);
         $contextMock = $this->createMock(\Magento\Framework\View\Element\Template\Context::class);

--- a/Test/Unit/Block/Customer/CreditCardTest.php
+++ b/Test/Unit/Block/Customer/CreditCardTest.php
@@ -25,13 +25,14 @@ use Magento\Framework\App\Request\Http;
 use Magento\Customer\Model\Session;
 use Magento\Framework\Data\Form\FormKey;
 use Bolt\Boltpay\Helper\Config;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
 /**
  * Class CreditCardTest
  *
  * @package Bolt\Boltpay\Test\Unit\Block
  */
-class CreditCardTest extends \PHPUnit\Framework\TestCase
+class CreditCardTest extends BoltTestCase
 {
     const CUSTOMER_ID = '11111';
     const PAGE_SIZE = '1';
@@ -73,7 +74,7 @@ class CreditCardTest extends \PHPUnit\Framework\TestCase
     /**
      * @inheritdoc
      */
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->initRequiredMocks();
         $this->initCurrentMock();

--- a/Test/Unit/Block/FormTest.php
+++ b/Test/Unit/Block/FormTest.php
@@ -25,13 +25,14 @@ use Magento\Framework\View\Element\Template\Context;
 use Bolt\Boltpay\Model\ResourceModel\CustomerCreditCard\CollectionFactory as CustomerCreditCardCollectionFactory;
 use Magento\Quote\Model\Quote\Address;
 use Bolt\Boltpay\Helper\FeatureSwitch\Decider;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
 /**
  * Class FormTest
  *
  * @package Bolt\Boltpay\Test\Unit\Block
  */
-class FormTest extends \PHPUnit\Framework\TestCase
+class FormTest extends BoltTestCase
 {
     /**
      * @var Context
@@ -81,7 +82,7 @@ class FormTest extends \PHPUnit\Framework\TestCase
     /**
      * @inheritdoc
      */
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->initRequiredMocks();
         $this->initCurrentMock();

--- a/Test/Unit/Block/InfoTest.php
+++ b/Test/Unit/Block/InfoTest.php
@@ -21,15 +21,16 @@ use Bolt\Boltpay\Block\Info;
 use Bolt\Boltpay\Test\Unit\TestHelper;
 use Bolt\Boltpay\Model\Payment as BoltPayment;
 use Magento\Sales\Model\Order;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
-class InfoTest extends \PHPUnit\Framework\TestCase
+class InfoTest extends BoltTestCase
 {
     /**
      * @var Info
      */
     protected $mock;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->mock = $this->createPartialMock(Info::class, ['getInfo', 'getMethod', 'getCcType', 'getCcLast4', 'getAdditionalInformation', 'getOrder', 'getAdditionalData']);
     }

--- a/Test/Unit/Block/JsProductPageTest.php
+++ b/Test/Unit/Block/JsProductPageTest.php
@@ -29,6 +29,7 @@ use Magento\Framework\App\Request\Http;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use \Magento\Catalog\Model\ProductRepository;
 use Bolt\Boltpay\Model\EventsForThirdPartyModules;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
 /**
  * Class JsTest
@@ -36,7 +37,7 @@ use Bolt\Boltpay\Model\EventsForThirdPartyModules;
  * @package Bolt\Boltpay\Test\Unit\Block
  * @coversDefaultClass \Bolt\Boltpay\Block\JsProductPage
  */
-class JsProductPageTest extends \PHPUnit\Framework\TestCase
+class JsProductPageTest extends BoltTestCase
 {
     const CURRENCY_CODE = 'USD';
     const PRODUCT_ID = '1';
@@ -112,7 +113,7 @@ class JsProductPageTest extends \PHPUnit\Framework\TestCase
     /**
      * @inheritdoc
      */
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->helperContextMock = $this->createMock(\Magento\Framework\App\Helper\Context::class);
         $this->contextMock = $this->createMock(\Magento\Framework\View\Element\Template\Context::class);

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -42,13 +42,14 @@ use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionException;
 use Magento\Framework\Composer\ComposerFactory;
 use Bolt\Boltpay\Model\EventsForThirdPartyModules;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
 /**
  * Class JsTest
  * @coversDefaultClass \Bolt\Boltpay\Block\Js
  * @package Bolt\Boltpay\Test\Unit\Block
  */
-class JsTest extends \PHPUnit\Framework\TestCase
+class JsTest extends BoltTestCase
 {
 
     /** @var int expected number of settings returned by {@see \Bolt\Boltpay\Block\Js::getSettings} */
@@ -127,7 +128,7 @@ class JsTest extends \PHPUnit\Framework\TestCase
      *
      * @throws ReflectionException if unable to create one of the required mocks
      */
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->objectManager = new ObjectManager($this);
         $this->helperContextMock = $this->createMock(Context::class);

--- a/Test/Unit/Block/MinifiedJsTest.php
+++ b/Test/Unit/Block/MinifiedJsTest.php
@@ -19,13 +19,14 @@ namespace Bolt\Boltpay\Test\Unit\Block;
 
 use Bolt\Boltpay\Block\MinifiedJs;
 use Bolt\Boltpay\Test\Unit\TestHelper;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
 /**
  * Class MinifiedJsTest
  * @coversDefaultClass \Bolt\Boltpay\Block\MinifiedJs
  * @package Bolt\Boltpay\Test\Unit\Block
  */
-class MinifiedJsTest extends \PHPUnit\Framework\TestCase
+class MinifiedJsTest extends BoltTestCase
 {
     const MINIFY_HTML = '<script>console.log("Bolt")</script>';
 
@@ -37,7 +38,7 @@ class MinifiedJsTest extends \PHPUnit\Framework\TestCase
     /**
      * @inheritdoc
      */
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->block = $this->createPartialMock(MinifiedJs::class, ['minifyJs']);
     }

--- a/Test/Unit/BoltTestCase.php
+++ b/Test/Unit/BoltTestCase.php
@@ -13,7 +13,7 @@ if (!defined('PHP_CURRENT_VERSION')) {
     define('PHP_CURRENT_VERSION', (float)phpversion());
 }
 
-if (PHP_CURRENT_VERSION < 7.2) {
+if (PHP_CURRENT_VERSION < 7.1) {
     class BoltTestCase extends TestCase
     {
         protected function skipTestInUnitTestsFlow()

--- a/Test/Unit/BoltTestCase.php
+++ b/Test/Unit/BoltTestCase.php
@@ -13,7 +13,7 @@ if (!defined('PHP_CURRENT_VERSION')) {
     define('PHP_CURRENT_VERSION', (float)phpversion());
 }
 
-if (PHP_CURRENT_VERSION < 7.1) {
+if (PHP_CURRENT_VERSION < 7.2) {
     class BoltTestCase extends TestCase
     {
         protected function skipTestInUnitTestsFlow()

--- a/Test/Unit/BoltTestCase.php
+++ b/Test/Unit/BoltTestCase.php
@@ -8,12 +8,9 @@ use ReflectionException;
 use ReflectionObject;
 use ReflectionProperty;
 use PHPUnit\Framework\Constraint\IsType;
+use PHPUnit\Runner\Version as PHPUnitVersion;
 
-if (!defined('PHP_CURRENT_VERSION')) {
-    define('PHP_CURRENT_VERSION', (float)phpversion());
-}
-
-if (PHP_CURRENT_VERSION < 7.2) {
+if (PHPUnitVersion::id() < 9) {
     class BoltTestCase extends TestCase
     {
         protected function skipTestInUnitTestsFlow()

--- a/Test/Unit/BoltTestCase.php
+++ b/Test/Unit/BoltTestCase.php
@@ -3,13 +3,318 @@
 namespace Bolt\Boltpay\Test\Unit;
 
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionException;
+use ReflectionObject;
+use ReflectionProperty;
+use PHPUnit\Framework\Constraint\IsType;
 
-class BoltTestCase extends TestCase
-{
-    protected function skipTestInUnitTestsFlow()
+if (!defined('PHP_CURRENT_VERSION')) {
+    define('PHP_CURRENT_VERSION', (float)phpversion());
+}
+
+if (PHP_CURRENT_VERSION < 7.1) {
+    class BoltTestCase extends TestCase
     {
-        if (!class_exists('\Magento\TestFramework\Helper\Bootstrap')) {
-            $this->markTestSkipped('Skip integration test in unit test flow');
+        protected function skipTestInUnitTestsFlow()
+        {
+            if (!class_exists('\Magento\TestFramework\Helper\Bootstrap')) {
+                $this->markTestSkipped('Skip integration test in unit test flow');
+            }
+        }
+        
+        protected function setUp()
+        {
+            $this->setUpInternal();
+        }
+        
+        protected function tearDown()
+        {
+            parent::tearDown();
+            $this->tearDownInternal();
+        }
+        
+        protected function setUpInternal()
+        {
+            
+        }
+        
+        protected function tearDownInternal()
+        {
+            
         }
     }
+} else {
+    class BoltTestCase extends TestCase
+    {
+        protected function skipTestInUnitTestsFlow()
+        {
+            if (!class_exists('\Magento\TestFramework\Helper\Bootstrap')) {
+                $this->markTestSkipped('Skip integration test in unit test flow');
+            }
+        }
+        
+        protected function setUp(): void
+        {
+            $this->setUpInternal();
+        }
+        
+        protected function tearDown(): void
+        {
+            parent::tearDown();
+            $this->tearDownInternal();
+        }
+        
+        protected function setUpInternal()
+        {
+
+        }
+        
+        protected function tearDownInternal()
+        {
+
+        }
+        
+        protected function createPartialMock($originalClassName, array $methods): \PHPUnit\Framework\MockObject\MockObject
+        {
+            return $this->getMockBuilder($originalClassName)
+                        ->disableOriginalConstructor()
+                        ->disableOriginalClone()
+                        ->disableArgumentCloning()
+                        ->disallowMockingUnknownTypes()
+                        ->setMethods(empty($methods) ? null : $methods)
+                        ->getMock();
+        }
+        
+        public static function assertAttributeInstanceOf($expected, $attributeName, $classOrObject, $message = '')
+        {
+            static::assertInstanceOf(
+                $expected,
+                static::readAttribute($classOrObject, $attributeName),
+                $message
+            );
+        }
+        
+        public static function assertAttributeEquals($expected, $actualAttributeName, $actualClassOrObject, $message = '', $delta = 0.0, $maxDepth = 10, $canonicalize = false, $ignoreCase = false)
+        {
+            static::assertEquals(
+                $expected,
+                static::readAttribute($actualClassOrObject, $actualAttributeName),
+                $message,
+                $delta,
+                $maxDepth,
+                $canonicalize,
+                $ignoreCase
+            );
+        }
+        
+        public static function readAttribute($classOrObject, $attributeName)
+        {
+            if (!\is_string($attributeName)) {
+                throw InvalidArgumentHelper::factory(2, 'string');
+            }
+    
+            if (!\preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
+                throw InvalidArgumentHelper::factory(2, 'valid attribute name');
+            }
+    
+            if (\is_string($classOrObject)) {
+                if (!\class_exists($classOrObject)) {
+                    throw InvalidArgumentHelper::factory(
+                        1,
+                        'class name'
+                    );
+                }
+    
+                return static::getStaticAttribute(
+                    $classOrObject,
+                    $attributeName
+                );
+            }
+    
+            if (\is_object($classOrObject)) {
+                return static::getObjectAttribute(
+                    $classOrObject,
+                    $attributeName
+                );
+            }
+    
+            throw InvalidArgumentHelper::factory(
+                1,
+                'class name or object'
+            );
+        }
+        
+        public static function getObjectAttribute($object, $attributeName)
+        {
+            if (!\is_object($object)) {
+                throw InvalidArgumentHelper::factory(1, 'object');
+            }
+    
+            if (!\is_string($attributeName)) {
+                throw InvalidArgumentHelper::factory(2, 'string');
+            }
+    
+            if (!\preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
+                throw InvalidArgumentHelper::factory(2, 'valid attribute name');
+            }
+    
+            try {
+                $attribute = new ReflectionProperty($object, $attributeName);
+            } catch (ReflectionException $e) {
+                $reflector = new ReflectionObject($object);
+    
+                while ($reflector = $reflector->getParentClass()) {
+                    try {
+                        $attribute = $reflector->getProperty($attributeName);
+                        break;
+                    } catch (ReflectionException $e) {
+                    }
+                }
+            }
+    
+            if (isset($attribute)) {
+                if (!$attribute || $attribute->isPublic()) {
+                    return $object->$attributeName;
+                }
+    
+                $attribute->setAccessible(true);
+                $value = $attribute->getValue($object);
+                $attribute->setAccessible(false);
+    
+                return $value;
+            }
+    
+            throw new Exception(
+                \sprintf(
+                    'Attribute "%s" not found in object.',
+                    $attributeName
+                )
+            );
+        }
+        
+        public static function assertInternalType($expected, $actual, $message = '')
+        {
+            if (!\is_string($expected)) {
+                throw InvalidArgumentHelper::factory(1, 'string');
+            }
+    
+            $constraint = new IsType(
+                $expected
+            );
+    
+            static::assertThat($actual, $constraint, $message);
+        }
+        
+        /**
+         * @param string $messageRegExp
+         *
+         * @throws Exception
+         */
+        public function expectExceptionMessageRegExp($messageRegExp)
+        {
+            if (!\is_string($messageRegExp)) {
+                throw InvalidArgumentHelper::factory(1, 'string');
+            }
+    
+            $this->expectedExceptionMessageRegExp = $messageRegExp;
+        }
+    }
+}
+
+if (!class_exists('\PHPUnit\Framework\Constraint\ArraySubset')) {
+    class ArraySubset extends \PHPUnit\Framework\Constraint\Constraint
+    {
+        /**
+         * @var array|\Traversable
+         */
+        protected $subset;
+    
+        /**
+         * @var bool
+         */
+        protected $strict;
+    
+        /**
+         * @param array|\Traversable $subset
+         * @param bool               $strict Check for object identity
+         */
+        public function __construct($subset, $strict = false)
+        {
+            $this->strict = $strict;
+            $this->subset = $subset;
+        }
+    
+        /**
+         * Evaluates the constraint for parameter $other. Returns true if the
+         * constraint is met, false otherwise.
+         *
+         * @param array|\Traversable $other Array or Traversable object to evaluate.
+         *
+         * @return bool
+         */
+        protected function matches($other): bool
+        {
+            //type cast $other & $this->subset as an array to allow
+            //support in standard array functions.
+            $other        = $this->toArray($other);
+            $this->subset = $this->toArray($this->subset);
+    
+            $patched = \array_replace_recursive($other, $this->subset);
+    
+            if ($this->strict) {
+                return $other === $patched;
+            }
+    
+            return $other == $patched;
+        }
+    
+        /**
+         * Returns a string representation of the constraint.
+         *
+         * @return string
+         */
+        public function toString(): string
+        {
+            return 'has the subset ' . $this->exporter->export($this->subset);
+        }
+    
+        /**
+         * Returns the description of the failure
+         *
+         * The beginning of failure messages is "Failed asserting that" in most
+         * cases. This method should return the second part of that sentence.
+         *
+         * @param mixed $other Evaluated value or object.
+         *
+         * @return string
+         */
+        protected function failureDescription($other): string
+        {
+            return 'an array ' . $this->toString();
+        }
+    
+        /**
+         * @param array|\Traversable $other
+         *
+         * @return array
+         */
+        private function toArray($other)
+        {
+            if (\is_array($other)) {
+                return $other;
+            }
+    
+            if ($other instanceof \ArrayObject) {
+                return $other->getArrayCopy();
+            }
+    
+            if ($other instanceof \Traversable) {
+                return \iterator_to_array($other);
+            }
+    
+            // Keep BC even if we know that array would not be the expected one
+            return (array) $other;
+        }
+    }    
 }

--- a/Test/Unit/Controller/Adminhtml/Cart/DataTest.php
+++ b/Test/Unit/Controller/Adminhtml/Cart/DataTest.php
@@ -29,7 +29,7 @@ use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\Result\JsonFactory;
 use Magento\Framework\DataObject;
 use Magento\Framework\DataObjectFactory;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
 /**
@@ -37,7 +37,7 @@ use PHPUnit_Framework_MockObject_MockObject as MockObject;
  * @package Bolt\Boltpay\Test\Unit\Controller\Adminhtml\Cart
  * @coversDefaultClass \Bolt\Boltpay\Controller\Adminhtml\Cart\Data
  */
-class DataTest extends TestCase
+class DataTest extends BoltTestCase
 {
     const PLACE_ORDER_PAYLOAD = 'payload';
     const STORE_ID = '42';
@@ -93,7 +93,7 @@ class DataTest extends TestCase
      */
     private $request;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->initData();
         $this->initRequiredMocks();
@@ -193,12 +193,12 @@ class DataTest extends TestCase
             $this->dataObjectFactory
         );
         
-        $this->assertAttributeEquals($this->resultJsonFactory, 'resultJsonFactory', $instance);
-        $this->assertAttributeEquals($this->cartHelper, 'cartHelper', $instance);
-        $this->assertAttributeEquals($this->configHelper, 'configHelper', $instance);
-        $this->assertAttributeEquals($this->bugsnag, 'bugsnag', $instance);
-        $this->assertAttributeEquals($this->metricsClient, 'metricsClient', $instance);
-        $this->assertAttributeEquals($this->dataObjectFactory, 'dataObjectFactory', $instance);
+        static::assertAttributeEquals($this->resultJsonFactory, 'resultJsonFactory', $instance);
+        static::assertAttributeEquals($this->cartHelper, 'cartHelper', $instance);
+        static::assertAttributeEquals($this->configHelper, 'configHelper', $instance);
+        static::assertAttributeEquals($this->bugsnag, 'bugsnag', $instance);
+        static::assertAttributeEquals($this->metricsClient, 'metricsClient', $instance);
+        static::assertAttributeEquals($this->dataObjectFactory, 'dataObjectFactory', $instance);
     }
 
     /**
@@ -290,12 +290,12 @@ class DataTest extends TestCase
      */
     public function execute_ThrowsException()
     {
-        $exception = new \Exception("This is an exception");
+        $exception = new \Exception('This is an exception');
 
         $bugsnag = $this->createMock(Bugsnag::class);
         $bugsnag->expects($this->at(0))
             ->method('notifyException')
-            ->with($exception);
+            ->with($this->equalTo($exception));
 
         $data = $this->getMockBuilder(Data::class)
             ->setMethods(['getRequest'])
@@ -310,6 +310,8 @@ class DataTest extends TestCase
             ])
             ->getMock();
         $this->cartHelper->method('getBoltpayOrder')->willThrowException($exception);
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('This is an exception');
         $data->execute();
     }
 }

--- a/Test/Unit/Controller/Adminhtml/Customer/CreditCardTest.php
+++ b/Test/Unit/Controller/Adminhtml/Customer/CreditCardTest.php
@@ -18,7 +18,7 @@
 namespace Bolt\Boltpay\Test\Unit\Controller\Adminhtml\Customer;
 
 use Bolt\Boltpay\Controller\Adminhtml\Customer\CreditCard;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Magento\Customer\Api\AccountManagementInterface;
 use Magento\Customer\Api\AddressRepositoryInterface;
@@ -46,7 +46,7 @@ use Magento\Framework\View\Result\PageFactory;
 use Magento\Backend\Model\View\Result\ForwardFactory;
 use Magento\Framework\Controller\Result\JsonFactory;
 
-class CreditCardTest extends TestCase
+class CreditCardTest extends BoltTestCase
 {
     /**
      * @var MockObject|CreditCard
@@ -178,7 +178,7 @@ class CreditCardTest extends TestCase
      */
     private $resultJsonFactoryMock;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->contextMock = $this->createMock(Context::class);
         $this->coreRegistryMock = $this->createMock(Registry::class);

--- a/Test/Unit/Controller/Adminhtml/Customer/DeleteCreditCardTest.php
+++ b/Test/Unit/Controller/Adminhtml/Customer/DeleteCreditCardTest.php
@@ -18,7 +18,7 @@
 namespace Bolt\Boltpay\Test\Unit\Controller\Adminhtml\Customer;
 
 use Bolt\Boltpay\Controller\Adminhtml\Customer\DeleteCreditCard;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Magento\Backend\App\Action\Context;
 use Bolt\Boltpay\Model\CustomerCreditCardFactory;
 use Bolt\Boltpay\Helper\Bugsnag;
@@ -26,7 +26,7 @@ use Magento\Framework\App\Request\Http;
 use Magento\Framework\Message\Manager;
 use Magento\Store\App\Response\Redirect;
 
-class DeleteCreditCardTest extends TestCase
+class DeleteCreditCardTest extends BoltTestCase
 {
     const ID = '1';
 
@@ -65,7 +65,7 @@ class DeleteCreditCardTest extends TestCase
      */
     private $redirectMock;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->contextMock = $this->createMock(Context::class);
 

--- a/Test/Unit/Controller/Adminhtml/Order/ReceivedUrlTest.php
+++ b/Test/Unit/Controller/Adminhtml/Order/ReceivedUrlTest.php
@@ -17,7 +17,7 @@
 
 namespace Bolt\Boltpay\Test\Unit\Controller\Adminhtml\Order;
 
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Controller\Adminhtml\Order\ReceivedUrl;
 use Magento\Sales\App\Action;
 use Magento\Backend\App\Action\Context;
@@ -35,7 +35,7 @@ use PHPUnit_Framework_MockObject_MockObject;
 /**
  * @coversDefaultClass \Bolt\Boltpay\Controller\Adminhtml\Order\ReceivedUrl
  */
-class ReceivedUrlTest extends TestCase
+class ReceivedUrlTest extends BoltTestCase
 {
     const ORDER_ID = '1234';
     const STORE_ID = '1';
@@ -87,7 +87,7 @@ class ReceivedUrlTest extends TestCase
 
     private $order;
 
-    public function setUp()
+    public function setUpInternal()
     {
         $this->context = $this->createMock(Context::class, ['getBackendUrl']);
         $this->backendUrl = $this->createMock(UrlInterface::class, ['getUrl']);

--- a/Test/Unit/Controller/Adminhtml/Order/SaveTest.php
+++ b/Test/Unit/Controller/Adminhtml/Order/SaveTest.php
@@ -30,7 +30,7 @@ use Magento\Framework\DataObjectFactory;
 use Magento\Framework\UrlInterface;
 use Magento\Quote\Model\Quote;
 use Magento\Sales\Api\Data\OrderInterface;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
 /**
@@ -38,7 +38,7 @@ use PHPUnit_Framework_MockObject_MockObject as MockObject;
  * @package Bolt\Boltpay\Test\Unit\Controller\Adminhtml\Order
  * @coversDefaultClass \Bolt\Boltpay\Controller\Adminhtml\Order\Save
  */
-class SaveTest extends TestCase
+class SaveTest extends BoltTestCase
 {
     const ORDER_ID = '1234';
     const ORDER_STATUS = 'currentStatus';
@@ -84,7 +84,7 @@ class SaveTest extends TestCase
      */
     private $dataObjectFactory;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->initRequiredMocks();
     }
@@ -107,12 +107,12 @@ class SaveTest extends TestCase
             $this->dataObjectFactory
         );
         
-        $this->assertAttributeEquals($this->resultJsonFactory, 'resultJsonFactory', $instance);
-        $this->assertAttributeEquals($this->checkoutSession, 'checkoutSession', $instance);
-        $this->assertAttributeEquals($this->orderHelper, 'orderHelper', $instance);
-        $this->assertAttributeEquals($this->configHelper, 'configHelper', $instance);
-        $this->assertAttributeEquals($this->bugsnag, 'bugsnag', $instance);
-        $this->assertAttributeEquals($this->dataObjectFactory, 'dataObjectFactory', $instance);
+        static::assertAttributeEquals($this->resultJsonFactory, 'resultJsonFactory', $instance);
+        static::assertAttributeEquals($this->checkoutSession, 'checkoutSession', $instance);
+        static::assertAttributeEquals($this->orderHelper, 'orderHelper', $instance);
+        static::assertAttributeEquals($this->configHelper, 'configHelper', $instance);
+        static::assertAttributeEquals($this->bugsnag, 'bugsnag', $instance);
+        static::assertAttributeEquals($this->dataObjectFactory, 'dataObjectFactory', $instance);
     }
 
     /**

--- a/Test/Unit/Controller/Adminhtml/Order/SaveTest.php
+++ b/Test/Unit/Controller/Adminhtml/Order/SaveTest.php
@@ -183,9 +183,7 @@ class SaveTest extends TestCase
 
         $save = $this->getMockBuilder(Save::class)
             ->setMethods([
-                'getRequest',
-                'clearQuoteSession',
-                'clearOrderSession'
+                'getRequest'
             ])
             ->setConstructorArgs([
                 $this->context,
@@ -199,8 +197,6 @@ class SaveTest extends TestCase
             ->getMock();
 
         $save->expects($this->exactly(2))->method('getRequest')->willReturn($request);
-        $save->method('clearQuoteSession')->with($quote);
-        $save->method('clearOrderSession')->with($order);
 
         $save->execute();
     }

--- a/Test/Unit/Controller/Cart/CheckoutConfigTest.php
+++ b/Test/Unit/Controller/Cart/CheckoutConfigTest.php
@@ -17,13 +17,13 @@
 
 namespace Bolt\Boltpay\Test\Unit\Controller\Cart;
 
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 
 /**
  * @coversDefaultClass \Bolt\Boltpay\Controller\Cart\CheckoutConfig
  */
-class CheckoutConfigTest extends TestCase
+class CheckoutConfigTest extends BoltTestCase
 {
     /**
      * @var \Magento\Framework\App\Action\Context
@@ -48,7 +48,7 @@ class CheckoutConfigTest extends TestCase
     /**
      * Setup method, called before each test
      */
-    protected function setUp()
+    protected function setUpInternal()
     {
         $om = new ObjectManager($this);
         $this->context = $om->getObject(\Magento\Framework\App\Action\Context::class);

--- a/Test/Unit/Controller/Cart/DataTest.php
+++ b/Test/Unit/Controller/Cart/DataTest.php
@@ -23,7 +23,7 @@ use Magento\Framework\App\Action\Context;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\Result\JsonFactory;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
 /**
@@ -31,7 +31,7 @@ use PHPUnit_Framework_MockObject_MockObject as MockObject;
  * @package Bolt\Boltpay\Test\Unit\Controller\Cart
  * @coversDefaultClass \Bolt\Boltpay\Controller\Cart\Data
  */
-class DataTest extends TestCase
+class DataTest extends BoltTestCase
 {
     const HINT = 'hint!';
     const ORDER_REFERENCE = 1234;
@@ -74,7 +74,7 @@ class DataTest extends TestCase
      */
     private $resultJsonFactory;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->initResponseData();
         $this->initRequiredMocks();
@@ -150,8 +150,8 @@ class DataTest extends TestCase
             $this->cartHelper
         );
         
-        $this->assertAttributeEquals($this->resultJsonFactory, 'resultJsonFactory', $instance);
-        $this->assertAttributeEquals($this->cartHelper, 'cartHelper', $instance);
+        static::assertAttributeEquals($this->resultJsonFactory, 'resultJsonFactory', $instance);
+        static::assertAttributeEquals($this->cartHelper, 'cartHelper', $instance);
     }
 
     private function buildJsonMock($expected)

--- a/Test/Unit/Controller/Cart/EmailTest.php
+++ b/Test/Unit/Controller/Cart/EmailTest.php
@@ -26,7 +26,7 @@ use Magento\Framework\App\Action\Context;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Quote\Model\Quote;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
 /**
@@ -34,7 +34,7 @@ use PHPUnit_Framework_MockObject_MockObject as MockObject;
  * @package Bolt\Boltpay\Test\Unit\Controller\Cart
  * @coversDefaultClass \Bolt\Boltpay\Controller\Cart\Email
  */
-class EmailTest extends TestCase
+class EmailTest extends BoltTestCase
 {
     /**
      * @var Context
@@ -76,7 +76,7 @@ class EmailTest extends TestCase
      */
     private $currentMock;
 
-    public function setUp()
+    public function setUpInternal()
     {
         $this->initRequiredMocks();
         $this->initCurrentMock();
@@ -134,10 +134,10 @@ class EmailTest extends TestCase
             $this->cartHelper
         );
         
-        $this->assertAttributeEquals($this->checkoutSession, 'checkoutSession', $instance);
-        $this->assertAttributeEquals($this->customerSession, 'customerSession', $instance);
-        $this->assertAttributeEquals($this->bugsnag, 'bugsnag', $instance);
-        $this->assertAttributeEquals($this->cartHelper, 'cartHelper', $instance);
+        static::assertAttributeEquals($this->checkoutSession, 'checkoutSession', $instance);
+        static::assertAttributeEquals($this->customerSession, 'customerSession', $instance);
+        static::assertAttributeEquals($this->bugsnag, 'bugsnag', $instance);
+        static::assertAttributeEquals($this->cartHelper, 'cartHelper', $instance);
     }
 
     /**

--- a/Test/Unit/Controller/Cart/HintsTest.php
+++ b/Test/Unit/Controller/Cart/HintsTest.php
@@ -23,14 +23,14 @@ use Bolt\Boltpay\Helper\Bugsnag;
 use Bolt\Boltpay\Helper\Cart as CartHelper;
 use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\Result\JsonFactory;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
 /**
  * Class HintsTest
  * @package Bolt\Boltpay\Test\Unit\Controller\Cart
  * @coversDefaultClass \Bolt\Boltpay\Controller\Cart\Hints
  */
-class HintsTest extends TestCase
+class HintsTest extends BoltTestCase
 {
     /** @var JsonFactory */
     private $resultJsonFactory;
@@ -47,7 +47,7 @@ class HintsTest extends TestCase
     /** @var Hints */
     private $currentMock;
 
-    public function setUp()
+    public function setUpInternal()
     {
         $this->initRequiredMocks();
         $this->initCurrentMock();
@@ -89,9 +89,9 @@ class HintsTest extends TestCase
             $this->cartHelper
         );
         
-        $this->assertAttributeEquals($this->resultJsonFactory, 'resultJsonFactory', $instance);
-        $this->assertAttributeEquals($this->bugsnag, 'bugsnag', $instance);
-        $this->assertAttributeEquals($this->cartHelper, 'cartHelper', $instance);
+        static::assertAttributeEquals($this->resultJsonFactory, 'resultJsonFactory', $instance);
+        static::assertAttributeEquals($this->bugsnag, 'bugsnag', $instance);
+        static::assertAttributeEquals($this->cartHelper, 'cartHelper', $instance);
     }
 
     /**

--- a/Test/Unit/Controller/Customer/CreditCardTest.php
+++ b/Test/Unit/Controller/Customer/CreditCardTest.php
@@ -17,7 +17,7 @@
 
 namespace Bolt\Boltpay\Test\Unit\Controller\Customer;
 
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Magento\Framework\App\Action\Context;
 use Bolt\Boltpay\Controller\Customer\CreditCard;
 use Magento\Framework\App\ViewInterface;
@@ -27,7 +27,7 @@ use Magento\Framework\App\ViewInterface;
  * @package Bolt\Boltpay\Test\Unit\Controller\Customer
  * @coversDefaultClass \Bolt\Boltpay\Controller\Customer\CreditCard
  */
-class CreditCardTest extends TestCase
+class CreditCardTest extends BoltTestCase
 {
     /**
      * @var Context
@@ -44,7 +44,7 @@ class CreditCardTest extends TestCase
      */
     protected $_view;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->_context = $this->createPartialMock(Context::class, ['getView']);
         $this->_view = $this->createPartialMock(

--- a/Test/Unit/Controller/Customer/DeleteCreditCardTest.php
+++ b/Test/Unit/Controller/Customer/DeleteCreditCardTest.php
@@ -18,7 +18,7 @@
 namespace Bolt\Boltpay\Test\Unit\Controller\Customer;
 
 use Bolt\Boltpay\Controller\Customer\DeleteCreditCard;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Magento\Framework\App\Action\Context;
 use Bolt\Boltpay\Model\CustomerCreditCardFactory;
 use Bolt\Boltpay\Helper\Bugsnag;
@@ -28,7 +28,7 @@ use Magento\Store\App\Response\Redirect;
 use Magento\Framework\Data\Form\FormKey\Validator;
 use Magento\Customer\Model\Session;
 
-class DeleteCreditCardTest extends TestCase
+class DeleteCreditCardTest extends BoltTestCase
 {
     const ID = '1';
     const CUSTOMER_ID = '111';
@@ -78,7 +78,7 @@ class DeleteCreditCardTest extends TestCase
      */
     private $validatorMock;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->contextMock = $this->createMock(Context::class);
 

--- a/Test/Unit/Controller/Order/ReceivedUrlTest.php
+++ b/Test/Unit/Controller/Order/ReceivedUrlTest.php
@@ -33,7 +33,7 @@ use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Framework\UrlInterface;
 use Magento\Quote\Model\Quote;
 use Magento\Sales\Model\Order;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Magento\Backend\Model\UrlInterface as BackendUrl;
 use Magento\Framework\App\Response\RedirectInterface;
@@ -41,7 +41,7 @@ use Magento\Framework\App\Response\RedirectInterface;
 /**
  * @coversDefaultClass \Bolt\Boltpay\Controller\Order\ReceivedUrl
  */
-class ReceivedUrlTest extends TestCase
+class ReceivedUrlTest extends BoltTestCase
 {
     //TODO: figure out proper values for these things, probably some reverse engineering to be done.
     const DECODED_BOLT_PAYLOAD = '{"display_id":"' .self::JSON_DISPLAY_ID. '", "transaction_reference":"' .self::TRANSACTION_REFERENCE. '"}';
@@ -653,7 +653,7 @@ class ReceivedUrlTest extends TestCase
         $receivedUrl->execute();
     }
 
-    public function setUp()
+    public function setUpInternal()
     {
         $this->initRequiredMocks();
         $this->initAuthentication();

--- a/Test/Unit/Controller/Order/SaveTest.php
+++ b/Test/Unit/Controller/Order/SaveTest.php
@@ -30,7 +30,7 @@ use Magento\Framework\DataObjectFactory;
 use Magento\Framework\UrlInterface;
 use Magento\Sales\Model\Order;
 use Magento\Quote\Model\Quote;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
 /**
@@ -38,7 +38,7 @@ use PHPUnit_Framework_MockObject_MockObject as MockObject;
  * @package Bolt\Boltpay\Test\Unit\Controller\Order
  * @coversDefaultClass \Bolt\Boltpay\Controller\Order\Save
  */
-class SaveTest extends TestCase
+class SaveTest extends BoltTestCase
 {
     const ORDER_ID = 1234;
     const QUOTE_ID = 5678;
@@ -94,7 +94,7 @@ class SaveTest extends TestCase
      */
     private $resultJsonFactory;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->initRequiredMocks();
     }
@@ -117,12 +117,12 @@ class SaveTest extends TestCase
             $this->dataObjectFactory
         );
 
-        $this->assertAttributeEquals($this->resultJsonFactory, 'resultJsonFactory', $instance);
-        $this->assertAttributeEquals($this->checkoutSession, 'checkoutSession', $instance);
-        $this->assertAttributeEquals($this->orderHelper, 'orderHelper', $instance);
-        $this->assertAttributeEquals($this->configHelper, 'configHelper', $instance);
-        $this->assertAttributeEquals($this->bugsnagMock, 'bugsnag', $instance);
-        $this->assertAttributeEquals($this->dataObjectFactory, 'dataObjectFactory', $instance);
+        static::assertAttributeEquals($this->resultJsonFactory, 'resultJsonFactory', $instance);
+        static::assertAttributeEquals($this->checkoutSession, 'checkoutSession', $instance);
+        static::assertAttributeEquals($this->orderHelper, 'orderHelper', $instance);
+        static::assertAttributeEquals($this->configHelper, 'configHelper', $instance);
+        static::assertAttributeEquals($this->bugsnagMock, 'bugsnag', $instance);
+        static::assertAttributeEquals($this->dataObjectFactory, 'dataObjectFactory', $instance);
     }
 
     /**

--- a/Test/Unit/Controller/ReceivedUrlTraitTest.php
+++ b/Test/Unit/Controller/ReceivedUrlTraitTest.php
@@ -23,7 +23,7 @@ use Bolt\Boltpay\Helper\Order as OrderHelper;
 use Bolt\Boltpay\Test\Unit\TestHelper;
 use Magento\Quote\Model\Quote;
 use Magento\Sales\Model\Order;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Controller\ReceivedUrlTrait;
 use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\Framework\Exception\NoSuchEntityException;
@@ -32,7 +32,7 @@ use Magento\Framework\Exception\NoSuchEntityException;
  * Class ReceivedUrlTraitTest
  * @coversDefaultClass \Bolt\Boltpay\Controller\ReceivedUrlTrait
  */
-class ReceivedUrlTraitTest extends TestCase
+class ReceivedUrlTraitTest extends BoltTestCase
 {
     const QUOTE_ID = 1;
     const ORDER_ID = 2;
@@ -75,7 +75,7 @@ class ReceivedUrlTraitTest extends TestCase
      */
     private $configHelper;
 
-    public function setUp()
+    public function setUpInternal()
     {
         $this->currentMock = $this->getMockBuilder(ReceivedUrlTrait::class)
             ->enableOriginalConstructor()

--- a/Test/Unit/Controller/Shipping/PrefetchTest.php
+++ b/Test/Unit/Controller/Shipping/PrefetchTest.php
@@ -27,7 +27,7 @@ use Magento\Customer\Model\Session;
 use Magento\Framework\App\Action\Context;
 use Magento\Framework\App\RequestInterface;
 use Magento\Quote\Model\Quote;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
 /**
@@ -35,7 +35,7 @@ use PHPUnit_Framework_MockObject_MockObject as MockObject;
  * @package Bolt\Boltpay\Test\Unit\Controller\Shipping
  * @coversDefaultClass \Bolt\Boltpay\Controller\Shipping\Prefetch
  */
-class PrefetchTest extends TestCase
+class PrefetchTest extends BoltTestCase
 {
     const COUNTRY = 'Canada';
     const REGION = 'Arctic';
@@ -87,7 +87,7 @@ class PrefetchTest extends TestCase
      */
     private $currentMock;
 
-    public function setUp()
+    public function setUpInternal()
     {
         $this->initRequiredMocks();
         $this->initCurrentMock();
@@ -140,10 +140,10 @@ class PrefetchTest extends TestCase
             $this->geolocation
         );
         
-        $this->assertAttributeEquals($this->shippingMethods, 'shippingMethods', $instance);
-        $this->assertAttributeEquals($this->cartHelper, 'cartHelper', $instance);
-        $this->assertAttributeEquals($this->bugsnag, 'bugsnag', $instance);
-        $this->assertAttributeEquals($this->configHelper, 'configHelper', $instance);
+        static::assertAttributeEquals($this->shippingMethods, 'shippingMethods', $instance);
+        static::assertAttributeEquals($this->cartHelper, 'cartHelper', $instance);
+        static::assertAttributeEquals($this->bugsnag, 'bugsnag', $instance);
+        static::assertAttributeEquals($this->configHelper, 'configHelper', $instance);
     }
 
     /**

--- a/Test/Unit/Cron/DeactivateQuoteTest.php
+++ b/Test/Unit/Cron/DeactivateQuoteTest.php
@@ -17,7 +17,7 @@
 
 namespace Bolt\Boltpay\Test\Unit\Helper;
 
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Cron\DeactivateQuote;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\DB\Adapter\Pdo\Mysql;
@@ -28,7 +28,7 @@ use Bolt\Boltpay\Helper\Bugsnag;
  * Class DeactivateQuoteTest
  * @package Bolt\Boltpay\Test\Unit\Helper
  */
-class DeactivateQuoteTest extends TestCase
+class DeactivateQuoteTest extends BoltTestCase
 {
     /**
      * @var DeactivateQuote
@@ -50,7 +50,7 @@ class DeactivateQuoteTest extends TestCase
      */
     private $connection;
 
-    public function setUp()
+    public function setUpInternal()
     {
         $this->resourceConnection = $this->createPartialMock(
             ResourceConnection::class,

--- a/Test/Unit/Cron/DeleteOldWebHookLogsTest.php
+++ b/Test/Unit/Cron/DeleteOldWebHookLogsTest.php
@@ -17,7 +17,7 @@
 
 namespace Bolt\Boltpay\Test\Unit\Helper;
 
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Model\ResourceModel\WebhookLogFactory;
 use Bolt\Boltpay\Cron\DeleteOldWebHookLogs;
 
@@ -25,7 +25,7 @@ use Bolt\Boltpay\Cron\DeleteOldWebHookLogs;
  * Class DeleteOldWebHookLogsTest
  * @package Bolt\Boltpay\Test\Unit\Helper
  */
-class DeleteOldWebHookLogsTest extends TestCase
+class DeleteOldWebHookLogsTest extends BoltTestCase
 {
 
     /**
@@ -38,7 +38,7 @@ class DeleteOldWebHookLogsTest extends TestCase
      */
     private $webhookLogFactory;
 
-    public function setUp()
+    public function setUpInternal()
     {
         $this->webhookLogFactory = $this->createPartialMock(
             WebhookLogFactory::class,

--- a/Test/Unit/Exception/BoltExceptionTest.php
+++ b/Test/Unit/Exception/BoltExceptionTest.php
@@ -18,13 +18,14 @@
 namespace Bolt\Boltpay\Test\Unit\Exception;
 
 use Bolt\Boltpay\Exception\BoltException;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
 /**
  * BoltExceptionTest
  *
  * @package Bolt\Boltpay\Test\Unit\Block
  */
-class BoltExceptionTest extends \PHPUnit\Framework\TestCase
+class BoltExceptionTest extends BoltTestCase
 {
 
     /**

--- a/Test/Unit/Helper/ApiTest.php
+++ b/Test/Unit/Helper/ApiTest.php
@@ -248,24 +248,10 @@ class ApiTest extends BoltTestCase
 
         $reportMock = $this->createPartialMock(Report::class, ['setMetaData']);
         $dummyResponseBody = '{"data": {"logMerchantLogs": {"isSuccessful": true}}}';
-        // https://github.com/sebastianbergmann/phpunit/issues/3494
-        // Deprecate assertArraySubset()
-        if (class_exists('\PHPUnit\Framework\Constraint\ArraySubset')) {
-            $boltApiRequest = new \PHPUnit\Framework\Constraint\ArraySubset(
-                [
-                    'BOLT API REQUEST' => $request->getData()
-                ]
-            );
-        } else {
-            $boltApiRequest = new \Bolt\Boltpay\Test\Unit\ArraySubset(
-                [
-                    'BOLT API REQUEST' => $request->getData()
-                ]
-            );
-        }
+
         $reportMock->expects(self::exactly(3))->method('setMetaData')->withConsecutive(
             [
-                $boltApiRequest
+                TestHelper::buildArraySubset(['BOLT API REQUEST' => $request->getData()])
             ],
             [
                 [
@@ -404,24 +390,10 @@ class ApiTest extends BoltTestCase
 
         $reportMock = $this->createPartialMock(Report::class, ['setMetaData']);
         $emptyResponseBody = '';
-        // https://github.com/sebastianbergmann/phpunit/issues/3494
-        // Deprecate assertArraySubset()
-        if (class_exists('\PHPUnit\Framework\Constraint\ArraySubset')) {
-            $boltApiRequest = new \PHPUnit\Framework\Constraint\ArraySubset(
-                [
-                    'BOLT API REQUEST' => $request->getData()
-                ]
-            );
-        } else {
-            $boltApiRequest = new \Bolt\Boltpay\Test\Unit\ArraySubset(
-                [
-                    'BOLT API REQUEST' => $request->getData()
-                ]
-            );
-        }
+
         $reportMock->expects(self::exactly(3))->method('setMetaData')->withConsecutive(
             [
-                $boltApiRequest
+                TestHelper::buildArraySubset(['BOLT API REQUEST' => $request->getData()])
             ],
             [
                 [

--- a/Test/Unit/Helper/ApiTest.php
+++ b/Test/Unit/Helper/ApiTest.php
@@ -31,10 +31,9 @@ use Bolt\Boltpay\Model\Request;
 use Bolt\Boltpay\Model\Response;
 use Bolt\Boltpay\Helper\Log as LogHelper;
 use Bolt\Boltpay\Helper\Config as ConfigHelper;
-use PHPUnit\Framework\Constraint\ArraySubset;
 use ReflectionException;
 use Bolt\Boltpay\Helper\Bugsnag;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Magento\Framework\HTTP\ZendClient;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Zend_Http_Response;
@@ -42,7 +41,7 @@ use Zend_Http_Response;
 /**
  * @coversDefaultClass \Bolt\Boltpay\Helper\Api
  */
-class ApiTest extends TestCase
+class ApiTest extends BoltTestCase
 {
 
     /** @var string Dummy API url */
@@ -82,7 +81,7 @@ class ApiTest extends TestCase
     /**
      * @inheritdoc
      */
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->initRequiredMocks();
         $this->currentMock = $this->getMockBuilder(ApiHelper::class)
@@ -159,12 +158,12 @@ class ApiTest extends TestCase
             $this->bugsnag
         );
         
-        $this->assertAttributeEquals($this->zendClientFactory, 'httpClientFactory', $instance);
-        $this->assertAttributeEquals($this->configHelper, 'configHelper', $instance);
-        $this->assertAttributeEquals($this->responseFactory, 'responseFactory', $instance);
-        $this->assertAttributeEquals($this->requestFactory, 'requestFactory', $instance);
-        $this->assertAttributeEquals($this->logHelper, 'logHelper', $instance);
-        $this->assertAttributeEquals($this->bugsnag, 'bugsnag', $instance);
+        static::assertAttributeEquals($this->zendClientFactory, 'httpClientFactory', $instance);
+        static::assertAttributeEquals($this->configHelper, 'configHelper', $instance);
+        static::assertAttributeEquals($this->responseFactory, 'responseFactory', $instance);
+        static::assertAttributeEquals($this->requestFactory, 'requestFactory', $instance);
+        static::assertAttributeEquals($this->logHelper, 'logHelper', $instance);
+        static::assertAttributeEquals($this->bugsnag, 'bugsnag', $instance);
     }
 
     /**
@@ -249,13 +248,24 @@ class ApiTest extends TestCase
 
         $reportMock = $this->createPartialMock(Report::class, ['setMetaData']);
         $dummyResponseBody = '{"data": {"logMerchantLogs": {"isSuccessful": true}}}';
+        // https://github.com/sebastianbergmann/phpunit/issues/3494
+        // Deprecate assertArraySubset()
+        if (class_exists('\PHPUnit\Framework\Constraint\ArraySubset')) {
+            $boltApiRequest = new \PHPUnit\Framework\Constraint\ArraySubset(
+                [
+                    'BOLT API REQUEST' => $request->getData()
+                ]
+            );
+        } else {
+            $boltApiRequest = new \Bolt\Boltpay\Test\Unit\ArraySubset(
+                [
+                    'BOLT API REQUEST' => $request->getData()
+                ]
+            );
+        }
         $reportMock->expects(self::exactly(3))->method('setMetaData')->withConsecutive(
             [
-                new ArraySubset(
-                    [
-                        'BOLT API REQUEST' => $request->getData()
-                    ]
-                )
+                $boltApiRequest
             ],
             [
                 [
@@ -394,13 +404,24 @@ class ApiTest extends TestCase
 
         $reportMock = $this->createPartialMock(Report::class, ['setMetaData']);
         $emptyResponseBody = '';
+        // https://github.com/sebastianbergmann/phpunit/issues/3494
+        // Deprecate assertArraySubset()
+        if (class_exists('\PHPUnit\Framework\Constraint\ArraySubset')) {
+            $boltApiRequest = new \PHPUnit\Framework\Constraint\ArraySubset(
+                [
+                    'BOLT API REQUEST' => $request->getData()
+                ]
+            );
+        } else {
+            $boltApiRequest = new \Bolt\Boltpay\Test\Unit\ArraySubset(
+                [
+                    'BOLT API REQUEST' => $request->getData()
+                ]
+            );
+        }
         $reportMock->expects(self::exactly(3))->method('setMetaData')->withConsecutive(
             [
-                new ArraySubset(
-                    [
-                        'BOLT API REQUEST' => $request->getData()
-                    ]
-                )
+                $boltApiRequest
             ],
             [
                 [

--- a/Test/Unit/Helper/ApiTest.php
+++ b/Test/Unit/Helper/ApiTest.php
@@ -18,7 +18,6 @@
 namespace Bolt\Boltpay\Test\Unit\Helper;
 
 use Bolt\Boltpay\Helper\Api as ApiHelper;
-
 use Bolt\Boltpay\Test\Unit\TestHelper;
 use Bugsnag\Report;
 use Exception;
@@ -35,7 +34,7 @@ use Bolt\Boltpay\Helper\Config as ConfigHelper;
 use PHPUnit\Framework\Constraint\ArraySubset;
 use ReflectionException;
 use Bolt\Boltpay\Helper\Bugsnag;
-use \PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestCase;
 use Magento\Framework\HTTP\ZendClient;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Zend_Http_Response;
@@ -359,7 +358,8 @@ class ApiTest extends TestCase
         $this->zendClientFactory->expects(static::once())->method('create')->willReturn($client);
         $client->expects(static::once())->method('setRawData')->willReturnSelf();
         $client->expects(static::once())->method('request')
-            ->willThrowException(new Exception('Expected exception message'));
+            ->will($this->throwException(new LocalizedException(new \Magento\Framework\Phrase('Expected exception message'))));
+        $this->expectException(LocalizedException::class);
         $this->currentMock->sendRequest($request);
     }
     

--- a/Test/Unit/Helper/ArrayHelperTest.php
+++ b/Test/Unit/Helper/ArrayHelperTest.php
@@ -16,7 +16,7 @@
  */
 namespace Bolt\Boltpay\Test\Unit\Helper;
 
-use \PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Helper\ArrayHelper;
 
 /**
@@ -24,7 +24,7 @@ use Bolt\Boltpay\Helper\ArrayHelper;
  *
  * @package Bolt\Boltpay\Test\Unit\Helper
  */
-class ArrayHelperTest extends TestCase
+class ArrayHelperTest extends BoltTestCase
 {
     /**
      * @test

--- a/Test/Unit/Helper/BugsnagTest.php
+++ b/Test/Unit/Helper/BugsnagTest.php
@@ -27,7 +27,7 @@ use Magento\Framework\Filesystem\DirectoryList;
 use Magento\Framework\UrlInterface;
 use Magento\Store\Model\StoreManager;
 use Magento\Store\Model\StoreManagerInterface;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Helper\Bugsnag;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use ReflectionException;
@@ -35,7 +35,7 @@ use ReflectionException;
 /**
  * @coversDefaultClass \Bolt\Boltpay\Helper\Bugsnag
  */
-class BugsnagTest extends TestCase
+class BugsnagTest extends BoltTestCase
 {
     /** @var string Dummy store url */
     const STORE_URL = 'http://store.local/';
@@ -64,7 +64,7 @@ class BugsnagTest extends TestCase
      *
      * @throws ReflectionException if unable to set internal mock properties
      */
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->contextMock = $this->createMock(Context::class);
         $this->configHelperMock = $this->createPartialMock(Config::class, ['getComposerVersion','isSandboxModeSet','isTestEnvSet','getModuleVersion']);

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -312,7 +312,7 @@ class CartTest extends BoltTestCase
     /**
      * Setup test dependencies, called before each test
      */
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->originalObjectManager = ObjectManager::getInstance();
         $this->testAddressData = [
@@ -455,7 +455,7 @@ class CartTest extends BoltTestCase
         $this->objectsToClean = array();
     }
 
-    protected function tearDown()
+    protected function tearDownInternal()
     {
         TestUtils::cleanupSharedFixtures($this->objectsToClean);
         ObjectManager::setInstance($this->originalObjectManager);

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -1660,7 +1660,7 @@ class CartTest extends BoltTestCase
         $destinationQuoteShippingAddress = $this->createMock(Quote\Address::class);
         $destinationQuote->method('getBillingAddress')->willReturn($destinationQuoteBillingAddress);
         $destinationQuote->method('getShippingAddress')->willReturn($destinationQuoteShippingAddress);
-        $currentMock = $this->getCurrentMock(['transferData', 'quoteResourceSave']);
+        $currentMock = $this->getCurrentMock(['quoteResourceSave']);
         return [$sourceQuote, $destinationQuote, $currentMock];
     }
 
@@ -1680,7 +1680,6 @@ class CartTest extends BoltTestCase
         $destinationQuote->expects(self::once())->method('getId')->willReturn(self::PARENT_QUOTE_ID);
         $destinationQuote->expects(self::never())->method('removeAllItems');
         $sourceQuote->expects(self::never())->method('getAllVisibleItems');
-        $currentMock->expects(static::never())->method('transferData');
         $currentMock->expects(static::never())->method('quoteResourceSave');
         $currentMock->replicateQuoteData($sourceQuote, $destinationQuote);
     }

--- a/Test/Unit/Helper/CheckboxesHandlerTest.php
+++ b/Test/Unit/Helper/CheckboxesHandlerTest.php
@@ -18,7 +18,7 @@
 namespace Bolt\Boltpay\Test\Unit\Helper;
 
 use Bolt\Boltpay\Helper\CheckboxesHandler;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Magento\Framework\App\Helper\Context;
 use Magento\Newsletter\Model\SubscriberFactory;
 use Bolt\Boltpay\Helper\Bugsnag;
@@ -28,7 +28,7 @@ use Magento\Quote\Model\Quote\Address;
 /**
  * @coversDefaultClass \Bolt\Boltpay\Helper\CheckboxesHandler
  */
-class CheckboxesHandlerTest extends TestCase
+class CheckboxesHandlerTest extends BoltTestCase
 {
 
     const EMAIL = 'test@bolt.com';
@@ -52,7 +52,7 @@ class CheckboxesHandlerTest extends TestCase
     private $subscriber;
 
 
-    public function setUp()
+    public function setUpInternal()
     {
         $this->context = $this->getMockBuilder(Context::class)
             ->disableOriginalConstructor()

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -27,7 +27,7 @@ use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\App\Request\Http as Request;
 use Magento\Framework\Encryption\EncryptorInterface;
 use Magento\Framework\Module\ModuleResource;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Magento\Directory\Model\RegionFactory;
 use Bolt\Boltpay\Test\Unit\TestHelper;
@@ -39,7 +39,7 @@ use Magento\Framework\App\Config\Storage\WriterInterface;
  * @package Bolt\Boltpay\Test\Unit\Helper
  * @coversDefaultClass \Bolt\Boltpay\Helper\Config
  */
-class ConfigTest extends TestCase
+class ConfigTest extends BoltTestCase
 {
     const KEY_ENCRYPTED = 'KeyValue_Encripted';
     const KEY_DECRYPTED = 'KeyValue_Decrypted';
@@ -148,7 +148,7 @@ JSON;
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUpInternal()
     {
         $this->encryptor = $this->createMock(EncryptorInterface::class);
         $this->moduleResource = $this->createMock(ModuleResource::class);
@@ -250,12 +250,12 @@ JSON;
             $this->composerFactory
         );
         
-        $this->assertAttributeEquals($this->encryptor, 'encryptor', $instance);
-        $this->assertAttributeEquals($this->moduleResource, 'moduleResource', $instance);
-        $this->assertAttributeEquals($this->productMetadata, 'productMetadata', $instance);
-        $this->assertAttributeEquals($this->boltConfigSettingFactoryMock, 'boltConfigSettingFactory', $instance);
-        $this->assertAttributeEquals($this->regionFactory, 'regionFactory', $instance);
-        $this->assertAttributeEquals($this->composerFactory, 'composerFactory', $instance);
+        static::assertAttributeEquals($this->encryptor, 'encryptor', $instance);
+        static::assertAttributeEquals($this->moduleResource, 'moduleResource', $instance);
+        static::assertAttributeEquals($this->productMetadata, 'productMetadata', $instance);
+        static::assertAttributeEquals($this->boltConfigSettingFactoryMock, 'boltConfigSettingFactory', $instance);
+        static::assertAttributeEquals($this->regionFactory, 'regionFactory', $instance);
+        static::assertAttributeEquals($this->composerFactory, 'composerFactory', $instance);
     }
 
     /**
@@ -829,7 +829,7 @@ JSON;
     public function getClientIp()
     {
         $request = $this->createMock(\Magento\Framework\App\Request\Http::class);
-        $this->setInaccessibleProperty($this->currentMock, '_request', $request);
+        TestHelper::setInaccessibleProperty($this->currentMock, '_request', $request);
         $request->method('getServer')->with('HTTP_CLIENT_IP', false)->willReturn(self::TEST_IP[2]);
         $this->assertEquals(self::TEST_IP[2], $this->currentMock->getClientIp());
     }
@@ -840,7 +840,7 @@ JSON;
     public function getClientIp_false()
     {
         $request = $this->createMock(\Magento\Framework\App\Request\Http::class);
-        $this->setInaccessibleProperty($this->currentMock, '_request', $request);
+        TestHelper::setInaccessibleProperty($this->currentMock, '_request', $request);
         $request->method('getServer')->withAnyParameters()->willReturn(false);
         $this->assertEquals('', $this->currentMock->getClientIp());
     }
@@ -1018,22 +1018,6 @@ JSON;
             ["cms_index_index"],
             $pageBlacklist
         );
-    }
-
-    /**
-     * @param  $object
-     * @param  $property
-     * @param  $value
-     * @throws \ReflectionException
-     */
-    private static function setInaccessibleProperty($object, $property, $value)
-    {
-        $reflection = new \ReflectionClass(
-            ($object instanceof MockObject) ? get_parent_class($object) : $object
-        );
-        $reflectionProperty = $reflection->getProperty($property);
-        $reflectionProperty->setAccessible(true);
-        $reflectionProperty->setValue($object, $value);
     }
 
     /**

--- a/Test/Unit/Helper/DiscountTest.php
+++ b/Test/Unit/Helper/DiscountTest.php
@@ -23,7 +23,7 @@ use Bolt\Boltpay\Test\Unit\TestHelper;
 use Magento\Framework\DataObject;
 use Magento\Framework\Exception\LocalizedException;
 use PHPUnit\Framework\MockObject\MockObject;
-use \PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Helper\Discount;
 use Magento\Framework\App\Helper\Context;
 use Magento\Framework\App\ResourceConnection;
@@ -50,7 +50,7 @@ use Bolt\Boltpay\Model\EventsForThirdPartyModules;
  * @package Bolt\Boltpay\Test\Unit\Helper
  * @coversDefaultClass \Bolt\Boltpay\Helper\Discount
  */
-class DiscountTest extends TestCase
+class DiscountTest extends BoltTestCase
 {
     /**
      * @var MockObject|Discount mocked instance of the class tested
@@ -206,7 +206,7 @@ class DiscountTest extends TestCase
     /**
      * Setup test dependencies, called before each test
      */
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->context = $this->createMock(Context::class);
         $this->resource = $this->createMock(ResourceConnection::class);

--- a/Test/Unit/Helper/FeatureSwitch/DeciderTest.php
+++ b/Test/Unit/Helper/FeatureSwitch/DeciderTest.php
@@ -30,14 +30,14 @@ use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Session\SessionManagerInterface as CoreSession;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
 /**
  * Class DeciderTest
  * @package Bolt\Boltpay\Test\Unit\Helper\FeatureSwitch
  * @coversDefaultClass \Bolt\Boltpay\Helper\FeatureSwitch\Decider
  */
-class DeciderTest  extends TestCase
+class DeciderTest  extends BoltTestCase
 {
     /**
      * @var Context
@@ -82,7 +82,7 @@ class DeciderTest  extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUpInternal()
     {
 
         $this->context = $this->createMock(Context::class);
@@ -133,11 +133,11 @@ class DeciderTest  extends TestCase
             $this->fsFactory
         );
         
-        $this->assertAttributeEquals($this->session, '_session', $instance);
-        $this->assertAttributeEquals($this->state, '_state', $instance);
-        $this->assertAttributeEquals($this->manager, '_manager', $instance);
-        $this->assertAttributeEquals($this->fsRepo, '_fsRepo', $instance);
-        $this->assertAttributeEquals($this->fsFactory, '_fsFactory', $instance);
+        static::assertAttributeEquals($this->session, '_session', $instance);
+        static::assertAttributeEquals($this->state, '_state', $instance);
+        static::assertAttributeEquals($this->manager, '_manager', $instance);
+        static::assertAttributeEquals($this->fsRepo, '_fsRepo', $instance);
+        static::assertAttributeEquals($this->fsFactory, '_fsFactory', $instance);
     }
 
     /**

--- a/Test/Unit/Helper/FeatureSwitch/ManagerTest.php
+++ b/Test/Unit/Helper/FeatureSwitch/ManagerTest.php
@@ -23,14 +23,14 @@ use Bolt\Boltpay\Helper\GraphQL\Client as GQL;
 use Bolt\Boltpay\Model\Response as BoltResponse;
 use Magento\Framework\App\Helper\Context;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
 /**
  * Class ManagerTest
  *
  * @coversDefaultClass \Bolt\Boltpay\Helper\FeatureSwitch\Manager
  */
-class ManagerTest extends TestCase
+class ManagerTest extends BoltTestCase
 {
     /**
      * @var Context
@@ -55,7 +55,7 @@ class ManagerTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUpInternal()
     {
 
         $this->context = $this->createMock(Context::class);
@@ -86,8 +86,8 @@ class ManagerTest extends TestCase
             $this->fsRepo
         );
         
-        $this->assertAttributeEquals($this->gql, 'gql', $instance);
-        $this->assertAttributeEquals($this->fsRepo, 'fsRepo', $instance);
+        static::assertAttributeEquals($this->gql, 'gql', $instance);
+        static::assertAttributeEquals($this->fsRepo, 'fsRepo', $instance);
     }
 
     /**

--- a/Test/Unit/Helper/GeolocationTest.php
+++ b/Test/Unit/Helper/GeolocationTest.php
@@ -17,7 +17,7 @@
 
 namespace Bolt\Boltpay\Test\Unit\Helper;
 
-use \PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Helper\Geolocation;
 use Magento\Framework\App\Helper\Context;
 use Bolt\Boltpay\Helper\Config as ConfigHelper;
@@ -30,7 +30,7 @@ use Magento\Framework\App\CacheInterface;
  * @package Bolt\Boltpay\Test\Unit\Helper
  * @coversDefaultClass \Bolt\Boltpay\Helper\Geolocation
  */
-class GeolocationTest extends TestCase
+class GeolocationTest extends BoltTestCase
 {
     const API_KEY = 'api_key';
     const CLIENT_IP = '127.0.0.1';
@@ -69,7 +69,7 @@ class GeolocationTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUpInternal()
     {
         $this->context = $this->createPartialMock(Context::class, ['getMpGiftCards']);
         $this->configHelper = $this->createPartialMock(ConfigHelper::class, ['getGeolocationApiKey', 'getClientIp']);
@@ -106,10 +106,10 @@ class GeolocationTest extends TestCase
             $this->cache
         );
         
-        $this->assertAttributeEquals($this->configHelper, 'configHelper', $instance);
-        $this->assertAttributeEquals($this->bugsnag, 'bugsnag', $instance);
-        $this->assertAttributeEquals($this->httpClientFactory, 'httpClientFactory', $instance);
-        $this->assertAttributeEquals($this->cache, 'cache', $instance);
+        static::assertAttributeEquals($this->configHelper, 'configHelper', $instance);
+        static::assertAttributeEquals($this->bugsnag, 'bugsnag', $instance);
+        static::assertAttributeEquals($this->httpClientFactory, 'httpClientFactory', $instance);
+        static::assertAttributeEquals($this->cache, 'cache', $instance);
     }
 
     /**

--- a/Test/Unit/Helper/GraphQL/ClientTest.php
+++ b/Test/Unit/Helper/GraphQL/ClientTest.php
@@ -26,7 +26,7 @@ use Bolt\Boltpay\Model\Response as BoltResponse;
 use Bolt\Boltpay\Model\RequestFactory;
 use Bolt\Boltpay\Helper\Log as LogHelper;
 use Bolt\Boltpay\Helper\Bugsnag;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Magento\Framework\App\Helper\Context;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Zend\Http\Response;
@@ -36,7 +36,7 @@ use Zend\Http\Response;
  * @package Bolt\Boltpay\Test\Unit\Helper\GraphQL
  * @coversDefaultClass \Bolt\Boltpay\Helper\GraphQL\Client
  */
-class ClientTest extends TestCase
+class ClientTest extends BoltTestCase
 {
 
     /**
@@ -82,7 +82,7 @@ class ClientTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUpInternal()
     {
 
         $this->context = $this->createMock(Context::class);
@@ -126,12 +126,12 @@ class ClientTest extends TestCase
             $this->bugsnag
         );
         
-        $this->assertAttributeEquals($this->zendClientFactory, 'httpClientFactory', $instance);
-        $this->assertAttributeEquals($this->boltConfig, 'configHelper', $instance);
-        $this->assertAttributeEquals($this->responseFactory, 'responseFactory', $instance);
-        $this->assertAttributeEquals($this->requestFactory, 'requestFactory', $instance);
-        $this->assertAttributeEquals($this->logger, 'logHelper', $instance);
-        $this->assertAttributeEquals($this->bugsnag, 'bugsnag', $instance);
+        static::assertAttributeEquals($this->zendClientFactory, 'httpClientFactory', $instance);
+        static::assertAttributeEquals($this->boltConfig, 'configHelper', $instance);
+        static::assertAttributeEquals($this->responseFactory, 'responseFactory', $instance);
+        static::assertAttributeEquals($this->requestFactory, 'requestFactory', $instance);
+        static::assertAttributeEquals($this->logger, 'logHelper', $instance);
+        static::assertAttributeEquals($this->bugsnag, 'bugsnag', $instance);
     }
 
     /**

--- a/Test/Unit/Helper/HookTest.php
+++ b/Test/Unit/Helper/HookTest.php
@@ -22,7 +22,7 @@ use Bolt\Boltpay\Test\Unit\TestHelper;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\TestFramework\Inspection\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Magento\Framework\App\Helper\Context;
 use Magento\Framework\DataObjectFactory;
 use Magento\Framework\Webapi\Rest\Request;
@@ -42,7 +42,7 @@ use ReflectionException;
  * @coversDefaultClass \Bolt\Boltpay\Helper\Hook
  * @package Bolt\Boltpay\Test\Unit\Helper
  */
-class HookTest extends TestCase
+class HookTest extends BoltTestCase
 {
     const PAYLOAD = 'payload';
     const CORRECT_HMAC = 'correct HMAC';
@@ -80,7 +80,7 @@ class HookTest extends TestCase
     /**
      * Setup test dependencies, called before each test
      */
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->context = $this->createMock(Context::class);
         $this->request = $this->createMock(Request::class);
@@ -136,13 +136,13 @@ class HookTest extends TestCase
             $this->response
         );
         
-        $this->assertAttributeEquals($this->request, 'request', $instance);
-        $this->assertAttributeEquals($this->configHelper, 'configHelper', $instance);
-        $this->assertAttributeEquals($this->logHelper, 'logHelper', $instance);
-        $this->assertAttributeEquals($this->apiHelper, 'apiHelper', $instance);
-        $this->assertAttributeEquals($this->dataObjectFactory, 'dataObjectFactory', $instance);
-        $this->assertAttributeEquals($this->bugsnag, 'bugsnag', $instance);
-        $this->assertAttributeEquals($this->response, 'response', $instance);
+        static::assertAttributeEquals($this->request, 'request', $instance);
+        static::assertAttributeEquals($this->configHelper, 'configHelper', $instance);
+        static::assertAttributeEquals($this->logHelper, 'logHelper', $instance);
+        static::assertAttributeEquals($this->apiHelper, 'apiHelper', $instance);
+        static::assertAttributeEquals($this->dataObjectFactory, 'dataObjectFactory', $instance);
+        static::assertAttributeEquals($this->bugsnag, 'bugsnag', $instance);
+        static::assertAttributeEquals($this->response, 'response', $instance);
     }
 
     /**

--- a/Test/Unit/Helper/LogRetrieverTest.php
+++ b/Test/Unit/Helper/LogRetrieverTest.php
@@ -18,7 +18,7 @@
 namespace Bolt\Boltpay\Test\Unit\Helper;
 
 use Bolt\Boltpay\Helper\LogRetriever;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use org\bovigo\vfs\vfsStream;
 use Magento\Framework\Filesystem\Driver\File;
 use Bolt\Boltpay\Helper\Bugsnag;
@@ -28,7 +28,7 @@ use Bolt\Boltpay\Helper\Bugsnag;
  * @package Bolt\Boltpay\Test\Unit\Helper
  */
 
-class LogRetrieverTest extends TestCase
+class LogRetrieverTest extends BoltTestCase
 {
     /**
      * @var string
@@ -48,7 +48,7 @@ class LogRetrieverTest extends TestCase
     private $bugsnag;
     private $file;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $structure = [
             'log' => [

--- a/Test/Unit/Helper/LogTest.php
+++ b/Test/Unit/Helper/LogTest.php
@@ -20,7 +20,7 @@ namespace Bolt\Boltpay\Test\Unit\Helper;
 use Bolt\Boltpay\Logger\Logger as BoltLogger;
 use Bolt\Boltpay\Helper\Config as ConfigHelper;
 use Magento\Framework\App\Helper\Context;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Helper\Log;
 
 /**
@@ -28,7 +28,7 @@ use Bolt\Boltpay\Helper\Log;
  * @package Bolt\Boltpay\Test\Unit\Helper
  * @coversDefaultClass \Bolt\Boltpay\Helper\Log
  */
-class LogTest extends TestCase
+class LogTest extends BoltTestCase
 {
     const INFO_MESSAGE = 'info';
 
@@ -55,7 +55,7 @@ class LogTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUpInternal()
     {
         $this->context = $this->createMock(Context::class);
         $this->boltLoger = $this->createPartialMock(
@@ -95,8 +95,8 @@ class LogTest extends TestCase
             $this->configHelper
         );
         
-        $this->assertAttributeEquals($this->boltLoger, 'boltLogger', $instance);
-        $this->assertAttributeEquals($this->configHelper, 'configHelper', $instance);
+        static::assertAttributeEquals($this->boltLoger, 'boltLogger', $instance);
+        static::assertAttributeEquals($this->configHelper, 'configHelper', $instance);
     }
 
     /**

--- a/Test/Unit/Helper/MetricTest.php
+++ b/Test/Unit/Helper/MetricTest.php
@@ -17,10 +17,10 @@
 
 namespace Bolt\Boltpay\Test\Unit\Helper;
 
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Helper\Metric;
 
-class MetricTest extends TestCase
+class MetricTest extends BoltTestCase
 {
     const KEY = 'key';
     const DATA = ['value' => '2222'];
@@ -30,7 +30,7 @@ class MetricTest extends TestCase
      */
     protected $metric;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->metric = new Metric(self::KEY, self::DATA);
     }

--- a/Test/Unit/Helper/MetricsClientTest.php
+++ b/Test/Unit/Helper/MetricsClientTest.php
@@ -21,7 +21,7 @@ use Bolt\Boltpay\Helper\Config;
 use Bolt\Boltpay\Helper\Config as ConfigHelper;
 use Bolt\Boltpay\Helper\Metric;
 use Magento\Framework\App\CacheInterface;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Magento\Store\Model\StoreManagerInterface;
 use Bolt\Boltpay\Helper\Bugsnag;
 use Bolt\Boltpay\Helper\MetricsClient;
@@ -37,7 +37,7 @@ use GuzzleHttp\Exception\RequestException;
 use org\bovigo\vfs\vfsStream;
 use Bolt\Boltpay\Helper\FeatureSwitch\Decider;
 
-class MetricsClientTest extends TestCase
+class MetricsClientTest extends BoltTestCase
 {
     /**
      * @var \GuzzleHttp\Client
@@ -127,7 +127,7 @@ class MetricsClientTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUpInternal()
     {
         // common values
         $this->timeStamp = 1567541470604;

--- a/Test/Unit/Helper/ModuleRetrieverTest.php
+++ b/Test/Unit/Helper/ModuleRetrieverTest.php
@@ -24,9 +24,9 @@ use Bolt\Boltpay\Model\Api\Data\PluginVersion;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\DB\Adapter\AdapterInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
-class ModuleRetrieverTest extends TestCase
+class ModuleRetrieverTest extends BoltTestCase
 {
     /**
      * @var ModuleRetriever
@@ -62,7 +62,7 @@ class ModuleRetrieverTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUpInternal()
     {
         $this->dbResult = [
             [

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -69,7 +69,6 @@ use Magento\Sales\Model\Order\Payment\Transaction;
 use Magento\Sales\Model\Order\Payment\Transaction\Builder as TransactionBuilder;
 use Magento\Store\Model\ScopeInterface;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
-use PHPUnit\Framework\TestCase;
 use Bolt\Boltpay\Helper\Order as OrderHelper;
 use Bolt\Boltpay\Exception\BoltException;
 use ReflectionException;
@@ -264,7 +263,7 @@ class OrderTest extends BoltTestCase
      *
      * @throws ReflectionException from initRequiredMocks and initCurrentMock methods
      */
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->initRequiredMocks();
         $this->initCurrentMock(
@@ -287,7 +286,7 @@ class OrderTest extends BoltTestCase
     /**
      * Cleanup changes made by tests
      */
-    protected function tearDown()
+    protected function tearDownInternal()
     {
         Hook::$fromBolt = false;
     }
@@ -536,38 +535,38 @@ class OrderTest extends BoltTestCase
             $this->creditmemoManagement,
             $this->eventsForThirdPartyModules
         );
-        $this->assertAttributeEquals($this->apiHelper, 'apiHelper', $instance);
-        $this->assertAttributeEquals($this->configHelper, 'configHelper', $instance);
-        $this->assertAttributeEquals($this->regionModel, 'regionModel', $instance);
-        $this->assertAttributeEquals($this->quoteManagement, 'quoteManagement', $instance);
-        $this->assertAttributeEquals($this->emailSender, 'emailSender', $instance);
-        $this->assertAttributeEquals($this->invoiceService, 'invoiceService', $instance);
-        $this->assertAttributeEquals($this->invoiceSender, 'invoiceSender', $instance);
-        $this->assertAttributeEquals($this->searchCriteriaBuilder, 'searchCriteriaBuilder', $instance);
-        $this->assertAttributeEquals($this->orderRepository, 'orderRepository', $instance);
-        $this->assertAttributeEquals($this->transactionBuilder, 'transactionBuilder', $instance);
-        $this->assertAttributeEquals($this->timezone, 'timezone', $instance);
-        $this->assertAttributeEquals($this->dataObjectFactory, 'dataObjectFactory', $instance);
-        $this->assertAttributeEquals($this->logHelper, 'logHelper', $instance);
-        $this->assertAttributeEquals($this->bugsnag, 'bugsnag', $instance);
-        $this->assertAttributeEquals($this->cartHelper, 'cartHelper', $instance);
-        $this->assertAttributeEquals($this->resourceConnection, 'resourceConnection', $instance);
-        $this->assertAttributeEquals($this->sessionHelper, 'sessionHelper', $instance);
-        $this->assertAttributeEquals($this->discountHelper, 'discountHelper', $instance);
-        $this->assertAttributeEquals($this->date, 'date', $instance);
-        $this->assertAttributeEquals($this->webhookLogCollectionFactory, 'webhookLogCollectionFactory', $instance);
-        $this->assertAttributeEquals($this->webhookLogFactory, 'webhookLogFactory', $instance);
-        $this->assertAttributeEquals($this->featureSwitches, 'featureSwitches', $instance);
-        $this->assertAttributeEquals($this->checkboxesHandler, 'checkboxesHandler', $instance);
-        $this->assertAttributeEquals($this->customerCreditCardFactory, 'customerCreditCardFactory', $instance);
-        $this->assertAttributeEquals(
+        static::assertAttributeEquals($this->apiHelper, 'apiHelper', $instance);
+        static::assertAttributeEquals($this->configHelper, 'configHelper', $instance);
+        static::assertAttributeEquals($this->regionModel, 'regionModel', $instance);
+        static::assertAttributeEquals($this->quoteManagement, 'quoteManagement', $instance);
+        static::assertAttributeEquals($this->emailSender, 'emailSender', $instance);
+        static::assertAttributeEquals($this->invoiceService, 'invoiceService', $instance);
+        static::assertAttributeEquals($this->invoiceSender, 'invoiceSender', $instance);
+        static::assertAttributeEquals($this->searchCriteriaBuilder, 'searchCriteriaBuilder', $instance);
+        static::assertAttributeEquals($this->orderRepository, 'orderRepository', $instance);
+        static::assertAttributeEquals($this->transactionBuilder, 'transactionBuilder', $instance);
+        static::assertAttributeEquals($this->timezone, 'timezone', $instance);
+        static::assertAttributeEquals($this->dataObjectFactory, 'dataObjectFactory', $instance);
+        static::assertAttributeEquals($this->logHelper, 'logHelper', $instance);
+        static::assertAttributeEquals($this->bugsnag, 'bugsnag', $instance);
+        static::assertAttributeEquals($this->cartHelper, 'cartHelper', $instance);
+        static::assertAttributeEquals($this->resourceConnection, 'resourceConnection', $instance);
+        static::assertAttributeEquals($this->sessionHelper, 'sessionHelper', $instance);
+        static::assertAttributeEquals($this->discountHelper, 'discountHelper', $instance);
+        static::assertAttributeEquals($this->date, 'date', $instance);
+        static::assertAttributeEquals($this->webhookLogCollectionFactory, 'webhookLogCollectionFactory', $instance);
+        static::assertAttributeEquals($this->webhookLogFactory, 'webhookLogFactory', $instance);
+        static::assertAttributeEquals($this->featureSwitches, 'featureSwitches', $instance);
+        static::assertAttributeEquals($this->checkboxesHandler, 'checkboxesHandler', $instance);
+        static::assertAttributeEquals($this->customerCreditCardFactory, 'customerCreditCardFactory', $instance);
+        static::assertAttributeEquals(
             $this->customerCreditCardCollectionFactory,
             'customerCreditCardCollectionFactory',
             $instance
         );
-        $this->assertAttributeEquals($this->creditmemoFactory, 'creditmemoFactory', $instance);
-        $this->assertAttributeEquals($this->creditmemoManagement, 'creditmemoManagement', $instance);
-        $this->assertAttributeEquals($this->eventsForThirdPartyModules, 'eventsForThirdPartyModules', $instance);
+        static::assertAttributeEquals($this->creditmemoFactory, 'creditmemoFactory', $instance);
+        static::assertAttributeEquals($this->creditmemoManagement, 'creditmemoManagement', $instance);
+        static::assertAttributeEquals($this->eventsForThirdPartyModules, 'eventsForThirdPartyModules', $instance);
     }
 
     /**

--- a/Test/Unit/Helper/SecretObscurerTest.php
+++ b/Test/Unit/Helper/SecretObscurerTest.php
@@ -18,9 +18,9 @@
 namespace Bolt\Boltpay\Test\Unit\Helper;
 
 use Bolt\Boltpay\Helper\SecretObscurer;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
-class SecretObscurerTest extends TestCase
+class SecretObscurerTest extends BoltTestCase
 {
     /**
      * @test

--- a/Test/Unit/Helper/SessionTest.php
+++ b/Test/Unit/Helper/SessionTest.php
@@ -19,7 +19,7 @@ namespace Bolt\Boltpay\Test\Unit\Helper;
 
 use Bolt\Boltpay\Helper\Session;
 use Bolt\Boltpay\Helper\Config as ConfigHelper;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Magento\Framework\App\Helper\Context;
 use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\Backend\Model\Session\Quote as AdminCheckoutSession;
@@ -41,7 +41,7 @@ use Zend\Serializer\Adapter\PhpSerialize as Serialize;
  * @package Bolt\Boltpay\Test\Unit\Helper
  * @coversDefaultClass \Bolt\Boltpay\Helper\Session
  */
-class SessionTest extends TestCase
+class SessionTest extends BoltTestCase
 {
     const SESSION_ID = '1111';
     const QUOTE_ID = '1';
@@ -110,7 +110,7 @@ class SessionTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUpInternal()
     {
         $this->initRequiredMocks();
         $this->initCurrentMock();
@@ -216,16 +216,16 @@ class SessionTest extends TestCase
             $this->serialize
         );
         
-        $this->assertAttributeEquals($this->checkoutSession, 'checkoutSession', $instance);
-        $this->assertAttributeEquals($this->adminCheckoutSession, 'adminCheckoutSession', $instance);
-        $this->assertAttributeEquals($this->customerSession, 'customerSession', $instance);
-        $this->assertAttributeEquals($this->logHelper, 'logHelper', $instance);
-        $this->assertAttributeEquals($this->cache, 'cache', $instance);
-        $this->assertAttributeEquals($this->appState, 'appState', $instance);
-        $this->assertAttributeEquals($this->eventsForThirdPartyModules, 'eventsForThirdPartyModules', $instance);
-        $this->assertAttributeEquals($this->formKey, 'formKey', $instance);
-        $this->assertAttributeEquals($this->configHelper, 'configHelper', $instance);
-        $this->assertAttributeEquals($this->serialize, 'serialize', $instance);
+        static::assertAttributeEquals($this->checkoutSession, 'checkoutSession', $instance);
+        static::assertAttributeEquals($this->adminCheckoutSession, 'adminCheckoutSession', $instance);
+        static::assertAttributeEquals($this->customerSession, 'customerSession', $instance);
+        static::assertAttributeEquals($this->logHelper, 'logHelper', $instance);
+        static::assertAttributeEquals($this->cache, 'cache', $instance);
+        static::assertAttributeEquals($this->appState, 'appState', $instance);
+        static::assertAttributeEquals($this->eventsForThirdPartyModules, 'eventsForThirdPartyModules', $instance);
+        static::assertAttributeEquals($this->formKey, 'formKey', $instance);
+        static::assertAttributeEquals($this->configHelper, 'configHelper', $instance);
+        static::assertAttributeEquals($this->serialize, 'serialize', $instance);
     }
 
     /**

--- a/Test/Unit/Helper/SessionTest.php
+++ b/Test/Unit/Helper/SessionTest.php
@@ -174,7 +174,7 @@ class SessionTest extends TestCase
     private function initCurrentMock()
     {
         $this->currentMock = $this->getMockBuilder(Session::class)
-            ->setMethods(['replaceQuote', 'setSession'])
+            ->setMethods(['replaceQuote'])
             ->enableOriginalConstructor()
             ->setConstructorArgs(
                 [
@@ -300,7 +300,6 @@ class SessionTest extends TestCase
         $this->quote->expects(self::once())->method('getStoreId')->willReturn(self::STORE_ID);
         $this->cache->expects(self::once())->method('load')->willReturn('a:2:{s:11:"sessionType";s:8:"frontend";s:9:"sessionID";s:4:"1111";}');
 
-        $this->currentMock->expects(self::any())->method('setSession')->withAnyParameters()->willReturnSelf();
         $this->customerSession->expects(self::once())->method('loginById')->with(self::CUSTOMER_ID)->willReturnSelf();
 
         $this->checkoutSession->expects(self::once())->method('replaceQuote')->with($this->quote)->willReturnSelf();

--- a/Test/Unit/Helper/Shared/ApiUtilsTest.php
+++ b/Test/Unit/Helper/Shared/ApiUtilsTest.php
@@ -19,14 +19,14 @@ namespace Bolt\Boltpay\Test\Unit\Helper\Shared;
 
 use Bolt\Boltpay\Helper\Shared\ApiUtils;
 use Magento\Framework\Exception\LocalizedException;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
 /**
  * Class ApiUtilsTest
  *
  * @package Bolt\Boltpay\Test\Unit\Helper\Shared
  */
-class ApiUtilsTest extends TestCase
+class ApiUtilsTest extends BoltTestCase
 {
 
     /**

--- a/Test/Unit/Helper/Shared/CurrencyUtilsTest.php
+++ b/Test/Unit/Helper/Shared/CurrencyUtilsTest.php
@@ -18,14 +18,14 @@
 namespace Bolt\Boltpay\Test\Unit\Helper\Shared;
 
 use Bolt\Boltpay\Helper\Shared\CurrencyUtils;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
 /**
  * Class CurrencyUtilsTest
  *
  * @package Bolt\Boltpay\Test\Unit\Helper\Shared
  */
-class CurrencyUtilsTest extends TestCase
+class CurrencyUtilsTest extends BoltTestCase
 {
     /**
      * @test

--- a/Test/Unit/Model/Api/CreateOrderTest.php
+++ b/Test/Unit/Model/Api/CreateOrderTest.php
@@ -35,7 +35,7 @@ use Magento\Framework\Webapi\Rest\Request;
 use Magento\Framework\Webapi\Rest\Response;
 use Magento\Quote\Model\Quote;
 use Magento\Sales\Model\Order;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Helper\Order as OrderHelper;
 use Bolt\Boltpay\Exception\BoltException;
 use Bolt\Boltpay\Model\Api\CreateOrder;
@@ -48,7 +48,7 @@ use Bolt\Boltpay\Model\EventsForThirdPartyModules;
  * @package Bolt\Boltpay\Test\Unit\Model\Api
  * @coversDefaultClass \Bolt\Boltpay\Model\Api\CreateOrder
  */
-class CreateOrderTest extends TestCase
+class CreateOrderTest extends BoltTestCase
 {
     const STORE_ID = 1;
     const MINIMUM_ORDER_AMOUNT = 50;
@@ -153,7 +153,7 @@ class CreateOrderTest extends TestCase
     /**
      * @inheritdoc
      */
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->initRequiredMocks();
         $this->initCurrentMock();

--- a/Test/Unit/Model/Api/Data/BoltConfigSettingTest.php
+++ b/Test/Unit/Model/Api/Data/BoltConfigSettingTest.php
@@ -17,21 +17,21 @@
 
 namespace Bolt\Boltpay\Test\Unit\Model\Api;
 
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Model\Api\Data\BoltConfigSetting;
 
 /**
  * Class BoltConfigSettingTest
  * @package Bolt\Boltpay\Test\Unit\Model\Api
  */
-class BoltConfigSettingTest extends TestCase
+class BoltConfigSettingTest extends BoltTestCase
 {
     /**
      * @var BoltConfigSetting
      */
     protected $boltConfigSetting;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->boltConfigSetting = new BoltConfigSetting();
     }

--- a/Test/Unit/Model/Api/Data/CartDataTest.php
+++ b/Test/Unit/Model/Api/Data/CartDataTest.php
@@ -19,7 +19,7 @@ namespace Bolt\Boltpay\Test\Unit\Model\Api\Data;
 
 use Bolt\Boltpay\Api\Data\CartDataInterface;
 use Bolt\Boltpay\Model\Api\Data\CartData;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Magento\Framework\Reflection\TypeProcessor;
 use Zend\Code\Reflection\ClassReflection;
 
@@ -28,7 +28,7 @@ use Zend\Code\Reflection\ClassReflection;
  * @package Bolt\Boltpay\Test\Unit\Model\Api\Data
  * @coversDefaultClass \Bolt\Boltpay\Model\Api\Data\CartData
  */
-class CartDataTest extends TestCase
+class CartDataTest extends BoltTestCase
 {
     const DISPLAYID = '10001';
     const CURRENCY = 'CURRENCY';
@@ -49,7 +49,7 @@ class CartDataTest extends TestCase
      */
     private $typeProcessor;
 
-    public function setUp()
+    public function setUpInternal()
     {
         $this->cartData = new CartData;
         $this->cartData->setDisplayId(self::DISPLAYID);

--- a/Test/Unit/Model/Api/Data/DebugInfoTest.php
+++ b/Test/Unit/Model/Api/Data/DebugInfoTest.php
@@ -17,21 +17,21 @@
 
 namespace Bolt\Boltpay\Test\Unit\Model\Api\Data;
 
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Model\Api\Data\DebugInfo;
 
 /**
  * Class DebugInfoTest
  * @package Bolt\Boltpay\Test\Unit\Model\Api
  */
-class DebugInfoTest extends TestCase
+class DebugInfoTest extends BoltTestCase
 {
     /**
      * @var \Bolt\Boltpay\Model\Api\Data\DebugInfo
      */
     protected $debugInfo;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->debugInfo = new DebugInfo();
         $this->debugInfo->setPhpVersion('7.1');

--- a/Test/Unit/Model/Api/Data/PluginVersionTest.php
+++ b/Test/Unit/Model/Api/Data/PluginVersionTest.php
@@ -17,21 +17,21 @@
 
 namespace Bolt\Boltpay\Test\Unit\Model\Api;
 
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Model\Api\Data\PluginVersion;
 
 /**
  * Class PluginVersionTest
  * @package Bolt\Boltpay\Test\Unit\Model\Api
  */
-class PluginVersionTest extends TestCase
+class PluginVersionTest extends BoltTestCase
 {
     /**
      * @var PluginVersion
      */
     protected $pluginVersion;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->pluginVersion = new PluginVersion();
     }

--- a/Test/Unit/Model/Api/Data/ShippingDataTest.php
+++ b/Test/Unit/Model/Api/Data/ShippingDataTest.php
@@ -17,7 +17,7 @@
 
 namespace Bolt\Boltpay\Test\Unit\Model\Api\Data;
 
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Model\Api\Data\ShippingOption;
 use Bolt\Boltpay\Api\Data\ShippingDataInterface;
 use Bolt\Boltpay\Model\Api\Data\ShippingData;
@@ -27,7 +27,7 @@ use Bolt\Boltpay\Model\Api\Data\ShippingData;
  * @package Bolt\Boltpay\Test\Unit\Model\Api\Data
  * @coversDefaultClass \Bolt\Boltpay\Model\Api\Data\ShippingData
  */
-class ShippingDataTest extends TestCase
+class ShippingDataTest extends BoltTestCase
 {
     /**
      * @var ShippingDataInterface
@@ -39,7 +39,7 @@ class ShippingDataTest extends TestCase
      */
     private $shippingOptions;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->shippingOptions = [new ShippingOption];
         $this->shippingData = new ShippingData;

--- a/Test/Unit/Model/Api/Data/ShippingOptionTest.php
+++ b/Test/Unit/Model/Api/Data/ShippingOptionTest.php
@@ -17,7 +17,7 @@
 
 namespace Bolt\Boltpay\Test\Unit\Model\Api\Data;
 
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Model\Api\Data\ShippingOption;
 
 /**
@@ -25,7 +25,7 @@ use Bolt\Boltpay\Model\Api\Data\ShippingOption;
  * @package Bolt\Boltpay\Test\Unit\Model\Api\Data
  * @coversDefaultClass \Bolt\Boltpay\Model\Api\Data\ShippingOption
  */
-class ShippingOptionTest extends TestCase
+class ShippingOptionTest extends BoltTestCase
 {
     const REFERENCE = 'REFERENCE';
     const SERVICE = 'SERVICE';
@@ -37,7 +37,7 @@ class ShippingOptionTest extends TestCase
      */
     protected $shippingOption;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->shippingOption = new ShippingOption();
         $this->shippingOption->setReference(self::REFERENCE);

--- a/Test/Unit/Model/Api/Data/ShippingOptionsTest.php
+++ b/Test/Unit/Model/Api/Data/ShippingOptionsTest.php
@@ -17,13 +17,13 @@
 
 namespace Bolt\Boltpay\Test\Unit\Model\Api\Data;
 
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
 /**
  * Class ShippingOptionsTest
  * @package Bolt\Boltpay\Test\Unit\Model\Api
  */
-class ShippingOptionsTest extends TestCase
+class ShippingOptionsTest extends BoltTestCase
 {
     const TAX_RESULT = '111';
 
@@ -37,7 +37,7 @@ class ShippingOptionsTest extends TestCase
      */
     protected $shippingOptions;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->shippingOptions = new \Bolt\Boltpay\Model\Api\Data\ShippingOptions();
     }

--- a/Test/Unit/Model/Api/Data/ShippingTaxTest.php
+++ b/Test/Unit/Model/Api/Data/ShippingTaxTest.php
@@ -17,13 +17,13 @@
 
 namespace Bolt\Boltpay\Test\Unit\Model\Api\Data;
 
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
 /**
  * Class ShippingTaxTest
  * @package Bolt\Boltpay\Test\Unit\Model\Api\Data
  */
-class ShippingTaxTest extends TestCase
+class ShippingTaxTest extends BoltTestCase
 {
     const TAX_AMOUNT = '111';
 
@@ -32,7 +32,7 @@ class ShippingTaxTest extends TestCase
      */
     protected $shippingTax;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->shippingTax = new \Bolt\Boltpay\Model\Api\Data\ShippingTax;
     }

--- a/Test/Unit/Model/Api/Data/TaxDataTest.php
+++ b/Test/Unit/Model/Api/Data/TaxDataTest.php
@@ -21,14 +21,14 @@ use Bolt\Boltpay\Api\Data\TaxDataInterface;
 use Bolt\Boltpay\Model\Api\Data\ShippingOption;
 use Bolt\Boltpay\Model\Api\Data\TaxData;
 use Bolt\Boltpay\Model\Api\Data\TaxResult;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
 /**
  * Class TaxDataTest
  * @package Bolt\Boltpay\Test\Unit\Model\Api\Data
  * @coversDefaultClass \Bolt\Boltpay\Model\Api\Data\TaxData
  */
-class TaxDataTest extends TestCase
+class TaxDataTest extends BoltTestCase
 {
     /**
      * @var TaxDataInterface
@@ -45,7 +45,7 @@ class TaxDataTest extends TestCase
      */
     private $shippingOption;
 
-    public function setUp()
+    public function setUpInternal()
     {
         $this->taxResult = new TaxResult;
         $this->shippingOption = new ShippingOption;

--- a/Test/Unit/Model/Api/Data/TaxResultTest.php
+++ b/Test/Unit/Model/Api/Data/TaxResultTest.php
@@ -19,14 +19,14 @@ namespace Bolt\Boltpay\Test\Unit\Model\Api\Data;
 
 use Bolt\Boltpay\Api\Data\TaxResultInterface;
 use Bolt\Boltpay\Model\Api\Data\TaxResult;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
 /**
  * Class TaxResultTest
  * @package Bolt\Boltpay\Test\Unit\Model\Api\Data
  * @coversDefaultClass \Bolt\Boltpay\Model\Api\Data\TaxResult
  */
-class TaxResultTest extends TestCase
+class TaxResultTest extends BoltTestCase
 {
     const SUBTOTAL_AMOUNT = 5;
 
@@ -35,7 +35,7 @@ class TaxResultTest extends TestCase
      */
     private $taxResult;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->taxResult = new TaxResult;
         $this->taxResult->setSubtotalAmount(self::SUBTOTAL_AMOUNT);

--- a/Test/Unit/Model/Api/Data/UpdateCartResultTest.php
+++ b/Test/Unit/Model/Api/Data/UpdateCartResultTest.php
@@ -20,7 +20,7 @@ namespace Bolt\Boltpay\Test\Unit\Model\Api\Data;
 use Bolt\Boltpay\Api\Data\UpdateCartResultInterface;
 use Bolt\Boltpay\Model\Api\Data\CartData;
 use Bolt\Boltpay\Model\Api\Data\UpdateCartResult;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Magento\Framework\Reflection\TypeProcessor;
 use Zend\Code\Reflection\ClassReflection;
 
@@ -29,7 +29,7 @@ use Zend\Code\Reflection\ClassReflection;
  * @package Bolt\Boltpay\Test\Unit\Model\Api\Data
  * @coversDefaultClass \Bolt\Boltpay\Model\Api\Data\UpdateCartResult
  */
-class UpdateCartResultTest extends TestCase
+class UpdateCartResultTest extends BoltTestCase
 {    
     const STATUS = 'STATUS';
     const ORDERREFERENCE = 'ORDERREFERENCE';
@@ -57,7 +57,7 @@ class UpdateCartResultTest extends TestCase
      */
     private $typeProcessor;
 
-    public function setUp()
+    public function setUpInternal()
     {
         $this->updateCartResult = new UpdateCartResult;
         $this->orderCreate = new CartData;
@@ -106,7 +106,7 @@ class UpdateCartResultTest extends TestCase
      *
      * @covers ::getStatus
      */
-    public function getStatus()
+    public function getCartResultStatus()
     {
         $this->assertEquals(self::STATUS, $this->updateCartResult->getStatus());
     }

--- a/Test/Unit/Model/Api/DebugTest.php
+++ b/Test/Unit/Model/Api/DebugTest.php
@@ -32,7 +32,7 @@ use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Framework\Webapi\Rest\Response;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\StoreManagerInterface;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
 /**
  * Class CreateOrderTest
@@ -40,7 +40,7 @@ use PHPUnit\Framework\TestCase;
  * @package Bolt\Boltpay\Test\Unit\Model\Api
  * @coversDefaultClass \Bolt\Boltpay\Model\Api\Debug
  */
-class DebugTest extends TestCase
+class DebugTest extends BoltTestCase
 {
     /**
      * @var Debug
@@ -95,7 +95,7 @@ class DebugTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUpInternal()
     {
         // prepare response
         $this->responseMock = $this->createMock(Response::class);

--- a/Test/Unit/Model/Api/DiscountCodeValidationTest.php
+++ b/Test/Unit/Model/Api/DiscountCodeValidationTest.php
@@ -23,10 +23,11 @@ use Magento\Framework\DataObject;
 use Magento\SalesRule\Model\Rule;
 use Magento\SalesRule\Model\RuleRepository;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
+
 use Magento\SalesRule\Model\ResourceModel\Coupon\UsageFactory;
 use Magento\Framework\DataObjectFactory;
 use Magento\SalesRule\Model\Rule\CustomerFactory;
@@ -59,7 +60,7 @@ use Bolt\Boltpay\Test\Unit\TestHelper;
  * @package Bolt\Boltpay\Test\Unit\Model\Api
  * @coversDefaultClass \Bolt\Boltpay\Model\Api\DiscountCodeValidation
  */
-class DiscountCodeValidationTest extends TestCase
+class DiscountCodeValidationTest extends BoltTestCase
 {
     const PARENT_QUOTE_ID = "1000";
     const IMMUTABLE_QUOTE_ID = "1001";
@@ -226,7 +227,7 @@ class DiscountCodeValidationTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUpInternal()
     {
         $this->initRequiredMocks();        
     }

--- a/Test/Unit/Model/Api/FeatureSwitchesHookTest.php
+++ b/Test/Unit/Model/Api/FeatureSwitchesHookTest.php
@@ -31,9 +31,9 @@ use Magento\Framework\Webapi\Exception;
 use Magento\Framework\Webapi\Rest\Response\RendererFactory;
 use Magento\Framework\Webapi\Rest\Response;
 use Magento\Store\Model\StoreManagerInterface;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
-class FeatureSwitchesHookTest extends TestCase
+class FeatureSwitchesHookTest extends BoltTestCase
 {
     /**
      * @var HookHelper
@@ -79,7 +79,7 @@ class FeatureSwitchesHookTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUpInternal()
     {
         $rendererFactory = $this->createMock(RendererFactory::class);
         $errorProcessor = $this->createMock(ErrorProcessor::class);

--- a/Test/Unit/Model/Api/OrderManagementTest.php
+++ b/Test/Unit/Model/Api/OrderManagementTest.php
@@ -34,7 +34,7 @@ use Magento\Framework\Webapi\Rest\Request;
 use Magento\Framework\Webapi\Rest\Response;
 use Magento\Quote\Model\Quote;
 use Magento\Sales\Model\Order;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Helper\Order as OrderHelper;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Bolt\Boltpay\Helper\Cart as CartHelper;
@@ -46,7 +46,7 @@ use ReflectionException;
  * @package Bolt\Boltpay\Test\Unit\Model\Api
  * @coversDefaultClass \Bolt\Boltpay\Model\Api\OrderManagement
  */
-class OrderManagementTest extends TestCase
+class OrderManagementTest extends BoltTestCase
 {
     const ORDER_ID = 123;
     const QUOTE_ID = 456;
@@ -103,7 +103,7 @@ class OrderManagementTest extends TestCase
     /**
      * @inheritdoc
      */
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->initRequiredMocks();
         $this->initCurrentMock([]);

--- a/Test/Unit/Model/Api/ShippingMethodsTest.php
+++ b/Test/Unit/Model/Api/ShippingMethodsTest.php
@@ -21,7 +21,7 @@ use Bolt\Boltpay\Exception\BoltException;
 use Bolt\Boltpay\Model\Api\ShippingMethods as BoltShippingMethods;
 use Bolt\Boltpay\Test\Unit\TestHelper;
 use Magento\Framework\Webapi\Exception as WebapiException;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Helper\Hook as HookHelper;
 use Bolt\Boltpay\Helper\Cart as CartHelper;
 use Magento\Quote\Model\Quote;
@@ -49,6 +49,7 @@ use Magento\SalesRule\Model\Rule;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Zend\Serializer\Adapter\PhpSerialize as Serialize;
 use Bolt\Boltpay\Model\EventsForThirdPartyModules;
+use Magento\Framework\Phrase;
 
 /**
  * Class ShippingMethodsTest
@@ -56,7 +57,7 @@ use Bolt\Boltpay\Model\EventsForThirdPartyModules;
  * @package Bolt\Boltpay\Test\Unit\Model\Api
  * @coversDefaultClass \Bolt\Boltpay\Model\Api\ShippingMethods
  */
-class ShippingMethodsTest extends TestCase
+class ShippingMethodsTest extends BoltTestCase
 {
     const PARENT_QUOTE_ID = 1000;
     const IMMUTABLE_QUOTE_ID = 1001;
@@ -195,7 +196,7 @@ class ShippingMethodsTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUpInternal()
     {
         $this->createFactoryMocks();
 
@@ -547,7 +548,7 @@ class ShippingMethodsTest extends TestCase
         $this->currentMock->expects(self::once())->method('couponInvalidForShippingAddress')
             ->withAnyParameters()->willReturn(true);
 
-        self::setInaccessibleProperty($this->currentMock, 'taxAdjusted', true);
+        TestHelper::setInaccessibleProperty($this->currentMock, 'taxAdjusted', true);
         $this->bugsnag->expects(self::once())->method('registerCallback')->willReturnCallback(
             function (callable $fn) use ($shippingOptions) {
                 $reportMock = $this->createPartialMock(\stdClass::class, ['setMetaData']);
@@ -994,9 +995,9 @@ class ShippingMethodsTest extends TestCase
         $this->expectExceptionMessage('No Shipping Methods retrieved');
         $this->expectExceptionCode(BoltErrorResponse::ERR_SERVICE);
 
-        self::setInaccessibleProperty($this->currentMock, 'threshold', 0);
+        TestHelper::setInaccessibleProperty($this->currentMock, 'threshold', 0);
         $this->currentMock->getShippingOptions($quote, $addressData);
-        self::setInaccessibleProperty($this->currentMock, 'threshold', 1);
+        TestHelper::setInaccessibleProperty($this->currentMock, 'threshold', 1);
     }
 
     /**
@@ -1315,7 +1316,7 @@ Room 4000',
 
         $this->initCurrentMock();
 
-        self::setInaccessibleProperty(
+        TestHelper::setInaccessibleProperty(
             $this->currentMock,
             'quote',
             $immutableQuoteMock
@@ -1340,7 +1341,7 @@ Room 4000',
         $quote = $this->createPartialMock(Quote::class, ['getAllVisibleItems','getTotals']);
         $quote->expects(self::once())->method('getAllVisibleItems')->willReturn([]);
         $quote->expects(self::once())->method('getTotals')->willReturnSelf();
-        self::setInaccessibleProperty($this->currentMock, 'quote', $quote);
+        TestHelper::setInaccessibleProperty($this->currentMock, 'quote', $quote);
 
         $this->expectException(BoltException::class);
         $this->expectExceptionCode(6103);
@@ -1375,7 +1376,7 @@ Room 4000',
 
         $this->initCurrentMock();
         $quote = $this->getQuoteMock([]);
-        self::setInaccessibleProperty($this->currentMock, 'quote', $quote);
+        TestHelper::setInaccessibleProperty($this->currentMock, 'quote', $quote);
 
         $this->expectException(LocalizedException::class);
         $this->expectExceptionCode(6103);
@@ -1425,7 +1426,7 @@ Room 4000',
         ];
         $this->initCurrentMock();
         $quote = $this->getQuoteMock([]);
-        self::setInaccessibleProperty($this->currentMock, 'quote', $quote);
+        TestHelper::setInaccessibleProperty($this->currentMock, 'quote', $quote);
 
         $this->expectException(LocalizedException::class);
         $this->expectExceptionCode(6103);
@@ -1477,7 +1478,7 @@ Room 4000',
         ];
         $this->initCurrentMock();
         $quote = $this->getQuoteMock([]);
-        self::setInaccessibleProperty($this->currentMock, 'quote', $quote);
+        TestHelper::setInaccessibleProperty($this->currentMock, 'quote', $quote);
 
         // no exception expected
 
@@ -1693,22 +1694,6 @@ Room 4000',
         $method->setAccessible(true);
 
         return $method->invokeArgs($object, $args);
-    }
-
-    /**
-     * @param  $object
-     * @param  $property
-     * @param  $value
-     * @throws \ReflectionException
-     */
-    private static function setInaccessibleProperty($object, $property, $value)
-    {
-        $reflection = new \ReflectionClass(
-            ($object instanceof MockObject) ? get_parent_class($object) : $object
-        );
-        $reflectionProperty = $reflection->getProperty($property);
-        $reflectionProperty->setAccessible(true);
-        $reflectionProperty->setValue($object, $value);
     }
 
     /**

--- a/Test/Unit/Model/Api/ShippingMethodsTest.php
+++ b/Test/Unit/Model/Api/ShippingMethodsTest.php
@@ -213,7 +213,8 @@ class ShippingMethodsTest extends TestCase
                 'validateEmail',
                 'convertCustomAddressFieldsToCacheIdentifier',
                 'handleSpecialAddressCases',
-                'getCartItems'
+                'getCartItems',
+                'getImmutableQuoteIdFromBoltCartArray',
             ])->disableOriginalConstructor()
             ->getMock();
 
@@ -354,8 +355,12 @@ class ShippingMethodsTest extends TestCase
             ->willReturn(false);
 
         $this->initCurrentMock(['catchExceptionAndSendError']);
-
-        $exception =  new BoltException(
+        
+        $this->cartHelper->method('getImmutableQuoteIdFromBoltCartArray')
+            ->with($cart)
+            ->willReturn(self::IMMUTABLE_QUOTE_ID);
+        
+        $exception = new BoltException(
             __('Unknown quote id: %1.', self::IMMUTABLE_QUOTE_ID),
             null,
             6103
@@ -397,6 +402,10 @@ class ShippingMethodsTest extends TestCase
         $this->cartHelper->method('validateEmail')
             ->with($shippingAddress['email'])
             ->willReturn(true);
+        
+        $this->cartHelper->method('getImmutableQuoteIdFromBoltCartArray')
+            ->with($cart)
+            ->willReturn(self::IMMUTABLE_QUOTE_ID);
 
         $this->configHelper->method('getResetShippingCalculation')
             ->withAnyParameters()
@@ -495,6 +504,10 @@ class ShippingMethodsTest extends TestCase
         $this->cartHelper->method('validateEmail')
             ->with($shippingAddress['email'])
             ->willReturn(true);
+
+        $this->cartHelper->method('getImmutableQuoteIdFromBoltCartArray')
+            ->with($cart)
+            ->willReturn(self::IMMUTABLE_QUOTE_ID);
 
         $this->configHelper->method('getResetShippingCalculation')
             ->withAnyParameters()
@@ -612,6 +625,10 @@ class ShippingMethodsTest extends TestCase
         $this->cartHelper->method('getQuoteById')
             ->with(self::IMMUTABLE_QUOTE_ID)
             ->willReturn($quote);
+        
+        $this->cartHelper->method('getImmutableQuoteIdFromBoltCartArray')
+            ->with($cart)
+            ->willReturn(self::IMMUTABLE_QUOTE_ID);
 
         $this->cartHelper->expects(self::once())->method('handleSpecialAddressCases')
             ->with($shippingAddress)

--- a/Test/Unit/Model/Api/ShippingTaxContextTest.php
+++ b/Test/Unit/Model/Api/ShippingTaxContextTest.php
@@ -30,7 +30,7 @@ use Bolt\Boltpay\Model\Api\ShippingTaxContext;
 use Bolt\Boltpay\Model\ErrorResponse as BoltErrorResponse;
 use Magento\Directory\Model\Region as RegionModel;
 use Magento\Framework\Webapi\Rest\Response;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
@@ -38,7 +38,7 @@ use PHPUnit\Framework\MockObject\MockObject;
  * @package Bolt\Boltpay\Test\Unit\Model\Api
  * @coversDefaultClass \Bolt\Boltpay\Model\Api\ShippingTaxContext
  */
-class ShippingTaxContextTest extends TestCase
+class ShippingTaxContextTest extends BoltTestCase
 {
     /**
      * @var HookHelper|MockObject
@@ -105,7 +105,7 @@ class ShippingTaxContextTest extends TestCase
      */
     private $currentMock;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->hookHelper = $this->createMock(HookHelper::class);
         $this->cartHelper = $this->createMock(CartHelper::class);
@@ -165,18 +165,18 @@ class ShippingTaxContextTest extends TestCase
             $this->shippingOptionFactory
         );
 
-        $this->assertAttributeInstanceOf(HookHelper::class, 'hookHelper', $instance);
-        $this->assertAttributeInstanceOf(CartHelper::class, 'cartHelper', $instance);
-        $this->assertAttributeInstanceOf(LogHelper::class, 'logHelper', $instance);
-        $this->assertAttributeInstanceOf(ConfigHelper::class, 'configHelper', $instance);
-        $this->assertAttributeInstanceOf(SessionHelper::class, 'sessionHelper', $instance);
-        $this->assertAttributeInstanceOf(DiscountHelper::class, 'discountHelper', $instance);
-        $this->assertAttributeInstanceOf(Bugsnag::class, 'bugsnag', $instance);
-        $this->assertAttributeInstanceOf(MetricsClient::class, 'metricsClient', $instance);
-        $this->assertAttributeInstanceOf(BoltErrorResponse::class, 'errorResponse', $instance);
-        $this->assertAttributeInstanceOf(RegionModel::class, 'regionModel', $instance);
-        $this->assertAttributeInstanceOf(Response::class, 'response', $instance);
-        $this->assertAttributeInstanceOf(
+        static::assertAttributeInstanceOf(HookHelper::class, 'hookHelper', $instance);
+        static::assertAttributeInstanceOf(CartHelper::class, 'cartHelper', $instance);
+        static::assertAttributeInstanceOf(LogHelper::class, 'logHelper', $instance);
+        static::assertAttributeInstanceOf(ConfigHelper::class, 'configHelper', $instance);
+        static::assertAttributeInstanceOf(SessionHelper::class, 'sessionHelper', $instance);
+        static::assertAttributeInstanceOf(DiscountHelper::class, 'discountHelper', $instance);
+        static::assertAttributeInstanceOf(Bugsnag::class, 'bugsnag', $instance);
+        static::assertAttributeInstanceOf(MetricsClient::class, 'metricsClient', $instance);
+        static::assertAttributeInstanceOf(BoltErrorResponse::class, 'errorResponse', $instance);
+        static::assertAttributeInstanceOf(RegionModel::class, 'regionModel', $instance);
+        static::assertAttributeInstanceOf(Response::class, 'response', $instance);
+        static::assertAttributeInstanceOf(
             ShippingOptionInterfaceFactory::class,
             'shippingOptionFactory',
             $instance

--- a/Test/Unit/Model/Api/ShippingTaxTest.php
+++ b/Test/Unit/Model/Api/ShippingTaxTest.php
@@ -19,7 +19,7 @@ namespace Bolt\Boltpay\Test\Unit\Model\Api;
 
 use Magento\Framework\Webapi\Exception as WebapiException;
 use Magento\Store\Model\Store;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Helper\Hook as HookHelper;
 use Bolt\Boltpay\Helper\Cart as CartHelper;
 use Magento\Directory\Model\Region as RegionModel;
@@ -45,7 +45,7 @@ use Bolt\Boltpay\Test\Unit\TestHelper;
  * @package Bolt\Boltpay\Test\Unit\Model\Api
  * @coversDefaultClass \Bolt\Boltpay\Model\Api\ShippingTax
  */
-class ShippingTaxTest extends TestCase
+class ShippingTaxTest extends BoltTestCase
 {
     const PARENT_QUOTE_ID = 1000;
     const IMMUTABLE_QUOTE_ID = 1001;
@@ -130,7 +130,7 @@ class ShippingTaxTest extends TestCase
      */
     private $currentMock;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->hookHelper = $this->createMock(HookHelper::class);
         $this->cartHelper = $this->createMock(CartHelper::class);
@@ -198,62 +198,62 @@ class ShippingTaxTest extends TestCase
     {
         $this->initCurrentMock();
 
-        $this->assertAttributeInstanceOf(
+        static::assertAttributeInstanceOf(
             HookHelper::class,
             'hookHelper',
             $this->currentMock
         );
-        $this->assertAttributeInstanceOf(
+        static::assertAttributeInstanceOf(
             CartHelper::class,
             'cartHelper',
             $this->currentMock
         );
-        $this->assertAttributeInstanceOf(
+        static::assertAttributeInstanceOf(
             LogHelper::class,
             'logHelper',
             $this->currentMock
         );
-        $this->assertAttributeInstanceOf(
+        static::assertAttributeInstanceOf(
             ConfigHelper::class,
             'configHelper',
             $this->currentMock
         );
-        $this->assertAttributeInstanceOf(
+        static::assertAttributeInstanceOf(
             SessionHelper::class,
             'sessionHelper',
             $this->currentMock
         );
-        $this->assertAttributeInstanceOf(
+        static::assertAttributeInstanceOf(
             DiscountHelper::class,
             'discountHelper',
             $this->currentMock
         );
-        $this->assertAttributeInstanceOf(
+        static::assertAttributeInstanceOf(
             Bugsnag::class,
             'bugsnag',
             $this->currentMock
         );
-        $this->assertAttributeInstanceOf(
+        static::assertAttributeInstanceOf(
             MetricsClient::class,
             'metricsClient',
             $this->currentMock
         );
-        $this->assertAttributeInstanceOf(
+        static::assertAttributeInstanceOf(
             BoltErrorResponse::class,
             'errorResponse',
             $this->currentMock
         );
-        $this->assertAttributeInstanceOf(
+        static::assertAttributeInstanceOf(
             RegionModel::class,
             'regionModel',
             $this->currentMock
         );
-        $this->assertAttributeInstanceOf(
+        static::assertAttributeInstanceOf(
             Response::class,
             'response',
             $this->currentMock
         );
-        $this->assertAttributeInstanceOf(
+        static::assertAttributeInstanceOf(
             ShippingOptionInterfaceFactory::class,
             'shippingOptionFactory',
             $this->currentMock

--- a/Test/Unit/Model/Api/ShippingTest.php
+++ b/Test/Unit/Model/Api/ShippingTest.php
@@ -29,7 +29,7 @@ use Magento\Quote\Api\ShippingMethodManagementInterface;
 use Magento\Quote\Model\Quote;
 use PHPUnit\Framework\MockObject\MockObject;
 use Bolt\Boltpay\Model\Api\Shipping;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Api\Data\ShippingOptionInterface;
 use Magento\Quote\Api\Data\ShippingMethodInterface;
 use Bolt\Boltpay\Api\Data\ShippingOptionInterfaceFactory;
@@ -39,7 +39,7 @@ use Bolt\Boltpay\Api\Data\ShippingOptionInterfaceFactory;
  * @package Bolt\Boltpay\Test\Unit\Model\Api
  * @coversDefaultClass \Bolt\Boltpay\Model\Api\Shipping
  */
-class ShippingTest extends TestCase
+class ShippingTest extends BoltTestCase
 {
     const IMMUTABLE_QUOTE_ID = 1001;
     const PARENT_QUOTE_ID = 1000;
@@ -72,7 +72,7 @@ class ShippingTest extends TestCase
      */
     private $currentMock;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->shippingTaxContext = $this->createMock(ShippingTaxContext::class);
         $this->shippingDataFactory = $this->createMock(ShippingDataInterfaceFactory::class);
@@ -125,12 +125,12 @@ class ShippingTest extends TestCase
     {
         $this->initCurrentMock();
 
-        $this->assertAttributeInstanceOf(
+        static::assertAttributeInstanceOf(
             ShippingDataInterfaceFactory::class,
             'shippingDataFactory',
             $this->currentMock
         );
-        $this->assertAttributeInstanceOf(
+        static::assertAttributeInstanceOf(
             ShippingMethodManagementInterface::class,
             'shippingMethodManagement',
             $this->currentMock

--- a/Test/Unit/Model/Api/TaxTest.php
+++ b/Test/Unit/Model/Api/TaxTest.php
@@ -25,7 +25,7 @@ use Magento\Checkout\Api\TotalsInformationManagementInterface;
 use Bolt\Boltpay\Api\Data\TaxDataInterfaceFactory;
 use Bolt\Boltpay\Api\Data\TaxDataInterface;
 use Bolt\Boltpay\Api\Data\TaxResultInterfaceFactory;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Model\Api\Tax;
 use PHPUnit\Framework\MockObject\MockObject;
 use Magento\Quote\Api\Data\TotalsInterface;
@@ -38,7 +38,7 @@ use Magento\Quote\Model\Quote;
  * @package Bolt\Boltpay\Test\Unit\Model\Api
  * @coversDefaultClass \Bolt\Boltpay\Model\Api\Tax
  */
-class TaxTest extends TestCase
+class TaxTest extends BoltTestCase
 {
     const CURRENCY_CODE = 'USD';
     const IMMUTABLE_QUOTE_ID = 1001;
@@ -76,7 +76,7 @@ class TaxTest extends TestCase
      */
     private $currentMock;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->shippingTaxContext = $this->createMock(ShippingTaxContext::class);
 
@@ -133,22 +133,22 @@ class TaxTest extends TestCase
     {
         $this->initCurrentMock();
 
-        $this->assertAttributeInstanceOf(
+        static::assertAttributeInstanceOf(
             TaxDataInterfaceFactory::class,
             'taxDataFactory',
             $this->currentMock
         );
-        $this->assertAttributeInstanceOf(
+        static::assertAttributeInstanceOf(
             TaxResultInterfaceFactory::class,
             'taxResultFactory',
             $this->currentMock
         );
-        $this->assertAttributeInstanceOf(
+        static::assertAttributeInstanceOf(
             TotalsInformationManagementInterface::class,
             'totalsInformationManagement',
             $this->currentMock
         );
-        $this->assertAttributeInstanceOf(
+        static::assertAttributeInstanceOf(
             TotalsInformationInterface::class,
             'addressInformation',
             $this->currentMock

--- a/Test/Unit/Model/Api/UpdateCartCommonTest.php
+++ b/Test/Unit/Model/Api/UpdateCartCommonTest.php
@@ -47,7 +47,7 @@ use Bolt\Boltpay\Helper\Session as SessionHelper;
 use Bolt\Boltpay\Model\Api\UpdateCartContext;
 use Bolt\Boltpay\Model\Api\UpdateCartCommon;
 use Bolt\Boltpay\Test\Unit\TestHelper;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use Magento\Framework\App\CacheInterface;
 use Bolt\Boltpay\Model\EventsForThirdPartyModules;
@@ -57,7 +57,7 @@ use Bolt\Boltpay\Model\EventsForThirdPartyModules;
  * @package Bolt\Boltpay\Test\Unit\Model\Api
  * @coversDefaultClass \Bolt\Boltpay\Model\Api\UpdateCartCommon
  */
-class UpdateCartCommonTest extends TestCase
+class UpdateCartCommonTest extends BoltTestCase
 {
     const PARENT_QUOTE_ID = 1000;
     const IMMUTABLE_QUOTE_ID = 1001;
@@ -195,7 +195,7 @@ class UpdateCartCommonTest extends TestCase
     protected $stockStateInterface;
 
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->request = $this->createMock(Request::class);
         $this->response = $this->createMock(Response::class);
@@ -392,52 +392,52 @@ class UpdateCartCommonTest extends TestCase
     {
         $this->initCurrentMock();
 
-        $this->assertAttributeInstanceOf(
+        static::assertAttributeInstanceOf(
             Request::class,
             'request',
             $this->currentMock
         );
-        $this->assertAttributeInstanceOf(
+        static::assertAttributeInstanceOf(
             Response::class,
             'response',
             $this->currentMock
         );
-        $this->assertAttributeInstanceOf(
+        static::assertAttributeInstanceOf(
             LogHelper::class,
             'logHelper',
             $this->currentMock
         );
-        $this->assertAttributeInstanceOf(
+        static::assertAttributeInstanceOf(
             Bugsnag::class,
             'bugsnag',
             $this->currentMock
         );
-        $this->assertAttributeInstanceOf(
+        static::assertAttributeInstanceOf(
             CartHelper::class,
             'cartHelper',
             $this->currentMock
         );
-        $this->assertAttributeInstanceOf(
+        static::assertAttributeInstanceOf(
             HookHelper::class,
             'hookHelper',
             $this->currentMock
         );
-        $this->assertAttributeInstanceOf(
+        static::assertAttributeInstanceOf(
             BoltErrorResponse::class,
             'errorResponse',
             $this->currentMock
         );
-        $this->assertAttributeInstanceOf(
+        static::assertAttributeInstanceOf(
             RegionModel::class,
             'regionModel',
             $this->currentMock
         );
-        $this->assertAttributeInstanceOf(
+        static::assertAttributeInstanceOf(
             OrderHelper::class,
             'orderHelper',
             $this->currentMock
         );
-        $this->assertAttributeInstanceOf(
+        static::assertAttributeInstanceOf(
             RegionModel::class,
             'regionModel',
             $this->currentMock

--- a/Test/Unit/Model/Api/UpdateCartContextTest.php
+++ b/Test/Unit/Model/Api/UpdateCartContextTest.php
@@ -42,7 +42,7 @@ use Bolt\Boltpay\Helper\Discount as DiscountHelper;
 use Bolt\Boltpay\Helper\Session as SessionHelper;
 use Bolt\Boltpay\Model\Api\UpdateCartContext;
 use Bolt\Boltpay\Model\EventsForThirdPartyModules;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
@@ -50,7 +50,7 @@ use PHPUnit\Framework\MockObject\MockObject;
  * @package Bolt\Boltpay\Test\Unit\Model\Api
  * @coversDefaultClass \Bolt\Boltpay\Model\Api\UpdateCartContext
  */
-class UpdateCartContextTest extends TestCase
+class UpdateCartContextTest extends BoltTestCase
 {
     /**
      * @var Request|MockObject
@@ -177,7 +177,7 @@ class UpdateCartContextTest extends TestCase
      */
     private $currentMock;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->request = $this->createMock(Request::class);
         $this->response = $this->createMock(Response::class);
@@ -273,30 +273,30 @@ class UpdateCartContextTest extends TestCase
             $this->cartRepositoryInterface
         );
         
-        $this->assertAttributeInstanceOf(Request::class, 'request', $instance);
-        $this->assertAttributeInstanceOf(Response::class, 'response', $instance);
-        $this->assertAttributeInstanceOf(HookHelper::class, 'hookHelper', $instance);
-        $this->assertAttributeInstanceOf(BoltErrorResponse::class, 'errorResponse', $instance);
-        $this->assertAttributeInstanceOf(LogHelper::class, 'logHelper', $instance);
-        $this->assertAttributeInstanceOf(Bugsnag::class, 'bugsnag', $instance);
-        $this->assertAttributeInstanceOf(RegionModel::class, 'regionModel', $instance);
-        $this->assertAttributeInstanceOf(OrderHelper::class, 'orderHelper', $instance);
-        $this->assertAttributeInstanceOf(CartHelper::class, 'cartHelper', $instance);
-        $this->assertAttributeInstanceOf(CheckoutSession::class, 'checkoutSession', $instance);
-        $this->assertAttributeInstanceOf(RuleRepository::class, 'ruleRepository', $instance);
-        $this->assertAttributeInstanceOf(UsageFactory::class, 'usageFactory', $instance);
-        $this->assertAttributeInstanceOf(DataObjectFactory::class, 'objectFactory', $instance);
-        $this->assertAttributeInstanceOf(TimezoneInterface::class, 'timezone', $instance);
-        $this->assertAttributeInstanceOf(CustomerFactory::class, 'customerFactory', $instance);
-        $this->assertAttributeInstanceOf(ConfigHelper::class, 'configHelper', $instance);
-        $this->assertAttributeInstanceOf(DiscountHelper::class, 'discountHelper', $instance);
-        $this->assertAttributeInstanceOf(TotalsCollector::class, 'totalsCollector', $instance);
-        $this->assertAttributeInstanceOf(SessionHelper::class, 'sessionHelper', $instance);
-        $this->assertAttributeInstanceOf(CacheInterface::class, 'cache', $instance);
-        $this->assertAttributeInstanceOf(EventsForThirdPartyModules::class, 'eventsForThirdPartyModules', $instance);
-        $this->assertAttributeInstanceOf(ProductRepositoryInterface::class, 'productRepositoryInterface', $instance);
-        $this->assertAttributeInstanceOf(StockStateInterface::class, 'stockStateInterface', $instance);
-        $this->assertAttributeInstanceOf(CartRepositoryInterface::class, 'cartRepositoryInterface', $instance);
+        static::assertAttributeInstanceOf(Request::class, 'request', $instance);
+        static::assertAttributeInstanceOf(Response::class, 'response', $instance);
+        static::assertAttributeInstanceOf(HookHelper::class, 'hookHelper', $instance);
+        static::assertAttributeInstanceOf(BoltErrorResponse::class, 'errorResponse', $instance);
+        static::assertAttributeInstanceOf(LogHelper::class, 'logHelper', $instance);
+        static::assertAttributeInstanceOf(Bugsnag::class, 'bugsnag', $instance);
+        static::assertAttributeInstanceOf(RegionModel::class, 'regionModel', $instance);
+        static::assertAttributeInstanceOf(OrderHelper::class, 'orderHelper', $instance);
+        static::assertAttributeInstanceOf(CartHelper::class, 'cartHelper', $instance);
+        static::assertAttributeInstanceOf(CheckoutSession::class, 'checkoutSession', $instance);
+        static::assertAttributeInstanceOf(RuleRepository::class, 'ruleRepository', $instance);
+        static::assertAttributeInstanceOf(UsageFactory::class, 'usageFactory', $instance);
+        static::assertAttributeInstanceOf(DataObjectFactory::class, 'objectFactory', $instance);
+        static::assertAttributeInstanceOf(TimezoneInterface::class, 'timezone', $instance);
+        static::assertAttributeInstanceOf(CustomerFactory::class, 'customerFactory', $instance);
+        static::assertAttributeInstanceOf(ConfigHelper::class, 'configHelper', $instance);
+        static::assertAttributeInstanceOf(DiscountHelper::class, 'discountHelper', $instance);
+        static::assertAttributeInstanceOf(TotalsCollector::class, 'totalsCollector', $instance);
+        static::assertAttributeInstanceOf(SessionHelper::class, 'sessionHelper', $instance);
+        static::assertAttributeInstanceOf(CacheInterface::class, 'cache', $instance);
+        static::assertAttributeInstanceOf(EventsForThirdPartyModules::class, 'eventsForThirdPartyModules', $instance);
+        static::assertAttributeInstanceOf(ProductRepositoryInterface::class, 'productRepositoryInterface', $instance);
+        static::assertAttributeInstanceOf(StockStateInterface::class, 'stockStateInterface', $instance);
+        static::assertAttributeInstanceOf(CartRepositoryInterface::class, 'cartRepositoryInterface', $instance);
     }
 
     /**

--- a/Test/Unit/Model/Api/UpdateCartItemTraitTest.php
+++ b/Test/Unit/Model/Api/UpdateCartItemTraitTest.php
@@ -29,13 +29,13 @@ use Bolt\Boltpay\Helper\Shared\CurrencyUtils;
 use Bolt\Boltpay\Model\Api\UpdateCartContext;
 use Bolt\Boltpay\Model\Api\UpdateCartItemTrait;
 use Bolt\Boltpay\Test\Unit\TestHelper;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
 /**
  * Class UpdateCartItemTraitTest
  * @coversDefaultClass \Bolt\Boltpay\Controller\UpdateCartItemTrait
  */
-class UpdateCartItemTraitTest extends TestCase
+class UpdateCartItemTraitTest extends BoltTestCase
 {
     /**
      * @var ProductRepository|MockObject
@@ -53,7 +53,7 @@ class UpdateCartItemTraitTest extends TestCase
     private $currentMock;
 
 
-    public function setUp()
+    public function setUpInternal()
     {            
         $this->currentMock = $this->getMockBuilder(UpdateCartItemTrait::class)
             ->setMethods(['sendErrorResponse'])

--- a/Test/Unit/Model/Api/UpdateCartTest.php
+++ b/Test/Unit/Model/Api/UpdateCartTest.php
@@ -41,7 +41,7 @@ use Bolt\Boltpay\Model\Api\UpdateDiscountTrait;
 use Bolt\Boltpay\Test\Unit\TestHelper;
 use Bolt\Boltpay\Helper\Bugsnag;
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
 
 /**
@@ -49,7 +49,7 @@ use PHPUnit\Framework\TestCase;
  * @package Bolt\Boltpay\Test\Unit\Model\Api
  * @coversDefaultClass \Bolt\Boltpay\Model\Api\UpdateCart
  */
-class UpdateCartTest extends TestCase
+class UpdateCartTest extends BoltTestCase
 {
     const PARENT_QUOTE_ID = "1000";
     const IMMUTABLE_QUOTE_ID = "1001";
@@ -126,7 +126,7 @@ class UpdateCartTest extends TestCase
      */
     private $cacheMock;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->updateCartContext = $this->getMockBuilder(UpdateCartContext::class)
             ->setMethods(['getSessionHelper', 'getCache'])
@@ -417,17 +417,17 @@ class UpdateCartTest extends TestCase
     {
         $this->initCurrentMock();
 
-        $this->assertAttributeInstanceOf(
+        static::assertAttributeInstanceOf(
             CartDataInterfaceFactory::class,
             'cartDataFactory',
             $this->currentMock
         );
-        $this->assertAttributeInstanceOf(
+        static::assertAttributeInstanceOf(
             UpdateCartResultInterfaceFactory::class,
             'updateCartResultFactory',
             $this->currentMock
         );
-        $this->assertAttributeInstanceOf(
+        static::assertAttributeInstanceOf(
             SessionHelper::class,
             'sessionHelper',
             $this->currentMock

--- a/Test/Unit/Model/Api/UpdateDiscountTraitTest.php
+++ b/Test/Unit/Model/Api/UpdateDiscountTraitTest.php
@@ -38,13 +38,13 @@ use Bolt\Boltpay\Helper\Discount as DiscountHelper;
 use Bolt\Boltpay\Test\Unit\TestHelper;
 use Bolt\Boltpay\Model\EventsForThirdPartyModules;
 use Bolt\Boltpay\Helper\Session as SessionHelper;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
 /**
  * Class UpdateDiscountTraitTest
  * @coversDefaultClass \Bolt\Boltpay\Model\Api\UpdateDiscountTrait
  */
-class UpdateDiscountTraitTest extends TestCase
+class UpdateDiscountTraitTest extends BoltTestCase
 {
     const QUOTE_ID = 1;
     const ORDER_ID = 2;
@@ -138,7 +138,7 @@ class UpdateDiscountTraitTest extends TestCase
     private $currentMock;
 
 
-    public function setUp()
+    public function setUpInternal()
     {
         global $ifRunFilter;
         $ifRunFilter = false;
@@ -216,8 +216,7 @@ class UpdateDiscountTraitTest extends TestCase
         $this->initRequiredMocks();
     }
 
-    public function tearDown() {
-		parent::tearDown();
+    public function tearDownInternal() {
 		global $ifRunFilter;
         $ifRunFilter = false;
 	}

--- a/Test/Unit/Model/Api/UpdateSettingsTest.php
+++ b/Test/Unit/Model/Api/UpdateSettingsTest.php
@@ -27,7 +27,7 @@ use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\StoreManagerInterface;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
 /**
  * Class CreateOrderTest
@@ -35,7 +35,7 @@ use PHPUnit\Framework\TestCase;
  * @package Bolt\Boltpay\Test\Unit\Model\Api
  * @coversDefaultClass \Bolt\Boltpay\Model\Api\Debug
  */
-class UpdateTest extends TestCase
+class UpdateTest extends BoltTestCase
 {
     /**
      * @var UpdateSettings
@@ -80,7 +80,7 @@ class UpdateTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUpInternal()
     {
         // prepare bolt config setting factory
         $this->boltConfigSettingFactoryMock = $this->createMock(BoltConfigSettingFactory::class);

--- a/Test/Unit/Model/CustomerCreditCardTest.php
+++ b/Test/Unit/Model/CustomerCreditCardTest.php
@@ -18,7 +18,7 @@
 namespace Bolt\Boltpay\Test\Unit\Model;
 
 use Bolt\Boltpay\Model\CustomerCreditCard;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Model\Request as BoltRequest;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\DataObjectFactory;
@@ -31,7 +31,7 @@ use Magento\Framework\Registry;
 use Magento\Framework\Model\ResourceModel\AbstractResource;
 use Magento\Framework\Data\Collection\AbstractDb;
 
-class CustomerCreditCardTest extends TestCase
+class CustomerCreditCardTest extends BoltTestCase
 {
     const QUOTE_ID = '111';
     const QUOTE_GRAND_TOTAL = '112';
@@ -101,7 +101,7 @@ class CustomerCreditCardTest extends TestCase
     /**
      * Setup for CustomerCreditCardTest Class
      */
-    public function setUp()
+    public function setUpInternal()
     {
         $this->dataObjectFactory = $this->getMockBuilder(DataObjectFactory::class)
             ->disableOriginalConstructor()

--- a/Test/Unit/Model/ErrorResponseTest.php
+++ b/Test/Unit/Model/ErrorResponseTest.php
@@ -17,7 +17,7 @@
 
 namespace Bolt\Boltpay\Test\Unit\Model;
 
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Model\ErrorResponse;
 
 /**
@@ -25,14 +25,14 @@ use Bolt\Boltpay\Model\ErrorResponse;
  * @package Bolt\Boltpay\Test\Unit\Model
  * @coversDefaultClass \Bolt\Boltpay\Model\ErrorResponse
  */
-class ErrorResponseTest extends TestCase
+class ErrorResponseTest extends BoltTestCase
 {
     /**
      * @var ErrorResponse
      */
     private $currentMock;
 
-    public function setUp()
+    public function setUpInternal()
     {
         $this->currentMock = new ErrorResponse();
     }

--- a/Test/Unit/Model/FeatureSwitchTest.php
+++ b/Test/Unit/Model/FeatureSwitchTest.php
@@ -18,11 +18,11 @@
 namespace Bolt\Boltpay\Test\Unit\Model;
 
 use Bolt\Boltpay\Model\FeatureSwitch;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Test\Unit\TestHelper;
 use Bolt\Boltpay\Model\ResourceModel;
 
-class FeatureSwitchTest extends TestCase
+class FeatureSwitchTest extends BoltTestCase
 {
     /**
      * @var \Bolt\Boltpay\Model\FeatureSwitch
@@ -32,7 +32,7 @@ class FeatureSwitchTest extends TestCase
     /**
      * Setup for FeatureSwitchTest Class
      */
-    public function setUp()
+    public function setUpInternal()
     {
         $this->mockFeatureSwitch = $this->getMockBuilder(FeatureSwitch::class)
             ->disableOriginalConstructor()

--- a/Test/Unit/Model/PaymentTest.php
+++ b/Test/Unit/Model/PaymentTest.php
@@ -25,7 +25,7 @@ use Magento\Framework\App\State;
 use Magento\Quote\Model\Quote;
 use Magento\Store\Model\ScopeInterface;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Helper\Config as ConfigHelper;
 use Bolt\Boltpay\Helper\Order as OrderHelper;
 use Bolt\Boltpay\Helper\Api as ApiHelper;
@@ -56,7 +56,7 @@ use Magento\Framework\Event\Manager;
  * Class PaymentTest
  * @coversDefaultClass \Bolt\Boltpay\Model\Payment
  */
-class PaymentTest extends TestCase
+class PaymentTest extends BoltTestCase
 {
     const TITLE = 'Bolt Pay';
     /**
@@ -172,7 +172,7 @@ class PaymentTest extends TestCase
     /** @var MockObject|Manager */
     private $eventManager;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         global $boltPaymentTestActive;
         $this->initRequiredMocks();

--- a/Test/Unit/Model/ResourceModel/CustomerCreditCard/CollectionTest.php
+++ b/Test/Unit/Model/ResourceModel/CustomerCreditCard/CollectionTest.php
@@ -19,9 +19,9 @@ namespace Bolt\Boltpay\Test\Unit\Model\ResourceModel\CustomerCreditCard;
 
 use Bolt\Boltpay\Model\ResourceModel\CustomerCreditCard\Collection;
 use Bolt\Boltpay\Model\CustomerCreditCard;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
-class CollectionTest extends TestCase
+class CollectionTest extends BoltTestCase
 {
     const ID = '1110';
     const CUSTOMER_ID = '1111';
@@ -42,7 +42,7 @@ class CollectionTest extends TestCase
     /**
      * Setup for CollectionTest Class
      */
-    public function setUp()
+    public function setUpInternal()
     {
         $this->mockCustomerCreditCardCollection = $this->getMockBuilder(Collection::class)
             ->disableOriginalConstructor()

--- a/Test/Unit/Model/ResourceModel/CustomerCreditCardTest.php
+++ b/Test/Unit/Model/ResourceModel/CustomerCreditCardTest.php
@@ -18,9 +18,9 @@
 namespace Bolt\Boltpay\Test\Unit\Model\ResourceModel;
 
 use Bolt\Boltpay\Model\ResourceModel\CustomerCreditCard;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
-class CustomerCreditCardTest extends TestCase
+class CustomerCreditCardTest extends BoltTestCase
 {
     /**
      * @var \Bolt\Boltpay\Model\ResourceModel\CustomerCreditCard
@@ -30,7 +30,7 @@ class CustomerCreditCardTest extends TestCase
     /**
      * Setup for CustomerCreditCardTest Class
      */
-    public function setUp()
+    public function setUpInternal()
     {
         $this->mockCustomerCreditCard = $this->getMockBuilder(CustomerCreditCard::class)
             ->disableOriginalConstructor()

--- a/Test/Unit/Model/ResourceModel/FeatureSwitchTest.php
+++ b/Test/Unit/Model/ResourceModel/FeatureSwitchTest.php
@@ -18,10 +18,10 @@
 namespace Bolt\Boltpay\Test\Unit\Model\ResourceModel;
 
 use Bolt\Boltpay\Model\ResourceModel\FeatureSwitch;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Test\Unit\TestHelper;
 
-class FeatureSwitchTest extends TestCase
+class FeatureSwitchTest extends BoltTestCase
 {
     /**
      * @var \Bolt\Boltpay\Model\ResourceModel\FeatureSwitch
@@ -31,7 +31,7 @@ class FeatureSwitchTest extends TestCase
     /**
      * Setup for CustomerCreditCardTest Class
      */
-    public function setUp()
+    public function setUpInternal()
     {
         $this->mockFeatureSwitch = $this->getMockBuilder(FeatureSwitch::class)
             ->disableOriginalConstructor()

--- a/Test/Unit/Model/ResourceModel/WebhookLog/CollectionTest.php
+++ b/Test/Unit/Model/ResourceModel/WebhookLog/CollectionTest.php
@@ -18,10 +18,10 @@
 namespace Bolt\Boltpay\Test\Unit\Model\ResourceModel\WebhookLog;
 
 use Bolt\Boltpay\Model\ResourceModel\WebhookLog\Collection;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Test\Unit\TestHelper;
 
-class CollectionTest extends TestCase
+class CollectionTest extends BoltTestCase
 {
     const TRANSACTION_ID = '1111';
     const HOOK_TYPE = 'pending';
@@ -34,7 +34,7 @@ class CollectionTest extends TestCase
     /**
      * Setup for CollectionTest Class
      */
-    public function setUp()
+    public function setUpInternal()
     {
         $this->webhookLogCollectionMock = $this->getMockBuilder(Collection::class)
             ->disableOriginalConstructor()

--- a/Test/Unit/Model/ResourceModel/WebhookLogTest.php
+++ b/Test/Unit/Model/ResourceModel/WebhookLogTest.php
@@ -18,10 +18,10 @@
 namespace Bolt\Boltpay\Test\Unit\Model\ResourceModel;
 
 use Bolt\Boltpay\Model\ResourceModel\WebhookLog;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Test\Unit\TestHelper;
 
-class WebhookLogTest extends TestCase
+class WebhookLogTest extends BoltTestCase
 {
     /**
      * @var \Bolt\Boltpay\Model\ResourceModel\WebhookLog
@@ -31,7 +31,7 @@ class WebhookLogTest extends TestCase
     /**
      * Setup for CustomerCreditCardTest Class
      */
-    public function setUp()
+    public function setUpInternal()
     {
         $this->wehookLogMock = $this->getMockBuilder(WebhookLog::class)
             ->disableOriginalConstructor()

--- a/Test/Unit/Model/Service/InvoiceServiceTest.php
+++ b/Test/Unit/Model/Service/InvoiceServiceTest.php
@@ -18,7 +18,7 @@
 namespace Bolt\Boltpay\Test\Unit\Model;
 
 use Magento\Framework\Serialize\Serializer\Json as JsonSerializer;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Magento\Sales\Api\InvoiceRepositoryInterface;
 use Magento\Sales\Api\InvoiceCommentRepositoryInterface;
 use Magento\Framework\Api\SearchCriteriaBuilder;
@@ -36,7 +36,7 @@ use Magento\Sales\Model\Order\Item;
  * @package Bolt\Boltpay\Test\Unit\Model
  * @coversDefaultClass \Bolt\Boltpay\Model\Service\InvoiceService
  */
-class InvoiceServiceTest extends TestCase
+class InvoiceServiceTest extends BoltTestCase
 {
     const AMOUNT = 20;
 
@@ -100,7 +100,7 @@ class InvoiceServiceTest extends TestCase
      */
     private $currentMock;
 
-    public function setUp()
+    public function setUpInternal()
     {
         $this->repository = $this->createMock(InvoiceRepositoryInterface::class);
         $this->commentRepository = $this->createMock(InvoiceCommentRepositoryInterface::class);

--- a/Test/Unit/Model/ThirdPartyModuleFactoryTest.php
+++ b/Test/Unit/Model/ThirdPartyModuleFactoryTest.php
@@ -17,7 +17,7 @@
 
 namespace Bolt\Boltpay\Test\Unit\Model;
 
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Helper\Log as LogHelper;
 use Bolt\Boltpay\Model\ThirdPartyModuleFactory;
 use Magento\Framework\ObjectManagerInterface;
@@ -28,7 +28,7 @@ use Magento\Framework\Module\Manager;
  * @package Bolt\Boltpay\Test\Unit\Model
  * @coversDefaultClass \Bolt\Boltpay\Model\ThirdPartyModuleFactory
  */
-class ThirdPartyModuleFactoryTest extends TestCase
+class ThirdPartyModuleFactoryTest extends BoltTestCase
 {
     const MODULE_NAME = 'Bolt_Boltpay';
     const CLASS_NAME = 'Bolt\Boltpay\Model\ThirdPartyModuleFactory';
@@ -57,7 +57,7 @@ class ThirdPartyModuleFactoryTest extends TestCase
      */
     private $currentMock;
 
-    public function setUp()
+    public function setUpInternal()
     {
         $this->_moduleManager = $this->createPartialMock(
             Manager::class,

--- a/Test/Unit/Model/WebhookLogTest.php
+++ b/Test/Unit/Model/WebhookLogTest.php
@@ -18,7 +18,7 @@
 namespace Bolt\Boltpay\Test\Unit\Model;
 
 use Bolt\Boltpay\Model\WebhookLog;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Test\Unit\TestHelper;
 use Magento\Framework\Stdlib\DateTime\DateTime;
 use Magento\Framework\Model\Context;
@@ -26,7 +26,7 @@ use Magento\Framework\Registry;
 use Magento\Framework\Model\ResourceModel\AbstractResource;
 use Magento\Framework\Data\Collection\AbstractDb;
 
-class WebhookLogTest extends TestCase
+class WebhookLogTest extends BoltTestCase
 {
     const TRANSACTION_ID = '1111';
     const HOOK_TYPE = 'pending';
@@ -61,7 +61,7 @@ class WebhookLogTest extends TestCase
      */
     private $resourceCollection;
 
-    public function setUp()
+    public function setUpInternal()
     {
         $this->coreDate = $this->createPartialMock(DateTime::class, ['gmtDate']);
         $this->context = $this->createMock(Context::class);

--- a/Test/Unit/Observer/Adminhtml/ActionPredispatchTest.php
+++ b/Test/Unit/Observer/Adminhtml/ActionPredispatchTest.php
@@ -18,12 +18,12 @@
 namespace Bolt\Boltpay\Test\Unit\Observer\Adminhtml;
 
 use Bolt\Boltpay\Observer\Adminhtml\ActionPredispatch;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
 /**
  * @coversDefaultClass \Bolt\Boltpay\Observer\Adminhtml\ActionPredispatch
  */
-class ActionPredispatchTest extends TestCase
+class ActionPredispatchTest extends BoltTestCase
 {
     /**
      * @var \Bolt\Boltpay\Model\EventsForThirdPartyModules|\PHPUnit\Framework\MockObject\MockObject
@@ -38,7 +38,7 @@ class ActionPredispatchTest extends TestCase
     /**
      * Setup test dependencies, called before each test
      */
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->eventsForThirdPartyModulesMock = $this->createMock(
             \Bolt\Boltpay\Model\EventsForThirdPartyModules::class

--- a/Test/Unit/Observer/Adminhtml/Sales/CreatingInvoiceForRechargeOrderTest.php
+++ b/Test/Unit/Observer/Adminhtml/Sales/CreatingInvoiceForRechargeOrderTest.php
@@ -18,7 +18,7 @@
 namespace Bolt\Boltpay\Test\Unit\Observer\Adminhtml\Sales;
 
 use Magento\Sales\Model\Order;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Magento\Framework\Event\Observer;
 use Bolt\Boltpay\Observer\Adminhtml\Sales\CreateInvoiceForRechargedOrder;
 use Magento\Sales\Model\Service\InvoiceService;
@@ -29,7 +29,7 @@ use Bolt\Boltpay\Helper\Bugsnag;
  * Class OrderCreateProcessDataObserverTest
  * @coversDefaultClass \Bolt\Boltpay\Observer\Adminhtml\Sales\CreateInvoiceForRechargedOrder
  */
-class CreateInvoiceForRechargedOrderTest extends TestCase
+class CreateInvoiceForRechargedOrderTest extends BoltTestCase
 {
     /**
      * @var InvoiceService
@@ -66,7 +66,7 @@ class CreateInvoiceForRechargedOrderTest extends TestCase
      */
     protected $invoice;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->invoiceService = $this->createPartialMock(InvoiceService::class, ['prepareInvoice']);
         $this->invoiceSender = $this->createPartialMock(InvoiceSender::class, ['send']);

--- a/Test/Unit/Observer/Adminhtml/Sales/OrderCreateProcessDataObserverTest.php
+++ b/Test/Unit/Observer/Adminhtml/Sales/OrderCreateProcessDataObserverTest.php
@@ -19,7 +19,7 @@ namespace Bolt\Boltpay\Test\Unit\Observer\Adminhtml\Sales;
 
 use Magento\Framework\Event;
 use Magento\Quote\Model\Quote;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Magento\Framework\Event\Observer;
 use Bolt\Boltpay\Observer\Adminhtml\Sales\OrderCreateProcessDataObserver;
 use Magento\Framework\App\ProductMetadataInterface;
@@ -28,7 +28,7 @@ use Magento\Framework\App\ProductMetadataInterface;
  * Class OrderCreateProcessDataObserverTest
  * @coversDefaultClass \Bolt\Boltpay\Model\Payment
  */
-class OrderCreateProcessDataObserverTest extends TestCase
+class OrderCreateProcessDataObserverTest extends BoltTestCase
 {
     /**
      * @var OrderCreateProcessDataObserver
@@ -55,7 +55,7 @@ class OrderCreateProcessDataObserverTest extends TestCase
      */
     protected $quote;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->observer = $this->createPartialMock(
             Observer::class,

--- a/Test/Unit/Observer/Adminhtml/Sales/RechargeCustomerTest.php
+++ b/Test/Unit/Observer/Adminhtml/Sales/RechargeCustomerTest.php
@@ -17,7 +17,7 @@
 
 namespace Bolt\Boltpay\Test\Unit\Observer\Adminhtml\Sales;
 
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Observer\Adminhtml\Sales\RechargeCustomer;
 use Magento\Framework\Event\Observer;
 use Magento\Sales\Model\Order;
@@ -32,7 +32,7 @@ use Bolt\Boltpay\Helper\Order as OrderHelper;
  * Class RechargeCustomerTest
  * @coversDefaultClass \Bolt\Boltpay\Model\Payment
  */
-class RechargeCustomerTest extends TestCase
+class RechargeCustomerTest extends BoltTestCase
 {
     const ID  = '111';
     const QUOTE_ID  = '112';
@@ -77,7 +77,7 @@ class RechargeCustomerTest extends TestCase
      */
     private $customerCreditCardFactoryMock;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->initRequiredMocks();
         $this->initCurrentMock();

--- a/Test/Unit/Observer/ClearBoltShippingTaxCacheObserverTest.php
+++ b/Test/Unit/Observer/ClearBoltShippingTaxCacheObserverTest.php
@@ -19,7 +19,7 @@
 namespace Bolt\Boltpay\Test\Unit\Observer;
 
 use Bolt\Boltpay\Observer\ClearBoltShippingTaxCacheObserver;
-use \PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Magento\Framework\App\CacheInterface;
 use Magento\Framework\Event\Observer;
 use Bolt\Boltpay\Model\Api\ShippingMethods;
@@ -28,7 +28,7 @@ use Bolt\Boltpay\Model\Api\ShippingMethods;
  * Class ClearBoltShippingTaxCacheObserver
  * @coversDefaultClass \Bolt\Boltpay\Observer\ClearBoltShippingTaxCacheObserver
  */
-class ClearBoltShippingTaxCacheObserverTest extends TestCase
+class ClearBoltShippingTaxCacheObserverTest extends BoltTestCase
 {
     /**
      * @var ClearBoltShippingTaxCacheObserver
@@ -40,7 +40,7 @@ class ClearBoltShippingTaxCacheObserverTest extends TestCase
      */
     private $cache;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->cache = $this->createPartialMock(CacheInterface::class, ['clean', 'remove', 'save', 'load', 'getFrontend']);
         $this->currentMock = new ClearBoltShippingTaxCacheObserver($this->cache);

--- a/Test/Unit/Observer/TrackingSaveObserverTest.php
+++ b/Test/Unit/Observer/TrackingSaveObserverTest.php
@@ -25,7 +25,7 @@ use Magento\Framework\DataObjectFactory;
 use Bolt\Boltpay\Helper\Bugsnag;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Bolt\Boltpay\Observer\TrackingSaveObserver as Observer;
-use \PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Helper\MetricsClient;
 use Bolt\Boltpay\Helper\FeatureSwitch\Decider;
 use Bolt\Boltpay\Model\Request;
@@ -34,7 +34,7 @@ use Bolt\Boltpay\Model\Request;
  * Class TrackingSaveObserverTest
  * @coversDefaultClass \Bolt\Boltpay\Observer\TrackingSaveObserver
  */
-class TrackingSaveObserverTest extends TestCase
+class TrackingSaveObserverTest extends BoltTestCase
 {
     const ENTITY_ID = 123;
     /**
@@ -77,7 +77,7 @@ class TrackingSaveObserverTest extends TestCase
      */
     protected $observer;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->initRequiredMocks();
     }

--- a/Test/Unit/Plugin/AbstractLoginPluginTest.php
+++ b/Test/Unit/Plugin/AbstractLoginPluginTest.php
@@ -19,7 +19,7 @@ namespace Bolt\Boltpay\Test\Unit\Plugin;
 
 use Bolt\Boltpay\Test\Unit\TestHelper;
 use Magento\Quote\Model\Quote;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Plugin\AbstractLoginPlugin;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Customer\Model\Session as CustomerSession;
@@ -30,7 +30,7 @@ use Bolt\Boltpay\Helper\FeatureSwitch\Decider;
 /**
  * @coversDefaultClass \Bolt\Boltpay\Plugin\AbstractLoginPlugin
  */
-class AbstractLoginPluginTest extends TestCase
+class AbstractLoginPluginTest extends BoltTestCase
 {
     /**
      * @var AbstractLoginPlugin
@@ -71,7 +71,7 @@ class AbstractLoginPluginTest extends TestCase
      */
     private $decider;
 
-    public function setUp()
+    public function setUpInternal()
     {
         $this->customerSession = $this->createPartialMock(
             CustomerSession::class,

--- a/Test/Unit/Plugin/CheckSettingsUpdateTest.php
+++ b/Test/Unit/Plugin/CheckSettingsUpdateTest.php
@@ -17,7 +17,7 @@
 
 namespace Bolt\Boltpay\Test\Unit\Plugin;
 
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Magento\Config\Model\Config as MagentoConfig;
 use Bolt\Boltpay\Helper\Cart as CartHelper;
 use Bolt\Boltpay\Helper\Config as ConfigHelper;
@@ -28,7 +28,7 @@ use Bolt\Boltpay\Plugin\CheckSettingsUpdate;
 /**
  * @coversDefaultClass \Bolt\Boltpay\Plugin\CheckSettingsUpdate
  */
-class CheckSettingsUpdateTest extends TestCase
+class CheckSettingsUpdateTest extends BoltTestCase
 {
     const OLD_KEY = 'old_key';
     const NEW_KEY = 'new_key';
@@ -64,7 +64,7 @@ class CheckSettingsUpdateTest extends TestCase
      */
     private $bugsnag;
 
-    public function setUp()
+    public function setUpInternal()
     {
         /*
         $this->context = $this->getMockBuilder(Context::class)

--- a/Test/Unit/Plugin/ClearQuoteTest.php
+++ b/Test/Unit/Plugin/ClearQuoteTest.php
@@ -18,7 +18,7 @@
 namespace Bolt\Boltpay\Test\Unit\Plugin;
 
 use Bolt\Boltpay\Plugin\ClearQuote;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Checkout\Model\Session as CheckoutSession;
 use Bolt\Boltpay\Helper\Cart as CartHelper;
@@ -28,7 +28,7 @@ use Bolt\Boltpay\Helper\Cart as CartHelper;
  * @package Bolt\Boltpay\Test\Unit\Plugin
  * @coversDefaultClass \Bolt\Boltpay\Plugin\ClearQuote
  */
-class ClearQuoteTest extends TestCase
+class ClearQuoteTest extends BoltTestCase
 {
     /**
      * @var CartHelper
@@ -45,7 +45,7 @@ class ClearQuoteTest extends TestCase
      */
     protected $plugin;
 
-    public function setUp()
+    public function setUpInternal()
     {
         $this->cartHelper = $this->getMockBuilder(CartHelper::class)
             ->setMethods(['getIsActive', 'getQuoteById'])

--- a/Test/Unit/Plugin/LoginPostPluginTest.php
+++ b/Test/Unit/Plugin/LoginPostPluginTest.php
@@ -17,7 +17,7 @@
 
 namespace Bolt\Boltpay\Test\Unit\Plugin;
 
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Plugin\LoginPostPlugin;
 use Bolt\Boltpay\Helper\Bugsnag;
 use Magento\Checkout\Model\Session as CheckoutSession;
@@ -31,7 +31,7 @@ use Bolt\Boltpay\Helper\FeatureSwitch\Decider;
  * @package Bolt\Boltpay\Test\Unit\Plugin\Magento\GiftCard
  * @coversDefaultClass \Bolt\Boltpay\Plugin\LoginPostPlugin
  */
-class LoginPostPluginTest extends TestCase
+class LoginPostPluginTest extends BoltTestCase
 {
     /**
      * @var LoginPostPlugin
@@ -56,7 +56,7 @@ class LoginPostPluginTest extends TestCase
     /** @var @var Decider */
     private $decider;
 
-    public function setUp()
+    public function setUpInternal()
     {
         $this->customerSession = $this->createMock(CustomerSession::class);
         $this->checkoutSession = $this->createMock(CheckoutSession::class);

--- a/Test/Unit/Plugin/MageVision/FreeShippingAdmin/MethodPluginTest.php
+++ b/Test/Unit/Plugin/MageVision/FreeShippingAdmin/MethodPluginTest.php
@@ -18,7 +18,7 @@
 namespace Bolt\Boltpay\Test\Unit\Plugin\MageVision\FreeShippingAdmin;
 
 use Bolt\Boltpay\Test\Unit\TestHelper;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Magento\Framework\App\State;
 use Magento\Shipping\Model\Rate\ResultFactory;
 use Magento\Quote\Model\Quote\Address\RateResult\MethodFactory;
@@ -28,7 +28,7 @@ use Bolt\Boltpay\Plugin\MageVision\FreeShippingAdmin\MethodPlugin;
 /**
  * @coversDefaultClass \Bolt\Boltpay\Plugin\MageVision\FreeShippingAdmin\MethodPlugin
  */
-class MethodPluginTest extends TestCase
+class MethodPluginTest extends BoltTestCase
 {
     /**
      * @var ResultFactory
@@ -57,7 +57,7 @@ class MethodPluginTest extends TestCase
 
     private $subject;
 
-    public function setUp()
+    public function setUpInternal()
     {
         $this->rateResultFactory = $this->createPartialMock(ResultFactory::class, ['create', 'append']);
         $this->resultMethodFactory = $this->createPartialMock(MethodFactory::class, [

--- a/Test/Unit/Plugin/Magento/Framework/View/Element/UiComponent/DataProvider/DataProviderPluginTest.php
+++ b/Test/Unit/Plugin/Magento/Framework/View/Element/UiComponent/DataProvider/DataProviderPluginTest.php
@@ -18,11 +18,12 @@
 namespace Bolt\Boltpay\Test\Unit\Plugin\Magento\Framework\View\Element\UiComponent\DataProvider;
 
 use Bolt\Boltpay\Plugin\Magento\Framework\View\Element\UiComponent\DataProvider\DataProviderPlugin;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
 /**
  * @coversDefaultClass \Bolt\Boltpay\Plugin\Magento\Framework\View\Element\UiComponent\DataProvider\DataProviderPlugin
  */
-class DataProviderPluginTest extends \PHPUnit\Framework\TestCase
+class DataProviderPluginTest extends BoltTestCase
 {
     /**
      * @var \Magento\Sales\Model\ResourceModel\Order\Payment\CollectionFactory|\PHPUnit_Framework_MockObject_MockObject
@@ -49,7 +50,7 @@ class DataProviderPluginTest extends \PHPUnit\Framework\TestCase
      */
     private $paymentMock;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->paymentCollectionFactoryMock = $this->createPartialMock(
             \Magento\Sales\Model\ResourceModel\Order\Payment\CollectionFactory::class,

--- a/Test/Unit/Plugin/Magento/GiftCard/GenerateGiftCardAccountsOrderPluginTest.php
+++ b/Test/Unit/Plugin/Magento/GiftCard/GenerateGiftCardAccountsOrderPluginTest.php
@@ -17,7 +17,7 @@
 namespace Bolt\Boltpay\Test\Unit\Plugin\Magento\GiftCard;
 
 use Magento\Framework\Event\ObserverInterface;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Model\Payment as BoltPayment;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Bolt\Boltpay\Plugin\Magento\GiftCard\GenerateGiftCardAccountsOrderPlugin;
@@ -32,7 +32,7 @@ use PHPUnit_Framework_MockObject_MockObject as MockObject;
  * @package Bolt\Boltpay\Test\Unit\Plugin\Magento\GiftCard
  * @coversDefaultClass \Bolt\Boltpay\Plugin\Magento\GiftCard\GenerateGiftCardAccountsOrderPlugin
  */
-class GenerateGiftCardAccountsOrderPluginTest extends TestCase
+class GenerateGiftCardAccountsOrderPluginTest extends BoltTestCase
 {
     const OTHER_METHOD = 'NON_BOLT';
     const EXPECTS_NEVER = 'never';
@@ -62,7 +62,7 @@ class GenerateGiftCardAccountsOrderPluginTest extends TestCase
     /** @var GenerateGiftCardAccountsOrderPlugin  */
     protected $plugin;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $objectManager = new ObjectManager($this);
         $this->plugin = $objectManager->getObject(

--- a/Test/Unit/Plugin/Magento/Rewards/Controller/Cart/RemoveActionPluginTest.php
+++ b/Test/Unit/Plugin/Magento/Rewards/Controller/Cart/RemoveActionPluginTest.php
@@ -17,12 +17,12 @@
 
 namespace Bolt\Boltpay\Test\Unit\Plugin\Magento\Rewards\Controller\Cart;
 
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
 /**
  * @coversDefaultClass \Bolt\Boltpay\Plugin\Magento\Rewards\Controller\Cart\RemoveActionPlugin
  */
-class RemoveActionPluginTest extends TestCase
+class RemoveActionPluginTest extends BoltTestCase
 {
     /**
      * @var \Bolt\Boltpay\Helper\Config|\PHPUnit\Framework\MockObject\MockObject
@@ -52,7 +52,7 @@ class RemoveActionPluginTest extends TestCase
     /**
      * Setup method, called before each test
      */
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->configHelper = $this->createMock(\Bolt\Boltpay\Helper\Config::class);
         $this->subject = $this->getMockBuilder('\Magento\Reward\Controller\Cart\Remove')

--- a/Test/Unit/Plugin/Magento/Sales/Model/AdminOrder/CreatePluginTest.php
+++ b/Test/Unit/Plugin/Magento/Sales/Model/AdminOrder/CreatePluginTest.php
@@ -17,7 +17,7 @@
 
 namespace Bolt\Boltpay\Test\Unit\Plugin\Magento\Model\AdminOrder;
 
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Bolt\Boltpay\Plugin\Magento\Sales\Model\AdminOrder\CreatePlugin;
 use Bolt\Boltpay\Helper\Config as ConfigHelper;
@@ -29,7 +29,7 @@ use Magento\Sales\Model\AdminOrder\Create;
  * @package Bolt\Boltpay\Test\Unit\Plugin\Magento\Model\AdminOrder;
  * @coversDefaultClass \Bolt\Boltpay\Plugin\Magento\Sales\Model\AdminOrder\CreatePlugin
  */
-class CreatePluginTest extends TestCase
+class CreatePluginTest extends BoltTestCase
 {
     const STORE_PICKUP_ADDRESS_DATA = [
         'city' => 'Knoxville',
@@ -69,7 +69,7 @@ Room 1111',
     /** @var CreatePlugin */
     protected $plugin;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->configHelper = $this->createPartialMock(ConfigHelper::class, ['isStorePickupFeatureEnabled', 'isPickupInStoreShippingMethodCode', 'getPickupAddressData']);
         $this->adminCheckoutSession = $this->createPartialMock(AdminCheckoutSession::class, ['setData', 'getData', 'unsetData']);

--- a/Test/Unit/Plugin/Magento/TogglePaymentMethodsPluginTest.php
+++ b/Test/Unit/Plugin/Magento/TogglePaymentMethodsPluginTest.php
@@ -24,7 +24,7 @@ use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Quote\Model\Quote;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Magento\Quote\Api\Data\PaymentMethodInterface;
 
 /**
@@ -32,7 +32,7 @@ use Magento\Quote\Api\Data\PaymentMethodInterface;
  * @package Bolt\Boltpay\Test\Unit\Plugin\Magento
  * @coversDefaultClass \Bolt\Boltpay\Plugin\Magento\TogglePaymentMethodsPlugin
  */
-class TogglePaymentMethodsPluginTest extends TestCase
+class TogglePaymentMethodsPluginTest extends BoltTestCase
 {
     /** @var ObserverInterface|MockObject  */
     protected $subject;
@@ -58,7 +58,7 @@ class TogglePaymentMethodsPluginTest extends TestCase
     /** @var DataObject|MockObject  */
     protected $result;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->plugin = (new ObjectManager($this))->getObject(TogglePaymentMethodsPlugin::class);
         $this->subject = $this->createMock(

--- a/Test/Unit/Plugin/Magento/Ui/Component/Form/Element/SelectPluginTest.php
+++ b/Test/Unit/Plugin/Magento/Ui/Component/Form/Element/SelectPluginTest.php
@@ -17,10 +17,12 @@
 
 namespace Bolt\Boltpay\Test\Unit\Plugin\Magento\Ui\Component\Form\Element;
 
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
+
 /**
  * @coversDefaultClass \Bolt\Boltpay\Plugin\Magento\Ui\Component\Form\Element\SelectPlugin
  */
-class SelectPluginTest extends \PHPUnit\Framework\TestCase
+class SelectPluginTest extends BoltTestCase
 {
     /**
      * @var \Bolt\Boltpay\Plugin\Magento\Ui\Component\Form\Element\SelectPlugin|\PHPUnit_Framework_MockObject_MockObject
@@ -37,7 +39,7 @@ class SelectPluginTest extends \PHPUnit\Framework\TestCase
      */
     private $contextMock;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->subjectMock = $this->createMock(\Magento\Ui\Component\Form\Element\Select::class);
         $this->contextMock = $this->createMock(\Magento\Framework\View\Element\UiComponent\Context::class);

--- a/Test/Unit/Plugin/Mirasvit/Rewards/Model/PurchasePluginTest.php
+++ b/Test/Unit/Plugin/Mirasvit/Rewards/Model/PurchasePluginTest.php
@@ -17,7 +17,7 @@
 
 namespace Bolt\Boltpay\Test\Unit\Plugin\Mirasvit\Rewards\Model;
 
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Bolt\Boltpay\Plugin\Mirasvit\Rewards\Model\PurchasePlugin;
 use Magento\Framework\UrlInterface;
@@ -26,7 +26,7 @@ use Bolt\Boltpay\Helper\Bugsnag;
 /**
  * @coversDefaultClass \Bolt\Boltpay\Plugin\Mirasvit\Rewards\Model\PurchasePlugin
  */
-class PurchasePluginTest extends TestCase
+class PurchasePluginTest extends BoltTestCase
 {
     /**
      * @var PurchasePlugin
@@ -56,7 +56,7 @@ class PurchasePluginTest extends TestCase
     /** @var callable */
     private $callback;
 
-    public function setUp()
+    public function setUpInternal()
     {
         $this->urlInterface = $this->getMockBuilder(UrlInterface::class)
             ->getMock();

--- a/Test/Unit/Plugin/NonBoltOrderObserverTest.php
+++ b/Test/Unit/Plugin/NonBoltOrderObserverTest.php
@@ -41,14 +41,14 @@ use Magento\Quote\Api\CartRepositoryInterface as QuoteRepository;
 use Magento\Sales\Model\Order\Payment;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Bolt\Boltpay\Plugin\NonBoltOrderPlugin as Plugin;
-use \PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Model\Request;
 
 /**
  * Class NonBoltOrderPluginTest
  * @coversDefaultClass \Bolt\Boltpay\Plugin\NonBoltOrderPlugin
  */
-class NonBoltOrderObserverTest extends TestCase
+class NonBoltOrderObserverTest extends BoltTestCase
 {
     const IMMUTABLE_QUOTE_ID = 1001;
     const RESERVED_ORDER_ID = '100010001';
@@ -112,7 +112,7 @@ class NonBoltOrderObserverTest extends TestCase
      */
     protected $orderManagementInterface;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->initRequiredMocks();
     }

--- a/Test/Unit/Plugin/OrderPluginTest.php
+++ b/Test/Unit/Plugin/OrderPluginTest.php
@@ -16,7 +16,7 @@
  */
 namespace Bolt\Boltpay\Test\Unit\Plugin;
 
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Bolt\Boltpay\Plugin\OrderPlugin;
 use Magento\Sales\Model\Order;
@@ -28,7 +28,7 @@ use Bolt\Boltpay\Test\Unit\TestHelper;
 /**
  * @coversDefaultClass \Bolt\Boltpay\Plugin\OrderPlugin
  */
-class OrderPluginTest extends TestCase
+class OrderPluginTest extends BoltTestCase
 {
     /**
      * @var OrderPlugin
@@ -53,7 +53,7 @@ class OrderPluginTest extends TestCase
     /** @var callable|MockObject */
     protected $callback;
 
-    public function setUp()
+    public function setUpInternal()
     {
         $this->plugin = (new ObjectManager($this))->getObject(OrderPlugin::class);
         $this->subject = $this->createPartialMock(Order::class, [

--- a/Test/Unit/Plugin/OrderSenderPluginTest.php
+++ b/Test/Unit/Plugin/OrderSenderPluginTest.php
@@ -17,7 +17,7 @@
 
 namespace Bolt\Boltpay\Test\Unit\Plugin;
 
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Bolt\Boltpay\Plugin\OrderSenderPlugin;
 use Magento\Sales\Model\Order;
@@ -27,7 +27,7 @@ use Bolt\Boltpay\Model\Payment;
 /**
  * @coversDefaultClass \Bolt\Boltpay\Plugin\OrderSenderPlugin
  */
-class OrderSenderPluginTest extends TestCase
+class OrderSenderPluginTest extends BoltTestCase
 {
     /**
      * @var OrderSender
@@ -52,7 +52,7 @@ class OrderSenderPluginTest extends TestCase
     /** @var callable */
     private $callback;
 
-    public function setUp()
+    public function setUpInternal()
     {
         $this->order = $this->createPartialMock(Order::class, ['getPayment', 'getMethod', 'getState']);
         $this->subject = $this->createPartialMock(OrderSender::class, ['getPayment', 'getMethod']);

--- a/Test/Unit/Plugin/QuotePluginTest.php
+++ b/Test/Unit/Plugin/QuotePluginTest.php
@@ -18,7 +18,7 @@
 namespace Bolt\Boltpay\Test\Unit\Plugin;
 
 use Magento\Quote\Model\Quote;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Bolt\Boltpay\Plugin\QuotePlugin;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
@@ -28,7 +28,7 @@ use PHPUnit_Framework_MockObject_MockObject as MockObject;
  * @package Bolt\Boltpay\Test\Unit\Plugin
  * @coversDefaultClass \Bolt\Boltpay\Plugin\QuotePlugin
  */
-class QuotePluginTest extends TestCase
+class QuotePluginTest extends BoltTestCase
 {
     /**
      * @var Quote
@@ -48,7 +48,7 @@ class QuotePluginTest extends TestCase
     /** @var callable|MockObject */
     protected $callback;
 
-    public function setUp()
+    public function setUpInternal()
     {
         $this->subject = $this->getMockBuilder(Quote::class)
             ->setMethods(['getBoltParentQuoteId', 'getId', 'getIsActive', 'getBoltCheckoutType', 'getPayment', 'getMethod'])

--- a/Test/Unit/Plugin/RestoreQuotePluginTest.php
+++ b/Test/Unit/Plugin/RestoreQuotePluginTest.php
@@ -19,7 +19,7 @@ namespace Bolt\Boltpay\Test\Unit\Plugin;
 
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Payment;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Plugin\RestoreQuotePlugin;
 use Magento\Checkout\Model\Session as CheckoutSession;
 use Bolt\Boltpay\Model\Payment as BoltPayment;
@@ -29,7 +29,7 @@ use Bolt\Boltpay\Helper\Bugsnag;
 /**
  * @coversDefaultClass \Bolt\Boltpay\Plugin\RestoreQuotePlugin
  */
-class RestoreQuotePluginTest extends TestCase
+class RestoreQuotePluginTest extends BoltTestCase
 {
     /**
      * @var RestoreQuotePlugin
@@ -69,7 +69,7 @@ class RestoreQuotePluginTest extends TestCase
     /** @var callable|MockObject */
     protected $callback;
 
-    public function setUp()
+    public function setUpInternal()
     {
         $this->checkoutSession = $this->createPartialMock(
             CheckoutSession::class,

--- a/Test/Unit/Plugin/SalesRuleActionDiscountPluginTest.php
+++ b/Test/Unit/Plugin/SalesRuleActionDiscountPluginTest.php
@@ -17,7 +17,7 @@
 
 namespace Bolt\Boltpay\Test\Unit\Plugin;
 
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Plugin\SalesRuleActionDiscountPlugin;
 use Magento\Framework\DataObject;
 use Magento\Checkout\Model\Session as CheckoutSession;
@@ -30,7 +30,7 @@ use Bolt\Boltpay\Helper\Session as SessionHelper;
  * @package Bolt\Boltpay\Test\Unit\Plugin
  * @coversDefaultClass \Bolt\Boltpay\Plugin\SalesRuleActionDiscountPlugin
  */
-class SalesRuleActionDiscountPluginTest extends TestCase
+class SalesRuleActionDiscountPluginTest extends BoltTestCase
 {
     /**
      * @var SalesRuleActionDiscountPlugin
@@ -46,7 +46,7 @@ class SalesRuleActionDiscountPluginTest extends TestCase
     /** @var AbstractDiscount */
     protected $subject;
 
-    public function setUp()
+    public function setUpInternal()
     {
         $this->subject = $this->createMock(AbstractDiscount::class);
         $this->sessionHelper = $this->createPartialMock(SessionHelper::class,

--- a/Test/Unit/Plugin/SalesRuleQuoteDiscountPluginTest.php
+++ b/Test/Unit/Plugin/SalesRuleQuoteDiscountPluginTest.php
@@ -17,7 +17,7 @@
 
 namespace Bolt\Boltpay\Test\Unit\Plugin;
 
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Plugin\SalesRuleQuoteDiscountPlugin;
 use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\SalesRule\Model\Quote\Discount;
@@ -29,7 +29,7 @@ use Bolt\Boltpay\Helper\Session as SessionHelper;
  * @package Bolt\Boltpay\Test\Unit\Plugin
  * @coversDefaultClass \Bolt\Boltpay\Plugin\SalesRuleQuoteDiscountPlugin
  */
-class SalesRuleQuoteDiscountPluginTest extends TestCase
+class SalesRuleQuoteDiscountPluginTest extends BoltTestCase
 {
     /**
      * @var SalesRuleQuoteDiscountPlugin
@@ -45,7 +45,7 @@ class SalesRuleQuoteDiscountPluginTest extends TestCase
     /** @var Discount */
     protected $subject;
 
-    public function setUp()
+    public function setUpInternal()
     {
         $this->subject = $this->createMock(Discount::class);
         $this->sessionHelper = $this->createPartialMock(SessionHelper::class,

--- a/Test/Unit/Section/CustomerData/BoltCartTest.php
+++ b/Test/Unit/Section/CustomerData/BoltCartTest.php
@@ -20,14 +20,14 @@ namespace Bolt\Boltpay\Test\Unit\Section\CustomerData;
 use Bolt\Boltpay\Helper\Cart as CartHelper;
 use Bolt\Boltpay\Section\CustomerData\BoltCart;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
 /**
  * Class BoltCartTest
  * @package Bolt\Boltpay\Test\Unit\Section\CustomerData
  * @coversDefaultClass \Bolt\Boltpay\Section\CustomerData\BoltCart
  */
-class BoltCartTest extends TestCase
+class BoltCartTest extends BoltTestCase
 {
     /**
      * @var CartHelper
@@ -42,7 +42,7 @@ class BoltCartTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUpInternal()
     {
         $this->cartHelper = $this->createPartialMock(CartHelper::class, ['calculateCartAndHints']);
         $this->boltCart = (new ObjectManager($this))->getObject(

--- a/Test/Unit/Section/CustomerData/BoltHintsTest.php
+++ b/Test/Unit/Section/CustomerData/BoltHintsTest.php
@@ -6,9 +6,9 @@ use Bolt\Boltpay\Helper\Cart as CartHelper;
 use Bolt\Boltpay\Helper\Config as ConfigHelper;
 use Bolt\Boltpay\Section\CustomerData\BoltHints;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
-class BoltHintsTest extends TestCase
+class BoltHintsTest extends BoltTestCase
 {
     /**
      * @var CartHelper
@@ -29,7 +29,7 @@ class BoltHintsTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUpInternal()
     {
 
         $this->cartHelper = $this->createMock(CartHelper::class);

--- a/Test/Unit/Setup/RecurringDataTest.php
+++ b/Test/Unit/Setup/RecurringDataTest.php
@@ -18,7 +18,7 @@
 namespace Bolt\Boltpay\Test\Unit\Setup;
 
 use Bolt\Boltpay\Model\ErrorResponse;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Setup\RecurringData;
 use Bolt\Boltpay\Helper\FeatureSwitch\Manager;
 use Bolt\Boltpay\Model\ErrorResponse as BoltErrorResponse;
@@ -31,7 +31,7 @@ use Magento\Framework\Setup\ModuleContextInterface;
  * Class RecurringDataTest
  * @coversDefaultClass \Bolt\Boltpay\Setup\RecurringData
  */
-class RecurringDataTest extends TestCase
+class RecurringDataTest extends BoltTestCase
 {
     /**
      * @var Manager
@@ -68,7 +68,7 @@ class RecurringDataTest extends TestCase
      */
     private $currentMock;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->fsManager = $this->createPartialMock(Manager::class, ['updateSwitchesFromBolt']);
         $this->logHelper = $this->createPartialMock(LogHelper::class, ['addInfoLog']);

--- a/Test/Unit/Setup/RecurringTest.php
+++ b/Test/Unit/Setup/RecurringTest.php
@@ -17,7 +17,7 @@
 
 namespace Bolt\Boltpay\Test\Unit\Setup;
 
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Setup\Recurring;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\ModuleContextInterface;
@@ -29,7 +29,7 @@ use Bolt\Boltpay\Test\Unit\TestHelper;
  * Class RecurringTest
  * @coversDefaultClass \Bolt\Boltpay\Setup\Recurring
  */
-class RecurringTest extends TestCase
+class RecurringTest extends BoltTestCase
 {
     /**
      * @var ModuleDataSetupInterface
@@ -56,7 +56,7 @@ class RecurringTest extends TestCase
      */
     private $customTable;
 
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->setup = $this->createMock(ModuleDataSetupInterface::class);
         $this->context = $this->createMock(ModuleContextInterface::class);

--- a/Test/Unit/Setup/UpgradeSchemaTest.php
+++ b/Test/Unit/Setup/UpgradeSchemaTest.php
@@ -20,7 +20,7 @@ namespace Bolt\Boltpay\Test\Unit\Setup;
 use Bolt\Boltpay\Test\Unit\TestHelper;
 use Magento\Framework\Setup\ModuleContextInterface;
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Setup\UpgradeSchema;
 use Magento\Framework\DB\Adapter\AdapterInterface;
 use Magento\Framework\Setup\SchemaSetupInterface;
@@ -30,7 +30,7 @@ use ReflectionException;
 /**
  * @coversDefaultClass \Bolt\Boltpay\Setup\UpgradeSchema
  */
-class UpgradeSchemaTest extends TestCase
+class UpgradeSchemaTest extends BoltTestCase
 {
 
     /** @var AdapterInterface|MockObject mocked instance of the database connection class */
@@ -51,7 +51,7 @@ class UpgradeSchemaTest extends TestCase
     /**
      * Setup test dependencies, called before each test
      */
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->dbAdapter = $this->getMockBuilder(AdapterInterface::class)
             ->disableOriginalConstructor()

--- a/Test/Unit/TestHelper.php
+++ b/Test/Unit/TestHelper.php
@@ -19,11 +19,10 @@ class TestHelper extends TestCase
      */
     public static function getReflectedClass($class)
     {
-        if (is_subclass_of($class, '\PHPUnit\Framework\MockObject\MockObject')) {
-            return new ReflectionClass(get_parent_class($class));
-        } else if (is_subclass_of($class, 'PHPUnit_Framework_MockObject_MockObject')) {
+        if (is_subclass_of($class, '\PHPUnit\Framework\MockObject\MockObject') || is_subclass_of($class, 'PHPUnit_Framework_MockObject_MockObject')) {
             return new ReflectionClass(get_parent_class($class));
         }
+        
         return new ReflectionClass($class);
     }
 
@@ -160,6 +159,20 @@ class TestHelper extends TestCase
         $reflectionProperty = $reflection->getProperty($property);
         $reflectionProperty->setAccessible(true);
         $reflectionProperty->setValue($object, $value);
+    }
+    
+    /**
+     * @param array|\Traversable $subset
+     */
+    public static function buildArraySubset($subset)
+    {
+        // https://github.com/sebastianbergmann/phpunit/issues/3494
+        // Deprecate assertArraySubset()
+        if (class_exists('\PHPUnit\Framework\Constraint\ArraySubset')) {
+            return new \PHPUnit\Framework\Constraint\ArraySubset($subset);
+        } else {
+            return new \Bolt\Boltpay\Test\Unit\ArraySubset($subset);
+        }
     }
 }
 class_alias(UnirgyMock::class, '\Unirgy\Giftcert\Model\Cert');

--- a/Test/Unit/TestHelper.php
+++ b/Test/Unit/TestHelper.php
@@ -19,7 +19,9 @@ class TestHelper extends TestCase
      */
     public static function getReflectedClass($class)
     {
-        if (is_subclass_of($class, 'PHPUnit_Framework_MockObject_MockObject')) {
+        if (is_subclass_of($class, '\PHPUnit\Framework\MockObject\MockObject')) {
+            return new ReflectionClass(get_parent_class($class));
+        } else if (is_subclass_of($class, 'PHPUnit_Framework_MockObject_MockObject')) {
             return new ReflectionClass(get_parent_class($class));
         }
         return new ReflectionClass($class);
@@ -139,9 +141,25 @@ class TestHelper extends TestCase
      * @param $data
      * @return mixed
      */
-    public static function serialize ($class, $data){
+    public static function serialize ($class, $data)
+    {
         return (new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($class))
             ->getObject(\Zend\Serializer\Adapter\PhpSerialize::class)->serialize($data);
+    }
+    
+    /**
+     * @param  $object
+     * @param  $property
+     * @param  $value
+     * @throws \ReflectionException
+     */
+    public static function setInaccessibleProperty($object, $property, $value)
+    {
+        $reflection = self::getReflectedClass($object);
+
+        $reflectionProperty = $reflection->getProperty($property);
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue($object, $value);
     }
 }
 class_alias(UnirgyMock::class, '\Unirgy\Giftcert\Model\Cert');

--- a/Test/Unit/ThirdPartyModules/Aheadworks/Sarp2Test.php
+++ b/Test/Unit/ThirdPartyModules/Aheadworks/Sarp2Test.php
@@ -5,9 +5,9 @@ namespace Bolt\Boltpay\Test\Unit\ThirdPartyModules\Aheadworks;
 use Bolt\Boltpay\ThirdPartyModules\Aheadworks\Sarp2;
 use Magento\Framework\ObjectManager\ConfigLoaderInterface;
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 
-class Sarp2Test extends TestCase
+class Sarp2Test extends BoltTestCase
 {
     const CHECK_SPECIFICATION_FACTORY_CLASS = 'Magento\Payment\Model\Checks\SpecificationFactory';
 
@@ -34,7 +34,7 @@ class Sarp2Test extends TestCase
     /**
      * Setup test dependencies, called before each test
      */
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->objectManagerMock = $this->createMock(\Magento\Framework\ObjectManager\ObjectManager::class);
         $this->configLoaderMock = $this->createMock(\Magento\Framework\App\ObjectManager\ConfigLoader::class);

--- a/Test/Unit/ThirdPartyModules/Amasty/GiftCardAccountTest.php
+++ b/Test/Unit/ThirdPartyModules/Amasty/GiftCardAccountTest.php
@@ -25,13 +25,13 @@ use Magento\Quote\Model\Quote\Address;
 use Magento\Quote\Model\Quote\Address\Total;
 use Magento\Quote\Model\Quote\Item;
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Magento\Quote\Model\Quote;
 
 /**
  * @coversDefaultClass \Bolt\Boltpay\ThirdPartyModules\Amasty\GiftCardAccount
  */
-class GiftCardAccountTest extends TestCase
+class GiftCardAccountTest extends BoltTestCase
 {
     /** @var int Test order id */
     const ORDER_ID = 10001;
@@ -157,7 +157,7 @@ class GiftCardAccountTest extends TestCase
     /**
      * Setup test dependencies, called before each test
      */
-    protected function setUp()
+    protected function setUpInternal()
     {
         $this->giftcardAccountRepositoryMock = $this->getMockBuilder(
             '\Amasty\GiftCardAccount\Api\GiftCardAccountRepositoryInterface'

--- a/Test/Unit/ThirdPartyModules/IDme/GroupVerificationTest.php
+++ b/Test/Unit/ThirdPartyModules/IDme/GroupVerificationTest.php
@@ -20,7 +20,7 @@ namespace Bolt\Boltpay\Test\Unit\ThirdPartyModules\IDme;
 use Bolt\Boltpay\ThirdPartyModules\IDme\GroupVerification;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Quote\Model\Quote;
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Magento\Customer\Model\Session;
 
 /**
@@ -28,7 +28,7 @@ use Magento\Customer\Model\Session;
  * @package Bolt\Boltpay\Test\Unit\ThirdPartyModules\IDme
  * @coversDefaultClass \Bolt\Boltpay\ThirdPartyModules\IDme\GroupVerification
  */
-class GroupVerificationTest extends TestCase
+class GroupVerificationTest extends BoltTestCase
 {
     const IDME_UUID = 'IDME_UUID';
     const IDME_GROUP = 'IDME_GROUP';
@@ -52,7 +52,7 @@ class GroupVerificationTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUpInternal()
     {
         $this->customerSession = $this->quote = $this->createPartialMock(Session::class, [
             'setIdmeUuid',

--- a/Test/Unit/ViewModel/MinicartAddonsTest.php
+++ b/Test/Unit/ViewModel/MinicartAddonsTest.php
@@ -17,13 +17,13 @@
 
 namespace Bolt\Boltpay\Test\Unit\ViewModel;
 
-use PHPUnit\Framework\TestCase;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 
 /**
  * @coversDefaultClass \Bolt\Boltpay\ViewModel\MinicartAddons
  */
-class MinicartAddonsTest extends TestCase
+class MinicartAddonsTest extends BoltTestCase
 {
     const DEFAULT_LAYOUT = [
         [
@@ -62,7 +62,7 @@ class MinicartAddonsTest extends TestCase
     /**
      * Setup test dependencies, called before each test
      */
-    public function setUp()
+    public function setUpInternal()
     {
         $this->configHelper = $this->createMock(\Bolt\Boltpay\Helper\Config::class);
         $this->serializer = (new ObjectManager($this))

--- a/Test/Unit/phpunit.xml
+++ b/Test/Unit/phpunit.xml
@@ -22,7 +22,6 @@
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
-         strict="true"
          bootstrap="./framework/bootstrap.php"
         >
     <testsuite name="Bolt Unit Tests">
@@ -33,7 +32,7 @@
         <ini name="xdebug.max_nesting_level" value="300"/>
     </php>
     <filter>
-        <whitelist addUncoveredFilesFromWhiteList="true">
+        <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">../../../app/code/*</directory>
             <directory suffix=".php">../../../lib/internal/Magento</directory>
             <exclude>
@@ -48,8 +47,8 @@
     </listeners>
     <logging>
         <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
-        <coverage_html_placeholder>
+        <!--<coverage_html_placeholder>-->
             <log type="coverage-html" target="{{coverage_dir}}/test-reports/coverage" charset="UTF-8" yui="true" highlight="true"/>
-        </coverage_html_placeholder>
+        <!--</coverage_html_placeholder>-->
     </logging>
 </phpunit>

--- a/Test/Unit/phpunit.xml
+++ b/Test/Unit/phpunit.xml
@@ -47,8 +47,6 @@
     </listeners>
     <logging>
         <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
-        <!--<coverage_html_placeholder>-->
-            <log type="coverage-html" target="{{coverage_dir}}/test-reports/coverage" charset="UTF-8" yui="true" highlight="true"/>
-        <!--</coverage_html_placeholder>-->
+        <log type="coverage-html" target="{{coverage_dir}}/test-reports/coverage" charset="UTF-8" yui="true" highlight="true"/>
     </logging>
 </phpunit>


### PR DESCRIPTION
# Description
Make phpunit green on Magento 2.4

Fixes: https://boltpay.atlassian.net/browse/M2P-412

#changelog Make phpunit green on Magento 2.4

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
