### PR TITLE
[M2P395] Billing address is invalid if it was created or changed on native checkout page

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -346,9 +346,7 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
          * return string
          */
         var getCheckoutType = function() {
-            return trim(location.pathname, '/') === 'checkout'
-            && (settings.quote_is_virtual || location.hash === '#payment' || location.hash === '#shipping')
-                ? 'payment' : 'checkout';
+            return trim(location.pathname, '/') === 'checkout' ? 'payment' : 'checkout';
         };
 
         /**
@@ -406,9 +404,6 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
             });
         };
 
-        var isPaymentOnlyCheckout = function() {
-            return !(trim(location.pathname, '/') === 'checkout/cart') && trim(location.pathname, '/') === 'checkout'
-        }
         /**
          * Inject connect.js
          * return void
@@ -1196,7 +1191,7 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
             BoltState.codeIsLoaded.resolve();
         }
         /////////////////////////////////////////////////////
-        if (isPaymentOnlyCheckout()) {
+        if (getCheckoutType() === 'payment') {
             /////////////////////////////////////////////////////
             // Call Bolt order creation Magento endpoint on
             // customer billing address change on payment only page,
@@ -1205,7 +1200,7 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
             var billing_address_value;
             onAttributesChange(billing_address_selector, function(element) {
                 var address = element.value;
-                if(address === 'null' || address === '') return;
+                if (address === 'null' || address === '') return;
 
                 if (address !== billing_address_value) {
                     billing_address_value = address;

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -1036,10 +1036,11 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
 
                             hints = deepMergeObjects(hints, data.hints);
                             hints.prefill = prefill;
+
                             //////////////////////////
                             resolve(data.cart);
                             hintBarrier.resolve(hints);
-                            console.log(data.cart);
+
                             // open the checkout if auto-open flag is set
                             // one time only on page load
                             if (BoltState.initiateCheckout && allowAutoOpen) {
@@ -1197,7 +1198,6 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
         }
         /////////////////////////////////////////////////////
         if (isPaymentOnlyCheckout()) {
-            console.log('payment only');
             /////////////////////////////////////////////////////
             // Call Bolt order creation Magento endpoint on
             // customer billing address change on payment only page,

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -995,7 +995,6 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
                 params = params.join('&');
 
                 hintBarrier = boltBarrier();
-                cartBarrier = boltBarrier();
                 BoltState.boltCart = new Promise(function (resolve, reject) {
 
                     createRequest = true;
@@ -1036,8 +1035,8 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
 
                             hints = deepMergeObjects(hints, data.hints);
                             hints.prefill = prefill;
-
                             //////////////////////////
+
                             resolve(data.cart);
                             hintBarrier.resolve(hints);
 

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -1491,7 +1491,7 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
             ], function ($, quote) {
                 var prevAddress;
                 //If billing address has been changed we need to recreate the order token.
-		        quote.billingAddress.subscribe(function(newAddress){
+                quote.billingAddress.subscribe(function(newAddress){
                     if((!newAddress ^ !prevAddress || prevAddress.getKey() !== newAddress.getKey())){
                         prevAddress = newAddress;
                         quote.billingAddress(newAddress);

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -992,7 +992,7 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
                 params = params.join('&');
 
                 hintBarrier = boltBarrier();
-
+                cartBarrier = boltBarrier();
                 BoltState.boltCart = new Promise(function (resolve, reject) {
 
                     createRequest = true;
@@ -1007,24 +1007,28 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
                             if (BoltState.cartRestricted) {
                                 if (popUpOpen) reject(new Error(data.message));
                                 hintBarrier.resolve(hints);
+                                cartBarrier.resolve(cart);
                                 return;
                             }
 
                             if (data.status !== 'success') {
                                 reject(new Error(data.message || 'Network request failed'));
                                 hintBarrier.resolve(hints);
+                                cartBarrier.resolve(cart);
                                 return;
                             }
 
                             if (!data.cart) {
                                 reject(new Error('The cart info is missing.'));
                                 hintBarrier.resolve(hints);
+                                cartBarrier.resolve(cart);
                                 return;
                             }
 
                             if (!data.cart.orderToken) {
                                 reject(new Error('The cart is empty.'));
                                 hintBarrier.resolve(hints);
+                                cartBarrier.resolve(cart);
                                 return;
                             }
 
@@ -1036,8 +1040,8 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
                             //////////////////////////
 
                             resolve(data.cart);
+                            cartBarrier.resolve(data.cart);
                             hintBarrier.resolve(hints);
-
                             // open the checkout if auto-open flag is set
                             // one time only on page load
                             if (BoltState.initiateCheckout && allowAutoOpen) {
@@ -1051,7 +1055,7 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
                         .always(function() {
                             createRequest = false;
                         })
-                        boltCheckoutConfigure(BoltState.boltCart, hintBarrier.promise, callbacks);
+                        boltCheckoutConfigure(cartBarrier.promise, hintBarrier.promise, callbacks);
                 });
         }
 
@@ -1485,6 +1489,15 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
             'jquery',
             'Magento_Checkout/js/model/quote',
             ], function ($, quote) {
+                var prevAddress;
+                //If billing address has been changed we need to recreate the order token.
+		        quote.billingAddress.subscribe(function(newAddress){
+                    if((!newAddress ^ !prevAddress || prevAddress.getKey() !== newAddress.getKey())){
+                        prevAddress = newAddress;
+                        quote.billingAddress(newAddress);
+			            $(document).trigger('bolt:createOrder');
+                    }
+                });
                 // If quote total was changed through a method we didn't create,
                 // we should reload the bolt cart since totals are probably now out of sync.
                 quote.totals.subscribe(function (totals) {

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -406,6 +406,9 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
             });
         };
 
+        var isPaymentOnlyCheckout = function() {
+            return !(trim(location.pathname, '/') === 'checkout/cart') && trim(location.pathname, '/') === 'checkout'
+        }
         /**
          * Inject connect.js
          * return void
@@ -1007,28 +1010,24 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
                             if (BoltState.cartRestricted) {
                                 if (popUpOpen) reject(new Error(data.message));
                                 hintBarrier.resolve(hints);
-                                cartBarrier.resolve(cart);
                                 return;
                             }
 
                             if (data.status !== 'success') {
                                 reject(new Error(data.message || 'Network request failed'));
                                 hintBarrier.resolve(hints);
-                                cartBarrier.resolve(cart);
                                 return;
                             }
 
                             if (!data.cart) {
                                 reject(new Error('The cart info is missing.'));
                                 hintBarrier.resolve(hints);
-                                cartBarrier.resolve(cart);
                                 return;
                             }
 
                             if (!data.cart.orderToken) {
                                 reject(new Error('The cart is empty.'));
                                 hintBarrier.resolve(hints);
-                                cartBarrier.resolve(cart);
                                 return;
                             }
 
@@ -1038,10 +1037,9 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
                             hints = deepMergeObjects(hints, data.hints);
                             hints.prefill = prefill;
                             //////////////////////////
-
                             resolve(data.cart);
-                            cartBarrier.resolve(data.cart);
                             hintBarrier.resolve(hints);
+                            console.log(data.cart);
                             // open the checkout if auto-open flag is set
                             // one time only on page load
                             if (BoltState.initiateCheckout && allowAutoOpen) {
@@ -1055,8 +1053,8 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
                         .always(function() {
                             createRequest = false;
                         })
-                        boltCheckoutConfigure(cartBarrier.promise, hintBarrier.promise, callbacks);
                 });
+                boltCheckoutConfigure(BoltState.boltCart, hintBarrier.promise, callbacks);
         }
 
         var boltCheckoutSetup = function (el, dataChanged) {
@@ -1198,44 +1196,41 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
             BoltState.codeIsLoaded.resolve();
         }
         /////////////////////////////////////////////////////
+        if (isPaymentOnlyCheckout()) {
+            console.log('payment only');
+            /////////////////////////////////////////////////////
+            // Call Bolt order creation Magento endpoint on
+            // customer billing address change on payment only page,
+            // storing the live page data in Bolt cart.
+            /////////////////////////////////////////////////////
+            var billing_address_value;
+            onAttributesChange(billing_address_selector, function(element) {
+                var address = element.value;
+                if(address === 'null' || address === '') return;
 
-        if (getCheckoutType()=="payment") {
-        /////////////////////////////////////////////////////
-        // Call Bolt order creation Magento endpoint on
-        // customer billing address change on payment only page,
-        // storing the live page data in Bolt cart.
-        /////////////////////////////////////////////////////
-        var billing_address_value;
-        onAttributesChange(billing_address_selector, function(element) {
+                if (address !== billing_address_value) {
+                    billing_address_value = address;
+                    boltCheckoutSetup();
+                }
+            });
+            /////////////////////////////////////////////////////
 
-            var checkout_type = getCheckoutType();
-            var address = element.value;
-            if (checkout_type !== 'payment' || address === 'null') return;
+            /////////////////////////////////////////////////////
+            // Call Bolt order creation Magento endpoint on
+            // customer email change on payment only page, storing
+            // the live page data in Bolt cart.
+            /////////////////////////////////////////////////////
+            var customer_email_value;
+            onAttributesChange(customer_email_selector, function(element) {
 
-            if (address !== billing_address_value) {
-                billing_address_value = address;
-                boltCheckoutSetup();
-            }
-        });
-        /////////////////////////////////////////////////////
+                var email = element.value.trim();
+                if (email === "") return;
 
-        /////////////////////////////////////////////////////
-        // Call Bolt order creation Magento endpoint on
-        // customer email change on payment only page, storing
-        // the live page data in Bolt cart.
-        /////////////////////////////////////////////////////
-        var customer_email_value;
-        onAttributesChange(customer_email_selector, function(element) {
-
-            var checkout_type = getCheckoutType();
-            var email = element.value.trim();
-            if (checkout_type !== 'payment'|| email === "") return;
-
-            if (email !== customer_email_value) {
-                customer_email_value = email;
-                boltCheckoutSetup();
-            }
-        });
+                if (email !== customer_email_value) {
+                    customer_email_value = email;
+                    boltCheckoutSetup();
+                }
+            });
         }
 
         ///////////////////////////////////////////////////////////
@@ -1489,15 +1484,6 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
             'jquery',
             'Magento_Checkout/js/model/quote',
             ], function ($, quote) {
-                var prevAddress;
-                //If billing address has been changed we need to recreate the order token.
-                quote.billingAddress.subscribe(function(newAddress){
-                    if((!newAddress ^ !prevAddress || prevAddress.getKey() !== newAddress.getKey())){
-                        prevAddress = newAddress;
-                        quote.billingAddress(newAddress);
-			            $(document).trigger('bolt:createOrder');
-                    }
-                });
                 // If quote total was changed through a method we didn't create,
                 // we should reload the bolt cart since totals are probably now out of sync.
                 quote.totals.subscribe(function (totals) {


### PR DESCRIPTION
# Description
Subscribing to billing address change and creating a new order token for the updated billing address. Also using cartBarrier instead of BoltState.boltcart for configure call to make sure we have the latest cart values.

Fixes: [M2P395](https://boltpay.atlassian.net/browse/M2P-395) - Billing address is invalid if it was created or changed on native checkout page

#changelog (WIP)[M2P395] Billing address is invalid if it was created or changed on native checkout page

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
