### PR TITLE
[MA-565] Add an empty Debug to Universal API 

### DIFF
--- a/Api/DebugInterface.php
+++ b/Api/DebugInterface.php
@@ -24,4 +24,11 @@ interface DebugInterface
      * @return void
      */
     public function debug();
+
+    /**
+     * @param sring $type
+     *  
+     * @return \Bolt\Boltpay\Api\Data\DebugInfo
+     */
+    public function universalDebug($data);
 }

--- a/Api/DebugInterface.php
+++ b/Api/DebugInterface.php
@@ -30,5 +30,5 @@ interface DebugInterface
      *  
      * @return \Bolt\Boltpay\Api\Data\DebugInfo
      */
-    public function universalDebug($data);
+    public function universalDebug($type);
 }

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -349,7 +349,7 @@ class Config extends AbstractHelper
     /**
      * Enable Bolt Universal debug requests
      */
-    const XML_PATH_DEBUG_UNIVERSAL = 'payment/boltpay/platform_debug';
+    const XML_PATH_DEBUG_UNIVERSAL = 'payment/boltpay/universal_debug';
 
     /**
      * Minify JavaScript configuration path

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -347,6 +347,11 @@ class Config extends AbstractHelper
     const XML_PATH_BOLT_SSO = 'payment/boltpay/bolt_sso';
 
     /**
+     * Enable Bolt Universal debug requests
+     */
+    const XML_PATH_DEBUG_UNIVERSAL = 'payment/boltpay/platform_debug';
+
+    /**
      * Minify JavaScript configuration path
      */
     const XML_PATH_SHOULD_MINIFY_JAVASCRIPT = 'payment/boltpay/should_minify_javascript';
@@ -1980,6 +1985,22 @@ class Config extends AbstractHelper
     {
         return $this->getScopeConfig()->isSetFlag(
             self::XML_PATH_BOLT_SSO,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+    }
+
+    /**
+     * Get config value for whether or not Bolt Debug V2 is enabled.
+     *
+     * @param int|string|Store $storeId
+     *
+     * @return boolean
+     */
+    public function isBoltDebugUniversal($storeId = null)
+    {
+        return $this->getScopeConfig()->isSetFlag(
+            self::XML_PATH_DEBUG_UNIVERSAL,
             ScopeInterface::SCOPE_STORE,
             $storeId
         );

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -1820,7 +1820,7 @@ class Config extends AbstractHelper
         // Enable Bolt Universal Debug
         $boltSettings[] = $this->boltConfigSettingFactory->create()
             ->setName('universal_debug')
-            ->setValue(var_export($this->isBoltDebugUniversal(), true));
+            ->setValue(var_export($this->isBoltDebugUniversalEnabled(), true));
 
         return $boltSettings;
     }
@@ -2001,7 +2001,7 @@ class Config extends AbstractHelper
      *
      * @return boolean
      */
-    public function isBoltDebugUniversal($storeId = null)
+    public function isBoltDebugUniversalEnabled($storeId = null)
     {
         return $this->getScopeConfig()->isSetFlag(
             self::XML_PATH_DEBUG_UNIVERSAL,

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -1817,6 +1817,10 @@ class Config extends AbstractHelper
         $boltSettings[] = $this->boltConfigSettingFactory->create()
             ->setName('bolt_sso')
             ->setValue(var_export($this->isBoltSSOEnabled(), true));
+        // Enable Bolt Universal Debug
+        $boltSettings[] = $this->boltConfigSettingFactory->create()
+            ->setName('universal_debug')
+            ->setValue(var_export($this->isBoltDebugUniversal(), true));
 
         return $boltSettings;
     }

--- a/Model/Api/Debug.php
+++ b/Model/Api/Debug.php
@@ -186,7 +186,7 @@ class Debug implements DebugInterface
     public function universalDebug($type){
         
         // Validate Request
-        //$this->hookHelper->preProcessWebhook($this->storeManager->getStore()->getId());
+        $this->hookHelper->preProcessWebhook($this->storeManager->getStore()->getId());
         
         // If debug v2 is not enabled then throw an exception.
         if(!$this->configHelper->isBoltDebugUniversal()){

--- a/Model/Api/Debug.php
+++ b/Model/Api/Debug.php
@@ -28,6 +28,8 @@ use Bolt\Boltpay\Model\Api\Data\DebugInfoFactory;
 use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\Webapi\Rest\Response;
 use Magento\Store\Model\StoreManagerInterface;
+use Bolt\Boltpay\Exception\BoltException;
+use Bolt\Boltpay\Model\ErrorResponse as BoltErrorResponse;
 
 class Debug implements DebugInterface
 {
@@ -171,5 +173,36 @@ class Debug implements DebugInterface
             ])
         );
         $this->response->sendResponse();
+    }
+
+
+    /**
+     * This method will handle universal api debug requests based on the type of request it is.
+     * 
+     * @param string $type
+     * @return \Bolt\Boltpay\Api\Data\DebugInfo
+     * @throws BoltException
+     * **/
+    public function universalDebug($type){
+        
+        // Validate Request
+        //$this->hookHelper->preProcessWebhook($this->storeManager->getStore()->getId());
+        
+        // If debug v2 is not enabled then throw an exception.
+        if(!$this->configHelper->isBoltDebugUniversal()){
+            throw new BoltException(
+                __('Not allowed to fetch debug Data.'),
+                null,
+                BoltErrorResponse::ERR_SERVICE
+            );
+        }
+
+        // Throw debg not implemented exception for now untill it is implemented.
+        throw new BoltException(
+            __('Webhook of type Debug has not been implemented'),
+            null,
+            BoltErrorResponse::ERR_SERVICE
+        );
+
     }
 }

