### PR TITLE
M2P-489 - Persistent cart support

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -84,7 +84,7 @@ class Cart extends AbstractHelper
     const BOLT_CHECKOUT_TYPE_PPC = 2;
     const BOLT_CHECKOUT_TYPE_BACKOFFICE = 3;
     const BOLT_CHECKOUT_TYPE_PPC_COMPLETE = 4;
-    
+
     const MAGENTO_SKU_DELIMITER = '-';
 
     /** @var CacheInterface */
@@ -669,6 +669,7 @@ class Cart extends AbstractHelper
         }
 
         $cacheIdentifier .= $immutableQuote->getCustomerGroupId();
+        $cacheIdentifier .= $immutableQuote->getCustomerId();
 
         return $cacheIdentifier;
     }
@@ -1123,17 +1124,17 @@ class Cart extends AbstractHelper
 
             $child->setData($key, $value);
         }
-        
+
         // Reset the calculated items of address, so address->getAllItems() can return up-to-date data.
         if ($child instanceof \Magento\Customer\Model\Address\AbstractAddress) {
             $child->unsetData("cached_items_all");
         }
-        
+
         // Update the property Quote::KEY_ITEMS with proper items.
         if ($child instanceof \Magento\Quote\Model\Quote) {
             $child->setItems($child->getAllVisibleItems());
         }
-        
+
         if ($save) {
             $child->save();
         }
@@ -1374,7 +1375,7 @@ class Cart extends AbstractHelper
 
                 if ($this->deciderHelper->isCustomizableOptionsSupport()) {
                     try {
-                        $customizableOptions = $this->getProductCustomizableOptions($_product);                        
+                        $customizableOptions = $this->getProductCustomizableOptions($_product);
                         if ($customizableOptions) {
                             $itemSku = $this->getProductActualSkuByCustomizableOptions($itemSku, $customizableOptions);
                         }
@@ -1391,13 +1392,13 @@ class Cart extends AbstractHelper
                         $customizableOptions = null;
                     }
                 }
-                
+
                 try {
                     if ($customizableOptions || $item->getProductType() == \Magento\ConfigurableProduct\Model\Product\Type\Configurable::TYPE_CODE) {
                         $_product = $this->productRepository->get($itemSku);
                         $itemReference = $_product->getId();
                         $itemName = $_product->getName();
-                    }    
+                    }
                 } catch (\Exception $e) {
                     $this->bugsnag->registerCallback(function ($report) use ($item) {
                         $report->setMetaData([
@@ -1448,7 +1449,7 @@ class Cart extends AbstractHelper
                         }
                     }
                 }
-                
+
                 //By default this feature switch is enabled.
                 if ($this->deciderHelper->isCustomizableOptionsSupport() && !empty($customizableOptions)) {
                     foreach ($customizableOptions as $customizableOption) {
@@ -1458,7 +1459,7 @@ class Cart extends AbstractHelper
                         ];
                     }
                 }
-                
+
                 foreach ($this->getAdditionalAttributes($item->getSku(),$storeId, $additionalAttributes) as $attribute ) {
                     $properties[] = $attribute;
                 }
@@ -1529,12 +1530,12 @@ class Cart extends AbstractHelper
 
         return [$products, $totalAmount, $diff];
     }
-    
+
     /**
      * Return the selected customizable options of quote item.
-     * 
+     *
      * @param $product
-     * 
+     *
      * @return array
      */
     public function getProductCustomizableOptions($product)
@@ -1543,7 +1544,7 @@ class Cart extends AbstractHelper
         if (!$optionIds) {
             return [];
         }
-        
+
         $customizableOptions = [];
         foreach (explode(',', $optionIds->getValue()) as $optionId) {
             $option = $product->getOptionById($optionId);
@@ -1555,7 +1556,7 @@ class Cart extends AbstractHelper
                     ->setListener(new \Magento\Framework\DataObject());
 
                 $optionSku = $group->getOptionSku($confItemOption->getValue(), self::MAGENTO_SKU_DELIMITER);
-                
+
                 $customizableOptions[] = [
                     'title' => $option->getTitle(),
                     'value' => $group->getFormattedOptionValue($confItemOption->getValue()),
@@ -1563,17 +1564,17 @@ class Cart extends AbstractHelper
                 ];
             }
         }
