### PR TITLE
Use integration test instead of unit test for all methods in class Mode/Api/GetAccountTest

### DIFF
--- a/Test/Unit/Model/Api/GetAccountTest.php
+++ b/Test/Unit/Model/Api/GetAccountTest.php
@@ -17,147 +17,306 @@
 
 namespace Bolt\Boltpay\Test\Unit\Model\Api;
 
-use Bolt\Boltpay\Helper\Bugsnag;
-use Bolt\Boltpay\Helper\Hook as HookHelper;
-use Bolt\Boltpay\Model\Api\GetAccount;
-use Bolt\Boltpay\Test\Unit\BoltTestCase;
-use Exception;
-use Magento\Customer\Api\CustomerRepositoryInterface as CustomerRepository;
-use Magento\Customer\Api\Data\CustomerInterface;
-use Magento\Framework\Exception\NoSuchEntityException;
-use Magento\Framework\Webapi\Exception as WebapiException;
+use Bolt\Boltpay\Helper\Hook;
+use Bolt\Boltpay\Test\Unit\TestUtils;
+use Magento\Framework\Webapi\Rest\Request;
 use Magento\Framework\Webapi\Rest\Response;
-use Magento\Store\Api\Data\StoreInterface;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
+use Bolt\Boltpay\Model\Api\GetAccount;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Framework\Encryption\EncryptorInterface;
+use Magento\Store\Api\WebsiteRepositoryInterface;
 use Magento\Store\Model\StoreManagerInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use Magento\Framework\Webapi\Exception as WebapiException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Customer\Api\CustomerRepositoryInterface as CustomerRepository;