--- a/Model/Api/Debug.php
+++ b/Model/Api/Debug.php
@@ -188,8 +188,8 @@ class Debug implements DebugInterface
         // Validate Request
         $this->hookHelper->preProcessWebhook($this->storeManager->getStore()->getId());
         
-        // If debug v2 is not enabled then throw an exception.
-        if(!$this->configHelper->isBoltDebugUniversal()){
+        // If debug v2 is not enabled then throw an error to be returned.
+        if(!$this->configHelper->isBoltDebugUniversalEnabled()){
             throw new BoltException(
                 __('Not allowed to fetch debug Data.'),
                 null,

--- a/Model/Api/UniversalApi.php
+++ b/Model/Api/UniversalApi.php
@@ -29,6 +29,7 @@ use Bolt\Boltpay\Exception\BoltException;
 use Bolt\Boltpay\Helper\Bugsnag;
 use Bolt\Boltpay\Helper\Log as LogHelper;
 use Bolt\Boltpay\Model\ErrorResponse as BoltErrorResponse;
+use Bolt\Boltpay\Api\DebugInterface;
 use Magento\Framework\Webapi\Rest\Response;
 
 class UniversalApi implements UniversalApiInterface
@@ -88,6 +89,10 @@ class UniversalApi implements UniversalApiInterface
      */
     protected $response;
 
+    /** 
+     * @var DebugInterface
+     */
+    protected $debug;
 
     public function __construct(
         CreateOrderInterface $createOrder,
@@ -100,7 +105,8 @@ class UniversalApi implements UniversalApiInterface
         Bugsnag $bugsnag,
         LogHelper $logHelper,
         BoltErrorResponse $errorResponse,
-        Response $response
+        Response $response,
+        DebugInterface $debug
     )
     {
         $this->createOrder = $createOrder;
@@ -114,6 +120,7 @@ class UniversalApi implements UniversalApiInterface
         $this->logHelper = $logHelper;
         $this->errorResponse = $errorResponse;
         $this->response = $response;
+        $this->debug = $debug;
     }
 
     public function execute(
@@ -185,6 +192,14 @@ class UniversalApi implements UniversalApiInterface
                             isset($data['cart']) ? $data['cart'] : null,
                             isset($data['shipping_address']) ? $data['shipping_address'] : null,
                             isset($data['shipping_option']) ? $data['shipping_option'] : null
+                        )
+                    );
+                    break;
+                case "debug":
+                    //Returns DebugInterface
+                    $this->result->setData(
+                        $this->debug->universalDebug(
+                            isset($data['type']) ? $data['type'] : null
                         )
                     );
                     break;

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -1228,7 +1228,7 @@ JSON;
             ['universal_debug', 'true']
         ];
         $actual = $this->currentMock->getAllConfigSettings();
-        $this->assertEquals(44, count($actual));
+        $this->assertEquals(45, count($actual));
         for ($i = 0; $i < 2; $i++) {
             $this->assertEquals($expected[$i][0], $actual[$i]->getName());
             $this->assertEquals($expected[$i][1], $actual[$i]->getValue(), 'actual value for ' . $expected[$i][0] . ' is not equals to expected');

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -733,6 +733,7 @@ JSON;
             ['isOrderManagementEnabled', BoltConfig::XML_PATH_PRODUCT_ORDER_MANAGEMENT],
             ['isAlwaysPresentCheckoutEnabled', BoltConfig::XML_PATH_ALWAYS_PRESENT_CHECKOUT, false],
             ['isBoltSSOEnabled', BoltConfig::XML_PATH_BOLT_SSO],
+            ['isBoltDebugUniversalEnabled', BoltConfig::XML_PATH_DEBUG_UNIVERSAL],
             ['getUseAheadworksRewardPointsConfig', BoltConfig::XML_PATH_AHEADWORKS_REWARD_POINTS_ON_CART, false]
         ];
     }
