### PR TITLE
M2P-477 Fix discounts not showing in M2 orders when using V2 endpoints

### DIFF
--- a/Model/Api/UpdateCart.php
+++ b/Model/Api/UpdateCart.php
@@ -312,8 +312,8 @@ class UpdateCart extends UpdateCartCommon implements UpdateCartInterface
      */
     public function discountHandler($discount_code, $cart, $customer_name = null, $customer_email = null, $customer_phone = null)
     {
-        // Bolt server sends immutableQuoteId as order reference
-        $immutableQuoteId = $cart['order_reference'];
+        // Bolt server sends immutableQuoteId as metadata
+        $immutableQuoteId = $cart['metadata']['immutable_quote_id'];
 
         $result = $this->validateQuote($immutableQuoteId);
         list($parentQuote, $immutableQuote) = $result;

--- a/Model/Api/UpdateCart.php
+++ b/Model/Api/UpdateCart.php
@@ -327,8 +327,8 @@ class UpdateCart extends UpdateCartCommon implements UpdateCartInterface
 
         // Load logged in customer checkout and customer sessions from cached session id.
         // Replace the quote with $parentQuote in checkout session.
-        $this->sessionHelper->loadSession($parentQuote, $cart['metadata'] ?? []);
-        $this->cartHelper->resetCheckoutSession($this->sessionHelper->getCheckoutSession());
+        $this->updateSession($parentQuote, $cart['metadata'] ?? []);
+        // $this->cartHelper->resetCheckoutSession($this->sessionHelper->getCheckoutSession());
 
         if(!empty($discount_code)){
             // Get the coupon code

--- a/Model/Api/UpdateCart.php
+++ b/Model/Api/UpdateCart.php
@@ -328,7 +328,6 @@ class UpdateCart extends UpdateCartCommon implements UpdateCartInterface
         // Load logged in customer checkout and customer sessions from cached session id.
         // Replace the quote with $parentQuote in checkout session.
         $this->updateSession($parentQuote, $cart['metadata'] ?? []);
-        // $this->cartHelper->resetCheckoutSession($this->sessionHelper->getCheckoutSession());
 
         if(!empty($discount_code)){
             // Get the coupon code

--- a/Test/Unit/Model/Api/UpdateCartTest.php
+++ b/Test/Unit/Model/Api/UpdateCartTest.php
@@ -687,13 +687,6 @@ class UpdateCartTest extends BoltTestCase
         $this->currentMock->expects(self::once())->method('updateSession')
             ->with($parentQuoteMock);
             
-        // $this->currentMock->expects($this->exactly(2))
-        //     ->method('setShipment')
-        //     ->withConsecutive(
-        //         [$requestCart['shipments'][0], $immutableQuoteMock],
-        //         [$requestCart['shipments'][0], $parentQuoteMock]
-        //     );
-
         $this->currentMock->expects(self::once())->method('verifyCouponCode')
             ->with(self::COUPON_CODE, $parentQuoteMock)
             ->willReturn([$this->couponMock, null]);
@@ -718,10 +711,6 @@ class UpdateCartTest extends BoltTestCase
             'data' => $testCartData['discounts'],
             
         ];
-        
-        // $this->currentMock->expects(self::once())->method('generateResult')
-        //     ->with($immutableQuoteMock)
-        //     ->willReturn($result);
 
         $this->cacheMock->expects(static::once())
             ->method('clean')->with([\Bolt\Boltpay\Helper\Cart::BOLT_ORDER_TAG . '_' . self::PARENT_QUOTE_ID]);

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -19,6 +19,20 @@
 <!-- Rest API router. Web hooks and Shipping and Tax. -->
 <routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Webapi:etc/webapi.xsd">
+    <!-- V2 Universal API -->	
+    <route url="/V2/bolt/boltpay/api" method="POST">	
+        <service class="Bolt\Boltpay\Api\UniversalApiInterface" method="execute"/>	
+        <resources>	
+            <resource ref="anonymous" />	
+        </resources>	
+    </route>	
+    <!-- V2 Universal Hook -->	
+    <route url="/V2/bolt/boltpay/webhook" method="POST">	
+        <service class="Bolt\Boltpay\Api\UniversalWebhookInterface" method="execute"/>	
+        <resources>	
+            <resource ref="anonymous" />	
+        </resources>	
+    </route>
     <!-- Order Update hook -->
     <route url="/V1/bolt/boltpay/order/manage" method="POST">
         <service class="Bolt\Boltpay\Api\OrderManagementInterface" method="manage"/>


### PR DESCRIPTION
# Description
Adds v2 routes back into `webapi.xml` and changes the discount handler to use the metadata from the request for `immutable_quote_id`

Fixes: https://boltpay.atlassian.net/browse/M2P-477

#changelog M2P-477 Fix discounts not showing in M2 orders when using V2 endpoints
Adds Universal Endpoint Support

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
