### PR TITLE
ON-574 Bugfix: unable to create cart if any item has customizable options

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -84,6 +84,8 @@ class Cart extends AbstractHelper
     const BOLT_CHECKOUT_TYPE_PPC = 2;
     const BOLT_CHECKOUT_TYPE_BACKOFFICE = 3;
     const BOLT_CHECKOUT_TYPE_PPC_COMPLETE = 4;
+    
+    const MAGENTO_SKU_DELIMITER = '-';
 
     /** @var CacheInterface */
     private $cache;
@@ -1349,7 +1351,15 @@ class Cart extends AbstractHelper
                 ////////////////////////////////////
                 // Load item product object
                 ////////////////////////////////////
-                $_product = $this->productRepository->get(trim($item->getSku()));
+                $itemProduct = $item->getProduct();
+                $customizableOptions = $this->getProductCustomizableOptions($itemProduct);
+                $itemSku = trim($item->getSku());
+
+                if ($customizableOptions) {
+                    $itemSku = $this->getProductActualSkuByCustomizableOptions($itemSku, $customizableOptions);
+                }
+                
+                $_product = $this->productRepository->get($itemSku);
 
                 $product['reference']    = $_product->getId();
                 $product['name']         = $_product->getName();
@@ -1390,6 +1400,16 @@ class Cart extends AbstractHelper
                         }
                     }
                 }
+                
+                if ($customizableOptions) {
+                    foreach ($customizableOptions as $customizableOption) {
+                        $properties[] = (object) [
+                            'name' => $customizableOption['title'],
+                            'value' => $customizableOption['value']
+                        ];
+                    }
+                }
+                
                 foreach ($this->getAdditionalAttributes($item->getSku(),$storeId, $additionalAttributes) as $attribute ) {
                     $properties[] = $attribute;
                 }
@@ -1459,6 +1479,63 @@ class Cart extends AbstractHelper
         /////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         return [$products, $totalAmount, $diff];
