### PR TITLE
ON-425 Do not check if track new for magento <2.3.1

### DIFF
--- a/Observer/TrackingSaveObserver.php
+++ b/Observer/TrackingSaveObserver.php
@@ -97,13 +97,8 @@ class TrackingSaveObserver implements ObserverInterface
             $startTime = $this->metricsClient->getCurrentTime();
             $tracking = $observer->getEvent()->getTrack();
 
-            $origData = $tracking->getOrigData();
             // If we update track (don't create) and carrier and number are the same do nothing
-            if (
-                $origData &&
-                $origData['track_number'] == $tracking->getTrackNumber() &&
-                $origData['carrier_code'] == $tracking->getCarrierCode()
-            ) {
+            if (!$this->isTrackNew($tracking)) {
                 $this->metricsClient->processMetric(
                     'tracking_creation.success',
                     1,
@@ -224,6 +219,29 @@ class TrackingSaveObserver implements ObserverInterface
                 $startTime
             );
         }
+    }
+
+    /**
+     * @param Track $track
+     *
+     * @return bool
+     */
+    private function isTrackNew($track)
+    {
+        $version = $this->configHelper->getStoreVersion();
+        // we can not know if track new or not for magento < 2.3.1
+        if (version_compare($version, '2.3.1', '<')) {
+            return true;
+        }
+        $origData = $track->getOrigData();
+        if (
+            $origData &&
+            $origData['track_number'] == $track->getTrackNumber() &&
+            $origData['carrier_code'] == $track->getCarrierCode()
+        ) {
+            return false;
+        }
+        return true;
     }
 
     /**

--- a/Test/Unit/Observer/TrackingSaveObserverTest.php
+++ b/Test/Unit/Observer/TrackingSaveObserverTest.php
@@ -27,6 +27,7 @@ use Bolt\Boltpay\Helper\MetricsClient;
 use Bolt\Boltpay\Model\Request;
 use Bolt\Boltpay\Observer\TrackingSaveObserver as Observer;
 use Bolt\Boltpay\Test\Unit\BoltTestCase;
+use Exception;
 use Magento\Framework\DataObject;
 use Magento\Framework\DataObjectFactory;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
@@ -120,7 +121,12 @@ class TrackingSaveObserverTest extends BoltTestCase
         $track->expects($this->once())
             ->method('getCarrierCode')
             ->willReturn('United States Postal Service');
-        $track->method('getId')->willReturn(self::ENTITY_ID);
+        $track->expects($this->once())
+            ->method('getId')
+            ->willReturn(self::ENTITY_ID);
+        $this->configHelper->expects($this->once())
+            ->method('getStoreVersion')
+            ->willReturn('2.4.2');
 
         $eventObserver = $this->getMockBuilder(\Magento\Framework\Event\Observer::class)
             ->disableOriginalConstructor()
@@ -153,7 +159,6 @@ class TrackingSaveObserverTest extends BoltTestCase
                     'value' => 'XS',
                 ]]
             ]);
-
         $shipmentItem2->expects($this->once())
             ->method('getOrderItem')
             ->willReturn($orderItem2);
@@ -162,7 +167,6 @@ class TrackingSaveObserverTest extends BoltTestCase
         $orderItem2->expects($this->once())
             ->method('getParentItem')
             ->willReturn($orderItem1);
-
         $shipmentItem3->expects($this->once())
             ->method('getOrderItem')
             ->willReturn($orderItem3);
@@ -175,7 +179,6 @@ class TrackingSaveObserverTest extends BoltTestCase
         $orderItem3->expects($this->once())
             ->method('getProductOptions')
             ->willReturn([]);
-
         $shipment->expects($this->once())
             ->method('getItemsCollection')
             ->willReturn([$shipmentItem1, $shipmentItem2, $shipmentItem3]);
@@ -200,13 +203,19 @@ class TrackingSaveObserverTest extends BoltTestCase
             'is_non_bolt_order'  => false,
             'tracking_entity_id' => self::ENTITY_ID,
         ];
-
         $this->dataObject->expects($this->once())
             ->method('setApiData')
             ->with($expectedData);
 
         $this->apiHelper->expects($this->once())->method('buildRequest')->willReturn(new Request());
         $this->apiHelper->expects($this->once())->method('sendRequest')->willReturn(200);
+        $this->metricsClient->expects($this->once())->method('getCurrentTime')->willReturn(2000000000);
+        $this->metricsClient->expects($this->once())->method('processMetric')->with(
+            'tracking_creation.success',
+            1,
+            'tracking_creation.latency',
+            2000000000
+        );
         $this->decider->expects($this->once())->method('isTrackShipmentEnabled')->willReturn(true);
         $this->observer->execute($eventObserver);
     }
@@ -248,6 +257,9 @@ class TrackingSaveObserverTest extends BoltTestCase
             ->method('getCarrierCode')
             ->willReturn('United States Postal Service');
         $track->method('getId')->willReturn(self::ENTITY_ID);
+        $this->configHelper->expects($this->once())
+            ->method('getStoreVersion')
+            ->willReturn('2.2.0');
 
         $eventObserver = $this->getMockBuilder(\Magento\Framework\Event\Observer::class)
             ->disableOriginalConstructor()
@@ -280,7 +292,6 @@ class TrackingSaveObserverTest extends BoltTestCase
                     'value' => 'XS',
                 ]]
             ]);
-
         $shipment->expects($this->once())
             ->method('getItemsCollection')
             ->willReturn([$shipmentItem1]);
@@ -301,7 +312,6 @@ class TrackingSaveObserverTest extends BoltTestCase
             'is_non_bolt_order'  => false,
             'tracking_entity_id' => self::ENTITY_ID,
         ];
-
         $this->dataObject->expects($this->once())
             ->method('setApiData')
             ->with($expectedData);
@@ -356,6 +366,9 @@ class TrackingSaveObserverTest extends BoltTestCase
             ->method('getCarrierCode')
             ->willReturn((object) []);
         $track->method('getId')->willReturn(self::ENTITY_ID);
+        $this->configHelper->expects($this->once())
+            ->method('getStoreVersion')
+            ->willReturn('2.2.0');
 
         $eventObserver = $this->getMockBuilder(\Magento\Framework\Event\Observer::class)
             ->disableOriginalConstructor()
@@ -379,7 +392,6 @@ class TrackingSaveObserverTest extends BoltTestCase
         $orderItem1->expects($this->once())
             ->method('getParentItem')
             ->willReturn(true);
-
         $shipment->expects($this->once())
             ->method('getItemsCollection')
             ->willReturn([$shipmentItem1]);
@@ -426,7 +438,6 @@ class TrackingSaveObserverTest extends BoltTestCase
         $track->expects($this->once())
             ->method('getShipment')
             ->willReturn($shipment);
-
         $track->expects($this->once())
             ->method('getTrackNumber')
             ->willReturn('EZ4000000004');
@@ -434,6 +445,9 @@ class TrackingSaveObserverTest extends BoltTestCase
             ->method('getCarrierCode')
             ->willReturn('United States Postal Service');
         $track->method('getId')->willReturn(self::ENTITY_ID);
+        $this->configHelper->expects($this->once())
+            ->method('getStoreVersion')
+            ->willReturn('2.2.0');
 
         $eventObserver = $this->getMockBuilder(\Magento\Framework\Event\Observer::class)
             ->disableOriginalConstructor()
@@ -466,7 +480,6 @@ class TrackingSaveObserverTest extends BoltTestCase
                     'value' => 'XS',
                 ]]
             ]);
-
         $shipment->expects($this->once())
             ->method('getItemsCollection')
             ->willReturn([$shipmentItem]);
@@ -487,7 +500,6 @@ class TrackingSaveObserverTest extends BoltTestCase
             'is_non_bolt_order'  => true,
             'tracking_entity_id' => self::ENTITY_ID,
         ];
-
         $this->dataObject->expects($this->once())
             ->method('setApiData')
             ->with($expectedData);
@@ -524,6 +536,9 @@ class TrackingSaveObserverTest extends BoltTestCase
         $track->expects($this->never())
             ->method('getShipment')
             ->willReturn($shipment);
+        $this->configHelper->expects($this->never())
+            ->method('getStoreVersion')
+            ->willReturn('2.2.0');
 
         $eventObserver = $this->getMockBuilder(\Magento\Framework\Event\Observer::class)
             ->disableOriginalConstructor()
@@ -549,8 +564,8 @@ class TrackingSaveObserverTest extends BoltTestCase
             ->method('getItemsCollection')
             ->willReturn([$shipmentItem]);
 
-        $this->decider->expects($this->once())->method('isTrackShipmentEnabled')->willReturn(false);
         $this->apiHelper->expects($this->never())->method('sendRequest');
+        $this->decider->expects($this->once())->method('isTrackShipmentEnabled')->willReturn(false);
         $this->observer->execute($eventObserver);
     }
 
@@ -583,6 +598,9 @@ class TrackingSaveObserverTest extends BoltTestCase
         $track->expects($this->once())
             ->method('getShipment')
             ->willReturn($shipment);
+        $this->configHelper->expects($this->once())
+            ->method('getStoreVersion')
+            ->willReturn('2.2.0');
 
         $eventObserver = $this->getMockBuilder(\Magento\Framework\Event\Observer::class)
             ->disableOriginalConstructor()
@@ -608,8 +626,8 @@ class TrackingSaveObserverTest extends BoltTestCase
             ->method('getItemsCollection')
             ->willReturn([$shipmentItem]);
 
-        $this->decider->expects($this->once())->method('isTrackShipmentEnabled')->willReturn(true);
         $this->apiHelper->expects($this->never())->method('sendRequest');
+        $this->decider->expects($this->once())->method('isTrackShipmentEnabled')->willReturn(true);
         $this->observer->execute($eventObserver);
     }
 
@@ -620,14 +638,24 @@ class TrackingSaveObserverTest extends BoltTestCase
     {
         $track = $this->getMockBuilder(\Magento\Sales\Model\Order\Shipment\Track::class)->disableOriginalConstructor()->getMock();
 
-        $track->method('getTrackNumber')->willReturn('EZ4000000004');
-        $track->method('getCarrierCode')->willReturn('United States Postal Service');
-        $track->method('getOrigData')->willReturn(
-            [
-                'track_number' => 'EZ4000000004',
-                'carrier_code' => 'United States Postal Service',
-            ]
-        );
+        $track->expects($this->once())
+            ->method('getTrackNumber')
+            ->willReturn('EZ4000000004');
+        $track->expects($this->once())
+            ->method('getCarrierCode')
+            ->willReturn('United States Postal Service');
+        $track->expects($this->once())
+            ->method('getOrigData')
+            ->willReturn(
+                [
+                    'track_number' => 'EZ4000000004',
+                    'carrier_code' => 'United States Postal Service',
+                ]
+            );
+        $this->configHelper->expects($this->once())
+            ->method('getStoreVersion')
+            ->willReturn('2.4.2');
+
         $eventObserver = $this->getMockBuilder(\Magento\Framework\Event\Observer::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -642,8 +670,15 @@ class TrackingSaveObserverTest extends BoltTestCase
             ->method('getTrack')
             ->willReturn($track);
 
-        $this->decider->expects($this->once())->method('isTrackShipmentEnabled')->willReturn(true);
+        $this->metricsClient->expects($this->once())->method('getCurrentTime')->willReturn(2000000000);
+        $this->metricsClient->expects($this->once())->method('processMetric')->with(
+            'tracking_creation.success',
+            1,
+            'tracking_creation.latency',
+            2000000000
+        );
         $this->apiHelper->expects($this->never())->method('sendRequest');
+        $this->decider->expects($this->once())->method('isTrackShipmentEnabled')->willReturn(true);
         $this->observer->execute($eventObserver);
     }
 
@@ -652,7 +687,6 @@ class TrackingSaveObserverTest extends BoltTestCase
      */
     public function testExecute_throwException()
     {
-        $this->decider->expects($this->once())->method('isTrackShipmentEnabled')->willReturn(true);
         $eventObserver = $this->getMockBuilder(\Magento\Framework\Event\Observer::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -663,12 +697,14 @@ class TrackingSaveObserverTest extends BoltTestCase
         $eventObserver->expects($this->once())
             ->method('getEvent')
             ->willReturn($event);
-        $e = new \Exception(__('Exception'));
+        $e = new Exception(__('Exception'));
         $event->expects($this->once())
             ->method('getTrack')
             ->willThrowException($e);
 
+        $this->apiHelper->expects($this->never())->method('sendRequest');
         $this->bugsnag->expects(self::once())->method('notifyException')->with($e)->willReturnSelf();
+        $this->decider->expects($this->once())->method('isTrackShipmentEnabled')->willReturn(true);
         $this->observer->execute($eventObserver);
     }
 
@@ -711,6 +747,9 @@ class TrackingSaveObserverTest extends BoltTestCase
             ->method('getCarrierCode')
             ->willReturn((object) ['0' => 'United States Postal Service']);
         $track->method('getId')->willReturn(self::ENTITY_ID);
+        $this->configHelper->expects($this->once())
+            ->method('getStoreVersion')
+            ->willReturn('2.2.0');
 
         $eventObserver = $this->getMockBuilder(\Magento\Framework\Event\Observer::class)
             ->disableOriginalConstructor()
@@ -743,7 +782,6 @@ class TrackingSaveObserverTest extends BoltTestCase
                     'value' => 'XS',
                 ]]
             ]);