-        
+
         return $customizableOptions;
     }
-    
+
     /**
      * If the product has customizable options, the sku of selected option would be appended to product sku for quote item,
      * this function is to remove the sku of options and return actual sku of product.
-     * 
+     *
      * @param string $sku
      * @param array $customizableOptions
-     * 
+     *
      * @return string
      */
     public function getProductActualSkuByCustomizableOptions($sku, $customizableOptions)
@@ -2642,7 +2643,7 @@ class Cart extends AbstractHelper
             return false;
         }
     }
-    
+
     /**
      * Collect address total.
      *

--- a/Test/Unit/BoltTestCase.php
+++ b/Test/Unit/BoltTestCase.php
@@ -46,17 +46,6 @@ if (PHPUnitVersion::id() < 9) {
         public static function assertStringContainsString(string $needle, string $haystack, string $message = '')
         {
             $constraint = new StringContains($needle, false);
-
-            static::assertThat($haystack, $constraint, $message);
-        }
-
-        /**
-         * @throws \PHPUnit\Framework\ExpectationFailedException
-         * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
-         */
-        public static function assertStringContainsString(string $needle, string $haystack, string $message = '')
-        {
-            $constraint = new StringContains($needle, false);
             static::assertThat($haystack, $constraint, $message);
         }
     }

--- a/Test/Unit/BoltTestCase.php
+++ b/Test/Unit/BoltTestCase.php
@@ -9,6 +9,7 @@ use PHPUnit\Runner\Version as PHPUnitVersion;
 use ReflectionException;
 use ReflectionObject;
 use ReflectionProperty;
