### PR TITLE
M2P-518 Postpone connect.js load when possible

### DIFF
--- a/Block/Js.php
+++ b/Block/Js.php
@@ -418,15 +418,37 @@ class Js extends Template
         return $currentPage == 'catalog_product_view';
     }
     
-    public function isLoadConnectJsEnabled()
+    /**
+     * If feature switch M2_LOAD_CONNECT_JS_ON_SPECIFIC_PAGE is enabled,
+     * then we only fetch Bolt connect js on page load for the product page (PPC is enabled) and cart page.
+     */
+    public function isLoadConnectJs()
     {
         if ($this->featureSwitches->isLoadConnectJsOnSpecificPage()) {
-            if (!$this->isOnCartPage() && !$this->isBoltProductPage()) {
+            if ($this->isOnCartPage() || $this->isBoltProductPage()) {
+                return true;
+            } else {
                 return false;
             }
         }
         
         return true;
+    }
+    
+    /**
+     * If feature switch M2_LOAD_CONNECT_JS_ON_SPECIFIC_PAGE is enabled,
+     * then on the product page, with PPC disabled and minicart enabled,
+     * we load Bolt connect JS dynamically when the customer add product to cart.
+     */
+    public function isLoadConnectJsDynamic()
+    {
+        if ($this->featureSwitches->isLoadConnectJsOnSpecificPage()) {
+            if ($this->isMinicartEnabled() && !$this->isBoltPPCEnabled() && $this->isOnProductPage()) {
+                return true;
+            }
+        }
+        
+        return false;
     }
 
     /**
@@ -550,21 +572,6 @@ function($argName) {
     public function isLoggedIn(): bool
     {
         return $this->httpContext->getValue(\Magento\Customer\Model\Context::CONTEXT_AUTH);
-    }
-    
-    /**
-     * Check if cart is empty
-     *
-     * @return bool
-     */
-    public function isCartEmpty()
-    {
-        $quote = $this->getQuoteFromCheckoutSession();
-        if (empty($quote) || $quote->getItemsCount() === 0) {
-            return true;
-        }
-        
-        return false;
     }
 
     /**

--- a/Block/Js.php
+++ b/Block/Js.php
@@ -397,7 +397,7 @@ class Js extends Template
      */
     public function isBoltProductPage()
     {
-        return $this->isBoltPPCEnabled() && $this->isOnProductPage();
+        return $this->isOnProductPage() && $this->isBoltPPCEnabled();
     }
     
     /**

--- a/Block/Js.php
+++ b/Block/Js.php
@@ -420,15 +420,8 @@ class Js extends Template
     
     public function isLoadConnectJsEnabled()
     {
-$writer = new \Zend\Log\Writer\Stream(BP . '/var/log/boltdebug.log');
-$logger = new \Zend\Log\Logger();
-$logger->addWriter($writer);
-$logger->info(var_export($this->featureSwitches->isLoadConnectJsOnSpecificPage(), true));
-$logger->info('isOnCartPage  '.var_export($this->isOnCartPage(), true));
-$logger->info('isBoltProductPage  '.var_export($this->isBoltProductPage(), true));
         if ($this->featureSwitches->isLoadConnectJsOnSpecificPage()) {
-            if (!$this->isOnCartPage()
-                && !($this->isOnProductPage() && ($this->isBoltPPCEnabled() || ($this->isMinicartEnabled() && !$this->isCartEmpty())))) {
+            if (!$this->isOnCartPage() && !$this->isBoltProductPage()) {
                 return false;
             }
         }

--- a/Block/Js.php
+++ b/Block/Js.php
@@ -438,7 +438,9 @@ class Js extends Template
     /**
      * If feature switch M2_LOAD_CONNECT_JS_ON_SPECIFIC_PAGE is enabled,
      * then on the product page, with PPC disabled and minicart enabled,
-     * we load Bolt connect JS dynamically when the customer add product to cart.
+     * we load Bolt connect JS dynamically under the one of the following conditions:
+     * 1. The cart contains any item.
+     * 2. The cart is empty, and the customer add product to the cart.
      */
     public function isLoadConnectJsDynamic()
     {

--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -303,4 +303,9 @@ class Decider extends AbstractHelper
     {
         return $this->isSwitchEnabled(Definitions::M2_CUSTOMIZABLE_OPTIONS_SUPPORT);
     }
+    
+    public function isLoadConnectJsOnSpecificPage()
+    {
+        return $this->isSwitchEnabled(Definitions::M2_LOAD_CONNECT_JS_ON_SPECIFIC_PAGE);
+    }
 }

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -161,6 +161,11 @@ class Definitions
      * Support Customizable Options
      */
     const M2_CUSTOMIZABLE_OPTIONS_SUPPORT = 'M2_CUSTOMIZABLE_OPTIONS_SUPPORT';
+    
+    /**
+     * Enable connect.js on cart page or product page (if PPC enabled) only
+     */
+    const M2_LOAD_CONNECT_JS_ON_SPECIFIC_PAGE = 'M2_LOAD_CONNECT_JS_ON_SPECIFIC_PAGE';
 
     const DEFAULT_SWITCH_VALUES = [
         self::M2_SAMPLE_SWITCH_NAME => [
@@ -312,6 +317,12 @@ class Definitions
             self::VAL_KEY         => true,
             self::DEFAULT_VAL_KEY => false,
             self::ROLLOUT_KEY     => 100
-        ]
+        ],
+        self::M2_LOAD_CONNECT_JS_ON_SPECIFIC_PAGE => [
+            self::NAME_KEY        => self::M2_LOAD_CONNECT_JS_ON_SPECIFIC_PAGE,
+            self::VAL_KEY         => true,
+            self::DEFAULT_VAL_KEY => false,
+            self::ROLLOUT_KEY     => 100
+        ],
     ];
 }

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -322,7 +322,7 @@ class Definitions
             self::NAME_KEY        => self::M2_LOAD_CONNECT_JS_ON_SPECIFIC_PAGE,
             self::VAL_KEY         => true,
             self::DEFAULT_VAL_KEY => false,
