### PR TITLE
Use integration test instead of unit test for all methods in class  Mode/Api/CreateOrderTest

### DIFF
--- a/Test/Unit/TestUtils.php
+++ b/Test/Unit/TestUtils.php
@@ -204,14 +204,33 @@ class TestUtils {
 
         if ($productCollection->getSize() > 0) {
             /** @var \Magento\Catalog\Model\ResourceModel\Product\Collection $product */
-            $product =  $productCollection->getFirstItem();
-
-            if ($product->getTypeId() === ProductType::TYPE_SIMPLE) {
-                return Bootstrap::getObjectManager()->create(Product::class)->load($product->getId());
+            foreach ($productCollection as $product) {
+                if ($product->getTypeId() === ProductType::TYPE_SIMPLE) {
+                    return Bootstrap::getObjectManager()->create(Product::class)->load($product->getId());
+                }
             }
         }
 
         return self::createSimpleProduct();
+    }
+
+    /**
+     * @return mixed
+     */
+    public static function getVirtualProduct() {
+        $objectManager = Bootstrap::getObjectManager();
+        $productCollection = $objectManager->create(\Magento\Catalog\Model\ResourceModel\Product\Collection::class);
+
+        if ($productCollection->getSize() > 0) {
+            /** @var \Magento\Catalog\Model\ResourceModel\Product\Collection $product */
+            foreach ($productCollection as $product) {
+                if ($product->getTypeId() === ProductType::TYPE_VIRTUAL) {
+                    return Bootstrap::getObjectManager()->create(Product::class)->load($product->getId());
+                }
+            }
+        }
+
+        return self::createVirtualProduct();
     }
 
     /**


### PR DESCRIPTION
# Description
Use integration test instead of unit test for all methods in class  Mode/Api/CreateOrderTest

Fixes: (link Jira ticket)

#changelog Use integration test instead of unit test for all methods in class  Mode/Api/CreateOrderTest

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
