### PR TITLE
M2P-493 Bugfix: Cart tax mismatched if fixed discount applied on whole cart

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1866,7 +1866,7 @@ class Cart extends AbstractHelper
         if ($paymentOnly) {
             if ($immutableQuote->isVirtual()) {
                 if (!empty($cart['billing_address'])) {
-                    $this->totalsCollector->collectAddressTotals($immutableQuote, $address);
+                    $this->collectAddressTotals($immutableQuote, $address);
                     $address->save();
                 } elseif ($requireBillingAddress) {
                     $this->logAddressData($cartBillingAddress);
@@ -1892,7 +1892,7 @@ class Cart extends AbstractHelper
                     return [];
                 }
 
-                $this->totalsCollector->collectAddressTotals($immutableQuote, $address);
+                $this->collectAddressTotals($immutableQuote, $address);
                 $address->save();
 
                 // Shipping address
@@ -2598,5 +2598,11 @@ class Cart extends AbstractHelper
         } catch (LocalizedException $e) {
             return false;
         }
+    }
+    
+    public function collectAddressTotals($quote, $address)
+    {
+        $quote->setCartFixedRules([]);
+        $this->totalsCollector->collectAddressTotals($quote, $address);
     }
 }

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -2600,8 +2600,20 @@ class Cart extends AbstractHelper
         }
     }
     
+    /**
+     * Collect address total.
+     *
+     * @param \Magento\Quote\Model\Quote   $quote
+     * @param \Magento\Quote\Model\Quote\Address $address
+     *
+     */
     public function collectAddressTotals($quote, $address)
     {
+        /**
+         * To calculate a right discount value
+         * before calculate totals
+         * need to reset Cart Fixed Rules in the quote
+         */
         $quote->setCartFixedRules([]);
         $this->totalsCollector->collectAddressTotals($quote, $address);
     }

--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -711,7 +711,7 @@ class ShippingMethods implements ShippingMethodsInterface
 
             $quote->collectTotals();
 
-            $this->totalsCollector->collectAddressTotals($quote, $billingAddress);
+            $this->cartHelper->collectAddressTotals($quote, $billingAddress);
             $taxAmount = CurrencyUtils::toMinor($billingAddress->getTaxAmount(), $quote->getQuoteCurrencyCode());
 
             return [
@@ -732,7 +732,7 @@ class ShippingMethods implements ShippingMethodsInterface
         $shippingAddress->setShippingMethod(null);
 
         $quote->collectTotals();
-        $this->totalsCollector->collectAddressTotals($quote, $shippingAddress);
+        $this->cartHelper->collectAddressTotals($quote, $shippingAddress);
 
         $shippingMethodArray = $this->generateShippingMethodArray($quote, $shippingAddress);
 
@@ -761,7 +761,7 @@ class ShippingMethods implements ShippingMethodsInterface
                 $quote->setCouponCode($appliedQuoteCouponCode)->collectTotals()->save();
             }
 
-            $this->totalsCollector->collectAddressTotals($quote, $shippingAddress);
+            $this->cartHelper->collectAddressTotals($quote, $shippingAddress);
             if ($this->doesDiscountApplyToShipping($quote)) {
                 /**
                  * Unset values for shipping_amount_for_discount and base_shipping_amount_for_discount to allow
@@ -776,7 +776,7 @@ class ShippingMethods implements ShippingMethodsInterface
                 // Being a bug in Magento, or a bug in the tested store version, shipping discounts
                 // are not collected the first time the method is called.
                 // There was one loop step delay in applying discount to shipping options when method was called once.
-                $this->totalsCollector->collectAddressTotals($quote, $shippingAddress);
+                $this->cartHelper->collectAddressTotals($quote, $shippingAddress);
             }
 
             $discountAmount = $this->eventsForThirdPartyModules->runFilter("collectShippingDiscounts", $shippingAddress->getShippingDiscountAmount(), $quote, $shippingAddress);
@@ -849,7 +849,7 @@ class ShippingMethods implements ShippingMethodsInterface
         }
 
         $shippingAddress->setShippingMethod(null);
-        $this->totalsCollector->collectAddressTotals($quote, $shippingAddress);
+        $this->cartHelper->collectAddressTotals($quote, $shippingAddress);
         $shippingAddress->save();
 
         if ($errors) {

--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -21,7 +21,6 @@ use Bolt\Boltpay\Api\Data\ShippingOptionsInterface;
 use Bolt\Boltpay\Api\ShippingMethodsInterface;
 use Bolt\Boltpay\Helper\Hook as HookHelper;
 use Bolt\Boltpay\Helper\Cart as CartHelper;
-use Magento\Quote\Model\Quote\TotalsCollector;
 use Magento\Directory\Model\Region as RegionModel;
 use Magento\Framework\Exception\LocalizedException;
 use Bolt\Boltpay\Api\Data\ShippingOptionsInterfaceFactory;
@@ -83,11 +82,6 @@ class ShippingMethods implements ShippingMethodsInterface
      * @var ShippingTaxInterfaceFactory
      */
     private $shippingTaxInterfaceFactory;
-
-    /**
-     * @var TotalsCollector
-     */
-    private $totalsCollector;
 
     /**
      * Shipping method converter
@@ -185,7 +179,6 @@ class ShippingMethods implements ShippingMethodsInterface
      * @param ShippingOptionsInterfaceFactory $shippingOptionsInterfaceFactory
      * @param ShippingTaxInterfaceFactory     $shippingTaxInterfaceFactory
      * @param CartHelper                      $cartHelper
-     * @param TotalsCollector                 $totalsCollector
      * @param ShippingMethodConverter         $converter
      * @param ShippingOptionInterfaceFactory  $shippingOptionInterfaceFactory
      * @param Bugsnag                         $bugsnag
@@ -209,7 +202,6 @@ class ShippingMethods implements ShippingMethodsInterface
         ShippingOptionsInterfaceFactory $shippingOptionsInterfaceFactory,
         ShippingTaxInterfaceFactory $shippingTaxInterfaceFactory,
         CartHelper $cartHelper,
-        TotalsCollector $totalsCollector,
         ShippingMethodConverter $converter,
         ShippingOptionInterfaceFactory $shippingOptionInterfaceFactory,
         Bugsnag $bugsnag,
@@ -232,7 +224,6 @@ class ShippingMethods implements ShippingMethodsInterface
         $this->regionModel = $regionModel;
         $this->shippingOptionsInterfaceFactory = $shippingOptionsInterfaceFactory;
         $this->shippingTaxInterfaceFactory = $shippingTaxInterfaceFactory;
-        $this->totalsCollector = $totalsCollector;
         $this->converter = $converter;
         $this->shippingOptionInterfaceFactory = $shippingOptionInterfaceFactory;
         $this->bugsnag = $bugsnag;


### PR DESCRIPTION
# Description
If fixed discount applied on whole cart, and the shipping address is taxable, the Bolt cart would experience an error `Cart Tax mismatched`.

Solution: To calculate a right discount value before calculate totals, we need to reset Cart Fixed Rules in the quote. If not, the $quote->getCartFixedRules() returns old value, and cause invalid discounts (https://github.com/magento/magento2/blob/6e0c28c39f6308339ffedabb159aeff6c4d70b46/app/code/Magento/SalesRule/Model/Rule/Action/Discount/CartFixed.php#L95)

Fixes: https://boltpay.atlassian.net/browse/M2P-493

#changelog Bugfix: Cart tax mismatched if fixed discount applied on whole cart

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
