### PR TITLE
ON-438 - Resolve issue with VAT validation

### DIFF
--- a/Plugin/Magento/Quote/Observer/Frontend/Quote/Address/AddressCollectTotalsObserverPlugin.php
+++ b/Plugin/Magento/Quote/Observer/Frontend/Quote/Address/AddressCollectTotalsObserverPlugin.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Plugin\Magento\Quote\Observer\Frontend\Quote\Address;
+
+use Magento\Framework\Event\Observer;
+use Magento\Quote\Api\Data\ShippingAssignmentInterface;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\Quote\Address;
+use Magento\Quote\Observer\Frontend\Quote\Address\CollectTotalsObserver;
+use Magento\Quote\Observer\Frontend\Quote\Address\VatValidator;
+
+/**
+ * Plugin for {@see \Magento\Quote\Observer\Frontend\Quote\Address\CollectTotalsObserver}
+ */
+class AddressCollectTotalsObserverPlugin
+{
+    /**
+     * @var VatValidator
+     */
+    private $vatValidator;
+
+    /**
+     * @var string
+     */
+    private $emailBefore;
+
+    /**
+     * AddressCollectTotalsObserverPlugin constructor.
+     *
+     * @param VatValidator $vatValidator
+     */
+    public function __construct(VatValidator $vatValidator)
+    {
+        $this->vatValidator = $vatValidator;
+    }
+
+    /**
+     * Collects customer email before they are overwritten by
+     *
+     * @see \Magento\Quote\Observer\Frontend\Quote\Address\CollectTotalsObserver::execute
+     *
+     * @param CollectTotalsObserver $subject original observer instance
+     * @param Observer              $observer object containing original event parameters
+     *
+     * @return void
+     */
+    public function beforeExecute($subject, $observer)
+    {
+        $this->emailBefore = $this->emailBefore ?: $observer->getQuote()->getCustomerEmail();
+    }
+
+    /**
+     * Due to known issue with {@see \Magento\Quote\Observer\Frontend\Quote\Address\CollectTotalsObserver::execute}
+     * where it overwrites customer data on the quote with empty values when:
+     *  1. quote customer is guest (customer_id is null)
+     *  2. VAT validation is enabled for shipping addresses in the configuration
+     * In this plugin we restore the customer email from value saved before the observer in question is executed
+     *
+     * @see  beforeExecute
+     *
+     * @link https://github.com/magento/magento2/pull/25405 PR resolving this issue, not in any releases currently
+     *
+     * @param CollectTotalsObserver $subject  original observer instance
+     * @param void                  $result   result of the original method call
+     * @param Observer              $observer object containing original event parameters
+     *
+     * @return void
+     */
+    public function afterExecute(CollectTotalsObserver $subject, $result, $observer)
+    {
+        /** @var ShippingAssignmentInterface $shippingAssignment */
+        $shippingAssignment = $observer->getShippingAssignment();
+        /** @var Address $address */
+        $address = $shippingAssignment->getShipping()->getAddress();
+        /** @var Quote $quote */
+        $quote = $observer->getQuote();
+
+        $customer = $quote->getCustomer();
+        $storeId = $customer->getStoreId();
+        if (!$customer->getDisableAutoGroupChange()
+            && $this->vatValidator->isEnabled($address, $storeId)
+            && !$customer->getId()) {
+            $quote->setCustomerEmail($this->emailBefore);
+            $quote->getCustomer()->setEmail($this->emailBefore);
+        }
+        return $result;
+    }
+}