+use PHPUnit\Framework\Constraint\StringContains;
 
 if (PHPUnitVersion::id() < 9) {
     class BoltTestCase extends TestCase
@@ -35,6 +36,18 @@ if (PHPUnitVersion::id() < 9) {
         public static function assertMatchesRegularExpression(string $pattern, string $string, string $message = '')
         {
             static::assertRegExp($pattern, $string, $message);
+
+        }
+
+        /**
+         * @throws \PHPUnit\Framework\ExpectationFailedException
+         * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+         */
+        public static function assertStringContainsString(string $needle, string $haystack, string $message = '')
+        {
+            $constraint = new StringContains($needle, false);
+
+            static::assertThat($haystack, $constraint, $message);
         }
 
         /**

--- a/Test/Unit/BoltTestCase.php
+++ b/Test/Unit/BoltTestCase.php
@@ -9,7 +9,6 @@ use PHPUnit\Runner\Version as PHPUnitVersion;
 use ReflectionException;
 use ReflectionObject;
 use ReflectionProperty;
-use PHPUnit\Framework\Constraint\StringContains;
 
 if (PHPUnitVersion::id() < 9) {
     class BoltTestCase extends TestCase

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -357,6 +357,7 @@ class CartTest extends BoltTestCase
             'isVirtual',
             'assignCustomer',
             'getCustomerGroupId',
+            'getCustomerId',
             'setIsActive',
             'getData',
             'getStore',
@@ -832,7 +833,7 @@ class CartTest extends BoltTestCase
      */
     public function getQuoteById_withQuoteIdNotCached_loadsQuoteById()
     {
-        
+
         $quote = TestUtils::createQuote();
         $quoteId = $quote->getId();
         $boltHelperCart = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
@@ -849,7 +850,7 @@ class CartTest extends BoltTestCase
      */
     public function getQuoteById_withQuoteIdNotCachedAndNotLoaded_returnsFalse()
     {
-        
+
         $boltHelperCart = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
         static::assertFalse($boltHelperCart->getQuoteById(self::IMMUTABLE_QUOTE_ID));
     }
@@ -864,7 +865,7 @@ class CartTest extends BoltTestCase
      */
     public function getQuoteById_withQuoteIdCached_returnsFromPropertyCache()
     {
-        
+
         $boltHelperCart = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
         $quote = TestUtils::createQuote();
         $quoteId = $quote->getId();
@@ -887,7 +888,7 @@ class CartTest extends BoltTestCase
      */
     public function getActiveQuoteById_always_getsActiveQuoteFromRepository()
     {
-        
+
         $boltHelperCart = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
         $quote = TestUtils::createQuote(['is_active' => true]);
         $quoteId = $quote->getId();
@@ -905,7 +906,7 @@ class CartTest extends BoltTestCase
      */
     public function getOrderByIncrementId_whenOrderCachedAndForceLoadTrue_loadsOrderByIncrementId()
     {
-        
+
         $order = TestUtils::createDumpyOrder();
         $boltHelperCart = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
         TestHelper::setProperty(
@@ -925,7 +926,7 @@ class CartTest extends BoltTestCase
      */
     public function saveQuote_always_savesQuoteUsingQuoteRepository()
     {
-        
+
         $quote = TestUtils::createQuote();
         $quote->setCustomerEmail('johnmc+testing@bolt.com');
         $boltHelperCart = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
@@ -945,7 +946,7 @@ class CartTest extends BoltTestCase
      */
     public function deleteQuote_always_deletesQuoteUsingQuoteRepository()
     {
-        
+
         $quote = TestUtils::createQuote();
         $quoteId = $quote->getId();
         $boltHelperCart = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
@@ -965,7 +966,7 @@ class CartTest extends BoltTestCase
      */
     public function quoteResourceSave_always_savesQuoteUsingResource()
     {
-        
+
         $quote = TestUtils::createQuote();
         $quote->setCustomerEmail('johnmc+testing@bolt.com');
         $quote->save();
@@ -988,7 +989,7 @@ class CartTest extends BoltTestCase
      */
     public function isBoltOrderCachingEnabled_always_returnsValueFromConfigHelper()
     {
-        
+
         $isBoltOrderCachingEnabled = true;
         $configWriter = Bootstrap::getObjectManager()->create(\Magento\Framework\App\Config\Storage\WriterInterface::class);
         $configWriter->save(ConfigHelper::XML_PATH_BOLT_ORDER_CACHING,
@@ -1014,7 +1015,7 @@ class CartTest extends BoltTestCase
      */
     public function loadFromCache_whenIdentifierNotFoundInCache_returnsFalse()
     {
-        
+
         $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
         $cache = Bootstrap::getObjectManager()->create(CacheInterface::class);
         $cachedValue = false;
@@ -1033,7 +1034,7 @@ class CartTest extends BoltTestCase
      */
     public function loadFromCache_whenIdentifierIsFoundInCacheAndUnserializeFalse_returnsValue()
     {
-        
+
         $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
         $cache = Bootstrap::getObjectManager()->create(CacheInterface::class);
         $cachedValue = 'Test cache value';
@@ -1060,7 +1061,7 @@ class CartTest extends BoltTestCase
      */
     public function loadFromCache_whenIdentifierIsFoundInCacheAndUnserializeTrue_returnsUnserializedValue()
     {
-        
+
         $cachedValue = $this->getTestCartData();
         $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
         $cache = Bootstrap::getObjectManager()->create(CacheInterface::class);
@@ -1130,7 +1131,7 @@ class CartTest extends BoltTestCase
      */
     public function setLastImmutableQuote_always_setsLastImmutableQuoteProperty()
     {
-        
+
         $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
         $quote = TestUtils::createQuote();
         TestHelper::invokeMethod(
@@ -1155,7 +1156,7 @@ class CartTest extends BoltTestCase
      */
     public function getLastImmutableQuote_always_returnsLastImmutableQuoteProperty()
     {
-        
+
         $quote = TestUtils::createQuote();
         $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
         TestHelper::setProperty(
@@ -1193,7 +1194,7 @@ class CartTest extends BoltTestCase
      */
     public function getSessionQuoteStoreId_withSessionQuote_returnsSessionQuoteStoreId()
     {
-        
+
         $cartSession = Bootstrap::getObjectManager()->create(CheckoutSession::class);
         $quote = TestUtils::createQuote(['store_id'=>self::STORE_ID]);
         $cartSession->setQuote($quote);
@@ -1210,7 +1211,7 @@ class CartTest extends BoltTestCase
      */
     public function getSessionQuoteStoreId_withoutSessionQuote_returnsNull()
     {
-        
+
         $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
         static::assertEquals(null, $cartHelper->getSessionQuoteStoreId());
     }
@@ -1257,7 +1258,7 @@ class CartTest extends BoltTestCase
      */
     public function getCartCacheIdentifier_always_returnsCartCacheIdentifier()
     {
-        
+
         $testCartData = $this->getTestCartData();
         $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
         $result = TestHelper::invokeMethod($cartHelper, 'getCartCacheIdentifier', [$testCartData]);
@@ -1273,11 +1274,13 @@ class CartTest extends BoltTestCase
      */
     public function getCartCacheIdentifier_withGiftMessageID_returnsCartCacheIdentifier()
     {
-        
+
         $testCartData = $this->getTestCartData();
         $quote = TestUtils::createQuote([
             'gift_message_id'=> self::GIFT_MESSAGE_ID,
-            'customer_group_id' => self::CUSTOMER_GROUP_ID
+            'customer_group_id' => self::CUSTOMER_GROUP_ID,
+            'customer_id' => self::CUSTOMER_ID,
+
         ]);
 
         $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
@@ -1286,7 +1289,10 @@ class CartTest extends BoltTestCase
         $result = TestHelper::invokeMethod($cartHelper, 'getCartCacheIdentifier', [$testCartData]);
         unset($testCartData['display_id']);
         static::assertEquals(
-            hash('md5',json_encode($testCartData).self::GIFT_MESSAGE_ID.self::CUSTOMER_GROUP_ID),
+            hash(
+                'md5',
+                json_encode($testCartData).self::GIFT_MESSAGE_ID.self::CUSTOMER_GROUP_ID.self::CUSTOMER_ID
+            ),
             $result
         );
     }
@@ -1299,11 +1305,12 @@ class CartTest extends BoltTestCase
      */
     public function getCartCacheIdentifier_withGiftWrappingId_returnsCartCacheIdentifier()
     {
-        
+
         $testCartData = $this->getTestCartData();
         $quote = TestUtils::createQuote([
             'gw_id'=> self::GIFT_WRAPPING_ID,
-            'customer_group_id' => self::CUSTOMER_GROUP_ID
+            'customer_group_id' => self::CUSTOMER_GROUP_ID,
+            'customer_id' => self::CUSTOMER_ID,
         ]);
 
         $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
@@ -1312,7 +1319,10 @@ class CartTest extends BoltTestCase
         $result = TestHelper::invokeMethod($cartHelper, 'getCartCacheIdentifier', [$testCartData]);
         unset($testCartData['display_id']);
         static::assertEquals(
-            hash('md5',json_encode($testCartData).self::GIFT_WRAPPING_ID.self::CUSTOMER_GROUP_ID),
+            hash(
+                'md5',
+                json_encode($testCartData).self::GIFT_WRAPPING_ID.self::CUSTOMER_GROUP_ID.self::CUSTOMER_ID
+            ),
             $result
         );
     }
@@ -1414,7 +1424,7 @@ class CartTest extends BoltTestCase
      */
     public function getImmutableQuoteIdFromBoltOrder_always_returnsImmutableQuote()
     {
-        
+
         $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
         $boltOrder = (object)[
             'cart' => (object)[
@@ -1443,7 +1453,7 @@ class CartTest extends BoltTestCase
      */
     public function isQuoteAvailable_always_determinesIfQuoteIsAvailable()
     {
-        
+
         $quote = TestUtils::createQuote();
         $quoteId = $quote->getId();
         $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
@@ -1460,7 +1470,7 @@ class CartTest extends BoltTestCase
      */
     public function updateQuoteTimestamp_always_updatesQuoteTimestamp()
     {
-        
+
         $quote = TestUtils::createQuote();
         $quoteId = $quote->getId();
         $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
@@ -1624,7 +1634,7 @@ class CartTest extends BoltTestCase
         $currentMock = $this->getCurrentMock(['validateEmail']);
 
         $pitem = $this->getQuoteItemMock();
-        
+
         $this->quoteMock->expects(static::once())->method('getData')->willReturn(
             [
                 'entity_id'          => self::PARENT_QUOTE_ID,
@@ -1904,7 +1914,7 @@ class CartTest extends BoltTestCase
      */
     public function isAddressComplete_withVariousAddresses_determinesIfAddressIsComplete($address, $expectedResult)
     {
-        
+
         $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
         static::assertEquals(
             $expectedResult,
@@ -1978,7 +1988,7 @@ class CartTest extends BoltTestCase
         $sessionObject,
         $expectedResult
     ) {
-        
+
         $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
         TestHelper::setProperty($cartHelper, 'checkoutSession', $sessionObject);
         static::assertEquals($expectedResult, TestHelper::invokeMethod($cartHelper, 'isBackendSession'));
@@ -1991,7 +2001,7 @@ class CartTest extends BoltTestCase
      */
     public function isBackendSession_withVariousSessionObjectsProvider()
     {
-        
+
         return [
             'Backend session' => [
                 'sessionObject'  => Bootstrap::getObjectManager()->create(\Magento\Backend\Model\Session\Quote::class),
@@ -2042,7 +2052,7 @@ class CartTest extends BoltTestCase
             'another_random_empty_field' => [],
         ];
 
-        
+
         $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
 
         $quote = Bootstrap::getObjectManager()->create(Quote::class);
@@ -2102,7 +2112,7 @@ class CartTest extends BoltTestCase
             'another_random_empty_field' => [],
         ];
 
-        
+
         $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
 
         $quote = Bootstrap::getObjectManager()->create(Quote::class);
@@ -2148,7 +2158,7 @@ class CartTest extends BoltTestCase
      */
     public function validateEmail_withVarousEmailAddresses_determinesIfEmailIsValid($email, $expectedResult)
     {
-        
+
         $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
         static::assertEquals($expectedResult, $cartHelper->validateEmail($email));
     }
@@ -2179,7 +2189,7 @@ class CartTest extends BoltTestCase
      */
     public function getWebsiteId_always_returnsWebsiteIdFromSessionQuote()
     {
-        
+
         $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
         $checkoutSession = Bootstrap::getObjectManager()->create(CheckoutSession::class);
         $store = Bootstrap::getObjectManager()->create(Store::class)->setWebsiteId(self::WEBSITE_ID);
@@ -2198,7 +2208,7 @@ class CartTest extends BoltTestCase
      */
     public function handleSpecialAddressCases_withPuertoRicoAddress_handlessPuertoRicoAddressSpecialCase()
     {
-        
+
         $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
         $addressData = ['country_code' => 'PR'];
         $result = $cartHelper->handleSpecialAddressCases($addressData);
@@ -2218,7 +2228,7 @@ class CartTest extends BoltTestCase
      */
     public function hasProductRestrictions_withToggleCheckoutEmpty_returnsFalse()
     {
-        
+
         $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
         $quote = TestUtils::createQuote();
         static::assertFalse($cartHelper->hasProductRestrictions($quote));
@@ -2234,7 +2244,7 @@ class CartTest extends BoltTestCase
      */
     public function hasProductRestrictions_withNoProductAndItemRestrictionMethods_returnsFalse()
     {
-        
+
         $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
         $quote = TestUtils::createQuote();
         $configWriter = Bootstrap::getObjectManager()->create(\Magento\Framework\App\Config\Storage\WriterInterface::class);
@@ -2256,7 +2266,7 @@ class CartTest extends BoltTestCase
      */
     public function hasProductRestrictions_withNoQuoteItems_returnsFalse()
     {
-        
+
         $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
         $quote = TestUtils::createQuote();
         $configWriter = Bootstrap::getObjectManager()->create(\Magento\Framework\App\Config\Storage\WriterInterface::class);
@@ -2502,7 +2512,7 @@ ORDER
         */
         public function deactivateSessionQuote_ifQuoteIsActive_deactivatesQuote()
         {
-            
+
             $quote = TestUtils::createQuote(['is_active'=> true]);
             $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
             $cartHelper->deactivateSessionQuote($quote);
@@ -2518,7 +2528,7 @@ ORDER
         */
         public function doesOrderExist_withExistingOrder_basedOnGetOrderByIncrementId_returnsOrder()
         {
-            
+
             $order = TestUtils::createDumpyOrder();
             $boltHelperCart = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
             static::assertEquals($order->getId(), $boltHelperCart->doesOrderExist(
@@ -2537,7 +2547,7 @@ ORDER
         */
         public function doesOrderExist_withExistingOrder_basedOnGetOrderByQuoteId_returnsOrder()
         {
-            
+
             $quote = TestUtils::createQuote();
             $order = TestUtils::createDumpyOrder(['quote_id' => $quote->getId()]);
             $boltHelperCart = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
@@ -2558,7 +2568,7 @@ ORDER
         */
         public function doesOrderExist_getOrderByIncrementIdReturnsFalse_getOrderByQuoteIdReturnsFalse_returnsFalse()
         {
-        
+
         $boltHelperCart = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
         static::assertFalse(
             $boltHelperCart->doesOrderExist(
@@ -2573,7 +2583,7 @@ ORDER
         */
         public function getOrderByQuoteId()
         {
-            
+
             $order = TestUtils::createDumpyOrder(['quote_id' => self::QUOTE_ID]);
             $boltHelperCart = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
             static::assertEquals($order->getId(), $boltHelperCart->getOrderByQuoteId(self::QUOTE_ID)->getId());
@@ -2585,7 +2595,7 @@ ORDER
          */
         public function getOrderById()
         {
-            
+
             $order = TestUtils::createDumpyOrder();
             $orderId = $order->getId();
             $boltHelperCart = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
@@ -2731,7 +2741,7 @@ ORDER
             $addSessionIdToMetadataValue,
             $metadataSessionIdAssertMethod
         ) {
-            
+
             $boltHelperCart = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
             $quote = TestUtils::createQuote();
             $product = TestUtils::getSimpleProduct();
@@ -2807,7 +2817,7 @@ ORDER
         */
         public function getCartData_withParentQuoteEmptyAndNoImmutableQuote_returnsEmptyArray()
         {
-            
+
             TestUtils::setQuoteToSession(null);
             $boltHelperCart = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
             static::assertEquals([], $boltHelperCart->getCartData(false, '', null));
@@ -2823,7 +2833,7 @@ ORDER
         */
         public function getCartData_withEmptyImmutableQuote_returnsEmptyArray()
         {
-            
+
             $boltHelperCart = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
             $quote = Bootstrap::getObjectManager()->create(Quote::class);
             TestUtils::setQuoteToSession($quote);
@@ -2844,7 +2854,7 @@ ORDER
             $addSessionIdToMetadataValue,
             $metadataSessionIdAssertMethod
         ) {
-        
+
         $boltHelperCart = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
         $quote = Bootstrap::getObjectManager()->create(Quote::class);
         $quote->setQuoteCurrencyCode("USD");
@@ -2958,7 +2968,7 @@ ORDER
         */
         public function getCartData_withVirtualQuoteAndInsufficientBillingAddressData_notifiesErrorAndReturnsEmptyArray()
         {
-            
+
             $boltHelperCart = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
             $quote = Bootstrap::getObjectManager()->create(Quote::class);
             $quote->setQuoteCurrencyCode("USD");
@@ -3000,7 +3010,7 @@ ORDER
             $addSessionIdToMetadataValue,
             $metadataSessionIdAssertMethod
         ) {
-        
+
         $boltHelperCart = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
         $quote = Bootstrap::getObjectManager()->create(Quote::class);
         $quote->setQuoteCurrencyCode("USD");
@@ -3644,7 +3654,7 @@ ORDER
         */
         public function getCartData_paymentOnlyAndShippingMethodMissing_notifiesErrorAndReturnsEmptyArray()
         {
-            
+
             $boltHelperCart = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
             $quote = Bootstrap::getObjectManager()->create(Quote::class);
             $quote->setQuoteCurrencyCode("USD");
@@ -3830,7 +3840,7 @@ ORDER
         */
         public function collectDiscounts_withNoDiscounts_returnsParametersUnchanged()
         {
-        
+
         $boltHelperCart = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
         $quote = Bootstrap::getObjectManager()->create(Quote::class);
         $quote->setBoltParentQuoteId(999999);
@@ -3990,7 +4000,7 @@ ORDER
         */
         public function collectDiscounts_withStoreCreditAndPaymentOnly_collectsDiscountFromQuote()
         {
-        
+
         $boltHelperCart = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
         $quote = Bootstrap::getObjectManager()->create(Quote::class);
         $appliedDiscount = 10; // $
@@ -4191,7 +4201,7 @@ ORDER
         $diff = 0;
         $paymentOnly = true;
         $appliedDiscount = 10; // $
-        
+
         $boltHelperCart = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
         $quote = Bootstrap::getObjectManager()->create(Quote::class);
         $appliedDiscount = 10; // $
@@ -4451,7 +4461,7 @@ ORDER
 
         $this->imageHelper->method('init')->willReturnSelf();
         $this->imageHelper->method('getUrl')->willReturn('no-image');
-        
+
         $this->deciderHelper->expects(self::exactly(2))->method('isCustomizableOptionsSupport')->willReturn(true);
 
         list($products, $totalAmount, $diff) = $this->currentMock->getCartItems(
@@ -4521,7 +4531,7 @@ ORDER
         $this->configHelper->method('getProductAttributesList')->willReturn([$attributeName]);
 
         $this->productRepository->method('get')->with(self::PRODUCT_SKU)->willReturn($this->productMock);
-        
+
         $this->deciderHelper->expects(self::exactly(2))->method('isCustomizableOptionsSupport')->willReturn(true);
 
         list($products, $totalAmount, $diff) = $this->currentMock->getCartItems(
@@ -4575,7 +4585,7 @@ ORDER
         $quoteItem->method('getProductId')->willReturn(self::PRODUCT_ID);
         $quoteItem->method('getProduct')->willReturn($productMock);
         $productMock->expects(static::once())->method('getTypeInstance')->willReturnSelf();
-        
+
         $this->deciderHelper->expects(self::exactly(2))->method('isCustomizableOptionsSupport')->willReturn(true);
 
         $this->imageHelper->method('init')
@@ -6314,7 +6324,7 @@ ORDER
         */
         public function assignQuoteCustomerByEncryptedUserId_withInvalidEncryptedUserId_throwsException($encryptedUserId)
         {
-            
+
             $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
             $quote = TestUtils::createQuote();
             $this->expectExceptionMessage("Incorrect encrypted_user_id");
@@ -6357,7 +6367,7 @@ ORDER
         */
         public function assignQuoteCustomerByEncryptedUserId_withInvalidSignature_throwsException()
         {
-            
+
             $cartHelper = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
             $quote = TestUtils::createQuote();
             $this->expectExceptionMessage("Incorrect signature");
@@ -6753,5 +6763,23 @@ ORDER
             [$this->immutableQuoteMock]
         );
         static::assertStringContainsString((string)$groupId, $result);
+    }
+
+    /**
+     * @test
+     * that convertExternalFieldsToCacheIdentifier returns cache identifier affected by the customer id
+     *
+     * @covers ::convertExternalFieldsToCacheIdentifier
+     */
+    public function convertExternalFieldsToCacheIdentifier_always_appendsCustomerIdToCacheIdentifier()
+    {
+        $customerId = mt_rand();
+        $this->immutableQuoteMock->expects(static::once())->method('getCustomerId')->willReturn($customerId);
+        $result = TestHelper::invokeMethod(
+            $this->currentMock,
+            'convertExternalFieldsToCacheIdentifier',
+            [$this->immutableQuoteMock]
+        );
+        static::assertStringContainsString((string)$customerId, $result);
     }
 }

--- a/etc/frontend/sections.xml
+++ b/etc/frontend/sections.xml
@@ -49,5 +49,14 @@
     <action name="rest/*/V1/carts/mine/gift-message">
         <section name="boltcart"/>
     </action>
+    <action name="customer/account/logout">
+        <section name="boltcart"/>
+    </action>
+    <action name="customer/account/loginPost">
+        <section name="boltcart"/>
+    </action>
+    <action name="customer/account/createPost">
+        <section name="boltcart"/>
+    </action>
 
 </config>

--- a/etc/frontend/sections.xml
+++ b/etc/frontend/sections.xml
@@ -58,5 +58,8 @@
     <action name="customer/account/createPost">
         <section name="boltcart"/>
     </action>
+    <action name="customer/ajax/login">
+        <section name="boltcart"/>
+    </action>
 
 </config>


### PR DESCRIPTION
# Description
If the cart persistence is allowed there are some edge cases where cart remains active after the customer browser session ends and if another customer logs in afterwards from the same browser it can “inherit” previous customer’s cart.

More context here https://docs.magento.com/user-guide/sales/cart-persistent-workflow.html

My suspicion is that something like this happened with RTA store. We patched it up but were not sure about the root cause.

The solution to address the above case is to add customer id to our cart cache identifier and to invalidate cart sections on customer log in. 

Fixes: https://boltpay.atlassian.net/browse/M2P-489

#changelog M2P-489 - Persistent cart support

# Type of change

- [x] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
