### PR TITLE
Reload Magento Cart after checkout exit (M2P-497) 

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -530,6 +530,7 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
 
             close: function () {
                 popUpOpen = false;
+                customerData.reload(['boltcart'], true);
                 trackCallbacks.onClose();
 
                 if (callbacks.success_url) {

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -530,7 +530,7 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
 
             close: function () {
                 popUpOpen = false;
-                customerData.reload(['cart'], true);
+               
                 trackCallbacks.onClose();
 
                 if (callbacks.success_url) {
@@ -541,6 +541,7 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
                     // after order was changed from inside the checkout,
                     // i.e. the discount was applied
                     invalidateBoltCart();
+                    customerData.reload(['cart'], true);
                 }
             },
 

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -530,7 +530,7 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
 
             close: function () {
                 popUpOpen = false;
-                customerData.reload(['boltcart'], true);
+                customerData.reload(['cart'], true);
                 trackCallbacks.onClose();
 
                 if (callbacks.success_url) {

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -527,8 +527,7 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
         var callbacks = {
 
             close: function () {
-                popUpOpen = false;
-               
+                popUpOpen = false;               
                 trackCallbacks.onClose();
 
                 if (callbacks.success_url) {

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -535,6 +535,9 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
                     // redirect on success order save
                     location.href = callbacks.success_url;
                 } else {
+                    // Checkout was closed without success. I.e. user exited the modal via pressing ESC
+                    // or clicking the X-close button on the top right of the modal.
+
                     // re-create order in case checkout was closed
                     // after order was changed from inside the checkout,
                     // i.e. the discount was applied


### PR DESCRIPTION
# Description
More details in Jira Ticket. Summary is that we would like to reload the Magento 2 cart when the user exits the checkout modal without completing checkout. Currently this is achieved using a callback from the M2 Admin, but it would be preferable if the plugin handles this. This change adds a cart reload line to the non-success portion of the modal's close handler. This is triggered when the user exits using either the X-close-button or ESC.


Fixes: https://boltpay.atlassian.net/browse/M2P-497

#changelog Reload Magento Cart after checkout exit (M2P-497) 

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
