### PR TITLE
M2P-407 - Show cart type (Visa/MC/Amex) on the order grid

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -441,7 +441,7 @@ class Config extends AbstractHelper
         "capture_merchant_metrics" => self::XML_PATH_CAPTURE_MERCHANT_METRICS,
         "track_checkout_funnel" => self::XML_PATH_TRACK_CHECKOUT_FUNNEL
     ];
-    
+
     /**
      *  Xml path to disable checkout
      *  From Magento 2.4.1, it makes Magento\Downloadable\Observer\IsAllowedGuestCheckoutObserver::XML_PATH_DISABLE_GUEST_CHECKOUT as private,
@@ -1863,6 +1863,10 @@ class Config extends AbstractHelper
         $boltSettings[] = $this->boltConfigSettingFactory->create()
                                                          ->setName('track_checkout_funnel')
                                                          ->setValue(var_export($this->shouldTrackCheckoutFunnel(), true));
+        // Show card type in the order grid
+        $boltSettings[] = $this->boltConfigSettingFactory->create()
+                                                         ->setName('show_cc_type_in_order_grid')
+                                                         ->setValue($this->getShowCcTypeInOrderGrid());
 
         return $boltSettings;
     }
@@ -1883,8 +1887,8 @@ class Config extends AbstractHelper
 
         if ($currentValue != $settingValue) {
             $this->getConfigWriter()->save(
-                self::CONFIG_SETTING_PATHS[$settingName], 
-                $settingValue, 
+                self::CONFIG_SETTING_PATHS[$settingName],
+                $settingValue,
                 ScopeInterface::SCOPE_STORE,
                 $storeId
             );

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -101,6 +101,11 @@ class Config extends AbstractHelper
     const XML_PATH_GLOBAL_CSS = 'payment/boltpay/global_css';
 
     /**
+     * Path for show card type in the order grid
+     */
+    const XML_PATH_SHOW_CC_TYPE_IN_ORDER_GRID = 'payment/boltpay/show_cc_type_in_order_grid';
+
+    /**
      * Path for Additional Checkout Button Class
      */
     const XML_PATH_ADDITIONAL_CHECKOUT_BUTTON_CLASS = 'payment/boltpay/additional_checkout_button_class';
@@ -767,6 +772,16 @@ class Config extends AbstractHelper
             ScopeInterface::SCOPE_STORE,
             $storeId
         );
+    }
+
+    /**
+     * Get show card type in the order grid
+     *
+     * @return  string
+     */
+    public function getShowCcTypeInOrderGrid()
+    {
+        return $this->getScopeConfig()->getValue(self::XML_PATH_SHOW_CC_TYPE_IN_ORDER_GRID);
     }
 
     /**

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -118,6 +118,17 @@ class Order extends AbstractHelper
     ];
 
     /**
+     * @var string[] Associative array containing supported credit card networks as keys and their respective labels as
+     *               values. Used for displaying in Order grids when related configuration is enabled.
+     */
+    const SUPPORTED_CC_TYPES = [
+        'amex'       => 'Amex',
+        'discover'   => 'Discover',
+        'mastercard' => 'MC',
+        'visa'       => 'Visa',
+    ];
+
+    /**
      * @var ApiHelper
      */
     private $apiHelper;

--- a/Plugin/Magento/Ui/Component/Form/Element/SelectPlugin.php
+++ b/Plugin/Magento/Ui/Component/Form/Element/SelectPlugin.php
@@ -17,6 +17,8 @@
 
 namespace Bolt\Boltpay\Plugin\Magento\Ui\Component\Form\Element;
 
