### PR TITLE
M2P-433 Reset BoltCollectSaleRuleDiscounts session data only if shippingAssignment has item

### DIFF
--- a/Plugin/SalesRuleQuoteDiscountPlugin.php
+++ b/Plugin/SalesRuleQuoteDiscountPlugin.php
@@ -31,11 +31,17 @@ class SalesRuleQuoteDiscountPlugin
     
     public function beforeCollect(\Magento\SalesRule\Model\Quote\Discount $subject, $quote, $shippingAssignment, $total)
     {
+        $items = $shippingAssignment->getItems();
+        
+        if (!count($items)) {
+            return [$quote, $shippingAssignment, $total];
+        }
+        
         $checkoutSession = $this->sessionHelper->getCheckoutSession();
         // Each time when collecting address discount amount, the BoltCollectSaleRuleDiscounts session data would be reset,
         // then it can store the updated info of applied sale rules.
         $checkoutSession->setBoltCollectSaleRuleDiscounts([]);
-       
+
         return [$quote, $shippingAssignment, $total];
     }
 }

--- a/Test/Unit/Model/Api/UpdateDiscountTraitTest.php
+++ b/Test/Unit/Model/Api/UpdateDiscountTraitTest.php
@@ -584,7 +584,7 @@ class UpdateDiscountTraitTest extends BoltTestCase
         $checkoutSession->expects(static::once())
                         ->method('getBoltCollectSaleRuleDiscounts')
                         ->willReturn([self::RULE_ID => 10]);
-        $this->sessionHelper->expects(static::once())->method('getCheckoutSession')
+        $this->sessionHelper->expects(static::exactly(2))->method('getCheckoutSession')
              ->willReturn($checkoutSession);
 
         $result = TestHelper::invokeMethod($this->currentMock, 'applyDiscount', [self::COUPON_CODE, $coupon, null, $quote]);
@@ -676,10 +676,10 @@ class UpdateDiscountTraitTest extends BoltTestCase
         $checkoutSession = $this->createPartialMock(CheckoutSession::class,
             ['getBoltCollectSaleRuleDiscounts']
         );
-        $checkoutSession->expects(static::once())
+        $checkoutSession->expects(self::once())
                         ->method('getBoltCollectSaleRuleDiscounts')
                         ->willReturn([self::RULE_ID => 10]);
-        $this->sessionHelper->expects(static::once())->method('getCheckoutSession')
+        $this->sessionHelper->expects(self::exactly(2))->method('getCheckoutSession')
              ->willReturn($checkoutSession);
 
         $result = [
@@ -999,7 +999,7 @@ class UpdateDiscountTraitTest extends BoltTestCase
         $checkoutSession->expects(static::once())
                         ->method('getBoltCollectSaleRuleDiscounts')
                         ->willReturn([self::RULE_ID => 10]);
-        $this->sessionHelper->expects(static::once())->method('getCheckoutSession')
+        $this->sessionHelper->expects(static::exactly(2))->method('getCheckoutSession')
              ->willReturn($checkoutSession);
 
         $result = TestHelper::invokeMethod($this->currentMock, 'applyingCouponCode', [self::COUPON_CODE, $coupon, $quote]);

--- a/Test/Unit/Model/Api/UpdateDiscountTraitTest.php
+++ b/Test/Unit/Model/Api/UpdateDiscountTraitTest.php
@@ -584,7 +584,7 @@ class UpdateDiscountTraitTest extends BoltTestCase
         $checkoutSession->expects(static::once())
                         ->method('getBoltCollectSaleRuleDiscounts')
                         ->willReturn([self::RULE_ID => 10]);
-        $this->sessionHelper->expects(static::exactly(2))->method('getCheckoutSession')
+        $this->sessionHelper->expects(static::once())->method('getCheckoutSession')
              ->willReturn($checkoutSession);
 
         $result = TestHelper::invokeMethod($this->currentMock, 'applyDiscount', [self::COUPON_CODE, $coupon, null, $quote]);
@@ -676,10 +676,10 @@ class UpdateDiscountTraitTest extends BoltTestCase
         $checkoutSession = $this->createPartialMock(CheckoutSession::class,
             ['getBoltCollectSaleRuleDiscounts']
         );
-        $checkoutSession->expects(self::once())
+        $checkoutSession->expects(static::once())
                         ->method('getBoltCollectSaleRuleDiscounts')
                         ->willReturn([self::RULE_ID => 10]);
-        $this->sessionHelper->expects(self::exactly(2))->method('getCheckoutSession')
+        $this->sessionHelper->expects(static::once())->method('getCheckoutSession')
              ->willReturn($checkoutSession);
 
         $result = [
@@ -999,7 +999,7 @@ class UpdateDiscountTraitTest extends BoltTestCase
         $checkoutSession->expects(static::once())
                         ->method('getBoltCollectSaleRuleDiscounts')
                         ->willReturn([self::RULE_ID => 10]);
-        $this->sessionHelper->expects(static::exactly(2))->method('getCheckoutSession')
+        $this->sessionHelper->expects(static::once())->method('getCheckoutSession')
              ->willReturn($checkoutSession);
 
         $result = TestHelper::invokeMethod($this->currentMock, 'applyingCouponCode', [self::COUPON_CODE, $coupon, $quote]);

--- a/Test/Unit/Plugin/SalesRuleQuoteDiscountPluginTest.php
+++ b/Test/Unit/Plugin/SalesRuleQuoteDiscountPluginTest.php
@@ -64,9 +64,7 @@ class SalesRuleQuoteDiscountPluginTest extends BoltTestCase
                 'sessionHelper' => $this->sessionHelper
             ]
         );
