### PR TITLE
Fixes joint shipping and tax by adding json serialization

### DIFF
--- a/Model/Api/Data/ShippingOptions.php
+++ b/Model/Api/Data/ShippingOptions.php
@@ -26,7 +26,7 @@ use Bolt\Boltpay\Api\Data\ShippingTaxInterface;
  *
  * @package Bolt\Boltpay\Model\Api\Data
  */
-class ShippingOptions implements ShippingOptionsInterface
+class ShippingOptions implements ShippingOptionsInterface, \JsonSerializable
 {
     /**
      * @var array
@@ -39,9 +39,15 @@ class ShippingOptions implements ShippingOptionsInterface
     private $taxResult;
 
     /**
+     * @var string
+     */
+    private $currency;
+
+    /**
      * Get all available shipping options.
      *
      * @api
+     * 
      * @return ShippingOptionInterface[]
      */
     public function getShippingOptions()
@@ -54,6 +60,7 @@ class ShippingOptions implements ShippingOptionsInterface
      *
      * @api
      * @param ShippingOptionInterface[]
+     * 
      * @return $this
      */
     public function setShippingOptions($shippingOptions)
@@ -66,6 +73,7 @@ class ShippingOptions implements ShippingOptionsInterface
      * Get order tax result.
      *
      * @api
+     * 
      * @return ShippingTaxInterface
      */
     public function getTaxResult()
@@ -102,5 +110,16 @@ class ShippingOptions implements ShippingOptionsInterface
         }
 
         return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'shipping_options' => $this->shippingOptions,
+            'tax_result' => $this->taxResult,
+        ];
     }
 }

--- a/Model/Api/Data/ShippingOptions.php
+++ b/Model/Api/Data/ShippingOptions.php
@@ -39,11 +39,6 @@ class ShippingOptions implements ShippingOptionsInterface, \JsonSerializable
     private $taxResult;
 
     /**
-     * @var string
-     */
-    private $currency;
-
-    /**
      * Get all available shipping options.
      *
      * @api

--- a/Model/Api/Data/ShippingTax.php
+++ b/Model/Api/Data/ShippingTax.php
@@ -23,7 +23,7 @@ use Bolt\Boltpay\Api\Data\ShippingTaxInterface;
  * Class ShippingTax. Tax property of the Shipping and Tax.
  * @package Bolt\Boltpay\Model\Api\Data
  */
-class ShippingTax implements ShippingTaxInterface
+class ShippingTax implements ShippingTaxInterface, \JsonSerializable
 {
     /**
      * @var int
@@ -53,5 +53,15 @@ class ShippingTax implements ShippingTaxInterface
     {
         $this->amount = $amount;
         return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function jsonSerialize()
+    {
+        return [
+            "amount" => $this->amount
+        ];
     }
 }


### PR DESCRIPTION
# Description
For the universal api the modal would fail to fetch shipping information when using joint shipping and tax. This was because the universal api formats its response using `json_encode` and the `ShippingOptions` object used by the joint shipping and tax method did not extend `\JsonSerializable`. Same is true of the `ShippingTax` class.

Fixes: no jira ticket

#changelog Fixes joint shipping and tax by adding json serialization

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
