### PR TITLE
M2P-536 Bugfix: Infinite loop on checkout page

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -1372,10 +1372,17 @@ $isLoadConnectJsDynamic = $block->isLoadConnectJsDynamic();
         }
         /////////////////////////////////////////////////////////////////////
 
+        if (getCheckoutType()==="payment") {
+            var country_selectors = ['div[name="billingAddressboltpay.country_id"] select[name=country_id]','div[name="shippingAddress.country_id"] select[name=country_id]','.payment-method-boltpay select[name=country_id]'];
+            var state_selectors = ['div[name="billingAddressboltpay.region_id"] select[name=region_id]','div[name="shippingAddress.region_id"] select[name=region_id]','.payment-method-boltpay select[name=region_id]'];
+        } else {
+            var country_selectors = ['select[name=country_id]'];
+            var state_selectors = ['select[name=region_id]'];                
+        }
+        
         ///////////////////////////////////////////////////////////
         // Monitor Country DOM element change and update hints
         ///////////////////////////////////////////////////////////
-        var country_selectors = ['select[name=country_id]'];
         monitorAttributesChange(country_selectors, function(element) {
             if (!element.value) {
                 delete hints.prefill.country;
@@ -1388,11 +1395,10 @@ $isLoadConnectJsDynamic = $block->isLoadConnectJsDynamic();
             configureHints();
         }, true);
         ///////////////////////////////////////////////////////////
-
+            
         ///////////////////////////////////////////////////////////
         // Monitor State DOM element change and update hints
         ///////////////////////////////////////////////////////////
-        var state_selectors = ['select[name=region_id]'];
         monitorAttributesChange(state_selectors, function(element) {
             if (!element.value) {
                 delete hints.prefill.state;


### PR DESCRIPTION
# Description
When working for the task https://boltpay.atlassian.net/browse/M2P-254, I found that on the checkout page, especially the payment step, the page always stuck on the loading screen. After investigation, it is because each payment has its own billing fields, and with the specific theme and some payment gateways, the callback monitorAttributesChange (https://github.com/BoltApp/bolt-magento2/blob/2.20.0/view/frontend/templates/js/replacejs.phtml#L1389) is triggered repeatedly and result in infinite loop.

Solution: Only trigger the callback for specific elements related to Bolt.

Fixes: https://boltpay.atlassian.net/browse/M2P-536

#changelog Bugfix: Infinite loop on checkout page

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