-            self::ROLLOUT_KEY     => 100
+            self::ROLLOUT_KEY     => 0
         ],
     ];
 }

--- a/Test/Unit/Block/JsProductPageTest.php
+++ b/Test/Unit/Block/JsProductPageTest.php
@@ -318,6 +318,7 @@ class JsProductPageTest extends BoltTestCase
     {
         $this->configHelper->expects(static::once())->method('getSelectProductPageCheckoutFlag')->willReturn(false);
         $this->configHelper->expects(static::once())->method('getProductPageCheckoutFlag')->willReturn(false);
+        $this->requestMock->expects(static::once())->method('getFullActionName')->willReturn('catalog_product_view');
         $this->assertEquals(false, $this->block->isBoltProductPage());
     }
 
@@ -339,6 +340,7 @@ class JsProductPageTest extends BoltTestCase
     {
         $this->configHelper->expects(static::once())->method('getSelectProductPageCheckoutFlag')->willReturn(true);
         $this->configHelper->expects(static::once())->method('getProductPageCheckoutFlag')->willReturn(false);
+        $this->requestMock->expects(static::once())->method('getFullActionName')->willReturn('catalog_product_view');
         $this->assertEquals(false, $this->block->isBoltProductPage());
     }
 

--- a/view/frontend/templates/js/boltjs.phtml
+++ b/view/frontend/templates/js/boltjs.phtml
@@ -44,7 +44,7 @@ $checkoutKey = $block->getCheckoutKey();
         $checkoutKey; ?>">
 </script>
 <?php
