### PR TITLE
M2P-507 Bugfix: Unable to validate coupon code if Universal API is enabled

### DIFF
--- a/ThirdPartyModules/Amasty/GiftCardAccount.php
+++ b/ThirdPartyModules/Amasty/GiftCardAccount.php
@@ -175,6 +175,8 @@ class GiftCardAccount
         
         try {
             return $giftcardAccountRepository->getByCode($couponCode);
+        } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
+            return null;
         } catch (\Exception $e) {
             return $e;
         }


### PR DESCRIPTION
# Description
In the latest version of Amasty Gift Card, if the code does not exist in Amasty Gift Card code pool, it would throw a NoSuchEntityException exception. But when verifying the code in update-cart endpoint, that's normal, cause the code could be a Magento coupon or other type of gift card. 

Solution: Swallow such a NoSuchEntityException exception

Tested with Amasty_GiftCard, Amasty_GiftCardAccount, Aheadworks_Giftcard, Mageplaza_GiftCard

Fixes: https://boltpay.atlassian.net/browse/M2P-507

#changelog Bugfix: Unable to validate coupon code if Universal API is enabled

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