-        $this->shippingAssignment = $this->createPartialMock(ShippingAssignmentInterface::class,
-            ['getItems']
-        );
+        $this->shippingAssignment = $this->createMock(ShippingAssignmentInterface::class);
     }
 
     /**
@@ -83,7 +81,7 @@ class SalesRuleQuoteDiscountPluginTest extends BoltTestCase
                             ->willReturn($this->checkoutSession);
         $this->shippingAssignment->expects(self::once())
                             ->method('getItems')
-                            ->with([['item']]);
+                            ->willReturn(['item']);
         $this->plugin->beforeCollect($this->subject, null, $this->shippingAssignment, null);
     }
     
@@ -101,7 +99,7 @@ class SalesRuleQuoteDiscountPluginTest extends BoltTestCase
                             ->willReturn($this->checkoutSession);
         $this->shippingAssignment->expects(self::once())
                             ->method('getItems')
-                            ->with([]);
+                            ->willReturn([]);
         $this->plugin->beforeCollect($this->subject, null, $this->shippingAssignment, null);
     }
 }

--- a/Test/Unit/Plugin/SalesRuleQuoteDiscountPluginTest.php
+++ b/Test/Unit/Plugin/SalesRuleQuoteDiscountPluginTest.php
@@ -23,6 +23,7 @@ use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\SalesRule\Model\Quote\Discount;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Bolt\Boltpay\Helper\Session as SessionHelper;
+use Magento\Quote\Api\Data\ShippingAssignmentInterface;
 
 /**
  * Class SalesRuleQuoteDiscountPluginTest
@@ -44,6 +45,9 @@ class SalesRuleQuoteDiscountPluginTest extends BoltTestCase
     
     /** @var Discount */
     protected $subject;
+    
+    /** @var ShippingAssignmentInterface */
+    protected $shippingAssignment;
 
     public function setUpInternal()
     {
@@ -60,6 +64,9 @@ class SalesRuleQuoteDiscountPluginTest extends BoltTestCase
                 'sessionHelper' => $this->sessionHelper
             ]
         );
+        $this->shippingAssignment = $this->createPartialMock(ShippingAssignmentInterface::class,
+            ['getItems']
+        );
     }
 
     /**
@@ -74,6 +81,27 @@ class SalesRuleQuoteDiscountPluginTest extends BoltTestCase
         $this->sessionHelper->expects(self::once())
                             ->method('getCheckoutSession')
                             ->willReturn($this->checkoutSession);
-        $this->plugin->beforeCollect($this->subject, null, null, null);
+        $this->shippingAssignment->expects(self::once())
+                            ->method('getItems')
+                            ->with([['item']]);
+        $this->plugin->beforeCollect($this->subject, null, $this->shippingAssignment, null);
+    }
+    
+    /**
+     * @test
+     * @covers ::beforeCollect
+     */
+    public function beforeCollecte_noItemInShippingAssignment_doNothing()
+    {
+        $this->checkoutSession->expects(self::never())
+                            ->method('setBoltCollectSaleRuleDiscounts')
+                            ->with([]);
+        $this->sessionHelper->expects(self::never())
+                            ->method('getCheckoutSession')
+                            ->willReturn($this->checkoutSession);
+        $this->shippingAssignment->expects(self::once())
+                            ->method('getItems')
+                            ->with([]);
+        $this->plugin->beforeCollect($this->subject, null, $this->shippingAssignment, null);
     }
 }


### PR DESCRIPTION
# Description
Currently each time when collecting address discount amount, the BoltCollectSaleRuleDiscounts session data would be reset, then the plugin SalesRuleActionDiscountPlugin stores the discount amount in the checkout session to make the discount data of quote up-to-date. But in some contexts, the shippingAssignment of billing address has no item, as a result, our plugin just clear the BoltCollectSaleRuleDiscounts session data, and does not collect discount data, so the callback of update_cart endpoint fails to apply coupon.

Solution: Reset BoltCollectSaleRuleDiscounts session data only if shippingAssignment has item

Fixes: https://boltpay.atlassian.net/browse/M2P-433

#changelog Reset BoltCollectSaleRuleDiscounts session data only if shippingAssignment has item

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