-if ($block->isLoadConnectJsEnabled()) {
+if ($block->isLoadConnectJs()) {
     $connectJsUrl = $block->getConnectJsUrl();
 ?>
 <script

--- a/view/frontend/templates/js/boltjs.phtml
+++ b/view/frontend/templates/js/boltjs.phtml
@@ -23,13 +23,14 @@
 if ($block->shouldDisableBoltCheckout()) {
     return;
 }
+
 //check if we need Bolt on this page
 if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled() && !$block->isBoltProductPage()) {
     return;
 }
 
 $trackJsUrl = $block->getTrackJsUrl();
-$connectJsUrl = $block->getConnectJsUrl();
+$connectJsUrl = $block->isLoadConnectJsEnabled() ? $block->getConnectJsUrl() : '';
 $checkoutKey = $block->getCheckoutKey();
 ?>
 <script>console.log("Bolt M2 Version: <?= /* @noEscape */ $block->getModuleVersion()?>");</script>

--- a/view/frontend/templates/js/boltjs.phtml
+++ b/view/frontend/templates/js/boltjs.phtml
@@ -30,7 +30,6 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled() && !$block-
 }
 
 $trackJsUrl = $block->getTrackJsUrl();
-$connectJsUrl = $block->isLoadConnectJsEnabled() ? $block->getConnectJsUrl() : '';
 $checkoutKey = $block->getCheckoutKey();
 ?>
 <script>console.log("Bolt M2 Version: <?= /* @noEscape */ $block->getModuleVersion()?>");</script>
@@ -44,6 +43,10 @@ $checkoutKey = $block->getCheckoutKey();
         data-publishable-key="<?= /* @noEscape */
         $checkoutKey; ?>">
 </script>
+<?php
+if ($block->isLoadConnectJsEnabled()) {
+    $connectJsUrl = $block->getConnectJsUrl();
+?>
 <script
         id="bolt-connect"
         type="text/javascript"
@@ -54,3 +57,6 @@ $checkoutKey = $block->getCheckoutKey();
         data-publishable-key="<?= /* @noEscape */
         $checkoutKey; ?>">
 </script>
+<?php
+}
+?>

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -32,7 +32,7 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
 }
 
 $connectJsUrl = $block->getConnectJsUrl();
-$isLoadConnectJsDynamic = !$block->isLoadConnectJsEnabled();
+$isLoadConnectJsDynamic = $block->isLoadConnectJsDynamic();
 ?>
 
 <script type="text/javascript">
@@ -412,19 +412,10 @@ $isLoadConnectJsDynamic = !$block->isLoadConnectJsEnabled();
          * return void
          */
         var insertConnectScript = function() {
-            var scriptTag = document.getElementById('bolt-connect');
-            var publishableKey = getCheckoutKey();
-            if (scriptTag) {
-                scriptTag.setAttribute('data-publishable-key', publishableKey);
-                return;
+            if (insertConnectScriptWithoutSrc()) {
+                var scriptTag = document.getElementById('bolt-connect');
+                scriptTag.setAttribute('src', settings.connect_url);
             }
-            scriptTag = document.createElement('script');
-            scriptTag.setAttribute('type', 'text/javascript');
-            scriptTag.setAttribute('async', '');
-            scriptTag.setAttribute('src', settings.connect_url);
-            scriptTag.setAttribute('id', 'bolt-connect');
-            scriptTag.setAttribute('data-publishable-key', publishableKey);
-            document.head.appendChild(scriptTag);
         };
         
         var insertConnectScriptWithoutSrc = function() {
@@ -432,7 +423,7 @@ $isLoadConnectJsDynamic = !$block->isLoadConnectJsEnabled();
             var publishableKey = getCheckoutKey();
             if (scriptTag) {
                 scriptTag.setAttribute('data-publishable-key', publishableKey);
-                return;
+                return false;
             }
             scriptTag = document.createElement('script');
             scriptTag.setAttribute('type', 'text/javascript');
@@ -440,6 +431,7 @@ $isLoadConnectJsDynamic = !$block->isLoadConnectJsEnabled();
             scriptTag.setAttribute('id', 'bolt-connect');
             scriptTag.setAttribute('data-publishable-key', publishableKey);
             document.head.appendChild(scriptTag);
+            return true;
         };
 
         /**
@@ -1418,14 +1410,7 @@ $isLoadConnectJsDynamic = !$block->isLoadConnectJsEnabled();
         // When we know that cart will be updated soon we call configure with promises
         // to make sure bolt checkout with outdated cart isn't available for user
         $(document).on("ajax:addToCart", function () {
-            <?php
-            if ($block->isMinicartEnabled() && !$this->isBoltPPCEnabled() && $this->isOnProductPage()) {
-            ?>
-            insertConnectScriptWithoutSrc();
-            $.getScript("<?= /* @noEscape */ $connectJsUrl; ?>", function(data, textStatus, jqxhr) {
-            <?php
-            }            
-            ?>
+            var callBoltAfterAddToCart = function() {
                 expectCartRendering = true;
                 // If merchant shows popup after add to cart
                 // delay 0 allows to render bolt button before we call configure
@@ -1434,12 +1419,23 @@ $isLoadConnectJsDynamic = !$block->isLoadConnectJsEnabled();
                 if (boltConfig.always_present_checkout) {
                     newItemAddedToCart = true;
                 }
+            }
             <?php
