### PR TITLE
M2P-463 Bugfix: JS error: Cannot read property 'prefill' of undefined

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -1105,6 +1105,12 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
                         // We haven't seen magento cart yet. If Magento cart isn't set it means that bolt cart is unactual
                         return;
                     }
+                    
+                    if (data.hints === undefined) {
+                        // In some contexts, the data only has data_id.
+                        return;
+                    }
+                    
                     boltCartDataID = data.data_id;
                     if (BoltState.magentoCart.data_id > boltCartDataID) {
                         // bolt cart is unactual


### PR DESCRIPTION
# Description

The parameter `data` of functon `boltCartDataListener` could only have data_id, while in the server side the function `getSectionData` is not triggered, so `boltCartDataListener` is triggered by some other events in client side, and cause this JS error.

So we need to check if data.hints exists before processing.

Fixes: https://boltpay.atlassian.net/browse/M2P-463

#changelog Bugfix: JS error: Cannot read property 'prefill' of undefined

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
