### PR TITLE
M2P-426 Bugfix: Update checkout session in the callback of discounts.code.apply api request

### DIFF
--- a/Model/Api/DiscountCodeValidation.php
+++ b/Model/Api/DiscountCodeValidation.php
@@ -153,6 +153,8 @@ class DiscountCodeValidation extends UpdateCartCommon implements DiscountCodeVal
         
         $parentQuote->getStore()->setCurrentCurrencyCode($parentQuote->getQuoteCurrencyCode());
         
+        $this->updateSession($parentQuote);
+     
         // Set the shipment if request payload has that info.
         if (!empty($requestArray['cart']['shipments'][0]['reference'])) {
             $this->setShipment($requestArray['cart']['shipments'][0], $immutableQuote);

--- a/Model/Api/UpdateCart.php
+++ b/Model/Api/UpdateCart.php
@@ -28,7 +28,6 @@ use Bolt\Boltpay\Model\Api\UpdateCartItemTrait;
 use Bolt\Boltpay\Model\ErrorResponse as BoltErrorResponse;
 use Bolt\Boltpay\Api\Data\CartDataInterfaceFactory;
 use Bolt\Boltpay\Api\Data\UpdateCartResultInterfaceFactory;
-use Bolt\Boltpay\Helper\Session as SessionHelper;
 use Magento\Quote\Model\Quote;
 use Bolt\Boltpay\Exception\BoltException;
 
@@ -58,11 +57,6 @@ class UpdateCart extends UpdateCartCommon implements UpdateCartInterface
      */
     protected $cartRequest;
 
-    /**
-     * @var SessionHelper
-     */
-    protected $sessionHelper;
-
 
     /**
      * UpdateCart constructor.
@@ -81,7 +75,6 @@ class UpdateCart extends UpdateCartCommon implements UpdateCartInterface
         $this->UpdateCartItemTraitConstructor($updateCartContext);
         $this->cartDataFactory = $cartDataFactory;
         $this->updateCartResultFactory = $updateCartResultFactory;
-        $this->sessionHelper = $updateCartContext->getSessionHelper();
     }
 
     /**
@@ -113,10 +106,7 @@ class UpdateCart extends UpdateCartCommon implements UpdateCartInterface
 
             $parentQuote->getStore()->setCurrentCurrencyCode($parentQuote->getQuoteCurrencyCode());
 
-            // Load logged in customer checkout and customer sessions from cached session id.
-            // Replace the quote with $parentQuote in checkout session.
-            $this->sessionHelper->loadSession($parentQuote);
-            $this->cartHelper->resetCheckoutSession($this->sessionHelper->getCheckoutSession());
+            $this->updateSession($parentQuote);
 
             if (!empty($cart['shipments'][0]['reference'])) {
                 $this->setShipment($cart['shipments'][0], $immutableQuote);

--- a/Model/Api/UpdateCartCommon.php
+++ b/Model/Api/UpdateCartCommon.php
@@ -39,6 +39,7 @@ use Bolt\Boltpay\Helper\ArrayHelper;
 use Bolt\Boltpay\Helper\Config as ConfigHelper;
 use Bolt\Boltpay\Model\EventsForThirdPartyModules;
 use Bolt\Boltpay\Exception\BoltException;
+use Bolt\Boltpay\Helper\Session as SessionHelper;
 
 /**
  * Class UpdateCartCommon
@@ -121,6 +122,11 @@ abstract class UpdateCartCommon
      * @var CartRepository
      */
     protected $cartRepository;
+    
+    /**
+     * @var SessionHelper
+     */
+    protected $sessionHelper;
 
     /**
      * UpdateCartCommon constructor.
@@ -146,6 +152,7 @@ abstract class UpdateCartCommon
         $this->checkoutSession = $updateCartContext->getCheckoutSession();
         $this->ruleRepository = $updateCartContext->getRuleRepository();
         $this->cartRepository = $updateCartContext->getCartRepositoryInterface();
+        $this->sessionHelper = $updateCartContext->getSessionHelper();
     }
 
     /**
@@ -312,6 +319,19 @@ abstract class UpdateCartCommon
         );
 
         return $products;
+    }
+    
+    /**
+     * Load logged in customer checkout and customer sessions from cached session id.
+     * Replace the quote with $parentQuote in checkout session.
+     * In this way, the quote object can be associated with cart properly as well.
+     * 
+     * @param Quote $quote
+     */
+    public function updateSession($quote)
+    {
+        $this->sessionHelper->loadSession($quote);
+        $this->cartHelper->resetCheckoutSession($this->sessionHelper->getCheckoutSession());
     }
 
     /**

--- a/Test/Unit/Model/Api/UpdateCartTest.php
+++ b/Test/Unit/Model/Api/UpdateCartTest.php
@@ -33,7 +33,6 @@ use Bolt\Boltpay\Model\Api\UpdateCartContext;
 use Bolt\Boltpay\Model\ErrorResponse as BoltErrorResponse;
 use Bolt\Boltpay\Api\Data\CartDataInterfaceFactory;
 use Bolt\Boltpay\Api\Data\UpdateCartResultInterfaceFactory;
-use Bolt\Boltpay\Helper\Session as SessionHelper;
 use Bolt\Boltpay\Helper\Log as LogHelper;
 use Bolt\Boltpay\Helper\Cart as CartHelper;
 use Bolt\Boltpay\Model\Api\UpdateCart;
@@ -75,11 +74,6 @@ class UpdateCartTest extends BoltTestCase
      * @var array
      */
     private $cartRequest;
-    
-    /**
-     * @var SessionHelper|MockObject
-     */
-    private $sessionHelper;
     
     /**
      * @var UpdateCartContext|MockObject
@@ -129,11 +123,10 @@ class UpdateCartTest extends BoltTestCase
     protected function setUpInternal()
     {
         $this->updateCartContext = $this->getMockBuilder(UpdateCartContext::class)
-            ->setMethods(['getSessionHelper', 'getCache'])
+            ->setMethods(['getCache'])
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->sessionHelper = $this->createMock(SessionHelper::class);
         $this->cartDataFactory = $this->createMock(CartDataInterfaceFactory::class);
         $this->updateCartResultFactory = $this->createMock(UpdateCartResultInterfaceFactory::class);
         $this->response = $this->createMock(Response::class);
@@ -150,17 +143,11 @@ class UpdateCartTest extends BoltTestCase
      */
     private function initCurrentMock(
         $methods = [],
-        $sessionHelper = null,
         $cartDataFactory = null,
         $updateCartResultFactory = null,
         $enableProxyingToOriginalMethods = false,
         $enableOriginalConstructor = true
-    ) {
-        if(!$sessionHelper) {
-            $sessionHelper = $this->sessionHelper;
-        }
-        $this->updateCartContext->method('getSessionHelper')->willReturn($sessionHelper);
-        
+    ) {        
         if(!$cartDataFactory) {
             $cartDataFactory = $this->cartDataFactory;
         }
@@ -427,11 +414,6 @@ class UpdateCartTest extends BoltTestCase
             'updateCartResultFactory',
             $this->currentMock
         );
-        static::assertAttributeInstanceOf(
-            SessionHelper::class,
-            'sessionHelper',
-            $this->currentMock
-        );
     }
     
     /**
@@ -472,25 +454,16 @@ class UpdateCartTest extends BoltTestCase
             self::PARENT_QUOTE_ID,
             self::PARENT_QUOTE_ID            
         );
-        
-        $sessionHelper = $this->getMockBuilder(SessionHelper::class)
-            ->setMethods(['loadSession','getCheckoutSession'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $sessionHelper->expects(self::once())->method('loadSession')->with($parentQuoteMock);
-        
-        $checkoutSession = $this->createMock(CheckoutSession::class);
-        $sessionHelper->expects(self::once())->method('getCheckoutSession')
-            ->willReturn($checkoutSession);
 
         $this->initCurrentMock([
             'validateQuote',
             'preProcessWebhook',
+            'updateSession',
             'setShipment',
             'generateResult',
             'verifyCouponCode',
             'applyDiscount'
-        ], $sessionHelper);        
+        ]);        
         
         $immutableQuoteMock = $this->getQuoteMock();
         
@@ -500,6 +473,9 @@ class UpdateCartTest extends BoltTestCase
             
         $this->currentMock->expects(self::once())->method('preProcessWebhook')
             ->with(self::STORE_ID);
+        
+        $this->currentMock->expects(self::once())->method('updateSession')
+            ->with($parentQuoteMock);
             
         $this->currentMock->expects($this->exactly(2))
             ->method('setShipment')
@@ -515,9 +491,7 @@ class UpdateCartTest extends BoltTestCase
         $this->currentMock->expects(self::once())->method('applyDiscount')
             ->with(self::COUPON_CODE, $this->couponMock, null, $parentQuoteMock)
             ->willReturn(true);
-        
-        $this->cartHelper->expects(self::once())->method('resetCheckoutSession')
-            ->with($checkoutSession);
+
         $this->cartHelper->expects(self::once())->method('replicateQuoteData')
             ->with($parentQuoteMock, $immutableQuoteMock);
 
@@ -575,26 +549,17 @@ class UpdateCartTest extends BoltTestCase
             self::PARENT_QUOTE_ID,
             self::PARENT_QUOTE_ID            
         );
-        
-        $sessionHelper = $this->getMockBuilder(SessionHelper::class)
-            ->setMethods(['loadSession','getCheckoutSession'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $sessionHelper->expects(self::once())->method('loadSession')->with($parentQuoteMock);
-        
-        $checkoutSession = $this->createMock(CheckoutSession::class);
-        $sessionHelper->expects(self::once())->method('getCheckoutSession')
-            ->willReturn($checkoutSession);
             
         $this->initCurrentMock([
             'validateQuote',
             'preProcessWebhook',
+            'updateSession',
             'setShipment',
             'generateResult',
             'getQuoteCart',
             'removeDiscount',
             'getAppliedStoreCredit'
-        ], $sessionHelper);        
+        ]);        
         
         $immutableQuoteMock = $this->getQuoteMock();
         
@@ -604,6 +569,9 @@ class UpdateCartTest extends BoltTestCase
             
         $this->currentMock->expects(self::once())->method('preProcessWebhook')
             ->with(self::STORE_ID);
+        
+        $this->currentMock->expects(self::once())->method('updateSession')
+            ->with($parentQuoteMock);
             
         $this->currentMock->expects($this->exactly(2))
             ->method('setShipment')
@@ -631,9 +599,7 @@ class UpdateCartTest extends BoltTestCase
         $this->currentMock->expects(self::once())->method('removeDiscount')
             ->with(self::COUPON_CODE, [self::COUPON_CODE => 'coupon'], $parentQuoteMock, self::WEBSITE_ID, self::STORE_ID)
             ->willReturn(true);
-        
-        $this->cartHelper->expects(self::once())->method('resetCheckoutSession')
-            ->with($checkoutSession);
+
         $this->cartHelper->expects(self::once())->method('replicateQuoteData')
             ->with($parentQuoteMock, $immutableQuoteMock);
 
@@ -681,25 +647,23 @@ class UpdateCartTest extends BoltTestCase
             self::PARENT_QUOTE_ID            
         );
         
-        $sessionHelper = $this->getMockBuilder(SessionHelper::class)
-            ->setMethods(['loadSession','getCheckoutSession'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $sessionHelper->expects(self::once())->method('loadSession')->with($parentQuoteMock);
-            
         $this->initCurrentMock([
             'validateQuote',
             'preProcessWebhook',
+            'updateSession',
             'setShipment',
             'generateResult',
             'getProduct',
             'verifyItemData',
             'addItemToQuote',
             'updateTotals'
-        ], $sessionHelper);
+        ]);
         
         $immutableQuoteMock = $this->getQuoteMock();
         
+        $this->currentMock->expects(self::once())->method('updateSession')
+            ->with($parentQuoteMock);
+            
         $this->currentMock->expects($this->exactly(2))
             ->method('setShipment')
             ->withConsecutive(
@@ -729,13 +693,7 @@ class UpdateCartTest extends BoltTestCase
         
         $this->currentMock->expects(self::once())->method('updateTotals')
             ->with($parentQuoteMock);
-        
-        $checkoutSession = $this->createMock(CheckoutSession::class);
-        $sessionHelper->expects(self::once())->method('getCheckoutSession')
-            ->willReturn($checkoutSession);
-        
-        $this->cartHelper->expects(self::once())->method('resetCheckoutSession')
-            ->with($checkoutSession);    
+  
         $this->cartHelper->expects(self::once())->method('replicateQuoteData')
             ->with($parentQuoteMock, $immutableQuoteMock);
 
@@ -793,24 +751,22 @@ class UpdateCartTest extends BoltTestCase
             self::PARENT_QUOTE_ID,
             self::PARENT_QUOTE_ID            
         );
-        
-        $sessionHelper = $this->getMockBuilder(SessionHelper::class)
-            ->setMethods(['loadSession','getCheckoutSession'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $sessionHelper->expects(self::once())->method('loadSession')->with($parentQuoteMock);
             
         $this->initCurrentMock([
             'validateQuote',
             'preProcessWebhook',
+            'updateSession',
             'setShipment',
             'generateResult',
             'removeItemFromQuote',
             'updateTotals',
             'getCartItems'
-        ], $sessionHelper);
+        ]);
         
         $immutableQuoteMock = $this->getQuoteMock();
+        
+        $this->currentMock->expects(self::once())->method('updateSession')
+            ->with($parentQuoteMock);
         
         $this->currentMock->expects($this->exactly(2))
             ->method('setShipment')
@@ -828,13 +784,7 @@ class UpdateCartTest extends BoltTestCase
         
         $this->currentMock->expects(self::once())->method('updateTotals')
             ->with($parentQuoteMock);
-        
-        $checkoutSession = $this->createMock(CheckoutSession::class);
-        $sessionHelper->expects(self::once())->method('getCheckoutSession')
-            ->willReturn($checkoutSession);
-        
-        $this->cartHelper->expects(self::once())->method('resetCheckoutSession')
-            ->with($checkoutSession);
+
         $this->cartHelper->expects(self::once())->method('replicateQuoteData')
             ->with($parentQuoteMock, $immutableQuoteMock);
         
@@ -960,7 +910,7 @@ class UpdateCartTest extends BoltTestCase
         $updateCartResultFactory->expects(self::once())->method('create')
             ->willReturn($updateCartResult);
             
-        $this->initCurrentMock(['getQuoteCart'], null, $cartDataFactory, $updateCartResultFactory);
+        $this->initCurrentMock(['getQuoteCart'], $cartDataFactory, $updateCartResultFactory);
         
         $this->currentMock->expects(self::once())->method('getQuoteCart')
             ->with($immutableQuoteMock)


### PR DESCRIPTION
# Description
When handling the discounts.code.apply api request, currently we do not update checkout session after retrieving quote by id, as a result, the quote object associated with cart is null.

Fixes: https://boltpay.atlassian.net/browse/M2P-426

#changelog Bugfix: Update checkout session in the callback of discounts.code.apply api request

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
