### PR TITLE
M2P-478 Bugfix: Discount rule is not removed when the product was deleted via Bolt modal

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1120,6 +1120,12 @@ class Cart extends AbstractHelper
 
             $child->setData($key, $value);
         }
+        
+        // Reset the calculated items of address, so address->getAllItems() can return up-to-date data.
+        if ($child instanceof \Magento\Customer\Model\Address\AbstractAddress) {
+            $child->unsetData("cached_items_all");
+        }
+        
         if ($save) {
             $child->save();
         }

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -1639,6 +1639,50 @@ class CartTest extends BoltTestCase
 
         TestHelper::invokeMethod($currentMock, 'transferData', [$this->quoteMock, $childQuoteMock]);
     }
+    
+    /**
+     * @test
+     * that transferData with default email and exclude fields parameters transfers data from provided parent Address to child Address, and unset cached_items_all field
+     *
+     * @covers ::transferData
+     *
+     * @throws ReflectionException if transferData method is not defined
+     */
+    public function transferData_withDefaultFields_transfersDataFromParentAddressToChildAddressAndSavesTheChild()
+    {
+        $currentMock = $this->getCurrentMock(['validateEmail']);
+
+        $addressParentShippingAddress = $this->createMock(Quote\Address::class);
+        
+        $addressParentShippingAddress->expects(static::once())->method('getData')->willReturn(
+            [
+                'email'     => $this->testAddressData['email'],
+                'firstname' => $this->testAddressData['first_name'],
+                'lastname'  => $this->testAddressData['last_name'],
+                'street'    => $this->testAddressData['street_address1'],
+                'city'      => $this->testAddressData['locality'],
+                'region'    => $this->testAddressData['region'],
+                'postcode'  => $this->testAddressData['postal_code'],
+            ]
+        );
+
+        $addressChildShippingAddress = $this->createMock(Quote\Address::class);
+        
+        $addressChildShippingAddress->expects(static::atLeastOnce())->method('setData')->withConsecutive(
+            ['email', $this->testAddressData['email']],
+            ['firstname', $this->testAddressData['first_name']],
+            ['lastname', $this->testAddressData['last_name']],
+            ['street', $this->testAddressData['street_address1']],
+            ['city', $this->testAddressData['locality']],
+            ['region', $this->testAddressData['region']],
+            ['postcode', $this->testAddressData['postal_code']]
+        );
+        $addressChildShippingAddress->expects(static::once())->method('save');
+        
+        $currentMock->expects(static::once())->method('validateEmail')->with($this->testAddressData['email'])->willReturn(true);
+
+        TestHelper::invokeMethod($currentMock, 'transferData', [$addressParentShippingAddress, $addressChildShippingAddress]);
+    }
 
     /**
      * Setup method for tests covering {@see \Bolt\Boltpay\Helper\Cart::replicateQuoteData}


### PR DESCRIPTION
# Description
Root cause: After cloning quote data from source to destination (https://github.com/BoltApp/bolt-magento2/blob/2.18.1/Helper/Cart.php#L1136), the items of destination quote address still have old data. 

So we need to reset the cached_items_all data.

Fixes: https://boltpay.atlassian.net/browse/M2P-478

#changelog Bugfix: Discount rule is not removed when the product was deleted via Bolt modal

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
