### PR TITLE
[MA-572] Fix integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,6 +293,8 @@ workflows:
       - unit-php71-magento22
       - unit-php70-magento22
       - integration-magento-php72-magento23
+      - integration-php72-magento23:
+          context: integration-tests-secrets
   tagger:
     triggers:
       - schedule:
@@ -303,17 +305,6 @@ workflows:
                 - master
     jobs:
       - tag-release-candidate
-  integration-tests:
-    triggers:
-      - schedule:
-          cron: "0 6 * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - integration-php72-magento23:
-          context: integration-tests-secrets
   merchant-branch-test:
     when: << pipeline.parameters.run_default_workflow >>
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,8 +293,6 @@ workflows:
       - unit-php71-magento22
       - unit-php70-magento22
       - integration-magento-php72-magento23
-      - integration-php72-magento23:
-          context: integration-tests-secrets
   tagger:
     triggers:
       - schedule:
@@ -305,6 +303,17 @@ workflows:
                 - master
     jobs:
       - tag-release-candidate
+  integration-tests:
+    triggers:
+      - schedule:
+          cron: "0 6 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - integration-php72-magento23:
+          context: integration-tests-secrets
   merchant-branch-test:
     when: << pipeline.parameters.run_default_workflow >>
     jobs:

--- a/Test/scripts/ci-integration.sh
+++ b/Test/scripts/ci-integration.sh
@@ -31,6 +31,7 @@ php bin/magento config:set payment/boltpay/api_key $BOLT_STAGING_MERCHANT_API_KE
 php bin/magento config:set payment/boltpay/signing_secret $BOLT_STAGING_MERCHANT_SIGNING_SECRET
 php bin/magento config:set payment/boltpay/publishable_key_checkout $BOLT_STAGING_MERCHANT_PUBLISHABLE_KEY
 php bin/magento config:set payment/boltpay/product_page_checkout 1
+php bin/magento config:set payment/boltpay/is_pre_auth 0
 
 # install and run ngrok
 wget -O ngrok.zip https://bolt-devops.s3-us-west-2.amazonaws.com/testing/ngrok.zip


### PR DESCRIPTION
So https://github.com/BoltApp/bolt-magento2/pull/1133 broke our integration tests. This is because the sandbox merchant we use don't have preauth enabled. Originally I wanted to revert the PR but I decided to just set is_pre_auth to 0 in the script. Also change integration tests to run for every commit. A successful run only takes about 10 minutes, which is a not a long time.

Fixes: (link Jira ticket)

#changelog Fix integration tests

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