-            if ($block->isMinicartEnabled() && !$this->isBoltPPCEnabled() && $this->isOnProductPage()) {
+            if ($isLoadConnectJsDynamic) {
             ?>
-            });
+            if (insertConnectScriptWithoutSrc()) {
+                $.getScript("<?= /* @noEscape */ $connectJsUrl; ?>", function(data, textStatus, jqxhr) {
+                    callBoltAfterAddToCart();
+                });
+            } else {
+                callBoltAfterAddToCart();
+            }
             <?php
-            }            
+            } else {
+            ?>
+            callBoltAfterAddToCart();
+            <?php
+            }
             ?>
         });
         $(document).on("ajax:addToCart:error", function () {
@@ -1505,7 +1501,7 @@ $isLoadConnectJsDynamic = !$block->isLoadConnectJsEnabled();
         ////////////////////////////////////////////////////
         
         <?php
-        if ($block->isMinicartEnabled() && !$this->isBoltPPCEnabled() && $this->isOnProductPage()) {
+        if ($isLoadConnectJsDynamic) {
         ?>
         magentoCartDataListenerLoadConnectJs = function(data) {
             if (data.items !== undefined && data.items.length > 0) {

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -30,6 +30,9 @@ if ($block->shouldDisableBoltCheckout()) { return;
 //product page checkout has its own JS script
 if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
 }
+
+$connectJsUrl = $block->getConnectJsUrl();
+$isLoadConnectJsEnabled = $block->isLoadConnectJsEnabled();
 ?>
 
 <script type="text/javascript">
@@ -1400,14 +1403,28 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
         // When we know that cart will be updated soon we call configure with promises
         // to make sure bolt checkout with outdated cart isn't available for user
         $(document).on("ajax:addToCart", function () {
-            expectCartRendering = true;
-            // If merchant shows popup after add to cart
-            // delay 0 allows to render bolt button before we call configure
-            setTimeout(callConfigureWithPromises, 0);
-            // set flag to animate always present button when we catch cart updating
-            if (boltConfig.always_present_checkout) {
-                newItemAddedToCart = true;
-            }
+            <?php
+            if ($isLoadConnectJsEnabled) {
+            ?>
+            $.getScript("<?= /* @noEscape */ $connectJsUrl; ?>", function(data, textStatus, jqxhr) {
+            <?php
+            }            
+            ?>
+                expectCartRendering = true;
+                // If merchant shows popup after add to cart
+                // delay 0 allows to render bolt button before we call configure
+                setTimeout(callConfigureWithPromises, 0);
+                // set flag to animate always present button when we catch cart updating
+                if (boltConfig.always_present_checkout) {
+                    newItemAddedToCart = true;
+                }
+            <?php
+            if ($isLoadConnectJsEnabled) {
+            ?>
+            });
+            <?php
+            }            
+            ?>
         });
         $(document).on("ajax:addToCart:error", function () {
             invalidateBoltCart();

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -32,7 +32,7 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
 }
 
 $connectJsUrl = $block->getConnectJsUrl();
-$isLoadConnectJsEnabled = $block->isLoadConnectJsEnabled();
+$isLoadConnectJsDynamic = !$block->isLoadConnectJsEnabled();
 ?>
 
 <script type="text/javascript">
@@ -422,6 +422,21 @@ $isLoadConnectJsEnabled = $block->isLoadConnectJsEnabled();
             scriptTag.setAttribute('type', 'text/javascript');
             scriptTag.setAttribute('async', '');
             scriptTag.setAttribute('src', settings.connect_url);
+            scriptTag.setAttribute('id', 'bolt-connect');
+            scriptTag.setAttribute('data-publishable-key', publishableKey);
+            document.head.appendChild(scriptTag);
+        };
+        
+        var insertConnectScriptWithoutSrc = function() {
+            var scriptTag = document.getElementById('bolt-connect');
+            var publishableKey = getCheckoutKey();
+            if (scriptTag) {
+                scriptTag.setAttribute('data-publishable-key', publishableKey);
+                return;
+            }
+            scriptTag = document.createElement('script');
+            scriptTag.setAttribute('type', 'text/javascript');
+            scriptTag.setAttribute('async', '');
             scriptTag.setAttribute('id', 'bolt-connect');
             scriptTag.setAttribute('data-publishable-key', publishableKey);
             document.head.appendChild(scriptTag);
@@ -1404,8 +1419,9 @@ $isLoadConnectJsEnabled = $block->isLoadConnectJsEnabled();
         // to make sure bolt checkout with outdated cart isn't available for user
         $(document).on("ajax:addToCart", function () {
             <?php
-            if ($isLoadConnectJsEnabled) {
+            if ($block->isMinicartEnabled() && !$this->isBoltPPCEnabled() && $this->isOnProductPage()) {
             ?>
+            insertConnectScriptWithoutSrc();
             $.getScript("<?= /* @noEscape */ $connectJsUrl; ?>", function(data, textStatus, jqxhr) {
             <?php
             }            
@@ -1419,7 +1435,7 @@ $isLoadConnectJsEnabled = $block->isLoadConnectJsEnabled();
                     newItemAddedToCart = true;
                 }
             <?php
-            if ($isLoadConnectJsEnabled) {
+            if ($block->isMinicartEnabled() && !$this->isBoltPPCEnabled() && $this->isOnProductPage()) {
             ?>
             });
             <?php
@@ -1487,6 +1503,19 @@ $isLoadConnectJsEnabled = $block->isLoadConnectJsEnabled();
         ////////////////////////////////////////////////////
         boltCheckoutSetup();
         ////////////////////////////////////////////////////
+        
+        <?php
+        if ($block->isMinicartEnabled() && !$this->isBoltPPCEnabled() && $this->isOnProductPage()) {
+        ?>
+        magentoCartDataListenerLoadConnectJs = function(data) {
+            if (data.items !== undefined && data.items.length > 0) {
+                insertConnectScript();
+            }            
+        }
+        customerData.get('cart').subscribe(magentoCartDataListenerLoadConnectJs);
+        <?php
+        }
+        ?>
     });
 
     if ((trim(location.pathname, '/') === 'checkout/cart') || (trim(location.pathname, '/') === 'checkout')) {


### PR DESCRIPTION
# Description
Some merchant claim that bolt script affect their side speed.

So we implement the following logic under feature switch M2_LOAD_CONNECT_JS_ON_SPECIFIC_PAGE (disabled by default):

1. Fetch connect.js on page load only under the one of the following conditions:
    1) On the cart page
    2) On the product page and PPC is enabled

2. If on product page, PPC is disabled and mini cart support is enabled, then we dynamically load connect.js under the one of the following conditions:
    1) The cart contains any item.
    2) The cart is empty, and the customer add product to the cart.

Fixes: https://boltpay.atlassian.net/browse/M2P-518

#changelog Postpone connect.js load when possible

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
