### PR TITLE
M2P-416 Bugfix: Bolt PPC error if Aheadworks GiftCard is enabled

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -2354,9 +2354,11 @@ class Cart extends AbstractHelper
         }
 
         $quote->setIsActive(false);
-
+        $this->saveQuote($quote);
         $cart_data = $this->getCartData(false, '', $quote);
         $this->quoteResourceSave($quote);
+        $this->saveQuote($quote);
+        
         return $cart_data;
     }
 

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -5366,6 +5366,8 @@ ORDER
         $this->productRepository->expects(static::once())->method('getById')->with(self::PRODUCT_ID)
             ->willReturn($this->productMock);
         $this->quoteMock->expects(static::once())->method('setIsActive')->with(false);
+        $this->quoteResource->expects(static::once())->method('save')->with($this->quoteMock);
+        $this->quoteRepository->expects(static::exactly(2))->method('save')->with($this->quoteMock);
 
         static::assertEquals($expectedCartData, $cartMock->createCart($items));
     }
@@ -5480,6 +5482,8 @@ ORDER
         $this->productRepository->expects(static::exactly(2))->method('getById')->with(self::PRODUCT_ID)
             ->willReturn($this->productMock);
         $this->quoteMock->expects(static::once())->method('setIsActive')->with(false);
+        $this->quoteResource->expects(static::once())->method('save')->with($this->quoteMock);
+        $this->quoteRepository->expects(static::exactly(2))->method('save')->with($this->quoteMock);
 
         static::assertEquals($expectedCartData, $cartMock->createCart($items));
     }
@@ -5557,6 +5561,8 @@ ORDER
         $this->productRepository->expects(static::once())->method('getById')->with(self::PRODUCT_ID)
             ->willReturn($this->productMock);
         $this->quoteMock->expects(static::once())->method('setIsActive')->with(false);
+        $this->quoteResource->expects(static::once())->method('save')->with($this->quoteMock);
+        $this->quoteRepository->expects(static::exactly(2))->method('save')->with($this->quoteMock);
 
         static::assertEquals($expectedCartData, $cartMock->createCart($items));
     }


### PR DESCRIPTION
# Description
We create a fresh quote for Bolt PPC, then after the data of this quote updates, it should be saved via repository.

Fixes: https://boltpay.atlassian.net/browse/M2P-416

#changelog Bugfix: Bolt PPC error if Aheadworks GiftCard is enabled

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
