### PR TITLE
EN-3825 - Assign customer an appropriate group id in backoffice order creation process

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -828,8 +828,8 @@ class Cart extends AbstractHelper
     /**
      * Create order on bolt
      *
-     * @param bool   $paymentOnly              flag that represents the type of checkout
-     * @param string $placeOrderPayload        additional data collected from the (one page checkout) page,
+     * @param bool        $paymentOnly         flag that represents the type of checkout
+     * @param null|string $placeOrderPayload   additional data collected from the (one page checkout) page,
      *                                         i.e. billing address to be saved with the order
      * @param null|int    $storeId             The ID of the Magento store
      *
@@ -837,7 +837,7 @@ class Cart extends AbstractHelper
      * @throws LocalizedException
      * @throws Zend_Http_Client_Exception
      */
-    public function getBoltpayOrder($paymentOnly, $placeOrderPayload, $storeId = null)
+    public function getBoltpayOrder($paymentOnly, $placeOrderPayload = null, $storeId = null)
     {
         //Get cart data
         $cart = $this->getCartData($paymentOnly, $placeOrderPayload);
@@ -1021,7 +1021,7 @@ class Cart extends AbstractHelper
             $hints['prefill'] = array_merge($hints['prefill'], $prefill);
         };
 
-        // Logged in customes.
+        // Logged in customers.
         // Merchant scope and prefill.
         if ($this->customerSession->isLoggedIn()) {
             $customer = $this->customerSession->getCustomer();
@@ -1579,16 +1579,16 @@ class Cart extends AbstractHelper
      * Get cart data.
      * The reference of total methods: dev/tests/api-functional/testsuite/Magento/Quote/Api/CartTotalRepositoryTest.php
      *
-     * @param bool $paymentOnly             flag that represents the type of checkout
-     * @param string $placeOrderPayload     additional data collected from the (one page checkout) page,
-     *                                         i.e. billing address to be saved with the order
-     * @param Quote $immutableQuote         If passed do not create new clone, get data existing one data.
-     *                                          discount validation, bugsnag report
+     * @param bool        $paymentOnly       flag that represents the type of checkout
+     * @param string|null $placeOrderPayload additional data collected from the (one page checkout) page,
+     *                                       i.e. billing address to be saved with the order
+     * @param Quote|null  $immutableQuote    If passed do not create new clone, get data existing one data.
+     *                                       discount validation, bugsnag report
      *
      * @return array
      * @throws \Exception
      */
-    public function getCartData($paymentOnly, $placeOrderPayload, $immutableQuote = null)
+    public function getCartData($paymentOnly, $placeOrderPayload = null, $immutableQuote = null)
     {
 
         // If the immutable quote is passed (i.e. discount code validation, bugsnag report generation)
@@ -1677,12 +1677,12 @@ class Cart extends AbstractHelper
     /**
      * Build cart data from quote.
      *
-     * @param Quote $quote
-     * @param Quote $immutableQuote
-     * @param array $items
-     * @param bool $paymentOnly             flag that represents the type of checkout
+     * @param Quote  $quote
+     * @param Quote  $immutableQuote
+     * @param array  $items
+     * @param bool   $paymentOnly           flag that represents the type of checkout
      * @param string $placeOrderPayload     additional data collected from the (one page checkout) page,
-     * @param bool $requireBillingAddress   require that the billing address is set
+     * @param bool   $requireBillingAddress require that the billing address is set
      *
      * @return array
      * @throws \Exception
@@ -2521,5 +2521,22 @@ class Cart extends AbstractHelper
     protected function encryptMetadataValue($data)
     {
         return base64_encode($this->configHelper->encrypt($data));
+    }
+
+    /**
+     * Retrieves customer by email and website id
+     *
+     * @param string   $email
+     * @param int|null $websiteId
+     *
+     * @return false|\Magento\Customer\Api\Data\CustomerInterface
+     */
+    public function getCustomerByEmail($email, $websiteId = null)
+    {
+        try {
+            return $this->customerRepository->get($email, $websiteId);
+        } catch (LocalizedException $e) {
+            return false;
+        }
     }
 }

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -542,7 +542,7 @@ class Order extends AbstractHelper
     private function addCustomerDetails($quote, $email)
     {
         $quote->setCustomerEmail($email);
-        if (!$quote->getCustomerId() && $quote->getData('bolt_checkout_type') !== CartHelper::BOLT_CHECKOUT_TYPE_BACKOFFICE) {
+        if (!$quote->getCustomerId() && $quote->getData('bolt_checkout_type') != CartHelper::BOLT_CHECKOUT_TYPE_BACKOFFICE) {
             $quote->setCustomerId(null);
             $quote->setCheckoutMethod('guest');
             $quote->setCustomerIsGuest(true);
@@ -947,7 +947,7 @@ class Order extends AbstractHelper
 
         if ($parentQuote) {
             $this->dispatchPostCheckoutEvents($order, $parentQuote);
-            
+
             $this->eventsForThirdPartyModules->dispatchEvent("deleteRedundantDiscounts", $parentQuote);
 
             // If Amasty Reward Points Extension is present

--- a/Model/Response.php
+++ b/Model/Response.php
@@ -21,6 +21,10 @@ use Magento\Framework\DataObject;
 
 /**
  * Response object
+ *
+ * @method \stdClass getResponse
+ * @method int getStoreId
+ * @method $this setStoreId(int $storeId)
  */
 class Response extends DataObject
 {

--- a/Test/Unit/Controller/Adminhtml/Cart/DataTest.php
+++ b/Test/Unit/Controller/Adminhtml/Cart/DataTest.php
@@ -24,16 +24,21 @@ use Bolt\Boltpay\Helper\Config;
 use Bolt\Boltpay\Helper\MetricsClient;
 use Bolt\Boltpay\Model\Response;
 use Magento\Backend\App\Action\Context;
+use Magento\Backend\Model\View\Result\ForwardFactory;
+use Magento\Catalog\Helper\Product;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\Result\JsonFactory;
-use Magento\Framework\DataObject;
 use Magento\Framework\DataObjectFactory;
 use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Result\PageFactory;
+use Magento\Store\Model\StoreManagerInterface;
 
 /**
  * Class DataTest
+ *
  * @package Bolt\Boltpay\Test\Unit\Controller\Adminhtml\Cart
  * @coversDefaultClass \Bolt\Boltpay\Controller\Adminhtml\Cart\Data
  */
@@ -45,6 +50,7 @@ class DataTest extends BoltTestCase
     const IS_PREAUTH = true;
     const HINT = 'hint!';
     const RESPONSE_TOKEN = 'response_token';
+    const CUSTOMER_EMAIL = 'test@bolt.com';
 
     /**
      * @var Context
@@ -59,28 +65,28 @@ class DataTest extends BoltTestCase
     /**
      * @var MockObject|Cart
      */
-    private $cartHelper;
+    private $cartHelperMock;
 
     /**
      * @var MockObject|Config
      */
-    private $configHelper;
+    private $configHelperMock;
 
     /**
      * @var Bugsnag
      */
-    private $bugsnag;
+    private $bugsnagHelperMock;
 
     /**
      * @var MetricsClient
      */
-    private $metricsClient;
+    private $metricsClientMock;
 
     private $happyCartArray;
 
     private $noTokenCartArray;
 
-    private $dataObjectFactory;
+    private $dataObjectFactoryMock;
 
     private $happyCartData;
 
@@ -93,6 +99,61 @@ class DataTest extends BoltTestCase
      */
     private $request;
 
+    /**
+     * @var MockObject|\Magento\Backend\Model\Session\Quote
+     */
+    private $sessionMock;
+
+    /**
+     * @var \Magento\Sales\Model\AdminOrder\Create|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $orderCreateModel;
+
+    /**
+     * @var \Magento\Quote\Model\Quote|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $quoteMock;
+
+    /**
+     * @var \Magento\Quote\Model\Quote\Address|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $quoteBillingAddressMock;
+
+    /**
+     * @var Product|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $productHelperMock;
+
+    /**
+     * @var Escaper|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $escaperMock;
+
+    /**
+     * @var PageFactory|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $resultPageFactoryMock;
+
+    /**
+     * @var StoreManagerInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $storeManagerMock;
+
+    /**
+     * @var ForwardFactory|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $resultForwardFactoryMock;
+
+    /**
+     * @var Data|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $currentMock;
+
+    /**
+     * @var Json|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $resultJsonMock;
+
     protected function setUpInternal()
     {
         $this->initData();
@@ -103,24 +164,26 @@ class DataTest extends BoltTestCase
     {
         $this->happyCartArray = ['orderToken' => self::RESPONSE_TOKEN];
         $this->happyCartData = [
-            'cart' => [
+            'cart'           => [
                 'orderToken' => self::RESPONSE_TOKEN
-                ],
-            'hints' => self::HINT,
-            'publishableKey' => self::PUBLISHABLE_KEY,
-            'storeId' => self::STORE_ID,
-            'isPreAuth' => self::IS_PREAUTH
+            ],
+            'hints'          => self::HINT,
+            'storeId'        => self::STORE_ID,
+            'isPreAuth'      => self::IS_PREAUTH,
+            'backOfficeKey'  => self::PUBLISHABLE_KEY,
+            'paymentOnlyKey' => null
         ];
 
         $this->noTokenCartArray = ['orderToken' => ''];
         $this->noTokenCartData = [
-            'cart' => [
-                'orderToken' => ''
+            'cart'           => [
+                'errorMessage' => 'Bolt order was not created successfully'
             ],
-            'hints' => self::HINT,
-            'publishableKey' => self::PUBLISHABLE_KEY,
-            'storeId' => self::STORE_ID,
-            'isPreAuth' => self::IS_PREAUTH
+            'hints'          => self::HINT,
+            'storeId'        => self::STORE_ID,
+            'isPreAuth'      => self::IS_PREAUTH,
+            'backOfficeKey'  => self::PUBLISHABLE_KEY,
+            'paymentOnlyKey' => '',
         ];
 
         $this->map = [
@@ -132,31 +195,72 @@ class DataTest extends BoltTestCase
     {
         $this->context = $this->createMock(Context::class);
 
-        $this->metricsClient = $this->createMock(MetricsClient::class);
+        $this->metricsClientMock = $this->createMock(MetricsClient::class);
 
-        $this->bugsnag = $this->createMock(Bugsnag::class);
+        $this->bugsnagHelperMock = $this->createMock(Bugsnag::class);
 
         $this->request = $this->createMock(RequestInterface::class);
-        $this->request->method('getParam')
-            ->will($this->returnValueMap($this->map));
+        $this->request->method('getParam')->willReturnMap($this->map);
 
-        $this->cartHelper = $this->createMock(Cart::class);
-        $this->cartHelper->method('getSessionQuoteStoreId')
+        $this->cartHelperMock = $this->createMock(Cart::class);
+        $this->cartHelperMock->method('getSessionQuoteStoreId')
             ->willReturn(self::STORE_ID);
-        $this->cartHelper->method('getHints')
+        $this->cartHelperMock->method('getHints')
             ->willReturn(self::HINT);
 
-        $this->configHelper = $this->createMock(Config::class);
-        $this->configHelper->method('getPublishableKeyBackOffice')
-            ->willReturn(self::PUBLISHABLE_KEY)
-            ->with(self::STORE_ID);
-        $this->configHelper->method('getIsPreAuth')
-            ->willReturn(self::IS_PREAUTH)
-            ->with(self::STORE_ID);
+        $this->configHelperMock = $this->createMock(Config::class);
+        $this->configHelperMock->method('getPublishableKeyBackOffice')
+            ->willReturn(self::PUBLISHABLE_KEY);
+        $this->configHelperMock->method('getIsPreAuth')
+            ->willReturn(self::IS_PREAUTH);
 
+        $this->quoteMock = $this->createPartialMock(
+            \Magento\Quote\Model\Quote::class,
+            [
+                'getStoreId',
+                'getCustomerEmail',
+                'getCustomerId',
+                'setCustomerEmail',
+            ]
+        );
+
+        $this->resultJsonMock = $this->createMock(\Magento\Framework\Controller\Result\Json::class);
         $this->resultJsonFactory = $this->createMock(JsonFactory::class);
+        $this->resultJsonFactory->method('create')->willReturn($this->resultJsonMock);
 
-        $this->dataObjectFactory = $this->createMock(DataObjectFactory::class);
+        $this->dataObjectFactoryMock = $this->createMock(DataObjectFactory::class);
+        $this->sessionMock = $this->createPartialMock(
+            \Magento\Backend\Model\Session\Quote::class,
+            ['getStoreId']
+        );
+        $this->orderCreateModel = $this->getMockBuilder(
+            \Magento\Sales\Model\AdminOrder\Create::class
+        )->disableOriginalConstructor()
+            ->setMethods([])
+            ->getMock();
+        $this->quoteBillingAddressMock = $this->createMock(\Magento\Quote\Model\Quote\Address::class);
+        $this->productHelperMock = $this->createMock(Product::class);
+        $this->escaperMock = $this->createMock(Escaper::class);
+        $this->resultPageFactoryMock = $this->createMock(PageFactory::class);
+        $this->resultForwardFactoryMock = $this->createMock(ForwardFactory::class);
+        $this->storeManagerMock = $this->createMock(StoreManagerInterface::class);
+
+        $this->currentMock = $this->getMockBuilder(Data::class)
+            ->setConstructorArgs(
+                [
+                    $this->context,
+                    $this->resultJsonFactory,
+                    $this->cartHelperMock,
+                    $this->configHelperMock,
+                    $this->bugsnagHelperMock,
+                    $this->metricsClientMock,
+                    $this->dataObjectFactoryMock,
+                ]
+            )
+            ->setMethods(['_getSession', '_initSession', '_getOrderCreateModel'])
+            ->getMock();
+        $this->currentMock->method('_getSession')->willReturn($this->sessionMock);
+        $this->currentMock->method('_getOrderCreateModel')->willReturn($this->orderCreateModel);
     }
 
     private function buildJsonMocks($expected)
@@ -174,7 +278,7 @@ class DataTest extends BoltTestCase
             ->willReturn($json);
         return $resultJsonFactory;
     }
-    
+
     /**
      * @test
      * that constructor sets internal properties
@@ -186,57 +290,55 @@ class DataTest extends BoltTestCase
         $instance = new Data(
             $this->context,
             $this->resultJsonFactory,
-            $this->cartHelper,
-            $this->configHelper,
-            $this->bugsnag,
-            $this->metricsClient,
-            $this->dataObjectFactory
+            $this->cartHelperMock,
+            $this->configHelperMock,
+            $this->bugsnagHelperMock,
+            $this->metricsClientMock,
+            $this->dataObjectFactoryMock
         );
-        
+
         static::assertAttributeEquals($this->resultJsonFactory, 'resultJsonFactory', $instance);
-        static::assertAttributeEquals($this->cartHelper, 'cartHelper', $instance);
-        static::assertAttributeEquals($this->configHelper, 'configHelper', $instance);
-        static::assertAttributeEquals($this->bugsnag, 'bugsnag', $instance);
-        static::assertAttributeEquals($this->metricsClient, 'metricsClient', $instance);
-        static::assertAttributeEquals($this->dataObjectFactory, 'dataObjectFactory', $instance);
+        static::assertAttributeEquals($this->cartHelperMock, 'cartHelper', $instance);
+        static::assertAttributeEquals($this->configHelperMock, 'configHelper', $instance);
+        static::assertAttributeEquals($this->bugsnagHelperMock, 'bugsnag', $instance);
+        static::assertAttributeEquals($this->metricsClientMock, 'metricsClient', $instance);
+        static::assertAttributeEquals($this->dataObjectFactoryMock, 'dataObjectFactory', $instance);
     }
 
     /**
      * @test
+     *
+     * @covers ::execute
      */
     public function execute_NoBoltpayOrder()
     {
-        $this->cartHelper->method('getBoltpayOrder')
-            ->willReturn(null);
-
-        $dataObject = $this->createMock(DataObject::class);
-        $dataObject->method('getData')
-            ->willReturn($this->noTokenCartData);
-        $dataObject->expects($this->at(0))
-            ->method('setData')
-            ->with($this->equalTo('cart'), $this->equalTo($this->noTokenCartArray));
-
-        $this->dataObjectFactory = $this->createMock(DataObjectFactory::class);
-        $this->dataObjectFactory->method('create')
-            ->willReturn($dataObject);
+        $this->sessionMock->method('getStoreId')->willReturn(self::STORE_ID);
+        $this->cartHelperMock->method('getBoltpayOrder')->willReturn(null);
 
         $resultJsonFactory = $this->buildJsonMocks($this->noTokenCartData);
 
-        $data = $this->getMockBuilder(Data::class)
-            ->setMethods(['getRequest'])
-            ->setConstructorArgs([
-                $this->context,
-                $resultJsonFactory,
-                $this->cartHelper,
-                $this->configHelper,
-                $this->bugsnag,
-                $this->metricsClient,
-                $this->dataObjectFactory
-            ])
+        $currentMock = $this->getMockBuilder(Data::class)
+            ->setMethods(['getRequest', '_getSession', '_initSession', '_getOrderCreateModel'])
+            ->setConstructorArgs(
+                [
+                    $this->context,
+                    $resultJsonFactory,
+                    $this->cartHelperMock,
+                    $this->configHelperMock,
+                    $this->bugsnagHelperMock,
+                    $this->metricsClientMock,
+                    $this->dataObjectFactoryMock
+                ]
+            )
             ->getMock();
 
-        $data->method('getRequest')->willReturn($this->request);
-        $data->execute();
+        $currentMock->method('getRequest')->willReturn($this->request);
+        $currentMock->method('_getSession')->willReturn($this->sessionMock);
+        $currentMock->method('_getOrderCreateModel')->willReturn($this->orderCreateModel);
+        $this->orderCreateModel->method('getQuote')->willReturn($this->quoteMock);
+        $this->orderCreateModel->expects(static::once())->method('getBillingAddress')
+            ->willReturn($this->quoteBillingAddressMock);
+        $currentMock->execute();
     }
 
     /**
@@ -244,74 +346,140 @@ class DataTest extends BoltTestCase
      */
     public function execute_HappyPath()
     {
+        $this->sessionMock->method('getStoreId')->willReturn(self::STORE_ID);
+
         $boltpayOrder = $this->getMockBuilder(Response::class)
             ->setMethods(['getResponse'])
             ->disableOriginalConstructor()
             ->getMock();
         $boltpayOrder->method('getResponse')
-            ->willReturn(['token' => self::RESPONSE_TOKEN]);
+            ->willReturn((object)['token' => self::RESPONSE_TOKEN]);
 
-        $this->cartHelper->method('getBoltpayOrder')
+        $this->cartHelperMock->method('getBoltpayOrder')
             ->willReturn($boltpayOrder);
-
-        $dataObject = $this->createMock(DataObject::class);
-        $dataObject->method('getData')
-            ->willReturn($this->happyCartData);
-        $dataObject->expects($this->at(0))
-            ->method('setData')
-            ->with($this->equalTo('cart'), $this->equalTo($this->happyCartArray));
-
-        $this->dataObjectFactory = $this->createMock(DataObjectFactory::class);
-        $this->dataObjectFactory->method('create')
-            ->willReturn($dataObject);
 
         $resultJsonFactory = $this->buildJsonMocks($this->happyCartData);
 
-        $data = $this->getMockBuilder(Data::class)
-            ->setMethods(['getRequest'])
-            ->setConstructorArgs([
-                $this->context,
-                $resultJsonFactory,
-                $this->cartHelper,
-                $this->configHelper,
-                $this->bugsnag,
-                $this->metricsClient,
-                $this->dataObjectFactory
-            ])
+        $currentMock = $this->getMockBuilder(Data::class)
+            ->setMethods(['getRequest', '_getSession', '_initSession', '_getOrderCreateModel'])
+            ->setConstructorArgs(
+                [
+                    $this->context,
+                    $resultJsonFactory,
+                    $this->cartHelperMock,
+                    $this->configHelperMock,
+                    $this->bugsnagHelperMock,
+                    $this->metricsClientMock,
+                    $this->dataObjectFactoryMock
+                ]
+            )
             ->getMock();
-
-        $data->method('getRequest')->willReturn($this->request);
-        $data->execute();
+        $currentMock->method('getRequest')->willReturn($this->request);
+        $currentMock->method('_getSession')->willReturn($this->sessionMock);
+        $currentMock->method('_getOrderCreateModel')->willReturn($this->orderCreateModel);
+        $this->orderCreateModel->method('getQuote')->willReturn($this->quoteMock);
+        $this->orderCreateModel->expects(static::once())->method('getBillingAddress')
+            ->willReturn($this->quoteBillingAddressMock);
+        $currentMock->execute();
     }
 
     /**
      * @test
-     * @expectedException \Exception
      */
     public function execute_ThrowsException()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('This is an exception');
         $exception = new \Exception('This is an exception');
 
         $bugsnag = $this->createMock(Bugsnag::class);
-        $bugsnag->expects($this->at(0))
-            ->method('notifyException')
-            ->with($this->equalTo($exception));
+        $bugsnag->expects(static::once())->method('notifyException')->with($exception);
 
-        $data = $this->getMockBuilder(Data::class)
-            ->setMethods(['getRequest'])
-            ->setConstructorArgs([
-                $this->context,
-                $this->resultJsonFactory,
-                $this->cartHelper,
-                $this->configHelper,
-                $bugsnag,
-                $this->metricsClient,
-                $this->dataObjectFactory
-            ])
+        $currentMock = $this->getMockBuilder(Data::class)
+            ->setMethods(['getRequest', '_getSession', '_initSession', '_getOrderCreateModel'])
+            ->setConstructorArgs(
+                [
+                    $this->context,
+                    $this->resultJsonFactory,
+                    $this->cartHelperMock,
+                    $this->configHelperMock,
+                    $bugsnag,
+                    $this->metricsClientMock,
+                    $this->dataObjectFactoryMock
+                ]
+            )
             ->getMock();
-        $this->cartHelper->method('getBoltpayOrder')->willThrowException($exception);
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('This is an exception');
-        $data->execute();
+        $this->cartHelperMock->method('getBoltpayOrder')->willThrowException($exception);
+        $currentMock->method('getRequest')->willReturn($this->request);
+        $currentMock->method('_getSession')->willReturn($this->sessionMock);
+        $currentMock->method('_getOrderCreateModel')->willReturn($this->orderCreateModel);
+        $this->orderCreateModel->method('getQuote')->willReturn($this->quoteMock);
+        $this->sessionMock->expects(static::once())->method('getStoreId')->willReturn(self::STORE_ID);
+        $this->orderCreateModel->expects(static::once())->method('getBillingAddress')
+            ->willReturn($this->quoteBillingAddressMock);
+        $currentMock->execute();
+    }
+
+    /**
+     * @test
+     * that execute will return an error response and not attempt Bolt order creation if the session store id is not set
+     *
+     * @covers ::execute
+     */
+    public function execute_withSessionStoreIdNotSet_returnsErrorResponse()
+    {
+        $this->sessionMock->expects(static::once())->method('getStoreId')->willReturn(null);
+        $this->currentMock->expects(static::never())->method('_initSession');
+        $this->cartHelperMock->expects(static::never())->method('getBoltpayOrder');
+
+        $this->resultJsonMock->expects(static::once())->method('setData')->with(
+            [
+                'cart'           => ['errorMessage' => 'Order creation not initialized'],
+                'hints'          => [],
+                'backOfficeKey'  => '',
+                'paymentOnlyKey' => '',
+                'storeId'        => '',
+                'isPreAuth'      => '',
+            ]
+        );
+
+        $this->currentMock->execute();
+    }
+
+    /**
+     * @test
+     * that execute will return an error response and not attempt Bolt order creation if the session store id is not set
+     *
+     * @covers ::execute
+     */
+    public function execute_withAlreadyUsedCustomerEmail_returnsErrorResponse()
+    {
+        $this->sessionMock->expects(static::once())->method('getStoreId')->willReturn(self::STORE_ID);
+        $this->currentMock->expects(static::once())->method('_initSession');
+        $this->cartHelperMock->expects(static::never())->method('getBoltpayOrder');
+
+        $this->orderCreateModel->expects(static::once())->method('getQuote')->willReturn($this->quoteMock);
+        $this->orderCreateModel->expects(static::never())->method('getBillingAddress')
+            ->willReturn($this->quoteBillingAddressMock);
+
+        $this->quoteMock->expects(static::once())->method('getCustomerId')->willReturn(null);
+        $this->quoteMock->expects(static::once())->method('getCustomerEmail')->willReturn(self::CUSTOMER_EMAIL);
+        $this->cartHelperMock->expects(static::once())->method('getCustomerByEmail')->with(self::CUSTOMER_EMAIL)
+            ->willReturn(true);
+
+        $this->resultJsonMock->expects(static::once())->method('setData')->with(
+            [
+                'cart'           => [
+                    'errorMessage' => 'A customer with the same email address already exists in an associated website.'
+                ],
+                'hints'          => [],
+                'backOfficeKey'  => self::PUBLISHABLE_KEY,
+                'paymentOnlyKey' => '',
+                'storeId'        => self::STORE_ID,
+                'isPreAuth'      => self::IS_PREAUTH,
+            ]
+        );
+
+        $this->currentMock->execute();
     }
 }

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -6536,4 +6536,47 @@ ORDER
 
         $this->assertEquals($expected, $currentMock->calculateCartAndHints());
         }
+
+    /**
+     * @test
+     * that getCustomerByEmail returns customer model by email if it exists
+     *
+     * @covers ::getCustomerByEmail
+     */
+    public function getCustomerByEmail_withExistingCustomerEmail_returnsCustomerModel()
+    {
+        $this->customerRepository->expects(static::once())->method('get')->with(self::EMAIL_ADDRESS, self::WEBSITE_ID)
+            ->willReturn($this->customerMock);
+        static::assertEquals(
+            $this->customerMock,
+            $this->currentMock->getCustomerByEmail(self::EMAIL_ADDRESS, self::WEBSITE_ID)
+        );
+    }
+
+    /**
+     * @test
+     * that getCustomerByEmail returns false if unable to retrieve customer by email address
+     *
+     * @covers ::getCustomerByEmail
+     */
+    public function getCustomerByEmail_withExceptionOnGettingTheCustomer_returnsFalse()
+    {
+        $this->customerRepository->expects(static::once())->method('get')->with(self::EMAIL_ADDRESS, self::WEBSITE_ID)
+            ->willThrowException(
+                new NoSuchEntityException(
+                    __(
+                        'No such entity with %fieldName = %fieldValue, %field2Name = %field2Value',
+                        [
+                            'fieldName' => 'email',
+                            'fieldValue' => self::EMAIL_ADDRESS,
+                            'field2Name' => 'websiteId',
+                            'field2Value' => self::WEBSITE_ID
+                        ]
+                    )
+                )
+            );
+        static::assertFalse(
+            $this->currentMock->getCustomerByEmail(self::EMAIL_ADDRESS, self::WEBSITE_ID)
+        );
+    }
 }

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -33,6 +33,7 @@ use Bolt\Boltpay\Model\Response;
 use Bolt\Boltpay\Model\Service\InvoiceService;
 use Bugsnag\Report;
 use Exception;
+use Magento\Customer\Model\Customer;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\DataObject;
 use Magento\Framework\DB\Adapter\Pdo\Mysql;
@@ -44,6 +45,7 @@ use Magento\Framework\Exception\SessionException;
 use Magento\Quote\Model\Quote\Address;
 use Magento\Sales\Api\Data\OrderPaymentInterface;
 use Magento\Sales\Api\Data\TransactionInterface as TransactionInterface;
+use Magento\Sales\Model\AdminOrder\Create;
 use Magento\Sales\Model\Order\Email\Container\InvoiceIdentity as InvoiceEmailIdentity;
 use Magento\Sales\Model\Order\Invoice as Invoice;
 use Magento\Sales\Model\Order as OrderModel;
@@ -264,6 +266,11 @@ class OrderTest extends BoltTestCase
     private $orderIncrementIdChecker;
 
     /**
+     * @var Create|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $adminOrderCreateModelMock;
+
+    /**
      * Setup test dependencies, called before each test
      *
      * @throws ReflectionException from initRequiredMocks and initCurrentMock methods
@@ -340,6 +347,7 @@ class OrderTest extends BoltTestCase
                     $this->eventsForThirdPartyModules,
                     $this->orderManagementMock,
                     $this->orderIncrementIdChecker,
+                    $this->adminOrderCreateModelMock
                 ]
             )
             ->setMethods($methods);
@@ -427,7 +435,21 @@ class OrderTest extends BoltTestCase
 
         $this->quoteMock = $this->getMockBuilder(Quote::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getCustomerId','getReservedOrderId','getId','isVirtual','setUpdatedAt','getStoreId','getBillingAddress','setIsActive','getIsActive', 'getBoltCheckoutType', 'setBoltCheckoutType'])
+            ->setMethods(
+                [
+                    'getCustomerId',
+                    'getReservedOrderId',
+                    'getId',
+                    'isVirtual',
+                    'setUpdatedAt',
+                    'getStoreId',
+                    'getBillingAddress',
+                    'setIsActive',
+                    'getIsActive',
+                    'getBoltCheckoutType',
+                    'setBoltCheckoutType'
+                ]
+            )
             ->getMock();
 
         $this->scopeConfigMock = $this->getMockBuilder(ScopeConfigInterface::class)
@@ -509,6 +531,8 @@ class OrderTest extends BoltTestCase
             ->disableOriginalConstructor()
             ->setMethods(['isIncrementIdUsed'])
             ->getMock();
+
+        $this->adminOrderCreateModelMock = $this->createMock(Create::class);
     }
 
     /**
@@ -2582,20 +2606,22 @@ class OrderTest extends BoltTestCase
 
     /**
      * @test
-     * @dataProvider trueAndFalseDataProvider
+     * @dataProvider prepareQuoteProvider
      *
      * @covers ::prepareQuote
      * @covers ::addCustomerDetails
      * @covers ::setPaymentMethod
      *
-     * @throws LocalizedException
-     * @throws ReflectionException
+     * @param int $boltCheckoutType
+     *
      * @throws AlreadyExistsException
+     * @throws LocalizedException
      * @throws NoSuchEntityException
+     * @throws ReflectionException
      * @throws SessionException
      * @throws Zend_Validate_Exception
      */
-    public function prepareQuote($isProductPage)
+    public function prepareQuote($boltCheckoutType)
     {
         $this->initCurrentMock(
             [
@@ -2624,12 +2650,20 @@ class OrderTest extends BoltTestCase
                 ]
             )
         );
-        $quoteMockMethodsList = ['getBoltParentQuoteId', 'getPayment', 'setPaymentMethod', 'getId'];
+        $quoteMockMethodsList = [
+            'getBoltParentQuoteId',
+            'getPayment',
+            'setPaymentMethod',
+            'getId',
+            'getData',
+            'getCustomer',
+            'getCustomerGroupId',
+        ];
         /** @var MockObject|Quote $immutableQuote */
         $immutableQuote = $this->createPartialMock(Quote::class, $quoteMockMethodsList);
         $immutableQuote->expects(self::any())->method('getId')->willReturn(self::IMMUTABLE_QUOTE_ID);
 
-        if ($isProductPage) {
+        if ($boltCheckoutType == CartHelper::BOLT_CHECKOUT_TYPE_PPC) {
             // immutableQuote the same object as parentQuote
             $immutableQuote->expects(self::once())->method('getBoltParentQuoteId')->willReturn(null);
             /** @var MockObject|Quote $parentQuote */
@@ -2681,7 +2715,33 @@ class OrderTest extends BoltTestCase
             }
         );
 
+        $parentQuote->method('getData')->willReturnMap([['bolt_checkout_type', null, $boltCheckoutType]]);
+
+        $customerMock = $this->createPartialMock(Customer::class, ['setGroupId']);
+
+        if ($boltCheckoutType == CartHelper::BOLT_CHECKOUT_TYPE_BACKOFFICE) {
+            $parentQuote->expects(static::once())->method('getCustomer')->willReturn($customerMock);
+            $parentQuote->expects(static::exactly(2))->method('getCustomerGroupId')->willReturn(1);
+            $customerMock->expects(static::once())->method('setGroupId')->with(1);
+            $this->adminOrderCreateModelMock->expects(static::once())->method('setData')->willReturnSelf();
+            $this->adminOrderCreateModelMock->expects(static::once())->method('setQuote')->willReturnSelf();
+            $this->adminOrderCreateModelMock->expects(static::once())->method('_prepareCustomer')->willReturnSelf();
+        }
+
         static::assertSame($parentQuote, $this->currentMock->prepareQuote($immutableQuote, $transaction));
+    }
+
+    /**
+     * @return array[]
+     */
+    public function prepareQuoteProvider()
+    {
+        return [
+            ['boltCheckoutType' => CartHelper::BOLT_CHECKOUT_TYPE_MULTISTEP],
+            ['boltCheckoutType' => CartHelper::BOLT_CHECKOUT_TYPE_PPC],
+            ['boltCheckoutType' => CartHelper::BOLT_CHECKOUT_TYPE_BACKOFFICE],
+            ['boltCheckoutType' => CartHelper::BOLT_CHECKOUT_TYPE_PPC_COMPLETE],
+        ];
     }
 
     /**

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -220,4 +220,10 @@
                 type="Bolt\Boltpay\Plugin\Magento\Quote\Observer\Frontend\Quote\Address\AddressCollectTotalsObserverPlugin"
                 sortOrder="10"/>
     </type>
+
+    <type name="Bolt\Boltpay\Helper\Order">
+        <arguments>
+            <argument name="adminOrderCreateModel" xsi:type="object">Magento\Sales\Model\AdminOrder\Create\Proxy</argument>
+        </arguments>
+    </type>
 </config>

--- a/view/adminhtml/templates/boltpay/js/replacejs.phtml
+++ b/view/adminhtml/templates/boltpay/js/replacejs.phtml
@@ -276,36 +276,34 @@ require([
 
 
     var isValidToken = function () {
-        var errors = [],
-            // shipping address mask overlay
-            addressShippingOverlay = $('#address-shipping-overlay')[0],
-            // if the shipping address is not masked (i.e. overlay is not visible) shipping is required
-            shippingRequired = addressShippingOverlay && addressShippingOverlay.offsetParent === null,
-            isShippingMethodSelected = $('input[name="order[shipping_method]"][type=radio]:checked').length,
-            email = $('input[name="order[account][email]"]').val();
+        try {
+            var // shipping address mask overlay
+                addressShippingOverlay = $('#address-shipping-overlay')[0],
+                // if the shipping address is not masked (i.e. overlay is not visible) shipping is required
+                shippingRequired = addressShippingOverlay && addressShippingOverlay.offsetParent === null,
+                isShippingMethodSelected = $('input[name="order[shipping_method]"][type=radio]:checked').length;
 
-        if (!cart.orderToken) {
-            errors.push('Invalid Order Token');
-        }
+            if (create_request) {
+                throw '<?php echo __('There is a pending Bolt Cart creation request, please wait.'); ?>';
+            }
 
-        if (!email || !email.trim()) {
-            errors.push('Please specify the "Email"!');
-        }
+            if (cart.errorMessage) {
+                throw cart.errorMessage;
+            }
 
-        if (shippingRequired && ! isShippingMethodSelected) {
-            errors.push('Please specify the "Shipping Method"!');
-        }
-
-        if (errors.length) {
-            var errorMsg = errors.join(', ');
-
-            console.error('BoltPay Check: ', errorMsg);
-            alert(errorMsg);
-
+            if (shippingRequired && !isShippingMethodSelected) {
+                throw '<?php echo __('Please specify the "Shipping Method"!'); ?>';
+            }
+            return true;
+        } catch (e) {
+            if (typeof e === 'string') {
+                console.error('BoltPay Check: ', e);
+                require(['Magento_Ui/js/modal/alert'], function (alert) {
+                    alert({ content: e });
+                });
+            }
             return false;
         }
-
-        return true;
     };
 
     var callbacks = {
@@ -332,7 +330,7 @@ require([
                 callback();
             };
 
-            if (settings.is_pre_auth) {
+            if (settings.isPreAuth) {
                 processSuccess();
                 return;
             }
@@ -383,32 +381,29 @@ require([
         params = params.join('&');
 
         // set cart and hints data in a response callback
-        var onSuccess = function(data){
+        var onSuccess = function(data) {
 
             cart = data.cart;
-            create_request = null;
 
-            var prefill = isObject(data.hints.prefill) ?
-                deepMergeObjects(hints.prefill, data.hints.prefill)
+            var prefill = isObject(data.hints.prefill)
+                ? deepMergeObjects(hints.prefill, data.hints.prefill)
                 : hints.prefill;
             hints = deepMergeObjects(hints, data.hints);
             hints.prefill = prefill;
 
             settings.storeId = data.storeId;
-            settings.is_pre_auth = data.isPreAuth;
+            settings.isPreAuth = data.isPreAuth;
 
             if (data.backOfficeKey) {
                 insertConnectScript(data.backOfficeKey);
             }
-            if (data.paymentOnlyKey && settings.pay_by_link_url && data.cart.orderToken ) {
+            if (data.paymentOnlyKey && settings.pay_by_link_url && cart.orderToken) {
+                $(".bolt-checkout-options-separator").toggle(!!data.backOfficeKey);
                 $(".bolt-checkout-pay-by-link").html("Send <a id='bolt-pay-by-link' href='"
-                    + settings.pay_by_link_url + "?publishable_key=" + data.paymentOnlyKey
-                    + "&token=" + data.cart.orderToken
+                    + settings.pay_by_link_url + "?" + $.param({ publishable_key: data.paymentOnlyKey, token: cart.orderToken })
                     + "'>this link</a> to consumer to receive payment");
             }
-            if (data.backOfficeKey && data.paymentOnlyKey && settings.pay_by_link_url) {
-                $(".bolt-checkout-options-separator").show();
-            }
+            create_request = null;
         };
 
         var onError = function(error) {
@@ -546,28 +541,14 @@ require([
     }
     /////////////////////////////////////////////////////////////////////
 
-    /////////////////////////////////////////////////////
-    // Call Bolt order creation Magento endpoint on
-    // customer email change, storing the live page data in Bolt cart.
-    // Email change triggers saving the email to quote in
-    // Magento ajax call. Add a delay (setTimeout) to ensure
-    // that Magento call runs first and the email is saved
-    // before it is read in Bolt order creation.
-    /////////////////////////////////////////////////////
-    var customer_email_selector  = 'input[name="order[account][email]"]';
-    var customer_email_value;
-    $(customer_email_selector).on("change", function() {
-        setTimeout(
-            function() {
-                var email = $(customer_email_selector).val().trim();
-                if (email === "") return;
-                if (email !== customer_email_value) {
-                    customer_email_value = email;
-                    createOrder();
-                }
-            },
-            1500
-        );
+    require(['Magento_Sales/order/create/form'], function() {
+        window.order.loadArea = function () {
+            var result = AdminOrder.prototype.loadArea.apply(window.order, arguments);
+            if (arguments[0] == false && arguments[1] == false) {
+                result.then(createOrder);
+            }
+            return result;
+        }
     });
 });
 


### PR DESCRIPTION
# Description
Trail Gear reported issues with customer creation during back office orders. Fixed, tested and approved in an extension made for them.The extension should be removed when this gets released and they update.

## Issue

How we did it so far is always creating a back-office order as a guest user, and never taking care of really creating a customer account and putting it into appropriate customer group. It was kind of hard-coded in the module. That's not how Magento does it and it's very strange that we missed it and no merchant pointed that out until now.

Basically, in the back-office create order flow either an existing customer is selected or a new one needs to be created in the process (Create New Customer button). No guests in Magento back-office orders. And all our back-office order customers in the create new customer flow were guests so far.

## Test cases

**Main flow - creating a new customer account with Bolt backoffice order:**

1. Go to Sales -> Orders -> Create New Order -> Create New Customer
2. Create order with Bolt keeping in mind chosen customer group and email
3. Order creation should succeed and take you to the usual order success page
4. There you need to make sure that the right column specifies the correct customer email, name and group, Also having a link saying Edit Customer is important, proving that a customer was succesfully created.
5. Optionally you can open said customer and verify its details match.

![image](https://user-images.githubusercontent.com/37150717/105889067-0e42ce80-600e-11eb-84c9-230528de48fa.png)

**A customer with the same email address already exists in an associated website.**

1. Go to Sales -> Orders -> Create New Order -> Create New Customer
2. For email address input an email address of a customer already registered with the selected website.
3. Clicking the Bolt button will display an alert saying "A customer with the same email address already exists in an associated website.".
4. Changing the customer email should create a new Bolt order and allow you to create the order.

![image](https://user-images.githubusercontent.com/37150717/105889153-2581bc00-600e-11eb-9d7f-e2960712af5e.png)

Fixes: https://boltpay.atlassian.net/browse/EN-3825, https://boltpay.atlassian.net/browse/ON-438

#changelog EN-3825 - Assign customer an appropriate group id in backoffice order creation …

# Type of change

- [x] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [x] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
