### PR TITLE
M2P-515 - Switch $blockAlreadyShown to protected scope

### DIFF
--- a/Block/Js.php
+++ b/Block/Js.php
@@ -42,7 +42,7 @@ class Js extends Template
     /**
      * @var array
      */
-    private static $blockAlreadyShown;
+    protected static $blockAlreadyShown;
 
     /**
      * @var HttpContext


### PR DESCRIPTION
# Description
An error occurred when trying to enable order tracking for The RTA Store's staging environment where $blockAlreadyShown could not be accessed. The issue here was that it couldn't access this variable in the private scope and it required the protected scope.

Fixes: (https://boltpay.atlassian.net/browse/M2P-515)

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#changelog M2P-515 - Switch $blockAlreadyShown to protected scope
- Changed $blockAlreadyShown to have protected scope

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
