### PR TITLE
[M2P-477] Fixes quote not being updated with discounts added during bolt checkout

### DIFF
--- a/Model/Api/UpdateCart.php
+++ b/Model/Api/UpdateCart.php
@@ -341,6 +341,10 @@ class UpdateCart extends UpdateCartCommon implements UpdateCartInterface
             $result = $this->applyDiscount($couponCode, $coupon, $giftCard, $parentQuote);
         }
 
+        $this->cartHelper->replicateQuoteData($parentQuote, $immutableQuote);
+
+        $this->cache->clean([\Bolt\Boltpay\Helper\Cart::BOLT_ORDER_TAG . '_' . $parentQuote->getId()]);
+
         //need to rename one of the keys of the result array for universal api
         $result['discount_description'] = $result['description'];
         unset($result['description']);


### PR DESCRIPTION
# Description
Bug found in RC testing, discounts were not included in the Magento order. This adds the quote syncing that was left out of the special discount handler for the universal endpoint.

Note that these handlers will be refactored this sprint with https://boltpay.atlassian.net/browse/M2P-467

Fixes: https://boltpay.atlassian.net/browse/M2P-477

#changelog [M2P-477] Fixes quote not being updated with discounts added during bolt checkout

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