+use Exception;
+use Bolt\Boltpay\Test\Unit\TestHelper;
 
 /**
  * @coversDefaultClass \Bolt\Boltpay\Model\Api\GetAccount
  */
 class GetAccountTest extends BoltTestCase
 {
+    const TRACE_ID_HEADER = 'KdekiEGku3j1mU21Mnsx5g==';
+    const SECRET = '42425f51e0614482e17b6e913d74788eedb082e2e6f8067330b98ffa99adc809';
+    const APIKEY = '3c2d5104e7f9d99b66e1c9c550f6566677bf81de0d6f25e121fdb57e47c2eafc';
+
     /**
-     * @var Response|MockObject
+     * @var Response
      */
     private $response;
 
     /**
-     * @var CustomerRepository|MockObject
+     * @var ObjectManager
      */
-    private $customerRepository;
+    private $objectManager;
+
+    private $websiteId;
 
     /**
-     * @var StoreManagerInterface|MockObject
+     * @var ScopeInterface
      */
-    private $storeManager;
+    private $storeId;
 
     /**
-     * @var HookHelper|MockObject
+     * @var Request
      */
-    private $hookHelper;
+    private $request;
 
     /**
-     * @var Bugsnag|MockObject
+     * @var GetAccount
      */
-    private $bugsnag;
-
-    /**
-     * @var GetAccount|MockObject
-     */
-    private $currentMock;
+    private $getAccount;
 
     /**
      * @inheritdoc
      */
-    public function setUpInternal()
+    protected function setUpInternal()
     {
-        $this->response = $this->createMock(Response::class);
-        $this->customerRepository = $this->createMock(CustomerRepository::class);
-        $this->storeManager = $this->createMock(StoreManagerInterface::class);
-        $this->hookHelper = $this->createMock(HookHelper::class);
-        $this->bugsnag = $this->createMock(Bugsnag::class);
-        $this->currentMock = $this->getMockBuilder(GetAccount::class)
-            ->setMethods()
-            ->setConstructorArgs([
-                $this->response,
-                $this->customerRepository,
-                $this->storeManager,
-                $this->hookHelper,
-                $this->bugsnag
-            ])
-            ->getMock();
+        if (!class_exists('\Magento\TestFramework\Helper\Bootstrap')) {
+            return;
+        }
+        $this->objectManager = Bootstrap::getObjectManager();
+        $this->getAccount = $this->objectManager->create(GetAccount::class);
+        $this->resetRequest();
+        $this->resetResponse();
+
+        $store = $this->objectManager->get(StoreManagerInterface::class);
+        $this->storeId = $store->getStore()->getId();
+
+        $websiteRepository = $this->objectManager->get(WebsiteRepositoryInterface::class);
+        $this->websiteId = $websiteRepository->get('base')->getId();
+
+        $encryptor = $this->objectManager->get(EncryptorInterface::class);
+        $secret = $encryptor->encrypt(self::SECRET);
+        $apikey = $encryptor->encrypt(self::APIKEY);
+
+        $configData = [
+            [
+                'path' => 'payment/boltpay/signing_secret',
+                'value' => $secret,
+                'scope' => ScopeInterface::SCOPE_STORE,
+                'scopeId' => $this->storeId,
+            ],
+            [
+                'path' => 'payment/boltpay/api_key',
+                'value' => $apikey,
+                'scope' => ScopeInterface::SCOPE_STORE,
+                'scopeId' => $this->storeId,
+            ],
+            [
+                'path' => 'payment/boltpay/active',
+                'value' => 1,
+                'scope' => ScopeInterface::SCOPE_STORE,
+                'scopeId' => $this->storeId,
+            ],
+        ];
+        TestUtils::setupBoltConfig($configData);
+
+    }
+
+    protected function tearDownInternal()
+    {
+        if (!class_exists('\Magento\TestFramework\Helper\Bootstrap')) {
+            return;
+        }
+
+        $this->resetRequest();
+        $this->resetResponse();
+    }
+
+    private function resetRequest()
+    {
+        if (!$this->request) {
+            $this->request = $this->objectManager->get(Request::class);
+        }
+
+        $this->objectManager->removeSharedInstance(Request::class);
+        $this->request = null;
+
+    }
+
+    private function resetResponse()
+    {
+        if (!$this->response) {
+            $this->response = $this->objectManager->get(Response::class);
+        }
+
+        $this->objectManager->removeSharedInstance(Response::class);
+        $this->response = null;
+    }
+
+    /**
+     * Request getter
+     *
+     * @param array $bodyParams
+     *
+     * @return \Magento\Framework\App\RequestInterface
+     */
+    public function createRequest($bodyParams)
+    {
+        if (!$this->request) {
+            $this->request = $this->objectManager->get(Request::class);
+        }
+
+        $requestContent = json_encode($bodyParams);
+
+        $computed_signature = base64_encode(hash_hmac('sha256', $requestContent, self::SECRET, true));
+
+        $this->request->getHeaders()->clearHeaders();
+        $this->request->getHeaders()->addHeaderLine('X-Bolt-Hmac-Sha256', $computed_signature);
+        $this->request->getHeaders()->addHeaderLine('X-bolt-trace-id', self::TRACE_ID_HEADER);
+        $this->request->getHeaders()->addHeaderLine('Content-Type', 'application/json');
+
+        $this->request->setParams($bodyParams);
+
+        $this->request->setContent($requestContent);
+
+        return $this->request;
     }
 
     /**
      * @test
+     * @covers ::execute
      */
     public function execute_throwsException_ifVerifySignatureFails()
     {
-        $this->hookHelper->expects(static::once())->method('verifyRequest')->willReturn(false);
         $this->expectException(WebApiException::class);
         $this->expectExceptionMessage('Request is not authenticated.');
-        $this->currentMock->execute('test@bolt.com');
+        $this->getAccount->execute('test@bolt.com');
     }
 
     /**
      * @test
+     * @covers ::execute
      */
     public function execute_throwsException_ifEmailIsEmpty()
     {
-        $this->hookHelper->expects(static::once())->method('verifyRequest')->willReturn(true);
+        $this->createRequest([]);
+        $hookHelper = $this->objectManager->create(Hook::class);
+        $stubApiHelper = new stubBoltApiHelper();
+        $apiHelperProperty = new \ReflectionProperty(
+            Hook::class,
+            'apiHelper'
+        );
+        $apiHelperProperty->setAccessible(true);
+        $apiHelperProperty->setValue($hookHelper, $stubApiHelper);
+        $hookHelperProperty = new \ReflectionProperty(
+            GetAccount::class,
+            'hookHelper'
+        );
+        $hookHelperProperty->setAccessible(true);
+        $hookHelperProperty->setValue($this->getAccount, $hookHelper);
         $this->expectException(WebApiException::class);
         $this->expectExceptionMessage('Missing email in the request body.');
-        $this->currentMock->execute('');
+        $this->getAccount->execute('');
     }
 
     /**
      * @test
+     * @covers ::execute
      */
     public function execute_throwsException_ifEmailNotFound()
     {
-        $this->hookHelper->expects(static::once())->method('verifyRequest')->willReturn(true);
-        $store = $this->createMock(StoreInterface::class);
-        $this->storeManager->expects(static::once())->method('getStore')->willReturn($store);
-        $store->expects(static::once())->method('getWebsiteId')->willReturn(1);
-        $this->customerRepository->expects(static::once())->method('get')->with('test@bolt.com', 1)->willThrowException(new NoSuchEntityException());
+        $this->createRequest([]);
+        $hookHelper = $this->objectManager->create(Hook::class);
+        $stubApiHelper = new stubBoltApiHelper();
+        $apiHelperProperty = new \ReflectionProperty(
+            Hook::class,
+            'apiHelper'
+        );
+        $apiHelperProperty->setAccessible(true);
+        $apiHelperProperty->setValue($hookHelper, $stubApiHelper);
+        $hookHelperProperty = new \ReflectionProperty(
+            GetAccount::class,
+            'hookHelper'
+        );
+        $hookHelperProperty->setAccessible(true);
+        $hookHelperProperty->setValue($this->getAccount, $hookHelper);
         $this->expectException(NoSuchEntityException::class);
         $this->expectExceptionMessage('Customer not found with given email.');
-        $this->currentMock->execute('test@bolt.com');
+        $this->getAccount->execute('emailnotfound@bolt.com');
     }
 
     /**
      * @test
+     * @covers ::execute
      */
     public function execute_throwsException_ifExceptionIsThrown()
     {
-        $this->hookHelper->expects(static::once())->method('verifyRequest')->willReturn(true);
-        $store = $this->createMock(StoreInterface::class);
-        $this->storeManager->expects(static::once())->method('getStore')->willReturn($store);
-        $store->expects(static::once())->method('getWebsiteId')->willReturn(1);
         $exception = new Exception();
-        $this->customerRepository->expects(static::once())->method('get')->with('test@bolt.com', 1)->willThrowException($exception);
-        $this->bugsnag->expects(static::once())->method('notifyException')->with($exception);
+        $this->createRequest([]);
+        $hookHelper = $this->objectManager->create(Hook::class);
+        $stubApiHelper = new stubBoltApiHelper();
+        $apiHelperProperty = new \ReflectionProperty(
+            Hook::class,
+            'apiHelper'
+        );
+        $apiHelperProperty->setAccessible(true);
+        $apiHelperProperty->setValue($hookHelper, $stubApiHelper);
+        $hookHelperProperty = new \ReflectionProperty(
+            GetAccount::class,
+            'hookHelper'
+        );
+        $hookHelperProperty->setAccessible(true);
+        $hookHelperProperty->setValue($this->getAccount, $hookHelper);
+
+        $customerRepository = $this->createMock(CustomerRepository::class);
+        $customerRepository->expects(static::once())->method('get')->with('test@bolt.com', 1)->willThrowException($exception);
+        $customerRepositoryProperty = new \ReflectionProperty(
+            GetAccount::class,
+            'customerRepository'
+        );
+        $customerRepositoryProperty->setAccessible(true);
+        $customerRepositoryProperty->setValue($this->getAccount, $customerRepository);
+
         $this->expectException(WebApiException::class);
         $this->expectExceptionMessage('Internal Server Error');
-        $this->currentMock->execute('test@bolt.com');
+        $this->getAccount->execute('test@bolt.com');
     }
 
     /**
      * @test
+     * @covers ::execute
      */
     public function execute_returnsCustomerId_ifEverythingSucceeds()
     {
-        $this->hookHelper->expects(static::once())->method('verifyRequest')->willReturn(true);
-        $store = $this->createMock(StoreInterface::class);
-        $this->storeManager->expects(static::once())->method('getStore')->willReturn($store);
-        $store->expects(static::once())->method('getWebsiteId')->willReturn(1);
-        $customerInterface = $this->createMock(CustomerInterface::class);
-        $this->customerRepository->expects(static::once())->method('get')->with('test@bolt.com', 1)->willReturn($customerInterface);
-        $customerInterface->expects(static::once())->method('getId')->willReturn(1);
-        $this->response->expects(static::once())->method('setHeader')->with('Content-Type', 'application/json');
-        $this->response->expects(static::once())->method('setHttpResponseCode')->with(200);
-        $this->response->expects(static::once())->method('setBody')->with(json_encode(['id' => 1]));
-        $this->response->expects(static::once())->method('sendResponse');
-        $this->currentMock->execute('test@bolt.com');
+        $customer = TestUtils::createCustomer($this->websiteId, $this->storeId, array(
+            "street_address1" => "street",
+            "street_address2" => "",
+            "locality"        => "Los Angeles",
+            "region"          => "California",
+            'region_code'     => 'CA',
+            'region_id'       => '12',
+            "postal_code"     => "11111",
+            "country_code"    => "US",
+            "country"         => "United States",
+            "name"            => "lastname firstname",
+            "first_name"      => "firstname",
+            "last_name"       => "lastname",
+            "phone_number"    => "11111111",
+            "email_address"   => "john@bolt.com",
+        ));
+        $this->createRequest([]);
+        $hookHelper = $this->objectManager->create(Hook::class);
+        $stubApiHelper = new stubBoltApiHelper();
+        $apiHelperProperty = new \ReflectionProperty(
+            Hook::class,
+            'apiHelper'
+        );
+        $apiHelperProperty->setAccessible(true);
+        $apiHelperProperty->setValue($hookHelper, $stubApiHelper);
+        $hookHelperProperty = new \ReflectionProperty(
+            GetAccount::class,
+            'hookHelper'
+        );
+        $hookHelperProperty->setAccessible(true);
+        $hookHelperProperty->setValue($this->getAccount, $hookHelper);
+        $this->getAccount->execute('john@bolt.com');
+        $response = json_decode(TestHelper::getProperty($this->getAccount, 'response')->getBody(), true);
+        $this->assertEquals(['id' => $customer->getId()], $response);
     }
 }


### PR DESCRIPTION
# Description
Use integration test instead of unit test for all methods in class Mode/Api/GetAccountTest

Fixes: (link Jira ticket)

#changelog Use integration test instead of unit test for all methods in class Mode/Api/GetAccountTest

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
