### PR TITLE
ON-438 - Edit order support

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1700,6 +1700,11 @@ class Cart extends AbstractHelper
         //Store immutable quote id in metadata of cart
         $cart['metadata']['immutable_quote_id'] = $immutableQuote->getId();
 
+        //store order id from session to add support for order edit
+        if ($this->checkoutSession->getOrderId()) {
+            $cart['metadata']['original_order_entity_id'] = $this->checkoutSession->getOrderId();
+        }
+
         //Currency
         $currencyCode = $immutableQuote->getQuoteCurrencyCode();
         $cart['currency'] = $currencyCode;

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -269,7 +269,7 @@ class Order extends AbstractHelper
     /**
      * @var OrderIncrementIdChecker|null
      */
-    private $orderIncrementIdChecker;
+    protected $orderIncrementIdChecker;
 
     /**
      * Order constructor.

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -269,7 +269,7 @@ class Order extends AbstractHelper
     /**
      * @var OrderIncrementIdChecker|null
      */
-    protected $orderIncrementIdChecker;
+    private $orderIncrementIdChecker;
 
     /**
      * Order constructor.

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -167,6 +167,9 @@ class CartTest extends BoltTestCase
 
     const COUPON_DESCRIPTION = 'test coupon';
 
+    /** @var int Test original order entity id when editing orders */
+    const ORIGINAL_ORDER_ENTITY_ID = 234567;
+
     /** @var Context|MockObject */
     private $contextHelper;
 
@@ -390,7 +393,7 @@ class CartTest extends BoltTestCase
             'assignCustomer','setIsActive','getGiftMessageId',
             'getGwId'
         ]);
-        $this->checkoutSession = $this->createPartialMock(CheckoutSession::class, ['getQuote', 'getBoltCollectSaleRuleDiscounts']);
+        $this->checkoutSession = $this->createPartialMock(CheckoutSession::class, ['getQuote', 'getBoltCollectSaleRuleDiscounts', 'getOrderId']);
         $this->productRepository = $this->createPartialMock(ProductRepository::class, ['get', 'getbyId']);
 
         $this->apiHelper = $this->createMock(ApiHelper::class);
@@ -2868,7 +2871,7 @@ ORDER
         {
         $this->checkoutSession = $this->createPartialMock(
             \Magento\Backend\Model\Session\Quote::class,
-            ['getStore', 'getCustomerGroupId', 'getQuote']
+            ['getStore', 'getCustomerGroupId', 'getQuote', 'getOrderId']
         );
         $testItem = [
             'reference'    => self::PRODUCT_ID,
@@ -2958,6 +2961,99 @@ ORDER
         );
         }
 
