### PR TITLE
[MA-521] Account.js Mobile Retry Limit

### DIFF
--- a/view/frontend/templates/boltaccount.phtml
+++ b/view/frontend/templates/boltaccount.phtml
@@ -61,12 +61,17 @@ $checkoutKey = $block->getCheckoutKey();
                 // When magento constructs mobile menu it copies elements instead of moving
                 // We need to wait for this coping, remove first bolt-account-login div
                 // And only ofter that insert account.js script
+                var attempts = 0;
                 var timerId = setTimeout(function boltAccountLookup() {
                     var $account_div = $("div.bolt-account-login");
                     if ($account_div.length==2) {
                         $account_div.eq(0).remove();
                         insertAccountScript();
                     } else {
+                        if(attempts === 3){
+                            return insertAccountScript();
+                        }
+                        attempts ++;
                         timerId = setTimeout(boltAccountLookup, 1000)
                     }
                 }, 1000);

--- a/view/frontend/templates/boltaccount.phtml
+++ b/view/frontend/templates/boltaccount.phtml
@@ -61,6 +61,7 @@ $checkoutKey = $block->getCheckoutKey();
                 // When magento constructs mobile menu it copies elements instead of moving
                 // We need to wait for this coping, remove first bolt-account-login div
                 // And only ofter that insert account.js script
+                var ATTEMPT_LIMIT = 3;
                 var attempts = 0;
                 var timerId = setTimeout(function boltAccountLookup() {
                     var $account_div = $("div.bolt-account-login");
@@ -68,7 +69,7 @@ $checkoutKey = $block->getCheckoutKey();
                         $account_div.eq(0).remove();
                         insertAccountScript();
                     } else {
-                        if(attempts === 3){
+                        if(attempts === ATTEMPT_LIMIT){
                             return insertAccountScript();
                         }
                         attempts ++;


### PR DESCRIPTION
# Description

We have a problem with custom themes such as Monin where on mobile their menu does not change/append another copy of the element which results in the tracking not opening. The idea is to add a retry before injecting regardless. Ideally if we had a reload function inside of account.js we would just call that to bind tracking to the buttons with a mutation observer but since we cannot I went with the retry solution.

Fixes: [MA-521](https://boltpay.atlassian.net/browse/MA-521)

#changelog [MA-521] Account.js Mobile Retry Limit

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.


[MA-521]: https://boltpay.atlassian.net/browse/MA-521