+use Bolt\Boltpay\Helper\Order;
+
 class SelectPlugin
 {
 
@@ -40,7 +42,7 @@ class SelectPlugin
                 ]
         ) && $subject->getName() == 'payment_method') {
             $config = $subject->getData('config');
-            foreach (\Bolt\Boltpay\Helper\Order::TP_METHOD_DISPLAY as $key => $suffix) {
+            foreach (array_merge(Order::TP_METHOD_DISPLAY, Order::SUPPORTED_CC_TYPES) as $key => $suffix) {
                 $config['options'][] = [
                     'value'         => \Bolt\Boltpay\Model\Payment::METHOD_CODE . '_' . $key,
                     'label'         => 'Bolt-' . $suffix,

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -143,7 +143,7 @@ JSON;
     /**
      * @var WriterInterface
      */
-    private $configWriter; 
+    private $configWriter;
 
     /**
      * @inheritdoc
@@ -249,7 +249,7 @@ JSON;
             $this->regionFactory,
             $this->composerFactory
         );
-        
+
         static::assertAttributeEquals($this->encryptor, 'encryptor', $instance);
         static::assertAttributeEquals($this->moduleResource, 'moduleResource', $instance);
         static::assertAttributeEquals($this->productMetadata, 'productMetadata', $instance);
@@ -1213,7 +1213,7 @@ JSON;
             ['track_checkout_funnel', 'false'],
         ];
         $actual = $this->currentMock->getAllConfigSettings();
-        $this->assertEquals(42, count($actual));
+        $this->assertEquals(43, count($actual));
         for ($i = 0; $i < 2; $i ++) {
             $this->assertEquals($expected[$i][0], $actual[$i]->getName());
             $this->assertEquals($expected[$i][1], $actual[$i]->getValue(), 'actual value for ' . $expected[$i][0] . ' is not equals to expected');
@@ -1534,7 +1534,7 @@ Room 4000',
             ],
         ];
     }
-  
+
     /**
      * @test
      * @covers ::getComposerVersion
@@ -1590,9 +1590,9 @@ Room 4000',
                     $localMock->setting = $settingValue;
                 }
             );
-        
+
         $localMock->setConfigSetting($key_name, $expected);
-        
+
         $result = $localMock->setting;
         $this->assertEquals($expected, $result);
     }
@@ -1639,10 +1639,10 @@ Room 4000',
                     $localMock->setting = $settingValue;
                 }
             );
-        
+
         // Value of property should not have changed
         $localMock->setConfigSetting($key_name, $original);
-        
+
         $result = $localMock->setting;
         $this->assertEquals($original, $result);
     }

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -746,6 +746,7 @@ JSON;
     {
         return [
             ['getGlobalCSS', BoltConfig::XML_PATH_GLOBAL_CSS, '.replaceable-example-selector1 {color: black;}]'],
+            ['getShowCcTypeInOrderGrid', BoltConfig::XML_PATH_SHOW_CC_TYPE_IN_ORDER_GRID, '1'],
             ['getAdditionalCheckoutButtonClass', BoltConfig::XML_PATH_ADDITIONAL_CHECKOUT_BUTTON_CLASS, 'with-cards'],
             ['getPrefetchAddressFields', BoltConfig::XML_PATH_PREFETCH_ADDRESS_FIELDS, 'address_field1, address_field2'],
             ['getButtonColor', BoltConfig::XML_PATH_BUTTON_COLOR],

--- a/Test/Unit/Plugin/Magento/Ui/Component/Form/Element/SelectPluginTest.php
+++ b/Test/Unit/Plugin/Magento/Ui/Component/Form/Element/SelectPluginTest.php
@@ -59,8 +59,8 @@ class SelectPluginTest extends BoltTestCase
      *
      * @param string $namespace
      * @param string $name
-     * @param array $configBefore
-     * @param array $configAfter
+     * @param array  $configBefore
+     * @param array  $configAfter
      */
     public function afterPrepare($namespace, $name, $configBefore, $configAfter)
     {
@@ -91,18 +91,38 @@ class SelectPluginTest extends BoltTestCase
                 '__disableTmpl' => true,
             ],
             [
-		        'value'         => 'boltpay_affirm',
-		        'label'         => 'Bolt-Affirm',
-		        '__disableTmpl' => true,
+                'value'         => 'boltpay_affirm',
+                'label'         => 'Bolt-Affirm',
+                '__disableTmpl' => true,
             ],
-	        [
-		        'value'         => 'boltpay_braintree',
-		        'label'         => 'Bolt-Braintree',
-		        '__disableTmpl' => true,
+            [
+                'value'         => 'boltpay_braintree',
+                'label'         => 'Bolt-Braintree',
+                '__disableTmpl' => true,
             ],
             [
                 'value'         => 'boltpay_applepay',
                 'label'         => 'Bolt-ApplePay',
+                '__disableTmpl' => true,
+            ],
+            [
+                'value'         => 'boltpay_amex',
+                'label'         => 'Bolt-Amex',
+                '__disableTmpl' => true,
+            ],
+            [
+                'value'         => 'boltpay_discover',
+                'label'         => 'Bolt-Discover',
+                '__disableTmpl' => true,
+            ],
+            [
+                'value'         => 'boltpay_mastercard',
+                'label'         => 'Bolt-MC',
+                '__disableTmpl' => true,
+            ],
+            [
+                'value'         => 'boltpay_visa',
+                'label'         => 'Bolt-Visa',
                 '__disableTmpl' => true,
             ],
         ];

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -124,6 +124,11 @@
                         <comment>This CSS will be added to any page that displays the Bolt Checkout button.</comment>
                         <config_path>payment/boltpay/global_css</config_path>
                     </field>
+                    <field id="show_cc_type_in_order_grid" translate="label" type="select" sortOrder="110" showInDefault="1" showInWebsite="1" showInStore="0">
+                        <label>Show card type in the order grid</label>
+                        <config_path>payment/boltpay/show_cc_type_in_order_grid</config_path>
+                        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    </field>
                 </group>
                 <group id="boltpay_advanced" translate="label" type="text" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Advanced options</label>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -52,6 +52,7 @@ tr.shipping.totals td.amount span.price,
 .cart-container #customerbalance-placer .payment-option-title {display: none;}
 .cart-container #customerbalance-placer #use-customer-balance {width: 284px;}
 .payment-method-boltpay .payment-method-title img.payment-icon {padding: 8px; border: 1px solid #cccccc; width: 200px;}</global_css>
+                <show_cc_type_in_order_grid>0</show_cc_type_in_order_grid>
                 <additional_checkout_button_class>with-cards</additional_checkout_button_class>
                 <success_page>checkout/onepage/success</success_page>
                 <prefetch_shipping>0</prefetch_shipping>


### PR DESCRIPTION
# Description

Right now we show cart type (Visa/MC/Amex) on order details but not in order grid.
Need to add plugin setting "Show cart type (Visa/MC/Amex) on the order grid" disabled by default.
If the setting enabled and we know cart type we show Bolt-Visa or Bolt-MC or Bolt-Amex in the order grid
This is a request from the merchant Cabinet and continue changes we started in https://boltpay.atlassian.net/browse/M2P-357

Fixes: https://boltpay.atlassian.net/browse/M2P-407

#changelog M2P-407 - Show cart type (Visa/MC/Amex) on the order grid

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
