### PR TITLE
[ON-547] set pre auth to enabled by default

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -67,7 +67,7 @@ tr.shipping.totals td.amount span.price,
                 <api_emulate_session>1</api_emulate_session>
                 <should_minify_javascript>1</should_minify_javascript>
                 <capture_merchant_metrics>0</capture_merchant_metrics>
-                <is_pre_auth>0</is_pre_auth>
+                <is_pre_auth>1</is_pre_auth>
                 <track_checkout_funnel>0</track_checkout_funnel>
                 <enable_store_pickup_feature>0</enable_store_pickup_feature>
                 <always_present_checkout>0</always_present_checkout>


### PR DESCRIPTION
# Description
QOL change really. We are creating divisions with this feature enabled by default but the plugin does not have this enabled by default. 

Fixes: https://boltpay.atlassian.net/browse/ON-547

#changelog [ON-547] set pre auth to enabled by default

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
