### PR TITLE
MA-83 Universal Webhook Support

### DIFF
--- a/Api/Data/UniversalWebhookResultInterface.php
+++ b/Api/Data/UniversalWebhookResultInterface.php
@@ -39,19 +39,19 @@ interface UniversalWebhookResultInterface
     public function setStatus($status);
 
     /**
-     * Get error string
+     * Get error object
      * 
      * @api
-     * @return string
+     * @return array
      */
 
     public function getError();
 
     /**
-     * Set error string
+     * Set error object
      * 
      * @api
-     * @param string $error
+     * @param array $error
      * @return $this
      */
 

--- a/Api/Data/UniversalWebhookResultInterface.php
+++ b/Api/Data/UniversalWebhookResultInterface.php
@@ -15,27 +15,45 @@
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
- namespace Bolt\Boltpay\Api;
+namespace Bolt\Boltpay\Api\Data;
 
- /**
-  * Universal webhook interface. Passes the request data to the right helper functions to handle the request
-  */
- interface UniversalWebhookInterface
- {
+interface UniversalWebhookResultInterface
+{
     /**
-     * Hook format:
-     * {"type":"pending", "object":"transaction", "data":{requestData}}
+     * Get status string
+     * 
      * @api
-     * 
-     * @param string $type
-     * @param string $object
-     * @param mixed $data
-     * 
-     * @return Bolt\Boltpay\Api\Data\UniversalWebhookResultInterface
+     * @return string
      */
-    function execute(
-        $type = null,
-        $object = null,
-        $data = null
-    );
- }
+
+    public function getStatus();
+
+    /**
+     * Set status string
+     * 
+     * @api
+     * @param string $status
+     * @return $this
+     */
+
+    public function setStatus($status);
+
+    /**
+     * Get error string
+     * 
+     * @api
+     * @return string
+     */
+
+    public function getError();
+
+    /**
+     * Set error string
+     * 
+     * @api
+     * @param string $error
+     * @return $this
+     */
+
+    public function setError($error);
+}

--- a/Api/UniversalApiInterface.php
+++ b/Api/UniversalApiInterface.php
@@ -24,7 +24,7 @@
  {
      /**
       * Hook format:
-      * {"type":"create_order", "data":{requestData}}
+      * {"event":"create_order", "data":{requestData}}
       * @api
       * 
       * @param string $event

--- a/Model/Api/Data/UniversalWebhookResult.php
+++ b/Model/Api/Data/UniversalWebhookResult.php
@@ -61,7 +61,7 @@ class UniversalWebhookResult implements UniversalWebhookResultInterface
      * Get error string
      * 
      * @api
-     * @return string
+     * @return array
      */
 
     public function getError()
@@ -73,7 +73,7 @@ class UniversalWebhookResult implements UniversalWebhookResultInterface
      * Set error string
      * 
      * @api
-     * @param string $error  
+     * @param array $error  
      * @return $this
      */
     public function setError($error)

--- a/Model/Api/Data/UniversalWebhookResult.php
+++ b/Model/Api/Data/UniversalWebhookResult.php
@@ -27,7 +27,7 @@ class UniversalWebhookResult implements UniversalWebhookResultInterface
     private $status;
 
     /**
-     * @var string
+     * @var array
      */
     private $error;
 
@@ -58,7 +58,7 @@ class UniversalWebhookResult implements UniversalWebhookResultInterface
     }
 
     /**
-     * Get error string
+     * Get error object
      * 
      * @api
      * @return array
@@ -70,7 +70,7 @@ class UniversalWebhookResult implements UniversalWebhookResultInterface
     }
 
     /**
-     * Set error string
+     * Set error object
      * 
      * @api
      * @param array $error  

--- a/Model/Api/Data/UniversalWebhookResult.php
+++ b/Model/Api/Data/UniversalWebhookResult.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Model\Api\Data;
+
+use Bolt\Boltpay\Api\Data\UniversalWebhookResultInterface;
+
+class UniversalWebhookResult implements UniversalWebhookResultInterface
+{
+    /**
+     * @var string
+     */
+    private $status;
+
+    /**
+     * @var string
+     */
+    private $error;
+
+    /**
+     * Get status string
+     * 
+     * @api
+     * @return string
+     */
+
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    /**
+     * Set status string
+     * 
+     * @api
+     * @param string $status
+     * @return $this
+     */
+
+    public function setStatus($status)
+    {
+        $this->status = $status;
+        return $this;
+    }
+
+    /**
+     * Get error string
+     * 
+     * @api
+     * @return string
+     */
+
+    public function getError()
+    {
+        return $this->error;
+    }
+
+    /**
+     * Set error string
+     * 
+     * @api
+     * @param string $error  
+     * @return $this
+     */
+    public function setError($error)
+    {
+        $this->error = $error;
+        return $this;
+    }
+
+}