+    /**
+     * @test
+     * that getCartData adds original_order_entity_id for editted orders (order id is present on session)
+     *
+     * @covers ::getCartData
+     * @covers ::buildCartFromQuote
+     */
+    public function getCartData_forEdittedBackendOrders_addsOriginalOrderEntityIdToMetadata()
+    {
+        $this->checkoutSession = $this->createPartialMock(
+            \Magento\Backend\Model\Session\Quote::class,
+            ['getStore', 'getCustomerGroupId', 'getQuote', 'getOrderId']
+        );
+        $testItem = [
+            'reference'    => self::PRODUCT_ID,
+            'name'         => 'Test Product',
+            'total_amount' => 12345,
+            'unit_price'   => 12345,
+            'quantity'     => 1.0,
+            'sku'          => self::PRODUCT_SKU,
+            'type'         => 'physical',
+            'description'  => '',
+        ];
+        $getCartItemsResult = [[$testItem], 12345, 0];
+        $collectDiscountsResult = [[], 12345, 0];
+        $currentMock = $this->getCurrentMock(
+            [
+                'setLastImmutableQuote',
+                'getCartItems',
+                'getQuoteById',
+                'collectDiscounts',
+                'createImmutableQuote',
+                'getCalculationAddress'
+            ]
+        );
+        $this->setUpAddressMock($this->quoteBillingAddress);
+        $currentMock->expects(static::once())->method('createImmutableQuote')->with($this->quoteMock)
+            ->willReturn($this->immutableQuoteMock);
+        $currentMock->expects(static::once())->method('getCalculationAddress')->with($this->immutableQuoteMock)
+            ->willReturn($this->quoteBillingAddress);
+        $currentMock->expects(static::once())->method('getCartItems')->willReturn($getCartItemsResult);
+        $currentMock->expects(static::once())->method('collectDiscounts')->willReturn($collectDiscountsResult);
+        $this->checkoutSession->expects(static::once())->method('getQuote')->willReturn($this->quoteMock);
+        $this->quoteMock->expects(static::once())->method('getAllVisibleItems')->willReturn(true);
+        $this->immutableQuoteMock->expects(static::once())->method('getAllVisibleItems')->willReturn(true);
+        $this->quoteMock->expects(static::any())->method('getShippingAddress')
+            ->willReturn($this->quoteShippingAddress);
+        $this->immutableQuoteMock->expects(static::once())->method('isVirtual')->willReturn(true);
+        $this->immutableQuoteMock->expects(static::once())->method('getBillingAddress')
+            ->willReturn($this->quoteBillingAddress);
+        $this->immutableQuoteMock->expects(static::any())->method('getShippingAddress')
+            ->willReturn($this->getAddressMock());
+        $this->immutableQuoteMock->expects(static::atLeastOnce())->method('getBoltParentQuoteId')
+            ->willReturn(self::PARENT_QUOTE_ID);
+        $this->immutableQuoteMock->expects(static::atLeastOnce())->method('getId')
+            ->willReturn(self::IMMUTABLE_QUOTE_ID);
+        $this->immutableQuoteMock->expects(static::atLeastOnce())->method('getQuoteCurrencyCode')
+            ->willReturn(self::CURRENCY_CODE);
+        $this->immutableQuoteMock->expects(static::atLeastOnce())->method('getCustomerGroupId')
+            ->willReturn(null);
+
+        $storeMock = $this->createMock(\Magento\Store\Model\Store::class);
+        $storeMock->method('getId')->willReturn(self::STORE_ID);
+        $storeMock->method('getWebsiteId')->willReturn(1);
+
+        $this->checkoutSession->method('getStore')->willReturn($storeMock);
+        $this->checkoutSession->method('getCustomerGroupId')
+            ->willReturn(\Magento\Customer\Api\Data\GroupInterface::NOT_LOGGED_IN_ID);
+
+        $this->checkoutSession->method('getOrderId')->willReturn(self::ORIGINAL_ORDER_ENTITY_ID);
+        $result = $currentMock->getCartData(
+            true,
+            json_encode(
+                [
+                    'billingAddress' => [
+                        'firstname' => "IntegrationBolt",
+                        'lastname'  => "BoltTest",
+                        'company'   => "Bolt",
+                        'telephone' => "132 231 1234",
+                        'street'    => ["228 7th Avenue", "228 7th Avenue"],
+                        'city'      => "New York",
+                        'region'    => "New York",
+                        'country'   => "United States",
+                        'countryId' => "US",
+                        'email'     => self::EMAIL_ADDRESS,
+                        'postcode'  => "10011",
+                    ]
+                ]
+            )
+        );
+        static::assertEquals(self::ORIGINAL_ORDER_ENTITY_ID, $result['metadata']['original_order_entity_id']);
+    }
+
         /**
         * @test
         * that getCartData populates registry rule_data when executed from backend
@@ -2968,7 +3064,7 @@ ORDER
         {
         $this->checkoutSession = $this->createPartialMock(
             \Magento\Backend\Model\Session\Quote::class,
-            ['getStore', 'getCustomerGroupId', 'getQuote']
+            ['getStore', 'getCustomerGroupId', 'getQuote', 'getOrderId']
         );
         $testItem = [
             'reference'    => self::PRODUCT_ID,

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -545,7 +545,9 @@ class OrderTest extends BoltTestCase
             $this->customerCreditCardCollectionFactory,
             $this->creditmemoFactory,
             $this->creditmemoManagement,
-            $this->eventsForThirdPartyModules
+            $this->eventsForThirdPartyModules,
+            $this->orderManagementMock,
+            $this->orderIncrementIdChecker
         );
         static::assertAttributeEquals($this->apiHelper, 'apiHelper', $instance);
         static::assertAttributeEquals($this->configHelper, 'configHelper', $instance);

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -98,7 +98,7 @@ use Magento\TestFramework\Helper\Bootstrap;
  */
 class OrderTest extends BoltTestCase
 {
-    const INCREMENT_ID = 1234;
+    const INCREMENT_ID = 1000001;
     const QUOTE_ID = 5678;
     const IMMUTABLE_QUOTE_ID = self::QUOTE_ID + 1;
     const DISPLAY_ID = self::INCREMENT_ID;
@@ -259,6 +259,11 @@ class OrderTest extends BoltTestCase
     private $orderManagementMock;
 
     /**
+     * @var \Magento\Sales\Model\OrderIncrementIdChecker|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $orderIncrementIdChecker;
+
+    /**
      * Setup test dependencies, called before each test
      *
      * @throws ReflectionException from initRequiredMocks and initCurrentMock methods
@@ -333,7 +338,8 @@ class OrderTest extends BoltTestCase
                     $this->creditmemoFactory,
                     $this->creditmemoManagement,
                     $this->eventsForThirdPartyModules,
-                    $this->orderManagementMock
+                    $this->orderManagementMock,
+                    $this->orderIncrementIdChecker,
                 ]
             )
             ->setMethods($methods);
@@ -468,6 +474,11 @@ class OrderTest extends BoltTestCase
                 'setData',
                 'addData',
                 'getData',
+                'getOriginalIncrementId',
+                'getEditIncrement',
+                'setRelationChildId',
+                'setRelationChildRealId',
+                'getEntityId',
             ]
         );
         $this->orderConfigMock = $this->createPartialMock(
@@ -494,6 +505,7 @@ class OrderTest extends BoltTestCase
         $this->creditmemoManagement = $this->createMock(CreditmemoManagementInterface::class);
         $this->eventsForThirdPartyModules = $this->createMock(EventsForThirdPartyModules::class);
         $this->orderManagementMock = $this->createMock(\Magento\Sales\Api\OrderManagementInterface::class);
+        $this->orderIncrementIdChecker = $this->createMock(\Magento\Sales\Model\OrderIncrementIdChecker::class);
     }
 
     /**
@@ -2008,8 +2020,234 @@ class OrderTest extends BoltTestCase
         $this->orderMock->expects(self::once())->method('getPayment')->willReturn($paymentMock);
         $this->cartHelper->expects(self::once())->method('getOrderById')->with(self::ORDER_ID)->willReturn($this->orderMock);
         $this->expectException(LocalizedException::class);
-        $this->expectExceptionMessage('Payment method assigned to order 1234 is: paypal');
+        $this->expectExceptionMessage(sprintf("Payment method assigned to order %s is: paypal", self::INCREMENT_ID));
         $this->currentMock->processNewOrder($this->quoteMock, $transaction);
+    }
+
+    /**
+     * Setup method for tests covering the cases when transaction has original order entity id (edit order flow)
+     *
+     * @param int $originalIncrementId
+     * @param int $editIncrement
+     *
+     * @throws ReflectionException if unable to init current mock
+     */
+    protected function processNewOrder_withOriginalOrderId_SetUp($originalIncrementId, $editIncrement)
+    {
+        $this->initCurrentMock(['submitQuote', 'orderPostprocess']);
+        $originalOrderMock = $this->createPartialMock(
+            Order::class,
+            [
+                'getOriginalIncrementId',
+                'getEditIncrement',
+                'getId',
+                'getIncrementId',
+                'setRelationChildId',
+                'setRelationChildRealId',
+                'save',
+                'getEntityId',
+            ]
+        );
+        $transaction = new stdClass();
+        @$transaction->order->cart->metadata->original_order_entity_id = CartTest::ORIGINAL_ORDER_ENTITY_ID;
+        $this->orderRepository->expects(static::once())->method('get')->with(CartTest::ORIGINAL_ORDER_ENTITY_ID)
+            ->willReturn($originalOrderMock);
+        $originalOrderMock->expects(static::once())->method('getOriginalIncrementId')->willReturn($originalIncrementId);
+        $originalOrderMock->method('getIncrementId')->willReturn(self::INCREMENT_ID);
+        $originalOrderMock->method('getId')->willReturn(CartTest::ORIGINAL_ORDER_ENTITY_ID);
+
+        $this->quoteMock = $this->createPartialMock(Quote::class, ['setReservedOrderId']);
+        $this->quoteMock->expects(static::once())->method('setReservedOrderId')->with(
+            self::INCREMENT_ID . '-' . $editIncrement
+        );
+        $this->currentMock->expects(static::once())->method('submitQuote')
+            ->with(
+                $this->quoteMock,
+                [
+                    'original_increment_id' => self::INCREMENT_ID,
+                    'relation_parent_id' => CartTest::ORIGINAL_ORDER_ENTITY_ID,
+                    'relation_parent_real_id' => self::INCREMENT_ID,
+                    'edit_increment' => $editIncrement,
+                    'increment_id' => self::INCREMENT_ID . '-' . $editIncrement,
+                ]
+            )
+            ->willReturn($this->orderMock);
+
+        $this->orderMock->method('getId')->willReturn(self::ORDER_ID);
+        $paymentMock = $this->createMock(OrderPaymentInterface::class);
+        $paymentMock->expects(self::any())->method('getMethod')->willReturn(Payment::METHOD_CODE);
+        $this->orderMock->expects(self::once())->method('getPayment')->willReturn($paymentMock);
+        $this->cartHelper->expects(self::once())->method('getOrderById')->with(self::ORDER_ID)->willReturn(
+            $this->orderMock
+        );
+
+        $this->orderMock->expects(self::once())->method('getIncrementId')->willReturn(self::INCREMENT_ID);
+
+        $this->orderMock->expects(self::once())->method('addStatusHistoryComment')
+            ->with('BOLTPAY INFO :: This order was created via Bolt Pre-Auth Webhook');
+
+        $originalOrderMock->expects(static::once())->method('setRelationChildId')->with(self::ORDER_ID);
+        $originalOrderMock->expects(static::once())->method('setRelationChildRealId')->with(self::INCREMENT_ID);
+        $originalOrderMock->expects(static::once())->method('save');
+        $originalOrderMock->expects(static::once())->method('getEntityId')->willReturn(
+            CartTest::ORIGINAL_ORDER_ENTITY_ID
+        );
+
+        $this->currentMock->expects(self::once())->method('orderPostprocess')
+            ->with($this->orderMock, $this->quoteMock, $transaction);
+    }
+
+    /**
+     * @test
+     * that processNewOrder will supply the correct order data to {@see \Magento\Quote\Model\QuoteManagement::submit}
+     * in order to support Magento edit order functionality. Original order id is read from Bolt transaction metadata.
+     *
+     * @covers ::processNewOrder
+     */
+    public function processNewOrder_withOriginalOrderEntityId_submitsQuoteWithOriginalOrderData()
+    {
+        $previousEditIncrement = 0;
+        $editIncrement = $previousEditIncrement + 1;
+        $originalIncrementId = null;
+        $this->orderIncrementIdChecker->expects(static::once())->method('isIncrementIdUsed')
+            ->with(self::INCREMENT_ID . '-' . $editIncrement)->willReturn(false);
+        $transaction = new stdClass();
+        @$transaction->order->cart->metadata->original_order_entity_id = CartTest::ORIGINAL_ORDER_ENTITY_ID;
+
+        $this->processNewOrderSetUp($originalIncrementId, $editIncrement);
+        $this->orderMock->expects(static::once())->method('save');
+        $this->orderManagementMock->expects(static::once())->method('cancel')->with(CartTest::ORIGINAL_ORDER_ENTITY_ID);
+        self::assertEquals(
+            $this->currentMock->processNewOrder($this->quoteMock, $transaction),
+            $this->orderMock
+        );
+    }
+
+    /**
+     * @test
+     * that processNewOrder will successfully proceed after canceling the previous(edited) order fails
+     *
+     * @covers ::processNewOrder
+     */
+    public function processNewOrder_ifUnableToCancelPreviousOrder_proceedsWithExceptionNotify()
+    {
+        $previousEditIncrement = 0;
+        $editIncrement = $previousEditIncrement + 1;
+        $originalIncrementId = null;
+        $this->orderIncrementIdChecker->expects(static::once())->method('isIncrementIdUsed')
+            ->with(self::INCREMENT_ID . '-' . $editIncrement)->willReturn(false);
+        $transaction = new stdClass();
+        @$transaction->order->cart->metadata->original_order_entity_id = CartTest::ORIGINAL_ORDER_ENTITY_ID;
+
+        $this->processNewOrderSetUp($originalIncrementId, $editIncrement);
+        $this->orderMock->expects(static::never())->method('save');
+        $exception = new LocalizedException(__('We cannot cancel this order.'));
+        $this->orderManagementMock->expects(static::once())->method('cancel')
+            ->with(CartTest::ORIGINAL_ORDER_ENTITY_ID)
+            ->willThrowException($exception);
+        $this->bugsnag->expects(static::once())->method('notifyException')->with($exception);
+        self::assertEquals(
+            $this->currentMock->processNewOrder($this->quoteMock, $transaction),
+            $this->orderMock
+        );
+    }
+
+    /**
+     * @test
+     * that processNewOrder will recover from expected increment id being taken by incrementing edit number suffix until
+     * a free one is found
+     *
+     * @covers ::processNewOrder
+     */
+    public function processNewOrder_withOriginalOrderIncrementIdTaken_submitsQuoteWithOriginalOrderData()
+    {
+        $previousEditIncrement = 0;
+        $editIncrement = $previousEditIncrement + 2;
+        $originalIncrementId = null;
+        $this->orderIncrementIdChecker->expects(static::exactly(2))->method('isIncrementIdUsed')
+            ->withConsecutive(
+                [self::INCREMENT_ID . '-' . ($previousEditIncrement + 1)],
+                [self::INCREMENT_ID . '-' . ($previousEditIncrement + 2)]
+            )->willReturnOnConsecutiveCalls(true, false);
+        $transaction = new stdClass();
+        @$transaction->order->cart->metadata->original_order_entity_id = CartTest::ORIGINAL_ORDER_ENTITY_ID;
+
+        $this->processNewOrderSetUp($originalIncrementId, $editIncrement);
+        $this->orderMock->expects(static::once())->method('save');
+        $this->orderManagementMock->expects(static::once())->method('cancel')->with(CartTest::ORIGINAL_ORDER_ENTITY_ID);
+        self::assertEquals(
+            $this->currentMock->processNewOrder($this->quoteMock, $transaction),
+            $this->orderMock
+        );
+    }
+
+    /**
+     * @test
+     * that processNewOrder will only notify exception to Bugsnag if the original order doesn't exist for editing
+     *
+     * @covers ::processNewOrder
+     */
+    public function processNewOrder_withOriginalOrderNotFound_createsOrderWithoutEditOrderData()
+    {
+        $previousEditIncrement = 0;
+        $editIncrement = $previousEditIncrement + 1;
+        $originalIncrementId = null;
+        $this->initCurrentMock(['submitQuote', 'orderPostprocess']);
+        $originalOrderMock = $this->createPartialMock(
+            Order::class,
+            [
+                'getOriginalIncrementId',
+                'getEditIncrement',
+                'getId',
+                'getIncrementId',
+                'setRelationChildId',
+                'setRelationChildRealId',
+                'save',
+                'getEntityId',
+            ]
+        );
+        $transaction = new stdClass();
+        @$transaction->order->cart->metadata->original_order_entity_id = CartTest::ORIGINAL_ORDER_ENTITY_ID;
+        $exception = new NoSuchEntityException(__("The entity that was requested doesn't exist. Verify the entity and try again."));
+        $this->orderRepository->expects(static::once())->method('get')->with(CartTest::ORIGINAL_ORDER_ENTITY_ID)
+            ->willThrowException($exception);
+        $this->bugsnag->expects(static::once())->method('notifyException')->with($exception);
+        $originalOrderMock->expects(static::never())->method('getOriginalIncrementId')->willReturn($originalIncrementId);
+        $originalOrderMock->method('getIncrementId')->willReturn(self::INCREMENT_ID);
+        $originalOrderMock->method('getId')->willReturn(CartTest::ORIGINAL_ORDER_ENTITY_ID);
+        $this->orderIncrementIdChecker->expects(static::never())->method('isIncrementIdUsed')
+            ->with(self::INCREMENT_ID . '-' . $editIncrement)->willReturn(false);
+
+        $this->quoteMock = $this->createPartialMock(Quote::class, ['setReservedOrderId']);
+        $this->quoteMock->expects(static::never())->method('setReservedOrderId')->with(self::INCREMENT_ID . '-' . $editIncrement);
+        $this->currentMock->expects(static::once())->method('submitQuote')
+            ->with($this->quoteMock, [])
+            ->willReturn($this->orderMock);
+
+        $this->orderMock->method('getId')->willReturn(self::ORDER_ID);
+        $paymentMock = $this->createMock(OrderPaymentInterface::class);
+        $paymentMock->expects(self::any())->method('getMethod')->willReturn(Payment::METHOD_CODE);
+        $this->orderMock->expects(self::once())->method('getPayment')->willReturn($paymentMock);
+        $this->cartHelper->expects(self::once())->method('getOrderById')->with(self::ORDER_ID)->willReturn($this->orderMock);
+
+        $this->orderMock->expects(self::never())->method('getIncrementId')->willReturn(self::INCREMENT_ID);
+
+        $this->orderMock->expects(self::once())->method('addStatusHistoryComment')
+            ->with('BOLTPAY INFO :: This order was created via Bolt Pre-Auth Webhook');
+
+        $originalOrderMock->expects(static::never())->method('setRelationChildId')->with(self::ORDER_ID);
+        $originalOrderMock->expects(static::never())->method('setRelationChildRealId')->with(self::INCREMENT_ID);
+        $originalOrderMock->expects(static::never())->method('save');
+        $this->orderManagementMock->expects(static::never())->method('cancel')->with(CartTest::ORIGINAL_ORDER_ENTITY_ID);
+        $originalOrderMock->expects(static::never())->method('getEntityId')->willReturn(CartTest::ORIGINAL_ORDER_ENTITY_ID);
+        $this->orderMock->expects(static::never())->method('save');
+
+        $this->currentMock->expects(self::once())->method('orderPostprocess')
+            ->with($this->orderMock, $this->quoteMock, $transaction);
+        self::assertEquals(
+            $this->currentMock->processNewOrder($this->quoteMock, $transaction),
+            $this->orderMock
+        );
     }
 
     /**

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -352,7 +352,6 @@ class OrderTest extends BoltTestCase
         TestHelper::setProperty($this->currentMock, 'cartHelper', $this->cartHelper);
         TestHelper::setProperty($this->currentMock, 'discountHelper', $this->discountHelper);
         TestHelper::setProperty($this->currentMock, 'scopeConfig', $this->scopeConfigMock);
-        TestHelper::setProperty($this->currentMock, 'orderIncrementIdChecker', $this->orderIncrementIdChecker);
     }
 
     /**

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -352,6 +352,7 @@ class OrderTest extends BoltTestCase
         TestHelper::setProperty($this->currentMock, 'cartHelper', $this->cartHelper);
         TestHelper::setProperty($this->currentMock, 'discountHelper', $this->discountHelper);
         TestHelper::setProperty($this->currentMock, 'scopeConfig', $this->scopeConfigMock);
+        TestHelper::setProperty($this->currentMock, 'orderIncrementIdChecker', $this->orderIncrementIdChecker);
     }
 
     /**

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -545,9 +545,7 @@ class OrderTest extends BoltTestCase
             $this->customerCreditCardCollectionFactory,
             $this->creditmemoFactory,
             $this->creditmemoManagement,
-            $this->eventsForThirdPartyModules,
-            $this->orderManagementMock,
-            $this->orderIncrementIdChecker
+            $this->eventsForThirdPartyModules
         );
         static::assertAttributeEquals($this->apiHelper, 'apiHelper', $instance);
         static::assertAttributeEquals($this->configHelper, 'configHelper', $instance);

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -2114,7 +2114,7 @@ class OrderTest extends BoltTestCase
         $transaction = new stdClass();
         @$transaction->order->cart->metadata->original_order_entity_id = CartTest::ORIGINAL_ORDER_ENTITY_ID;
 
-        $this->processNewOrderSetUp($originalIncrementId, $editIncrement);
+        $this->processNewOrder_withOriginalOrderId_SetUp($originalIncrementId, $editIncrement);
         $this->orderMock->expects(static::once())->method('save');
         $this->orderManagementMock->expects(static::once())->method('cancel')->with(CartTest::ORIGINAL_ORDER_ENTITY_ID);
         self::assertEquals(
@@ -2139,7 +2139,7 @@ class OrderTest extends BoltTestCase
         $transaction = new stdClass();
         @$transaction->order->cart->metadata->original_order_entity_id = CartTest::ORIGINAL_ORDER_ENTITY_ID;
 
-        $this->processNewOrderSetUp($originalIncrementId, $editIncrement);
+        $this->processNewOrder_withOriginalOrderId_SetUp($originalIncrementId, $editIncrement);
         $this->orderMock->expects(static::never())->method('save');
         $exception = new LocalizedException(__('We cannot cancel this order.'));
         $this->orderManagementMock->expects(static::once())->method('cancel')
@@ -2172,7 +2172,7 @@ class OrderTest extends BoltTestCase
         $transaction = new stdClass();
         @$transaction->order->cart->metadata->original_order_entity_id = CartTest::ORIGINAL_ORDER_ENTITY_ID;
 
-        $this->processNewOrderSetUp($originalIncrementId, $editIncrement);
+        $this->processNewOrder_withOriginalOrderId_SetUp($originalIncrementId, $editIncrement);
         $this->orderMock->expects(static::once())->method('save');
         $this->orderManagementMock->expects(static::once())->method('cancel')->with(CartTest::ORIGINAL_ORDER_ENTITY_ID);
         self::assertEquals(

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -505,7 +505,10 @@ class OrderTest extends BoltTestCase
         $this->creditmemoManagement = $this->createMock(CreditmemoManagementInterface::class);
         $this->eventsForThirdPartyModules = $this->createMock(EventsForThirdPartyModules::class);
         $this->orderManagementMock = $this->createMock(\Magento\Sales\Api\OrderManagementInterface::class);
-        $this->orderIncrementIdChecker = $this->createMock(\Magento\Sales\Model\OrderIncrementIdChecker::class);
+        $this->orderIncrementIdChecker = $this->getMockBuilder(\Magento\Sales\Model\OrderIncrementIdChecker::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['isIncrementIdUsed'])
+            ->getMock();
     }
 
     /**


### PR DESCRIPTION
# Description
Reported by Trail Gear. Precondition: manual transaction capture.
There is Edit order action in Magento admin. The order being edited gets canceled and a creation of a new order started, as a copy of the canceled order. In the end the orders have a reference link to each other. 

Fixes: https://boltpay.atlassian.net/browse/ON-438

#changelog ON-438 - Edit order support

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [x] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
