### PR TITLE
M2P-356 fix tracking number format

### DIFF
--- a/Observer/TrackingSaveObserver.php
+++ b/Observer/TrackingSaveObserver.php
@@ -110,6 +110,17 @@ class TrackingSaveObserver implements ObserverInterface
     }
 
     /**
+     * @param $attribute
+     * @return mixed
+     */
+    private function deflate($attribute) {
+        if (is_object($attribute)) {
+            return get_object_vars($attribute)[0];
+        }
+        return $attribute;
+    }
+
+    /**
      * @param Observer $observer
      */
     public function execute(Observer $observer)
@@ -176,8 +187,8 @@ class TrackingSaveObserver implements ObserverInterface
 
             $trackingData = [
                 'transaction_reference' => $transactionReference,
-                'tracking_number'       => $tracking->getTrackNumber(),
-                'carrier'               => $tracking->getCarrierCode(),
+                'tracking_number'       => $this->deflate($tracking->getTrackNumber()),
+                'carrier'               => $this->deflate($tracking->getCarrierCode()),
                 'items'                 => $items,
                 'is_non_bolt_order'     => $isNonBoltOrder,
                 'tracking_entity_id'    => $tracking->getId(),

--- a/Observer/TrackingSaveObserver.php
+++ b/Observer/TrackingSaveObserver.php
@@ -111,11 +111,16 @@ class TrackingSaveObserver implements ObserverInterface
 
     /**
      * @param $attribute
-     * @return mixed
+     * @return mixed|null
      */
-    private function deflate($attribute) {
+    private function flatten($attribute) {
         if (is_object($attribute)) {
-            return get_object_vars($attribute)[0];
+            $flattend = get_object_vars($attribute);
+            if (count($flattend) == 1) {
+                return $flattend[0];
+            } else {
+                return null;
+            }
         }
         return $attribute;
     }
@@ -185,10 +190,36 @@ class TrackingSaveObserver implements ObserverInterface
 
             $apiKey = $this->configHelper->getApiKey($order->getStoreId());
 
+            $trackNumber = $this->flatten($tracking->getTrackNumber());
+            if ($trackNumber === null) {
+                $this->bugsnag->notifyError("Ill formatted track number",
+                    \sprintf("track number: %s", var_export($tracking->getTrackNumber(), true)));
+                $this->metricsClient->processMetric(
+                    "tracking_creation.failure",
+                    1,
+                    "tracking_creation.latency",
+                    $startTime
+                );
+                return;
+            }
+
+            $carrierCode = $this->flatten($tracking->getCarrierCode());
+            if ($carrierCode === null) {
+                $this->bugsnag->notifyError("Ill formatted carrier code",
+                    \sprintf("carrier code: %s", var_export($tracking->getCarrierCode(), true)));
+                $this->metricsClient->processMetric(
+                    "tracking_creation.failure",
+                    1,
+                    "tracking_creation.latency",
+                    $startTime
+                );
+                return;
+            }
+
             $trackingData = [
                 'transaction_reference' => $transactionReference,
-                'tracking_number'       => $this->deflate($tracking->getTrackNumber()),
-                'carrier'               => $this->deflate($tracking->getCarrierCode()),
+                'tracking_number'       => $trackNumber,
+                'carrier'               => $carrierCode,
                 'items'                 => $items,
                 'is_non_bolt_order'     => $isNonBoltOrder,
                 'tracking_entity_id'    => $tracking->getId(),

--- a/Test/Unit/Observer/TrackingSaveObserverTest.php
+++ b/Test/Unit/Observer/TrackingSaveObserverTest.php
@@ -496,7 +496,7 @@ class TrackingSaveObserverTest extends BoltTestCase
     /**
      * @test
      */
-    public function testExecuteIllFormattedTrackNumberCarrierCode()
+    public function testExecuteIllFormattedTrackNumberCarrierCodeSuccess()
     {
         $shipment = $this->getMockBuilder(\Magento\Sales\Model\Order\Shipment::class)->disableOriginalConstructor()->getMock();
         $shipmentItem1 = $this->getMockBuilder(\Magento\Sales\Model\Order\Shipment\Item::class)->disableOriginalConstructor()->getMock();
@@ -601,6 +601,93 @@ class TrackingSaveObserverTest extends BoltTestCase
 
         $this->apiHelper->expects($this->once())->method('buildRequest')->willReturn(new Request());
         $this->apiHelper->expects($this->once())->method('sendRequest')->willReturn(200);
+        $this->decider->expects($this->once())->method('isTrackShipmentEnabled')->willReturn(true);
+        $this->observer->execute($eventObserver);
+    }
+
+    /**
+     * @test
+     */
+    public function testExecuteIllFormattedTrackNumberNotifiesError()
+    {
+        $shipment = $this->getMockBuilder(\Magento\Sales\Model\Order\Shipment::class)->disableOriginalConstructor()->getMock();
+        $shipmentItem1 = $this->getMockBuilder(\Magento\Sales\Model\Order\Shipment\Item::class)->disableOriginalConstructor()->getMock();
+        $shipmentItem2 = $this->getMockBuilder(\Magento\Sales\Model\Order\Shipment\Item::class)->disableOriginalConstructor()->getMock();
+        $orderItem1 = $this->getMockBuilder(\Magento\Sales\Model\Order\Item::class)->disableOriginalConstructor()->getMock();
+        $orderItem2 = $this->getMockBuilder(\Magento\Sales\Model\Order\Item::class)->disableOriginalConstructor()->getMock();
+        $payment = $this->getMockBuilder(\Magento\Sales\Api\Data\OrderPaymentInterface::class)->getMockForAbstractClass();
+        $order = $this->getMockBuilder(\Magento\Sales\Model\Order::class)->disableOriginalConstructor()->getMock();
+        $track = $this->getMockBuilder(\Magento\Sales\Model\Order\Shipment\Track::class)->disableOriginalConstructor()->getMock();
+
+        $map = [
+            ['transaction_reference', '000123'],
+        ];
+        $payment->expects($this->once())
+            ->method('getAdditionalInformation')
+            ->will($this->returnValueMap($map));
+        $payment->expects($this->once())
+            ->method('getMethod')
+            ->willReturn(\Bolt\Boltpay\Model\Payment::METHOD_CODE);
+        $order->expects($this->once())
+            ->method('getPayment')
+            ->willReturn($payment);
+        $shipment->expects($this->once())
+            ->method('getOrder')
+            ->willReturn($order);
+        $track->expects($this->once())
+            ->method('getShipment')
+            ->willReturn($shipment);
+        $track->expects($this->exactly(2))
+            ->method('getTrackNumber')
+            ->willReturn((object)[]);
+
+        $eventObserver = $this->getMockBuilder(\Magento\Framework\Event\Observer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $event = $this->getMockBuilder(\Magento\Framework\Event::class)
+            ->setMethods(['getTrack'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $eventObserver->expects($this->once())
+            ->method('getEvent')
+            ->willReturn($event);
+        $event->expects($this->once())
+            ->method('getTrack')
+            ->willReturn($track);
+
+        $shipmentItem1->expects($this->once())
+            ->method('getOrderItem')
+            ->willReturn($orderItem1);
+        $orderItem1->expects($this->once())
+            ->method('getProductId')
+            ->willReturn(12345);
+        $orderItem1->expects($this->once())
+            ->method('getParentItem')
+            ->willReturn(false);
+        $orderItem1->expects($this->once())
+            ->method('getProductOptions')
+            ->willReturn([
+                'attributes_info' => [[
+                    "label"  => "Size",
+                    "value" => "XS" ,
+                ]]
+            ]);
+
+        $shipmentItem2->expects($this->once())
+            ->method('getOrderItem')
+            ->willReturn($orderItem2);
+        $orderItem2->expects($this->never())
+            ->method('getProductId');
+        $orderItem2->expects($this->once())
+            ->method('getParentItem')
+            ->willReturn($orderItem1);
+
+        $shipment->expects($this->once())
+            ->method('getItemsCollection')
+            ->willReturn([$shipmentItem1, $shipmentItem2]);
+
+        $this->apiHelper->expects($this->never())->method('sendRequest');
+        $this->bugsnag->expects($this->once())->method('notifyError');
         $this->decider->expects($this->once())->method('isTrackShipmentEnabled')->willReturn(true);
         $this->observer->execute($eventObserver);
     }

--- a/Test/Unit/Observer/TrackingSaveObserverTest.php
+++ b/Test/Unit/Observer/TrackingSaveObserverTest.php
@@ -527,10 +527,11 @@ class TrackingSaveObserverTest extends BoltTestCase
             ->willReturn($shipment);
         $track->expects($this->once())
             ->method('getTrackNumber')
-            ->willReturn((object)[ "0" => "EZ4000000004"]);
+            ->willReturn((object)["0" => "EZ4000000004"]);
         $track->expects($this->once())
             ->method("getCarrierCode")
             ->willReturn((object)["0" => "United States Postal Service"]);
+        $track->method("getId")->willReturn(SELF::ENTITY_ID);
 
         $eventObserver = $this->getMockBuilder(\Magento\Framework\Event\Observer::class)
             ->disableOriginalConstructor()
@@ -591,6 +592,7 @@ class TrackingSaveObserverTest extends BoltTestCase
                 ],
             ],
             'is_non_bolt_order' => false,
+            'tracking_entity_id' => SELF::ENTITY_ID,
         ];
 
         $this->dataObject->expects($this->once())

--- a/Test/Unit/Observer/TrackingSaveObserverTest.php
+++ b/Test/Unit/Observer/TrackingSaveObserverTest.php
@@ -608,7 +608,7 @@ class TrackingSaveObserverTest extends BoltTestCase
     /**
      * @test
      */
-    public function testExecuteIllFormattedTrackNumberNotifiesError()
+    public function testExecuteIllFormattedEmptyTrackNumberNotifiesError()
     {
         $shipment = $this->getMockBuilder(\Magento\Sales\Model\Order\Shipment::class)->disableOriginalConstructor()->getMock();
         $shipmentItem1 = $this->getMockBuilder(\Magento\Sales\Model\Order\Shipment\Item::class)->disableOriginalConstructor()->getMock();


### PR DESCRIPTION
# Description
Please include a summary of the change and which issue is fixed. Include the motivation for the changes, and comment on your PR if necessary for clarity.

Fix formatting issue for when the tracksaveobserver recieves a dropdown style track number and/or carrier code object instead of a string from the observer event. This is causing hail errors due to the plugin passing improperly formatted data. We just return the value of the first field that was selected.



Fixes: (link Jira [ticket](https://boltpay.atlassian.net/browse/M2P-356))

#changelog M2 p 356 fix tracking number format

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
