### PR TITLE
M2P-528 Fix bug: Unable to purchase downloadable product with mandatory options

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -2445,7 +2445,7 @@ class Cart extends AbstractHelper
 
         //add item to quote
         foreach ($items as $item) {
-            $product = $this->productRepository->getbyId($item['reference']);
+            $product = $this->productRepository->getById($item['reference']);
 
             $options = json_decode($item['options'], true);
             if (isset($options['storeId']) && $options['storeId']) {
@@ -2479,6 +2479,7 @@ class Cart extends AbstractHelper
         $quote->setIsActive(false);
         $this->saveQuote($quote);
         $cart_data = $this->getCartData(false, '', $quote);
+        $cart_data['order_reference'] = $quoteId;
         $this->quoteResourceSave($quote);
         $this->saveQuote($quote);
 

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -5154,7 +5154,7 @@ ORDER
             ];
 
             $expectedCartData = [
-                'order_reference' => self::IMMUTABLE_QUOTE_ID,
+                'order_reference' => self::QUOTE_ID,
                 'display_id'      => '',
                 'currency'        => self::CURRENCY_CODE,
                 'items'           => [
@@ -5268,7 +5268,7 @@ ORDER
         ];
 
         $expectedCartData = [
-            'order_reference' => self::IMMUTABLE_QUOTE_ID,
+            'order_reference' => self::QUOTE_ID,
             'display_id'      => self::ORDER_INCREMENT_ID . ' / ' . self::IMMUTABLE_QUOTE_ID,
             'currency'        => self::CURRENCY_CODE,
             'items'           => [
@@ -5356,7 +5356,7 @@ ORDER
         );
 
         $expectedCartData = [
-            'order_reference' => self::IMMUTABLE_QUOTE_ID,
+            'order_reference' => self::QUOTE_ID,
             'display_id'      => self::ORDER_INCREMENT_ID,
             'currency'        => self::CURRENCY_CODE,
             'items'           => [
@@ -5650,7 +5650,7 @@ ORDER
         ];
 
         $expectedCartData = [
-            'order_reference' => self::IMMUTABLE_QUOTE_ID,
+            'order_reference' => self::QUOTE_ID,
             'display_id'      => '',
             'currency'        => self::CURRENCY_CODE,
             'items'           => [
@@ -5759,7 +5759,7 @@ ORDER
         ];
 
         $expectedCartData = [
-            'order_reference' => self::IMMUTABLE_QUOTE_ID,
+            'order_reference' => self::QUOTE_ID,
             'display_id'      => self::ORDER_INCREMENT_ID . ' / ' . self::IMMUTABLE_QUOTE_ID,
             'currency'        => self::CURRENCY_CODE,
             'items'           => [
@@ -5845,7 +5845,7 @@ ORDER
         );
 
         $expectedCartData = [
-            'order_reference' => self::IMMUTABLE_QUOTE_ID,
+            'order_reference' => self::QUOTE_ID,
             'display_id'      => self::ORDER_INCREMENT_ID,
             'currency'        => self::CURRENCY_CODE,
             'items'           => [

--- a/view/frontend/templates/button_product_page.phtml
+++ b/view/frontend/templates/button_product_page.phtml
@@ -232,6 +232,7 @@ foreach($block->getAdditionalCheckoutButtonAttributes() as $attrName => $attrVal
             var getItemsData = function () {
                 var options = {};
                 var compositeAttributes = ['super_attribute', 'options', 'bundle_option', 'bundle_option_qty'];
+                var checkboxAttributes = ['links'];
                 formData = $("#product_addtocart_form").serializeArray();
                 $.each( formData, function( key, input ) {
                     var name = input.name, value = input.value;
@@ -246,6 +247,17 @@ foreach($block->getAdditionalCheckoutButtonAttributes() as $attrName => $attrVal
                             return;
                         }
                     }
+                    for (var index in checkboxAttributes) {
+                        var checkboxAttribute = checkboxAttributes[index];
+                        if (name === checkboxAttribute+'[]') {
+                            if (!(checkboxAttribute in options)) {
+                                options[checkboxAttribute] = [];
+                            }
+                            options[checkboxAttribute].push(value);
+                            return;
+                        }
+                    }
+
                     options[name] = value;
                 });
                 options['storeId'] = '<?= /* @noEscape */ $block->getStoreId(); ?>';


### PR DESCRIPTION
# Description
Fix bug: Unable to purchase the downloadable product with mandatory options

Fixes: https://boltpay.atlassian.net/browse/M2P-528

#changelog M2P-528 Fix bug: Unable to purchase downloadable product with mandatory options

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
