### PR TITLE
ON-588 - order success page not refreshing minicart fix

### DIFF
--- a/view/frontend/templates/checkout/success.phtml
+++ b/view/frontend/templates/checkout/success.phtml
@@ -25,3 +25,12 @@ if ($block->shouldDisableBoltCheckout()) { return;
         BoltTrack.recordEvent("OrderConfirmationView");
     </script>
 <?php endif; ?>
+<script>
+    require([
+        'Magento_Customer/js/customer-data'
+    ], function (customerData) {
+        var sections = ['cart'];
+        customerData.invalidate(sections);
+        customerData.reload(sections, true);
+    });
+</script>


### PR DESCRIPTION
# Description

TooldToday:

_One issue that we noticed today, not sure if it’s something with Bolt or not, but when an order is being placed and you land on the order success page, the minicart still holds the items in the cart, but when you click on the mini-cart it shows empty cart… 
I would assume Bolt should clear the minicart…._

Fixes: https://boltpay.atlassian.net/browse/ON-588

#changelog ON-588 - order success page not refreshing minicart fix

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
