### PR TITLE
Log instead of returning error

### DIFF
--- a/Model/Api/Data/DebugInfo.php
+++ b/Model/Api/Data/DebugInfo.php
@@ -52,7 +52,7 @@ class DebugInfo implements \JsonSerializable
     private $logs;
 
     /**
-     * @var AutomatedTestingConfig|string
+     * @var AutomatedTestingConfig
      */
     private $automatedTestingConfig;
 
@@ -172,7 +172,7 @@ class DebugInfo implements \JsonSerializable
     }
 
     /**
-     * @return AutomatedTestingConfig|string
+     * @return AutomatedTestingConfig
      */
     public function getAutomatedTestingConfig()
     {
@@ -180,7 +180,7 @@ class DebugInfo implements \JsonSerializable
     }
 
     /**
-     * @param AutomatedTestingConfig|string $automatedTestingConfig
+     * @param AutomatedTestingConfig $automatedTestingConfig
      *
      * @return $this
      */

--- a/Model/Api/Debug.php
+++ b/Model/Api/Debug.php
@@ -21,6 +21,7 @@ use Bolt\Boltpay\Api\DebugInterface;
 use Bolt\Boltpay\Helper\AutomatedTesting as AutomatedTestingHelper;
 use Bolt\Boltpay\Helper\Config as ConfigHelper;
 use Bolt\Boltpay\Helper\Hook as HookHelper;
+use Bolt\Boltpay\Helper\Log as LogHelper;
 use Bolt\Boltpay\Helper\LogRetriever;
 use Bolt\Boltpay\Helper\ModuleRetriever;
 use Bolt\Boltpay\Model\Api\Data\DebugInfoFactory;