--- a/Test/Unit/Plugin/Magento/Quote/Observer/Frontend/Quote/Address/AddressCollectTotalsObserverPluginTest.php
+++ b/Test/Unit/Plugin/Magento/Quote/Observer/Frontend/Quote/Address/AddressCollectTotalsObserverPluginTest.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Test\Unit\Plugin\Magento\Quote\Observer\Frontend\Quote\Address;
+
+use Bolt\Boltpay\Plugin\Magento\Quote\Observer\Frontend\Quote\Address\AddressCollectTotalsObserverPlugin;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
+use Bolt\Boltpay\Test\Unit\TestHelper;
+use Magento\Customer\Model\Customer;
+use Magento\Framework\Event\Observer;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\ShippingAssignment;
+use Magento\Quote\Observer\Frontend\Quote\Address\CollectTotalsObserver;
+use Magento\Quote\Observer\Frontend\Quote\Address\VatValidator;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use ReflectionException;
+
+/**
+ * @coversDefaultClass \Bolt\Boltpay\Plugin\Magento\Quote\Observer\Frontend\Quote\Address\AddressCollectTotalsObserverPlugin
+ */
+class AddressCollectTotalsObserverPluginTest extends BoltTestCase
+{
+
+    /** @var string Test email */
+    const EMAIL = 'example@example.com';
+
+    /** @var int Test customer id */
+    const CUSTOMER_ID = 123;
+
+    /** @var int Test store id */
+    const STORE_ID = 1;
+
+    /**
+     * @var VatValidator|MockObject
+     */
+    private $vatValidatorMock;
+
+    /**
+     * @var AddressCollectTotalsObserverPlugin|MockObject
+     */
+    private $currentMock;
+
+    /**
+     * @var Quote|MockObject
+     */
+    private $quoteMock;
+
+    /**
+     * @var CollectTotalsObserver|MockObject
+     */
+    private $subjectMock;
+
+    /**
+     * @var Observer|MockObject
+     */
+    private $observerMock;
+
+    /**
+     * @var Customer|MockObject
+     */
+    private $customerMock;
+
+    /**
+     * Configure common test dependencies
+     */
+    protected function setUpInternal()
+    {
+        $this->vatValidatorMock = $this->createMock(VatValidator::class);
+        $this->currentMock = $this->getMockBuilder(AddressCollectTotalsObserverPlugin::class)
+            ->enableOriginalConstructor()
+            ->setConstructorArgs([$this->vatValidatorMock])
+            ->setMethods(['isEnabled'])
+            ->getMock();
+        $this->quoteMock = $this->createPartialMock(
+            Quote::class,
+            [
+                'getCustomer',
+                'setCustomerEmail',
+                'getCustomerEmail',
+            ]
+        );
+        $this->customerMock = $this->createMock(\Magento\Customer\Model\Data\Customer::class);
+        $this->quoteMock->method('getCustomer')->willReturn($this->customerMock);
+        $this->subjectMock = $this->createMock(CollectTotalsObserver::class);
+        $this->observerMock = $this->createPartialMock(Observer::class, ['getQuote', 'getShippingAssignment']);
+        $this->observerMock->method('getQuote')->willReturn($this->quoteMock);
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     */
+    public function __construct_always_setsProperty()
+    {
+        $instance = new AddressCollectTotalsObserverPlugin($this->vatValidatorMock);
+        static::assertAttributeEquals($this->vatValidatorMock, 'vatValidator', $instance);
+    }
+
+    /**
+     * @test
+     * that beforeExecute collects customer email before they are overwritten
+     *
+     * @covers ::beforeExecute
+     */
+    public function beforeExecute_ifEmailIsNotCollected_collectsCustomerEmail()
+    {
+        $this->observerMock->method('getQuote')->willReturn($this->quoteMock);
+        $this->quoteMock->expects(static::once())->method('getCustomerEmail')->willReturn(self::EMAIL);
+        $this->currentMock->beforeExecute($this->subjectMock, $this->observerMock);
+        static::assertAttributeEquals(self::EMAIL, 'emailBefore', $this->currentMock);
+        $this->currentMock->beforeExecute($this->subjectMock, $this->observerMock);
+        static::assertAttributeEquals(self::EMAIL, 'emailBefore', $this->currentMock);
+    }
+
+    /**
+     * @test
+     * that afterExecute restores customer email value on quote with $emailBefore if
+     *  1. quote customer is guest (customer_id is null)
+     *  2. VAT validation is enabled in the configuration
+     *
+     * @dataProvider afterExecute_ifPreconditionsAreMet_restoresQuoteCustomerEmailProvider
+     *
+     * @covers ::afterExecute
+     * @param bool $customerDisableAutoGroupChange whether quote customer is exempt from auto group change
+     * @param bool $vatValidatorIsEnabledForAddress whether VAT validation is enabled for the shipping address
+     * @param int|null $customerId quote customer id
+     * @param bool $expectRestore whether to expect quote customer email value to be restored
+     *
+     * @throws ReflectionException if emailBefore property is not set
+     */
+    public function afterExecute_ifPreconditionsAreMet_restoresQuoteCustomerEmail(
+        $customerDisableAutoGroupChange,
+        $vatValidatorIsEnabledForAddress,
+        $customerId,
+        $expectRestore
+    ) {
+        TestHelper::setProperty($this->currentMock, 'emailBefore', self::EMAIL);
+        $shippingAssignmentMock = $this->createPartialMock(
+            ShippingAssignment::class,
+            ['getShipping', 'getAddress']
+        );
+        $shippingAssignmentMock->method('getShipping')->willReturnSelf();
+        $quoteAddressMock = $this->createMock(Quote\Address::class);
+        $shippingAssignmentMock->method('getAddress')->willReturn($quoteAddressMock);
+        $this->customerMock->method('getStoreId')->willReturn(self::STORE_ID);
+        $this->observerMock->method('getShippingAssignment')->willReturn($shippingAssignmentMock);
+        $this->customerMock->method('getDisableAutoGroupChange')->willReturn($customerDisableAutoGroupChange);
+        $this->vatValidatorMock->method('isEnabled')->with($quoteAddressMock, self::STORE_ID)
+            ->willReturn($vatValidatorIsEnabledForAddress);
+        $this->customerMock->method('getId')->willReturn($customerId);
+
+        $this->quoteMock->expects($expectRestore ? static::once() : static::never())->method('setCustomerEmail')
+            ->with(self::EMAIL);
+        $this->customerMock->expects($expectRestore ? static::once() : static::never())->method('setEmail')
+            ->with(self::EMAIL);
+        $result = null;
+        static::assertSame($result, $this->currentMock->afterExecute($this->subjectMock, $result, $this->observerMock));
+    }
+
+    /**
+     * Data provider for {@see afterExecute_ifPreconditionsAreMet_restoresQuoteCustomerEmail}
+     *
+     * @return array[]
+     */
+    public function afterExecute_ifPreconditionsAreMet_restoresQuoteCustomerEmailProvider()
+    {
+        return [
+            [
+                'customerDisableAutoGroupChange'  => false,
+                'vatValidatorIsEnabledForAddress' => false,
+                'customerId'                      => null,
+                'expectRestore'                   => false,
+            ],
+            [
+                'customerDisableAutoGroupChange'  => true,
+                'vatValidatorIsEnabledForAddress' => false,
+                'customerId'                      => null,
+                'expectRestore'                   => false,
+            ],
+            [
+                'customerDisableAutoGroupChange'  => true,
+                'vatValidatorIsEnabledForAddress' => true,
+                'customerId'                      => null,
+                'expectRestore'                   => false,
+            ],
+            [
+                'customerDisableAutoGroupChange'  => false,
+                'vatValidatorIsEnabledForAddress' => false,
+                'customerId'                      => self::CUSTOMER_ID,
+                'expectRestore'                   => false,
+            ],
+            [
+                'customerDisableAutoGroupChange'  => true,
+                'vatValidatorIsEnabledForAddress' => false,
+                'customerId'                      => self::CUSTOMER_ID,
+                'expectRestore'                   => false,
+            ],
+            [
+                'customerDisableAutoGroupChange'  => true,
+                'vatValidatorIsEnabledForAddress' => true,
+                'customerId'                      => self::CUSTOMER_ID,
+                'expectRestore'                   => false,
+            ],
+            [
+                'customerDisableAutoGroupChange'  => false,
+                'vatValidatorIsEnabledForAddress' => true,
+                'customerId'                      => self::CUSTOMER_ID,
+                'expectRestore'                   => false,
+            ],
+            [
+                'customerDisableAutoGroupChange'  => false,
+                'vatValidatorIsEnabledForAddress' => true,
+                'customerId'                      => null,
+                'expectRestore'                   => true,
+            ],
+        ];
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -301,4 +301,9 @@
                 sortOrder="1"/>
     </type>
 
+    <type name="Magento\Quote\Observer\Frontend\Quote\Address\CollectTotalsObserver">
+        <plugin name="bolt_boltpay_magento_quote_observer_frontend_quote_address_collect_totals_observer_plugin"
+                type="Bolt\Boltpay\Plugin\Magento\Quote\Observer\Frontend\Quote\Address\AddressCollectTotalsObserverPlugin"
+                sortOrder="10"/>
+    </type>
 </config>


### PR DESCRIPTION
# Description
This issue turned out to be caused by incompatibility between Bolt and specific Magento VAT configuration. This means that it can be reproduced in a blank Magento instance.
Configurations attributing to this issue are:
• “Customers → Customer Configuration → Create New Account Options → Enable Automatic Assignment to Customer Group” set to “Yes”
• “Customers → Customer Configuration → Create New Account Options → Tax Calculation Based On” set to “Shipping Address”

After filling in the email address, selecting a shipping option will trigger totals re-collection. During totals re-collection (sales_customer_validate_vat_number event), a CollectTotalsObserver will overwrite quote customer with an empty customer object since it’s a guest checkout, effectively removing the email address.
To remedy this a plugin is created for that particular observer, which will preserve the email after the observer execution.

Fixes: [ON-438](https://boltpay.atlassian.net/browse/ON-438)

#changelog ON-438 - Resolve issue with VAT validation

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [x] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
