### PR TITLE
M2P-465 Bugfix: The Bolt cart does not update when the Magento Gift Card is applied

### DIFF
--- a/Model/EventsForThirdPartyModules.php
+++ b/Model/EventsForThirdPartyModules.php
@@ -470,6 +470,11 @@ class EventsForThirdPartyModules
                     "module" => "Amasty_Rewards",
                     "boltClass" => Amasty_Rewards::class,
                 ],
+                [
+                    "module" => "Magento_GiftCardAccount",
+                    "checkClasses" => ["Magento\GiftCardAccount\Helper\Data"],
+                    "boltClass" => Magento_GiftCardAccount::class,
+                ],
             ],
         ],
         "filterApplyingGiftCardCode" => [

--- a/ThirdPartyModules/Magento/GiftCardAccount.php
+++ b/ThirdPartyModules/Magento/GiftCardAccount.php
@@ -179,4 +179,21 @@ class GiftCardAccount
             return null;
         }
     }
+    
+    public function getAdditionalJS($result)
+    {
+        $result .= '$(document).on("submit","form#giftcard-form",function(){
+            boltMagentoGiftInvalidateCart();
+        });         
+        $(document).on("click",".totals.giftcard .action.delete",function(){
+            boltMagentoGiftInvalidateCart();
+        });
+        function boltMagentoGiftInvalidateCart() {
+            if (localStorage) {
+                localStorage.setItem("bolt_cart_is_invalid", "true");
+                return;
+            }
+        }';
+        return $result;
+    }
 }


### PR DESCRIPTION
# Description
Root cause: the boltcart still has old data when the cart page is reloaded after Magento Gift Card is applied (https://github.com/BoltApp/bolt-magento2/blob/2.18.1/view/frontend/templates/js/replacejs.phtml#L1097).

So we need to force to invalidate the bolt cart.

Fixes: https://boltpay.atlassian.net/browse/M2P-465

#changelog Bugfix: The Bolt cart does not update when the Magento Gift Card is applied

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
