### PR TITLE
Remove universal API routes

### DIFF
--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -19,20 +19,6 @@
 <!-- Rest API router. Web hooks and Shipping and Tax. -->
 <routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Webapi:etc/webapi.xsd">
-    <!-- V2 Universal API -->
-    <route url="/V2/bolt/boltpay/api" method="POST">
-        <service class="Bolt\Boltpay\Api\UniversalApiInterface" method="execute"/>
-        <resources>
-            <resource ref="anonymous" />
-        </resources>
-    </route>
-    <!-- V2 Universal Hook -->
-    <route url="/V2/bolt/boltpay/webhook" method="POST">
-        <service class="Bolt\Boltpay\Api\UniversalWebhookInterface" method="execute"/>
-        <resources>
-            <resource ref="anonymous" />
-        </resources>
-    </route>
     <!-- Order Update hook -->
     <route url="/V1/bolt/boltpay/order/manage" method="POST">
         <service class="Bolt\Boltpay\Api\OrderManagementInterface" method="manage"/>


### PR DESCRIPTION
# Description
Given the issues with `updateCart` and the V2 api, we've decided to not include the V2 support in the 2.19.0 release. This PR just removes the routes added for the V2 api. This PR might not be merged as it is just being extra cautious.

Fixes: (link Jira ticket)

#changelog Remove universal API routes
Remove universal API routes

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
