### PR TITLE
ON-438 - persist the back office order note from the form up to the final order DB record

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1108,7 +1108,7 @@ class Cart extends AbstractHelper
         $save = true,
         $emailFields = ['customer_email', 'email'],
         $excludeFields = ['entity_id', 'address_id', 'reserved_order_id',
-            'address_sales_rule_id', 'cart_fixed_rules', 'cached_items_all']
+            'address_sales_rule_id', 'cart_fixed_rules', 'cached_items_all', 'customer_note']
     ) {
         foreach ($parent->getData() as $key => $value) {
             if (in_array($key, $excludeFields)) {
@@ -2358,7 +2358,7 @@ class Cart extends AbstractHelper
         $cart_data = $this->getCartData(false, '', $quote);
         $this->quoteResourceSave($quote);
         $this->saveQuote($quote);
-        
+
         return $cart_data;
     }
 


### PR DESCRIPTION
# Description
Reported by Trail Gear. Back office order note from the create order form does not get into the order. The reason is that this field often gets populated after the cart is sent to bolt, so not passed to / with the immutable quote, existing in the parent only. However, in our transfer data method an empty immutable quote order note field overwrites the parent quote one. The solution is to exclude this field from the transfer, keeping what's in the parent quote. This case exists in back-office flow only and does not collide with the frontend order note populated from the bolt modal.   

Fixes: [ON-438](https://boltpay.atlassian.net/browse/ON-438)

#changelog ON-438 - persist the back office order note from the form up to the final order DB record

# Type of change

- [x] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [x] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