@@ -1132,6 +1133,7 @@ JSON;
             'shouldCaptureMetrics',
             'shouldTrackCheckoutFunnel',
             'isBoltSSOEnabled',
+            'isBoltDebugUniversalEnabled',
         ]);
         $this->currentMock->method('isActive')->willReturn(true);
         $this->currentMock->method('getTitle')->willReturn('bolt test title');
@@ -1176,6 +1178,7 @@ JSON;
         $this->currentMock->method('shouldCaptureMetrics')->willReturn(false);
         $this->currentMock->method('shouldTrackCheckoutFunnel')->willReturn(false);
         $this->currentMock->method('isBoltSSOEnabled')->willReturn(false);
+        $this->currentMock->method('isBoltDebugUniversalEnabled')->willReturn(true);
 
         // check bolt settings
         $expected = [
@@ -1222,6 +1225,7 @@ JSON;
             ['capture_merchant_metrics', 'false'],
             ['track_checkout_funnel', 'false'],
             ['bolt_sso', 'false'],
+            ['universal_debug', 'true']
         ];
         $actual = $this->currentMock->getAllConfigSettings();
         $this->assertEquals(44, count($actual));

--- a/Test/Unit/Model/Api/UniversalApiTest.php
+++ b/Test/Unit/Model/Api/UniversalApiTest.php
@@ -228,12 +228,12 @@ class UniversalApiTest extends BoltTestCase
         $this->shippingMethods = $this->createMock(ShippingMethods::class);
         $this->tax = $this->createMock(Tax::class);
         $this->updateCart = $this->createMock(UpdateCart::class);
-        $this->debug = $this->createMock(Debug::class);
         $this->universalApiResult = $this->createMock(UniversalApiResult::class);
         $this->bugsnag = $this->createMock(Bugsnag::class);
         $this->logHelper = $this->createMock(LogHelper::class);
         $this->errorResponse = $this->createMock(BoltErrorResponse::class);
         $this->response = $this->createMock(Response::class);
+        $this->debug = $this->createMock(Debug::class);
     }
 
     private function initCurrentMock($methods = null)
@@ -246,12 +246,12 @@ class UniversalApiTest extends BoltTestCase
                 $this->shippingMethods,
                 $this->tax,
                 $this->updateCart,
-                $this->debug,
                 $this->universalApiResult,
                 $this->bugsnag,
                 $this->logHelper,
                 $this->errorResponse,
                 $this->response,