+    }
+    
+    /**
+     * Return the selected customizable options of quote item.
+     * 
+     * @param $product
+     * 
+     * @return array
+     */
+    public function getProductCustomizableOptions($product)
+    {
+        $optionIds = $product->getCustomOption('option_ids');
+        if (!$optionIds) {
+            return [];
+        }
+        
+        $customizableOptions = [];
+        foreach (explode(',', $optionIds->getValue()) as $optionId) {
+            $option = $product->getOptionById($optionId);
+            if ($option) {
+                $confItemOption = $product->getCustomOption(\Magento\Catalog\Model\Product\Type\AbstractType::OPTION_PREFIX . $optionId);
+
+                $group = $option->groupFactory($option->getType())
+                    ->setOption($option)
+                    ->setListener(new \Magento\Framework\DataObject());
+
+                $optionSku = $group->getOptionSku($confItemOption->getValue(), self::MAGENTO_SKU_DELIMITER);
+                
+                $customizableOptions[] = [
+                    'title' => $option->getTitle(),
+                    'value' => $group->getFormattedOptionValue($confItemOption->getValue()),
+                    'sku'   => $optionSku ?: ''
+                ];
+            }
+        }
+        
+        return $customizableOptions;
+    }
+    
+    /**
+     * If the product has customizable options, the sku of selected option would be appended to product sku for quote item,
+     * this function is to remove the sku of options and return actual sku of product.
+     * 
+     * @param string $sku
+     * @param array $customizableOptions
+     * 
+     * @return string
+     */
+    public function getProductActualSkuByCustomizableOptions($sku, $customizableOptions)
+    {
+        $skuElements = explode(self::MAGENTO_SKU_DELIMITER, $sku);
+        foreach ($customizableOptions as $customizableOption) {
+            if ($customizableOption['sku'] && ($skuKey = array_search($customizableOption['sku'], $skuElements)) !== false) {
+                unset($skuElements[$skuKey]);
+            }
+        }
+        return implode(self::MAGENTO_SKU_DELIMITER, $skuElements);
     }
 
     /**

--- a/Model/Api/UpdateCartCommon.php
+++ b/Model/Api/UpdateCartCommon.php
@@ -314,8 +314,16 @@ abstract class UpdateCartCommon
 
         foreach ($items as $item) {
             $product = [];
-                
-            $_product = $this->productRepository->get(trim($item->getSku()));           
+            
+            $itemProduct = $item->getProduct();
+            $customizableOptions = $this->cartHelper->getProductCustomizableOptions($itemProduct);
+            $itemSku = trim($item->getSku());
+
+            if ($customizableOptions) {
+                $itemSku = $this->cartHelper->getProductActualSkuByCustomizableOptions($itemSku, $customizableOptions);
+            }
+            
+            $_product = $this->productRepository->get($itemSku);         
 
             $product['reference']    = $_product->getId();
             $product['quantity']     = round($item->getQty());

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -4374,9 +4374,11 @@ ORDER
         $productTypeConfigurableMock->method('getOrderOptions')->willReturn($quoteItemOptions);
 
         $this->productMock = $this->getMockBuilder(Product::class)
-            ->setMethods(['getId', 'getDescription', 'getTypeInstance'])
+            ->setMethods(['getId', 'getDescription', 'getTypeInstance', 'getCustomOption'])
             ->disableOriginalConstructor()
             ->getMock();
+        
+        $this->productMock->method('getCustomOption')->with('option_ids')->willReturn([]);
         $this->productMock->method('getDescription')->willReturn('Product Description');
         $this->productMock->method('getTypeInstance')->willReturn($productTypeConfigurableMock);
 
@@ -4440,11 +4442,12 @@ ORDER
         $productTypeConfigurableMock->method('getOrderOptions')->willReturn($quoteItemOptions);
 
         $this->productMock = $this->getMockBuilder(Product::class)
-                                  ->setMethods(['getId', 'getDescription', 'getTypeInstance'])
+                                  ->setMethods(['getId', 'getDescription', 'getTypeInstance', 'getCustomOption'])
                                   ->disableOriginalConstructor()
                                   ->getMock();
         $this->productMock->method('getDescription')->willReturn('Product Description');
         $this->productMock->method('getTypeInstance')->willReturn($productTypeConfigurableMock);
+        $this->productMock->method('getCustomOption')->with('option_ids')->willReturn([]);
 
         $quoteItemMock = $this->getQuoteItemMock();
         $this->quoteMock->method('getAllVisibleItems')->willReturn([$quoteItemMock]);
@@ -4500,6 +4503,8 @@ ORDER
         $productMock = $this->createMock(Product::class);
         $productMock->method('getId')->willReturn(self::PRODUCT_ID);
         $productMock->method('getName')->willReturn('Test Product');
+        $productMock->method('getCustomOption')->with('option_ids')->willReturn([]);
+        
         $this->productRepository->expects(static::once())->method('get')->with(self::PRODUCT_SKU)
             ->willReturn($productMock);
         $quoteItem->method('getName')->willReturn('Test Product');
@@ -4594,6 +4599,8 @@ ORDER
         $productMock = $this->createMock(Product::class);
         $productMock->method('getId')->willReturn(self::PRODUCT_ID);
         $productMock->method('getName')->willReturn('Test Product');
+        $productMock->method('getCustomOption')->with('option_ids')->willReturn([]);
+        
         $this->productRepository->expects(static::once())->method('get')->with(self::PRODUCT_SKU)
             ->willReturn($productMock);
         $quoteItem->method('getName')->willReturn('Test Product');
@@ -4660,6 +4667,7 @@ ORDER
           $productMock = $this->createMock(Product::class);
           $productMock->method('getId')->willReturn(self::PRODUCT_ID);
           $productMock->method('getName')->willReturn('Test Product');
+          $productMock->method('getCustomOption')->with('option_ids')->willReturn([]);
           $this->productRepository->expects(static::once())->method('get')->with(self::PRODUCT_SKU)
             ->willReturn($productMock);
           $quoteItem->method('getName')->willReturn('Test Product');

--- a/Test/Unit/Model/Api/UpdateCartCommonTest.php
+++ b/Test/Unit/Model/Api/UpdateCartCommonTest.php
@@ -694,13 +694,13 @@ class UpdateCartCommonTest extends BoltTestCase
         $this->initCurrentMock();
         
         $quoteItem = $this->getMockBuilder(\Magento\Quote\Model\Quote\Item::class)
-            ->setMethods(['getProductId', 'getQty', 'getId', 'getSku', 'getCalculationPrice'])
+            ->setMethods(['getProductId', 'getQty', 'getId', 'getSku', 'getCalculationPrice', 'getProduct'])
             ->disableOriginalConstructor()
             ->getMock();
         $quoteItem->method('getProductId')->willReturn(100);
         $quoteItem->method('getQty')->willReturn(1);
         $quoteItem->method('getId')->willReturn(60);
-        $quoteItem->method('getSku')->willReturn('psku');
+        $quoteItem->method('getSku')->willReturn('psku-option');
         $quoteItem->method('getCalculationPrice')->willReturn(1000);
         
         $productMock = $this->createMock(Product::class);
@@ -708,6 +708,15 @@ class UpdateCartCommonTest extends BoltTestCase
         $this->productRepositoryInterface->expects(static::once())->method('get')->with('psku')
             ->willReturn($productMock);
         
+        $quoteItem->method('getProduct')->willReturn($productMock);
+        
+        $customizableOptions = ['customizableOptions'];
+        
+        $this->cartHelper->expects(self::once())->method('getProductCustomizableOptions')
+            ->with($productMock)->willReturn($customizableOptions);
+        $this->cartHelper->expects(self::once())->method('getProductActualSkuByCustomizableOptions')
+            ->with('psku-option', $customizableOptions)->willReturn('psku');
+            
         $quote = $this->getQuoteMock(
             self::PARENT_QUOTE_ID,
             self::PARENT_QUOTE_ID,


### PR DESCRIPTION
# Description
Actually this issue exists for any type of product which has **Customizable Options**. These custom options have their own SKUs, and M2 would combine the SKU of custom option with SKU of its parent product for quote item, eg. The parent product has SKU 24-MB01, and the SKU of its custom option is C1, then for the quote item in the cart, the SKU becomes 24-MB01-C1. The problem is this SKU 24-MB01-C1 does not exist in the DB, so productRepository->get would raise NoSuchEntityException.

This PR is to fix this bug and also add custom options to the properties of Bolt cart.

@ethanwayda22 As we discuss in the slack, the update-cart endpoint can not process with any item that has customizable options, cause if we add same product with different custom options into cart, the product id of these quote items are identical. 

Fixes: https://boltpay.atlassian.net/browse/ON-574

#changelog Bugfix: unable to create cart if any item has customizable options

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
