### PR TITLE
M2P-427 Avoid Undefined index exception if cart data is empty

### DIFF
--- a/Model/Api/DiscountCodeValidation.php
+++ b/Model/Api/DiscountCodeValidation.php
@@ -293,6 +293,9 @@ class DiscountCodeValidation extends UpdateCartCommon implements DiscountCodeVal
     {
         $is_has_shipment = !empty($this->requestArray['cart']['shipments'][0]['reference']);
         $cart = $this->cartHelper->getCartData($is_has_shipment, null, $quote);
+        if (empty($cart) || !isset($cart['total_amount']) || !isset($cart['tax_amount']) || !isset($cart['discounts'])) {
+            throw new \Exception('Something went wrong when getting cart data.');
+        }
         return [
             'total_amount' => $cart['total_amount'],
             'tax_amount'   => $cart['tax_amount'],

--- a/Model/Api/DiscountCodeValidation.php
+++ b/Model/Api/DiscountCodeValidation.php
@@ -293,7 +293,7 @@ class DiscountCodeValidation extends UpdateCartCommon implements DiscountCodeVal
     {
         $is_has_shipment = !empty($this->requestArray['cart']['shipments'][0]['reference']);
         $cart = $this->cartHelper->getCartData($is_has_shipment, null, $quote);
-        if (empty($cart) || !isset($cart['total_amount']) || !isset($cart['tax_amount']) || !isset($cart['discounts'])) {
+        if (empty($cart)) {
             throw new \Exception('Something went wrong when getting cart data.');
         }
         return [

--- a/Model/Api/UpdateCart.php
+++ b/Model/Api/UpdateCart.php
@@ -273,7 +273,11 @@ class UpdateCart extends UpdateCartCommon implements UpdateCartInterface
         $has_shipment = !empty($this->cartRequest['shipments'][0]['reference']);
         //make sure we recollect totals
         $quote->setTotalsCollectedFlag(false);
-        return $this->cartHelper->getCartData($has_shipment, null, $quote);
+        $cart = $this->cartHelper->getCartData($has_shipment, null, $quote);
+        if (empty($cart)) {
+            throw new \Exception('Something went wrong when getting cart data.');
+        }
+        return $cart;
     }
 
     /**

--- a/Test/Unit/Model/Api/DiscountCodeValidationTest.php
+++ b/Test/Unit/Model/Api/DiscountCodeValidationTest.php
@@ -943,6 +943,49 @@ class DiscountCodeValidationTest extends BoltTestCase
             [self::COUPON_CODE, $this->couponMock, $this->parentQuoteMock]
         );
     }
+    
+    /**
+     * @test
+     * @covers ::getCartTotals
+     */
+    public function getCartTotals()
+    {
+        $this->initCurrentMock();
+        
+        $cartData = [
+            'total_amount' => 10000,
+            'tax_amount'   => 0,
+            'discounts'    => [],
+        ];
+        
+        $this->cartHelper->expects(self::once())->method('getCartData')
+            ->with(false, null, $this->parentQuoteMock)
+            ->willReturn($cartData);
+        
+        $result = TestHelper::invokeMethod($this->currentMock, 'getCartTotals', [$this->parentQuoteMock]);
+        
+        $this->assertEquals($cartData, $result);
+    }
+    
+    /**
+     * @test
+     * @covers ::getCartTotals
+     */
+    public function getCartTotals_throwException()
+    {
+        $this->initCurrentMock();
+        
+        $cartData = [];
+        
+        $this->cartHelper->expects(self::once())->method('getCartData')
+            ->with(false, null, $this->parentQuoteMock)
+            ->willReturn($cartData);
+        
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Something went wrong when getting cart data.');
+        
+        TestHelper::invokeMethod($this->currentMock, 'getCartTotals', [$this->parentQuoteMock]);
+    }
 
     /**
      * Get quote mock with quote items


### PR DESCRIPTION
# Description
If the cart data is empty for some reason, it would cause an exception `Notice: Undefined index:`  (https://github.com/BoltApp/bolt-magento2/blob/2.17.0/Model/Api/DiscountCodeValidation.php#L291 and https://github.com/BoltApp/bolt-magento2/blob/2.17.0/Model/Api/UpdateCart.php#L277). 

We need to avoid this exception if cart data is empty.

Fixes: https://boltpay.atlassian.net/browse/M2P-427

#changelog M2P-427 Capture&handle exception if cart data is empty

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
