### PR TITLE
M2P-470 backoffice customer group fix

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -641,10 +641,10 @@ class Cart extends AbstractHelper
     }
 
     /**
-     * @param $immutableQuote
+     * @param Quote $immutableQuote
      * @return string
      */
-    private function convertExternalFieldsToCacheIdentifier($immutableQuote)
+    protected function convertExternalFieldsToCacheIdentifier($immutableQuote)
     {
         $cacheIdentifier = "";
         // add gift message id into cart cache identifier
@@ -666,6 +666,8 @@ class Cart extends AbstractHelper
                 }
             }
         }
+
+        $cacheIdentifier .= $immutableQuote->getCustomerGroupId();
 
         return $cacheIdentifier;
     }

--- a/Test/Unit/BoltTestCase.php
+++ b/Test/Unit/BoltTestCase.php
@@ -8,6 +8,7 @@ use PHPUnit\Runner\Version as PHPUnitVersion;
 use ReflectionException;
 use ReflectionObject;
 use ReflectionProperty;
+use PHPUnit\Framework\Constraint\StringContains;
 
 if (PHPUnitVersion::id() < 9) {
     class BoltTestCase extends TestCase
@@ -41,6 +42,17 @@ if (PHPUnitVersion::id() < 9) {
         public static function assertMatchesRegularExpression(string $pattern, string $string, string $message = '')
         {
             static::assertRegExp($pattern, $string, $message);
+
+        }
+
+        /**
+         * @throws \PHPUnit\Framework\ExpectationFailedException
+         * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+         */
+        public static function assertStringContainsString(string $needle, string $haystack, string $message = '')
+        {
+            $constraint = new StringContains($needle, false);
+            static::assertThat($haystack, $constraint, $message);
         }
     }
 } else {


### PR DESCRIPTION
# Description
Wrong customer group assigned to the customer on backoffice order after group change and Bolt modal reopening 

Fixes: https://boltpay.atlassian.net/browse/M2P-470

#changelog M2P-470 backoffice customer group fix

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
