### PR TITLE
[M2-plugin] Force cart reload when user exits modal.

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -530,6 +530,7 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
 
             close: function () {
                 popUpOpen = false;
+                customerData.reload(['boltcart'], true);
                 trackCallbacks.onClose();
 
                 if (callbacks.success_url) {

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -530,7 +530,7 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
 
             close: function () {
                 popUpOpen = false;
-                customerData.reload(['boltcart'], true);
+                customerData.reload(['cart'], true);
                 trackCallbacks.onClose();
 
                 if (callbacks.success_url) {


### PR DESCRIPTION
# Description
This code change forces a reload of the cart data if the user exits the modal before checkout. This handles the cases where: 1. User closes the modal via the 'X' close button. 2. User closes the modal via pressing ESC

Fixes: https://boltpay.atlassian.net/browse/M2P-497

#changelog [M2-plugin] Force cart reload when user exits modal.

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