+                $this->debug,
             ]);
         if ($methods) {
             $mockBuilder->setMethods($methods);

--- a/Test/Unit/Model/Api/UniversalApiTest.php
+++ b/Test/Unit/Model/Api/UniversalApiTest.php
@@ -27,6 +27,7 @@ use Bolt\Boltpay\Model\Api\Shipping;
 use Bolt\Boltpay\Model\Api\ShippingMethods;
 use Bolt\Boltpay\Model\Api\Tax;
 use Bolt\Boltpay\Model\Api\UpdateCart;
+use Bolt\Boltpay\Model\Api\Debug;
 use Bolt\Boltpay\Model\Api\Data\UniversalApiResult;
 use Bolt\Boltpay\Model\ErrorResponse as BoltErrorResponse;
 use Bolt\Boltpay\Test\Unit\BoltTestCase;
@@ -77,6 +78,11 @@ class UniversalApiTest extends BoltTestCase
      * @var MockObject|UpdateCart
      */
     private $updateCart;
+
+    /**
+     * @var MockObject|Debug
+     */
+    private $debug;
 
     /**
      * @var MockObject|UniversalApiResult
@@ -222,6 +228,7 @@ class UniversalApiTest extends BoltTestCase
         $this->shippingMethods = $this->createMock(ShippingMethods::class);
         $this->tax = $this->createMock(Tax::class);
         $this->updateCart = $this->createMock(UpdateCart::class);
+        $this->debug = $this->createMock(Debug::class);
         $this->universalApiResult = $this->createMock(UniversalApiResult::class);
         $this->bugsnag = $this->createMock(Bugsnag::class);
         $this->logHelper = $this->createMock(LogHelper::class);
@@ -239,11 +246,12 @@ class UniversalApiTest extends BoltTestCase
                 $this->shippingMethods,
                 $this->tax,
                 $this->updateCart,
+                $this->debug,
                 $this->universalApiResult,
                 $this->bugsnag,
                 $this->logHelper,
                 $this->errorResponse,
-                $this->response
+                $this->response,
             ]);
         if ($methods) {
             $mockBuilder->setMethods($methods);

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -243,6 +243,12 @@
                         <config_path>payment/boltpay/ip_whitelist</config_path>
                         <comment>Comma separated list of allowed IP addresses, used for test purposes. Leave empty for no restrictions. Clearing page cache is mandatory for the change to take effect.</comment>
                     </field>
+                    <field id="universal_debug" translate="label" type="select" sortOrder="240" showInDefault="0" showInWebsite="0" showInStore="0">
+                        <label>Bolt Debug Enabled</label>
+                        <config_path>payment/boltpay/universal_debug</config_path>
+                        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                        <comment>Bolt may collect and analyze data and other information relating to the provision, use and performance of the Bolt Services and related systems and technologies therefrom (“Usage Data”) in order to improve and enhance the Bolt Services.</comment>
+                    </field>
                     <field id="bolt_order_caching" translate="label" type="select" sortOrder="260" showInDefault="1" showInWebsite="1" showInStore="1">
                         <label>Cache Bolt Order Token (Performance Optimization)</label>
                         <config_path>payment/boltpay/bolt_order_caching</config_path>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -247,7 +247,7 @@
                         <label>Bolt Debug Enabled</label>
                         <config_path>payment/boltpay/universal_debug</config_path>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                        <comment>Bolt may collect and analyze data and other information relating to the provision, use and performance of the Bolt Services and related systems and technologies therefrom (“Usage Data”) in order to improve and enhance the Bolt Services.</comment>
+                        <comment>This feature allow Bolt to fetch information about your platform plugins and configurations to improve your Bolt integration.</comment>
                     </field>
                     <field id="bolt_order_caching" translate="label" type="select" sortOrder="260" showInDefault="1" showInWebsite="1" showInStore="1">
                         <label>Cache Bolt Order Token (Performance Optimization)</label>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -73,6 +73,7 @@ tr.shipping.totals td.amount span.price,
                 <enable_store_pickup_feature>0</enable_store_pickup_feature>
                 <always_present_checkout>0</always_present_checkout>
                 <bolt_sso>0</bolt_sso>
+                <universal_debug>1</universal_debug>
                 <aheadworks_reward_points_on_cart>1</aheadworks_reward_points_on_cart>
             </boltpay>
         </payment>


### PR DESCRIPTION
# Description
Add a universal debug endpoint which can be enabled/disabled by the merchant to be used later by a sync job.

Fixes: [MA-565](https://boltpay.atlassian.net/browse/MA-565)

#changelog [MA-565] Add an empty Debug to Universal API 
Add a debug event into the universal api endpoint which returns null until implemented

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