@@ -76,6 +77,11 @@ class Debug implements DebugInterface
     private $automatedTestingHelper;
 
     /**
+     * @var LogHelper
+     */
+    private $logHelper;
+
+    /**
      * @param Response                 $response
      * @param DebugInfoFactory         $debugInfoFactory
      * @param StoreManagerInterface    $storeManager
@@ -85,6 +91,7 @@ class Debug implements DebugInterface
      * @param ModuleRetriever          $moduleRetriever
      * @param LogRetriever             $logRetriever
      * @param AutomatedTestingHelper   $automatedTestingHelper
+     * @param LogHelper                $logHelper
      */
     public function __construct(
         Response $response,
@@ -95,7 +102,8 @@ class Debug implements DebugInterface
         ConfigHelper $configHelper,
         ModuleRetriever $moduleRetriever,
         LogRetriever $logRetriever,
-        AutomatedTestingHelper $automatedTestingHelper
+        AutomatedTestingHelper $automatedTestingHelper,
+        LogHelper $logHelper
     ) {
         $this->response = $response;
         $this->debugInfoFactory = $debugInfoFactory;
@@ -106,6 +114,7 @@ class Debug implements DebugInterface
         $this->moduleRetriever = $moduleRetriever;
         $this->logRetriever = $logRetriever;
         $this->automatedTestingHelper = $automatedTestingHelper;
+        $this->logHelper = $logHelper;
     }
 
     /**
@@ -144,7 +153,12 @@ class Debug implements DebugInterface
         $result->setLogs($this->logRetriever->getLogs());
 
         # populate automated testing config
-        $result->setAutomatedTestingConfig($this->automatedTestingHelper->getAutomatedTestingConfig());
+        $automatedTestingConfig = $this->automatedTestingHelper->getAutomatedTestingConfig();
+        if (is_string($automatedTestingConfig)) {
+            $this->logHelper->addInfoLog('getAutomatedTestingConfig error: ' . $automatedTestingConfig);
+        } else {
+            $result->setAutomatedTestingConfig($automatedTestingConfig);
+        }
 
         // prepare response
         $this->response->setHeader('Content-Type', 'application/json');

--- a/Test/Unit/BoltTestCase.php
+++ b/Test/Unit/BoltTestCase.php
@@ -3,23 +3,16 @@
 namespace Bolt\Boltpay\Test\Unit;
 
 use PHPUnit\Framework\Constraint\IsType;
+use PHPUnit\Framework\Constraint\StringContains;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Runner\Version as PHPUnitVersion;
 use ReflectionException;
 use ReflectionObject;
 use ReflectionProperty;
-use PHPUnit\Framework\Constraint\StringContains;
 
 if (PHPUnitVersion::id() < 9) {
     class BoltTestCase extends TestCase
     {
-        protected function skipTestInUnitTestsFlow()
-        {
-            if (!class_exists('\Magento\TestFramework\Helper\Bootstrap')) {
-                $this->markTestSkipped('Skip integration test in unit test flow');
-            }
-        }
-
         protected function setUp()
         {
             $this->setUpInternal();
@@ -42,7 +35,6 @@ if (PHPUnitVersion::id() < 9) {
         public static function assertMatchesRegularExpression(string $pattern, string $string, string $message = '')
         {
             static::assertRegExp($pattern, $string, $message);
-
         }
 
         /**
@@ -58,13 +50,6 @@ if (PHPUnitVersion::id() < 9) {
 } else {
     class BoltTestCase extends TestCase
     {
-        protected function skipTestInUnitTestsFlow()
-        {
-            if (!class_exists('\Magento\TestFramework\Helper\Bootstrap')) {
-                $this->markTestSkipped('Skip integration test in unit test flow');
-            }
-        }
-
         protected function setUp(): void
         {
             $this->setUpInternal();

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -1085,7 +1085,6 @@ class CartTest extends BoltTestCase
      */
     public function saveToCache_whenSerializeParameterIsTrue_savesSerializedDataToCache()
     {
-        $this->skipTestInUnitTestsFlow();
         $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
         $testCartData = $this->getTestCartData();
         TestHelper::invokeMethod(
@@ -5873,7 +5872,6 @@ ORDER
         */
         public function getHints_whenCheckoutTypeIsAdmin_setsVirtualTerminalModeToTrue()
         {
-        $this->skipTestInUnitTestsFlow();
         $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
         $result = $cartHelper->getHints(null, 'admin');
         static::assertTrue($result['virtual_terminal_mode']);
@@ -6133,7 +6131,6 @@ ORDER
         */
         public function getHints_withNonProductCheckoutTypeAndVirtualQuote_returnsHintsForQuoteBillingAddress()
         {
-            $this->skipTestInUnitTestsFlow();
             $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
             $quote = TestUtils::createQuote();
             $quoteId = $quote->getId();
@@ -6172,7 +6169,6 @@ ORDER
         */
         public function getHints_withNonProductCheckoutTypeAndNonVirtualQuote_returnsHintsForQuoteShippingAddress()
         {
-            $this->skipTestInUnitTestsFlow();
             $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
             $quote = TestUtils::createQuote();
             $quoteId = $quote->getId();
@@ -6208,7 +6204,6 @@ ORDER
         */
         public function getHints_withApplePayRelatedDataPhone_skipsPreFill()
         {
-            $this->skipTestInUnitTestsFlow();
             $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
             $quote = TestUtils::createQuote();
             $testAddressData = [
@@ -6242,7 +6237,6 @@ ORDER
         */
         public function getHints_withApplePayRelatedDataEmail_skipsPreFill()
         {
-            $this->skipTestInUnitTestsFlow();
             $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
             $quote = TestUtils::createQuote();
             $testAddressData = [
@@ -6276,7 +6270,6 @@ ORDER
         */
         public function getHints_withApplePayRelatedDataAddressLine_skipsPreFill()
         {
-            $this->skipTestInUnitTestsFlow();
             $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
             $quote = TestUtils::createQuote();
             $testAddressData = [
@@ -6693,7 +6686,6 @@ ORDER
      */
     public function getCustomerByEmail_withExistingCustomerEmail_returnsCustomerModel()
     {
-        $this->skipTestInUnitTestsFlow();
         $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
 
         $store = Bootstrap::getObjectManager()->get(\Magento\Store\Model\StoreManagerInterface::class);
@@ -6733,7 +6725,6 @@ ORDER
      */
     public function getCustomerByEmail_withExceptionOnGettingTheCustomer_returnsFalse()
     {
-        $this->skipTestInUnitTestsFlow();
         $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
         static::assertFalse(
             $cartHelper->getCustomerByEmail('test@gmail.com', self::WEBSITE_ID)

--- a/Test/Unit/Model/Api/DebugTest.php
+++ b/Test/Unit/Model/Api/DebugTest.php
@@ -20,18 +20,16 @@ namespace Bolt\Boltpay\Test\Unit\Model\Api;
 use Bolt\Boltpay\Helper\Hook;
 use Bolt\Boltpay\Model\Api\Debug;
 use Bolt\Boltpay\Test\Unit\BoltTestCase;
-use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
-use Magento\Framework\Webapi\Rest\Response;
-use Magento\TestFramework\Helper\Bootstrap;
-use Magento\Store\Model\StoreManagerInterface;
-use Magento\Store\Model\ScopeInterface;
-use Magento\Store\Api\WebsiteRepositoryInterface;
-use Magento\Framework\Encryption\EncryptorInterface;
-use Magento\Framework\Webapi\Rest\Request;
-use Bolt\Boltpay\Test\Unit\TestUtils;
 use Bolt\Boltpay\Test\Unit\TestHelper;
-use Bolt\Boltpay\Model\ResponseFactory as BoltResponseFactory;
-use Bolt\Boltpay\Model\RequestFactory as BoltRequestFactory;
+use Bolt\Boltpay\Test\Unit\TestUtils;
+use Magento\Framework\Encryption\EncryptorInterface;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Framework\Webapi\Rest\Request;
+use Magento\Framework\Webapi\Rest\Response;
+use Magento\Store\Api\WebsiteRepositoryInterface;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\TestFramework\Helper\Bootstrap;
 
 /**
  * Class CreateOrderTest
@@ -61,16 +59,18 @@ class DebugTest extends BoltTestCase
     private $objectManager;
 
     /**
-     * @var
+     * @var int
      */
     private $websiteId;
 
     /**
-     * @var ScopeInterface
+     * @var int
      */
     private $storeId;
 
-    /** @var Request */
+    /**
+     * @var Request
+     */
     private $request;
 
     /**
@@ -98,21 +98,21 @@ class DebugTest extends BoltTestCase
 
         $configData = [
             [
-                'path' => 'payment/boltpay/signing_secret',
-                'value' => $secret,
-                'scope' => ScopeInterface::SCOPE_STORE,
+                'path'    => 'payment/boltpay/signing_secret',
+                'value'   => $secret,
+                'scope'   => ScopeInterface::SCOPE_STORE,
                 'scopeId' => $this->storeId,
             ],
             [
-                'path' => 'payment/boltpay/api_key',
-                'value' => $apikey,
-                'scope' => ScopeInterface::SCOPE_STORE,
+                'path'    => 'payment/boltpay/api_key',
+                'value'   => $apikey,
+                'scope'   => ScopeInterface::SCOPE_STORE,
                 'scopeId' => $this->storeId,
             ],
             [
-                'path' => 'payment/boltpay/active',
-                'value' => 1,
-                'scope' => ScopeInterface::SCOPE_STORE,
+                'path'    => 'payment/boltpay/active',
+                'value'   => 1,
+                'scope'   => ScopeInterface::SCOPE_STORE,
                 'scopeId' => $this->storeId,
             ],
         ];
@@ -166,7 +166,6 @@ class DebugTest extends BoltTestCase
 
         $this->objectManager->removeSharedInstance(Request::class);
         $this->request = null;
-
     }
 
     public function resetResponse()
@@ -181,11 +180,11 @@ class DebugTest extends BoltTestCase
 
     /**
      * @test
+     *
      * @covers ::debug
      */
     public function debug_successful()
     {
-        $this->skipTestInUnitTestsFlow();
         $this->createRequest([]);
         $hookHelper = $this->objectManager->create(Hook::class);
 


### PR DESCRIPTION
For getAutomatedTestingConfig, log the error instead of returning it. Also remove the last of skipTestInUnitTestsFlow.

Fixes: (link Jira ticket)

#changelog Log instead of returning error

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