--- a/Model/Api/UniversalWebhook.php
+++ b/Model/Api/UniversalWebhook.php
@@ -50,6 +50,11 @@ class UniversalWebhook implements UniversalWebhookInterface
     private $logHelper;
 
     /**
+     * @var BoltErrorResponse
+     */
+    protected $errorResponse;
+
+    /**
      * @var Response
      */
     private $response;
@@ -59,6 +64,7 @@ class UniversalWebhook implements UniversalWebhookInterface
         Result $result,
         Bugsnag $bugsnag,
         LogHelper $logHelper,
+        BoltErrorResponse $errorResponse,
         Response $response
     )
     {
@@ -66,6 +72,7 @@ class UniversalWebhook implements UniversalWebhookInterface
         $this->result = $result;
         $this->bugsnag = $bugsnag;
         $this->logHelper = $logHelper;
+        $this->errorResponse = $errorResponse;
         $this->response = $response;
     }
 
@@ -119,11 +126,13 @@ class UniversalWebhook implements UniversalWebhookInterface
      */
     private function formatResponse($result)
     {
-        //formats the response from the api result interface. may not be necessary
+        //formats the response from the api result interface.
         $response = [
             'status' => $this->result->getStatus()
         ];
 
+        //currently this is never used as error response is handled separately
+        //leaving as failsafe
         if ($response['status'] == "failed")
         {
             $response['error'] = $this->result->getError();
@@ -143,11 +152,8 @@ class UniversalWebhook implements UniversalWebhookInterface
      */
     protected function sendErrorResponse($errCode, $message, $httpStatusCode)
     {
-        //TODO: additional error response according to handler being called
-        $additionalErrorResponseData = [];
-
         $encodeErrorResult = $this->errorResponse
-            ->prepareErrorMessage($errCode, $message, $additionalErrorResponseData);
+            ->prepareErrorMessage($errCode, $message);
 
         $this->logHelper->addInfoLog('### sendErrorResponse');
         $this->logHelper->addInfoLog($encodeErrorResult);

--- a/Model/Api/UniversalWebhook.php
+++ b/Model/Api/UniversalWebhook.php
@@ -18,8 +18,153 @@
 namespace Bolt\Boltpay\Model\Api;
 
 use Bolt\Boltpay\Api\UniversalWebhookInterface;
+use Bolt\Boltpay\Api\OrderManagementInterface;
+use Bolt\Boltpay\Api\Data\UniversalWebhookResultInterface as Result;
+use Bolt\Boltpay\Exception\BoltException;
+use Bolt\Boltpay\Helper\Bugsnag;
+use Bolt\Boltpay\Helper\Log as LogHelper;
+use Bolt\Boltpay\Model\ErrorResponse as BoltErrorResponse;
+use Magento\Framework\Webapi\Rest\Response;
 
 class UniversalWebhook implements UniversalWebhookInterface
 {
+
+    /**
+     * @var OrderManagementInterface
+     */
+    private $orderManagement;
+
+    /**
+     * @var Result
+     */
+    private $result;
+
+    /**
+     * @var Bugsnag
+     */
+    private $bugsnag;
+
+    /**
+     * @var LogHelper
+     */
+    private $logHelper;
+
+    /**
+     * @var Response
+     */
+    private $response;
+
+    public function __construct(
+        OrderManagementInterface $orderManagement,
+        Result $result,
+        Bugsnag $bugsnag,
+        LogHelper $logHelper,
+        Response $response
+    )
+    {
+        $this->orderManagement = $orderManagement;
+        $this->result = $result;
+        $this->bugsnag = $bugsnag;
+        $this->logHelper = $logHelper;
+        $this->response = $response;
+    }
+
+    /**
+     * @api
+     * 
+     * @param string $type
+     * @param string $object
+     * @param mixed $data
+     * 
+     * @return boolean
+     */
+    public function execute(
+        $type = null,
+        $object = null,
+        $data = null
+    )
+    {
+        try {
+            // This just reuses the existing manage function by pulling the necessary data from the request.
+            $this->orderManagement->manage(
+                isset($data['id']) ? $data['id'] : null, //transaction id
+                isset($data['reference']) ? $data['reference'] : null, //bolt transaction id
+                isset($data['order']['cart']['order_reference']) ? $data['order']['cart']['order_reference'] : null, //parent quote id
+                isset($type) ? $type : null,
+                isset($data['amount']['amount']) ? $data['amount']['amount'] : null, 
+                isset($data['amount']['currency']) ? $data['amount']['currency'] : null,
+                isset($data['status']) ? $data['status'] : null,
+                isset($data['order']['cart']['display_id']) ? $data['order']['cart']['display_id'] : null,
+                isset($data['source_transaction']['id']) ? $data['source_transaction']['id'] : null,
+                isset($data['source_transaction']['reference']) ? $data['source_transaction']['reference'] : null
+            );
+        }
+        catch (BoltException $e) {
+            $this->sendErrorResponse(
+                $e->getCode(),
+                $e->getMessage(),
+                422
+            );
+            return false;
+        }
+        $this->result->setStatus('success');
+
+        $this->sendSuccessResponse($this->result);
+
+        return true;
+    }
+
+    /**
+     * @param UniversalWebhookResultInterface $result
+     */
+    private function formatResponse($result)
+    {
+        //formats the response from the api result interface. may not be necessary
+        $response = [
+            'status' => $this->result->getStatus()
+        ];
+
+        if ($response['status'] == "failed")
+        {
+            $response['error'] = $this->result->getError();
+        }
+
+        return json_encode($response);
+    }
+
+    //TODO: extract this out, duplicated with UniversalApi::sendErrorResponse
+    /**
+     * @param int        $errCode
+     * @param string     $message
+     * @param int        $httpStatusCode
+     *
+     * @return void
+     * @throws \Exception
+     */
+    protected function sendErrorResponse($errCode, $message, $httpStatusCode)
+    {
+        //TODO: additional error response according to handler being called
+        $additionalErrorResponseData = [];
+
+        $encodeErrorResult = $this->errorResponse
+            ->prepareErrorMessage($errCode, $message, $additionalErrorResponseData);
+
+        $this->logHelper->addInfoLog('### sendErrorResponse');
+        $this->logHelper->addInfoLog($encodeErrorResult);
+        
+        $this->bugsnag->notifyException(new \Exception($message));
+
+        $this->response->setHttpResponseCode($httpStatusCode);
+        $this->response->setBody($encodeErrorResult);
+        $this->response->sendResponse();
+    }
+
+    protected function sendSuccessResponse($result)
+    {
+        //creates and sends error response. Uses formatResponse
+        $this->response->setHttpResponseCode(200);
+        $this->response->setBody($this->formatResponse($result));
+        $this->response->sendResponse();
+    }
 
 }

--- a/Model/Api/UniversalWebhook.php
+++ b/Model/Api/UniversalWebhook.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Model\Api;
+
+use Bolt\Boltpay\Api\UniversalWebhookInterface;
+
+class UniversalWebhook implements UniversalWebhookInterface
+{
+
+}

--- a/Test/Unit/Model/Api/UniversalWebhookTest.php
+++ b/Test/Unit/Model/Api/UniversalWebhookTest.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Test\Unit\Model\Api;
+
+use Bolt\Boltpay\Model\Api\UniversalWebhook;
+
+use Bolt\Boltpay\Model\Api\OrderManagement;
+use Bolt\Boltpay\Model\Api\Data\UniversalWebhookResult as Result;
+use Bolt\Boltpay\Exception\BoltException;
+use Bolt\Boltpay\Helper\Bugsnag;
+use Bolt\Boltpay\Helper\Log as LogHelper;
+use Bolt\Boltpay\Model\ErrorResponse as BoltErrorResponse;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
+use Magento\Framework\Webapi\Rest\Response;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+
+class UniversalWebhookTest extends BoltTestCase
+{
+    /**
+     * @var MockObject|OrderManagement
+     */
+    private $orderManagement;
+
+    /**
+     * @var Result
+     */
+    private $result;
+
+    /**
+     * @var Bugsnag
+     */
+    private $bugsnag;
+
+    /**
+     * @var LogHelper
+     */
+    private $logHelper;
+
+    /**
+     * @var BoltErrorResponse
+     */
+    private $errorResponse;
+
+    /**
+     * @var Response
+     */
+    private $response;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUpInternal()
+    {
+        $this->initRequiredMocks();
+        $this->initCurrentMock();
+    }
+
+    /**
+     * @test
+     */
+    public function exceptionHandled_sendsErrorResponse()
+    {
+        $exception = new BoltException(
+            __("Test error message"),
+            null,
+            BoltErrorResponse::ERR_SERVICE
+        );
+
+        $this->orderManagement->expects(self::once())
+            ->method('manage')
+            ->willThrowException($exception);
+
+        $this->expectErrorResponse(
+            BoltErrorResponse::ERR_SERVICE,
+            __("Test error message"),
+            422
+        );
+
+        $this->currentMock->execute();
+    }
+
+    /**
+     * @test
+     */
+    public function updateOrder_returnsTrue()
+    {
+        $type = 'testType';
+        $object = 'transaction';
+        $data = [
+            'id' => '1234',
+            'reference' => 'XXXX-XXXX-XXXX',
+            'order' => [
+                'cart' => [
+                    'order_reference' => '5678',
+                    'display_id' => '000001234'
+                ]
+            ],
+            'amount' => [
+                'amount' => '2233',
+                'currency' => 'USD'
+            ],
+            'status' => 'completed',
+            'source_transaction' => [
+                'id' => 'string',
+                'reference' => 'otherstring'
+            ]
+        ];
+
+        $expectedResult = json_encode(['status' => 'success']);
+        $this->expectSuccessResponse($expectedResult, 200);
+
+        $this->assertTrue($this->currentMock->execute($type, $object, $data));
+    }
+
+    private function expectSuccessResponse($result, $httpResponseCode)
+    {
+        $this->response->expects(self::once())
+            ->method('setHttpResponseCode')
+            ->with($httpResponseCode);
+
+        $this->response->expects(self::once())
+            ->method('setBody')
+            ->with($result);
+
+        $this->response->expects(self::once())
+            ->method('sendResponse');
+    }
+
+    private function expectErrorResponse($errCode, $message, $httpStatusCode)
+    {
+        $encodeErrorResult = '';
+
+        $this->errorResponse->expects(self::once())
+            ->method('prepareErrorMessage')
+            ->with($errCode, $message)
+            ->willReturn($encodeErrorResult);
+
+        $this->bugsnag->expects(self::once())
+            ->method('notifyException')
+            ->with(new \Exception($message));
+
+        $this->response->expects(self::once())
+            ->method('setHttpResponseCode')
+            ->with($httpStatusCode);
+        $this->response->expects(self::once())
+            ->method('setBody')
+            ->with($encodeErrorResult);
+        $this->response->expects(self::once())
+            ->method('sendResponse');
+    }
+
+    private function initRequiredMocks()
+    {
+        $this->orderManagement = $this->createMock(OrderManagement::class);
+        $this->bugsnag = $this->createMock(Bugsnag::class);
+        $this->logHelper = $this->createMock(LogHelper::class);
+        $this->errorResponse = $this->createMock(BoltErrorResponse::class);
+        $this->response = $this->createMock(Response::class);
+
+        $this->result = $this->getMockBuilder(Result::class)
+            ->enableProxyingToOriginalMethods()
+            ->getMock();
+    }
+
+    private function initCurrentMock($methods = null)
+    {
+        $mockBuilder = $this->getMockBuilder(UniversalWebhook::class)
+            ->setConstructorArgs([
+                $this->orderManagement,
+                $this->result,
+                $this->bugsnag,
+                $this->logHelper,
+                $this->errorResponse,
+                $this->response
+            ]);
+        if ($methods) {
+            $mockBuilder->setMethods($methods);
+        } else {
+            $mockBuilder->enableProxyingToOriginalMethods();
+        }
+
+        $this->currentMock = $mockBuilder->getMock();
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -37,6 +37,8 @@
     <!-- For V2 universal endpoint -->
     <preference for="Bolt\Boltpay\Api\UniversalApiInterface" type="Bolt\Boltpay\Model\Api\UniversalApi" />
     <preference for="Bolt\Boltpay\Api\Data\UniversalApiResultInterface" type="Bolt\Boltpay\Model\Api\Data\UniversalApiResult" />
+    <preference for="Bolt\Boltpay\Api\UniversalWebhookInterface" type="Bolt\Boltpay\Model\Api\UniversalWebhook" />
+    <preference for="Bolt\Boltpay\Api\Data\UniversalWebhookResultInterface" type="Bolt\Boltpay\Model\Api\Data\UniversalWebhookResult" />
 
     <!-- For rest api hook integration -->
     <preference for="Bolt\Boltpay\Api\OrderManagementInterface" type="Bolt\Boltpay\Model\Api\OrderManagement" />

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -19,9 +19,16 @@
 <!-- Rest API router. Web hooks and Shipping and Tax. -->
 <routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Webapi:etc/webapi.xsd">
-    <!-- V2 Universal hook -->
+    <!-- V2 Universal API -->
     <route url="/V2/bolt/boltpay/api" method="POST">
         <service class="Bolt\Boltpay\Api\UniversalApiInterface" method="execute"/>
+        <resources>
+            <resource ref="anonymous" />
+        </resources>
+    </route>
+    <!-- V2 Universal Hook -->
+    <route url="/V2/bolt/boltpay/webhook" method="POST">
+        <service class="Bolt\Boltpay\Api\UniversalWebhookInterface" method="execute"/>
         <resources>
             <resource ref="anonymous" />
         </resources>


### PR DESCRIPTION
# Description
This PR goes along with https://github.com/BoltApp/bolt-magento2/pull/1085. This adds a webhook endpoint for V2 webhooks to be sent to and simply pulls the data needed to pass to the existing `OrderManagement::manage` method and returns either a success response or the error thrown by `OrderManagement::manage`

The inclusion of the result interface is a bit excessive for now as we are continuing to create and send the responses manually as opposed to returning the interface to the Magento REST handler. I'm including it here as in https://boltpay.atlassian.net/browse/MA-493 I hope to clean up the response handling to make better use of interfaces if we still cannot simply return interfaces to the Magento REST handler.

[Relevant slack discussion](https://boltpay.slack.com/archives/CQ864R9JQ/p1610377344014400)

Fixes: https://boltpay.atlassian.net/browse/MA-83

#changelog MA-83 Universal Webhook Support
Support for V2 Universal Webhook

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