-
         $shipmentItem2->expects($this->once())
             ->method('getOrderItem')
             ->willReturn($orderItem2);
@@ -752,7 +790,6 @@ class TrackingSaveObserverTest extends BoltTestCase
         $orderItem2->expects($this->once())
             ->method('getParentItem')
             ->willReturn($orderItem1);
-
         $shipment->expects($this->once())
             ->method('getItemsCollection')
             ->willReturn([$shipmentItem1, $shipmentItem2]);
@@ -773,7 +810,6 @@ class TrackingSaveObserverTest extends BoltTestCase
             'is_non_bolt_order'  => false,
             'tracking_entity_id' => self::ENTITY_ID,
         ];
-
         $this->dataObject->expects($this->once())
             ->method('setApiData')
             ->with($expectedData);
@@ -819,6 +855,9 @@ class TrackingSaveObserverTest extends BoltTestCase
         $track->expects($this->exactly(2))
             ->method('getTrackNumber')
             ->willReturn((object) []);
+        $this->configHelper->expects($this->once())
+            ->method('getStoreVersion')
+            ->willReturn('2.2.0');
 
         $eventObserver = $this->getMockBuilder(\Magento\Framework\Event\Observer::class)
             ->disableOriginalConstructor()
@@ -851,7 +890,6 @@ class TrackingSaveObserverTest extends BoltTestCase
                     'value' => 'XS',
                 ]]
             ]);
-
         $shipmentItem2->expects($this->once())
             ->method('getOrderItem')
             ->willReturn($orderItem2);
@@ -860,7 +898,6 @@ class TrackingSaveObserverTest extends BoltTestCase
         $orderItem2->expects($this->once())
             ->method('getParentItem')
             ->willReturn($orderItem1);
-
         $shipment->expects($this->once())
             ->method('getItemsCollection')
             ->willReturn([$shipmentItem1, $shipmentItem2]);


### PR DESCRIPTION
We use some trick to know if the track just created or not.

If the track isn't just created we do not send it to the server, because it means we already sent it before.
But this trick works for Magento >=2.3.1 only
Before this comment, https://github.com/magento/magento2/commit/2307e16105e031c0826d218cf81ffe7949191a0b Magento in `Sales/Model/ResourceModel/Order/Shipment/Relation::processRelation` uses trackcollection to go over tracks when it saves shipment.
Trackcollection updates all tracks when it getIterator, so we have no way to know if the object from observer is new or not.
In this case, we can just send the track to bolt, it's not a very big deal, actually bolt server does nothing when it receives a duplicate track.

Fixes: [ON-425](https://boltpay.atlassian.net/browse/ON-425)

#changelog Do not check if track new for magento <2.3.1

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
