### PR TITLE
M2P-537 Add support for Magento native In-Store Pickup step 1

### DIFF
--- a/Api/Data/ShipToStoreOptionInterface.php
+++ b/Api/Data/ShipToStoreOptionInterface.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Api\Data;
+
+/**
+ * Ship to store option interface.
+ *
+ * @api
+ */
+interface ShipToStoreOptionInterface
+{
+    /**
+     * Get shipping reference.
+     *
+     * @api
+     * @return string
+     */
+    public function getReference();
+
+    /**
+     * Set shipping reference.
+     *
+     * @api
+     * @param $reference
+     *
+     * @return $this
+     */
+    public function setReference($reference);
+    
+    /**
+     * Get shipping cost.
+     *
+     * @api
+     * @return int
+     */
+    public function getCost();
+
+    /**
+     * Set shipping cost.
+     *
+     * @api
+     * @param int $cost
+     * @return $this
+     */
+    public function setCost($cost);
+    
+    /**
+     * Get store name.
+     *
+     * @api
+     * @return string
+     */
+    public function getStoreName();
+
+    /**
+     * Set store name.
+     *
+     * @api
+     * @param string $storeName
+     * @return $this
+     */
+    public function setStoreName($storeName);
+    
+    /**
+     * Get store address.
+     *
+     * @api
+     * @return \Bolt\Boltpay\Api\Data\StoreAddressInterface
+     */
+    public function getAddress();
+
+    /**
+     * Set store address.
+     *
+     * @api
+     * @param \Bolt\Boltpay\Api\Data\StoreAddressInterface $storeAddress
+     * @return $this
+     */
+    public function setAddress($address);
+
+    /**
+     * Get distance.
+     *
+     * @api
+     * @return float
+     */
+    public function getDistance();
+
+    /**
+     * Set distance.
+     *
+     * @api
+     * @param float $distance
+     * @return $this
+     */
+    public function setDistance($distance);
+
+    /**
+     * Get distance unit.
+     *
+     * @api
+     * @return string
+     */
+    public function getDistanceUnit();
+
+    /**
+     * Set distance unit.
+     *
+     * @api
+     * @param string $distanceUnit
+     *
+     * @return $this
+     */
+    public function setDistanceUnit($distanceUnit);
+    
+    /**
+     * Get shipping tax.
+     *
+     * @api
+     * @return int
+     */
+    public function getTaxAmount();
+
+    /**
+     * Set shipping tax.
+     *
+     * @api
+     * @param $taxAmount
+     *
+     * @return $this
+     */
+    public function setTaxAmount($taxAmount);
+}

--- a/Api/Data/ShippingDataInterface.php
+++ b/Api/Data/ShippingDataInterface.php
@@ -41,4 +41,21 @@ interface ShippingDataInterface extends ShippingTaxDataInterface
      * @return $this
      */
     public function setShippingOptions($shippingOptions);
+    
+    /**
+     * Get all available ship to store options.
+     *
+     * @api
+     * @return \Bolt\Boltpay\Api\Data\ShipToStoreOptionInterface[]
+     */
+    public function getShipToStoreOptions();
+
+    /**
+     * Set available ship to store options.
+     *
+     * @api
+     * @param \Bolt\Boltpay\Api\Data\ShipToStoreOptionInterface[]
+     * @return $this
+     */
+    public function setShipToStoreOptions($shipToStoreOptions);
 }

--- a/Api/Data/StoreAddressInterface.php
+++ b/Api/Data/StoreAddressInterface.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Api\Data;
+
+interface StoreAddressInterface
+{
+    /**
+     * Get street address1.
+     *
+     * @api
+     * @return string
+     */
+    public function getStreetAddress1();
+
+    /**
+     * Set street address1.
+     *
+     * @api
+     * @param $streetAddress1
+     *
+     * @return $this
+     */
+    public function setStreetAddress1($streetAddress1);
+    
+    /**
+     * Get street address2.
+     *
+     * @api
+     * @return string|null
+     */
+    public function getStreetAddress2();
+
+    /**
+     * Set street address2.
+     *
+     * @api
+     * @param $streetAddress2
+     *
+     * @return $this
+     */
+    public function setStreetAddress2($streetAddress2);
+    
+    /**
+     * Get locality.
+     *
+     * @api
+     * @return string
+     */
+    public function getLocality();
+
+    /**
+     * Set locality.
+     *
+     * @api
+     * @param $locality
+     *
+     * @return $this
+     */
+    public function setLocality($locality);
+    
+    /**
+     * Get region.
+     *
+     * @api
+     * @return string
+     */
+    public function getRegion();
+
+    /**
+     * Set region.
+     *
+     * @api
+     * @param $region
+     *
+     * @return $this
+     */
+    public function setRegion($region);
+    
+    /**
+     * Get postal code.
+     *
+     * @api
+     * @return string
+     */
+    public function getPostalCode();
+
+    /**
+     * Set postal code.
+     *
+     * @api
+     * @param $postalCode
+     *
+     * @return $this
+     */
+    public function setPostalCode($postalCode);
+    
+    /**
+     * Get country code.
+     *
+     * @api
+     * @return string
+     */
+    public function getCountryCode();
+    
+    /**
+     * Set country code.
+     *
+     * @api
+     * @param $countryCode
+     *
+     * @return $this
+     */
+    public function setCountryCode($countryCode);
+}

--- a/Api/Data/TaxDataInterface.php
+++ b/Api/Data/TaxDataInterface.php
@@ -58,4 +58,21 @@ interface TaxDataInterface extends ShippingTaxDataInterface
      * @api
      */
     public function setShippingOption($shippingOption);
+    
+    /**
+     * Get all available ship to store option.
+     *
+     * @api
+     * @return \Bolt\Boltpay\Api\Data\ShipToStoreOptionInterface
+     */
+    public function getShipToStoreOption();
+
+    /**
+     * Set available ship to store option.
+     *
+     * @api
+     * @param \Bolt\Boltpay\Api\Data\ShipToStoreOptionInterface
+     * @return $this
+     */
+    public function setShipToStoreOption($shipToStoreOption);
 }

--- a/Model/Api/Data/ShipToStoreOption.php
+++ b/Model/Api/Data/ShipToStoreOption.php
@@ -1,0 +1,250 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Model\Api\Data;
+
+use Bolt\Boltpay\Api\Data\ShipToStoreOptionInterface;
+
+/**
+ * Class ShipToStoreOption.
+ *
+ * @package Bolt\Boltpay\Model\Api\Data
+ */
+class ShipToStoreOption implements ShipToStoreOptionInterface, \JsonSerializable
+{
+    /**
+     * @var string
+     */
+    private $reference;
+
+    /**
+     * @var int
+     */
+    private $cost;
+
+    /**
+     * @var string
+     */
+    private $storeName;
+
+    /**
+     * @var \Bolt\Boltpay\Api\Data\StoreAddressInterface
+     */
+    private $address;
+    
+    /**
+     * @var float
+     */
+    private $distance;
+    
+    /**
+     * @var string
+     */
+    private $distanceUnit;
+    
+    /**
+     * @var int
+     */
+    private $taxAmount;
+
+    /**
+     * Get shipping reference.
+     *
+     * @api
+     * @return string
+     */
+    public function getReference()
+    {
+        return $this->reference;
+    }
+
+    /**
+     * Set shipping reference.
+     *
+     * @api
+     * @param $reference
+     *
+     * @return $this
+     */
+    public function setReference($reference)
+    {
+        $this->reference = $reference;
+        return $this;
+    }
+    
+    /**
+     * Get shipping cost.
+     *
+     * @api
+     * @return int
+     */
+    public function getCost()
+    {
+        return $this->cost;
+    }
+
+    /**
+     * Set shipping cost.
+     *
+     * @api
+     * @param int $cost
+     * @return $this
+     */
+    public function setCost($cost)
+    {
+        $this->cost = $cost;
+        return $this;
+    }
+    
+    /**
+     * Get store name.
+     *
+     * @api
+     * @return string
+     */
+    public function getStoreName()
+    {
+        return $this->storeName;
+    }
+
+    /**
+     * Set store name.
+     *
+     * @api
+     * @param string $storeName
+     * @return $this
+     */
+    public function setStoreName($storeName)
+    {
+        $this->storeName = $storeName;
+        return $this;
+    }
+    
+    /**
+     * Get store address.
+     *
+     * @api
+     * @return \Bolt\Boltpay\Api\Data\StoreAddressInterface
+     */
+    public function getAddress()
+    {
+        return $this->address;
+    }
+
+    /**
+     * Set store address.
+     *
+     * @api
+     * @param \Bolt\Boltpay\Api\Data\StoreAddressInterface $storeAddress
+     * @return $this
+     */
+    public function setAddress($address)
+    {
+        $this->address = $address;
+        return $this;
+    }
+
+    /**
+     * Get distance.
+     *
+     * @api
+     * @return float
+     */
+    public function getDistance()
+    {
+        return $this->distance;
+    }
+
+    /**
+     * Set distance.
+     *
+     * @api
+     * @param float $distance
+     * @return $this
+     */
+    public function setDistance($distance)
+    {
+        $this->distance = $distance;
+        return $this;
+    }
+
+    /**
+     * Get distance unit.
+     *
+     * @api
+     * @return string
+     */
+    public function getDistanceUnit()
+    {
+        return $this->distanceUnit;
+    }
+
+    /**
+     * Set distance unit.
+     *
+     * @api
+     * @param string $distanceUnit
+     *
+     * @return $this
+     */
+    public function setDistanceUnit($distanceUnit)
+    {
+        $this->distanceUnit = $distanceUnit;
+        return $this;
+    }
+    
+    /**
+     * Get shipping tax.
+     *
+     * @api
+     * @return int
+     */
+    public function getTaxAmount()
+    {
+        return $this->taxAmount;
+    }
+
+    /**
+     * Set shipping tax.
+     *
+     * @api
+     * @param $taxAmount
+     *
+     * @return $this
+     */
+    public function setTaxAmount($taxAmount)
+    {
+        $this->taxAmount = $taxAmount;
+        return $this;
+    }
+    
+    /**
+     * @inheritDoc
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'reference' => $this->reference,
+            'cost' => $this->cost,
+            'store_name' => $this->storeName,
+            'address' => $this->address,
+            'distance' => $this->distance,
+            'distance_unit' => $this->distanceUnit,
+            'tax_amount' => $this->taxAmount
+        ];
+    }
+}

--- a/Model/Api/Data/ShippingData.php
+++ b/Model/Api/Data/ShippingData.php
@@ -19,6 +19,7 @@ namespace Bolt\Boltpay\Model\Api\Data;
 
 use Bolt\Boltpay\Api\Data\ShippingDataInterface;
 use Bolt\Boltpay\Api\Data\ShippingOptionInterface;
+use Bolt\Boltpay\Api\Data\ShipToStoreOptionInterface;
 
 /**
  * Class ShippingData. Shipping options property of Shipping.
@@ -31,6 +32,11 @@ class ShippingData implements ShippingDataInterface, \JsonSerializable
      * @var array
      */
     private $shippingOptions = [];
+    
+    /**
+     * @var array
+     */
+    private $shipToStoreOptions = [];
 
     /**
      * Get all available shipping options.
@@ -55,6 +61,30 @@ class ShippingData implements ShippingDataInterface, \JsonSerializable
         $this->shippingOptions = $shippingOptions;
         return $this;
     }
+    
+    /**
+     * Get all available ship to store options.
+     *
+     * @api
+     * @return \Bolt\Boltpay\Api\Data\ShipToStoreOptionInterface[]
+     */
+    public function getShipToStoreOptions()
+    {
+        return $this->shipToStoreOptions;
+    }
+
+    /**
+     * Set available ship to store options.
+     *
+     * @api
+     * @param \Bolt\Boltpay\Api\Data\ShipToStoreOptionInterface[]
+     * @return $this
+     */
+    public function setShipToStoreOptions($shipToStoreOptions)
+    {
+        $this->shipToStoreOptions = $shipToStoreOptions;
+        return $this;
+    }
 
     /**
      * @inheritDoc
@@ -62,7 +92,8 @@ class ShippingData implements ShippingDataInterface, \JsonSerializable
     public function jsonSerialize()
     {
         return [
-            'shipping_options' => $this->shippingOptions
+            'shipping_options' => $this->shippingOptions,
+            'ship_to_store_options' => $this->shipToStoreOptions
         ];
     }
 }

--- a/Model/Api/Data/StoreAddress.php
+++ b/Model/Api/Data/StoreAddress.php
@@ -1,0 +1,224 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Model\Api\Data;
+
+use Bolt\Boltpay\Api\Data\StoreAddressInterface;
+
+/**
+ * Class StoreAddress.
+ *
+ * @package Bolt\Boltpay\Model\Api\Data
+ */
+class StoreAddress implements StoreAddressInterface, \JsonSerializable
+{
+    /**
+     * @var string
+     */
+    private $streetAddress1;
+
+    /**
+     * @var string|null
+     */
+    private $streetAddress2;
+
+    /**
+     * @var string
+     */
+    private $locality;
+
+    /**
+     * @var string
+     */
+    private $region;
+    
+    /**
+     * @var string
+     */
+    private $postalCode;
+    
+    /**
+     * @var string
+     */
+    private $countryCode;
+    
+    
+    /**
+     * Get street address1.
+     *
+     * @api
+     * @return string
+     */
+    public function getStreetAddress1()
+    {
+        return $this->streetAddress1;
+    }
+
+    /**
+     * Set street address1.
+     *
+     * @api
+     * @param $streetAddress1
+     *
+     * @return $this
+     */
+    public function setStreetAddress1($streetAddress1)
+    {
+        $this->streetAddress1 = $streetAddress1;
+        return $this;
+    }
+
+    /**
+     * Get street address2.
+     *
+     * @api
+     * @return string|null
+     */
+    public function getStreetAddress2()
+    {
+        return $this->streetAddress2;
+    }
+
+    /**
+     * Set street address2.
+     *
+     * @api
+     * @param $streetAddress2
+     *
+     * @return $this
+     */
+    public function setStreetAddress2($streetAddress2)
+    {
+        $this->streetAddress2 = $streetAddress2;
+        return $this;
+    }
+    
+    /**
+     * Get locality.
+     *
+     * @api
+     * @return string
+     */
+    public function getLocality()
+    {
+        return $this->locality;
+    }
+
+    /**
+     * Set locality.
+     *
+     * @api
+     * @param $locality
+     *
+     * @return $this
+     */
+    public function setLocality($locality)
+    {
+        $this->locality = $locality;
+        return $this;
+    }
+    
+    /**
+     * Get region.
+     *
+     * @api
+     * @return string
+     */
+    public function getRegion()
+    {
+        return $this->region;
+    }
+
+    /**
+     * Set region.
+     *
+     * @api
+     * @param $region
+     *
+     * @return $this
+     */
+    public function setRegion($region)
+    {
+        $this->region = $region;
+        return $this;
+    }
+    
+    /**
+     * Get postal code.
+     *
+     * @api
+     * @return string
+     */
+    public function getPostalCode()
+    {
+        return $this->postalCode;
+    }
+
+    /**
+     * Set postal code.
+     *
+     * @api
+     * @param $postalCode
+     *
+     * @return $this
+     */
+    public function setPostalCode($postalCode)
+    {
+        $this->postalCode = $postalCode;
+        return $this;
+    }
+    
+    /**
+     * Get country code.
+     *
+     * @api
+     * @return string
+     */
+    public function getCountryCode()
+    {
+        return $this->countryCode;
+    }
+
+    /**
+     * Set country code.
+     *
+     * @api
+     * @param $countryCode
+     *
+     * @return $this
+     */
+    public function setCountryCode($countryCode)
+    {
+        $this->countryCode = $countryCode;
+        return $this;
+    }
+    
+    /**
+     * @inheritDoc
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'street_address1' => $this->streetAddress1,
+            'street_address2' => $this->streetAddress2,
+            'locality' => $this->locality,
+            'region' => $this->region,
+            'postal_code' => $this->postalCode,
+            'country_code' => $this->countryCode,
+        ];
+    }
+}

--- a/Model/Api/Data/TaxData.php
+++ b/Model/Api/Data/TaxData.php
@@ -20,6 +20,7 @@ namespace Bolt\Boltpay\Model\Api\Data;
 use Bolt\Boltpay\Api\Data\TaxDataInterface;
 use Bolt\Boltpay\Api\Data\TaxResultInterface;
 use Bolt\Boltpay\Api\Data\ShippingOptionInterface;
+use Bolt\Boltpay\Api\Data\ShipToStoreOptionInterface;
 
 /**
  * Class TaxData. Tax result and Shipping option properties of Tax.
@@ -37,6 +38,11 @@ class TaxData implements TaxDataInterface, \JsonSerializable
      * @var ShippingOptionInterface
      */
     private $shippingOption;
+    
+    /**
+     * @var ShipToStoreOptionInterface
+     */
+    private $shipToStoreOption;
 
     /**
      * Get order tax result.
@@ -86,6 +92,30 @@ class TaxData implements TaxDataInterface, \JsonSerializable
         $this->shippingOption = $shippingOption;
         return $this;
     }
+    
+    /**
+     * Get all available ship to store option.
+     *
+     * @api
+     * @return \Bolt\Boltpay\Api\Data\ShipToStoreOptionInterface
+     */
+    public function getShipToStoreOption()
+    {
+        return $this->shipToStoreOption;
+    }
+
+    /**
+     * Set available ship to store option.
+     *
+     * @api
+     * @param \Bolt\Boltpay\Api\Data\ShipToStoreOptionInterface
+     * @return $this
+     */
+    public function setShipToStoreOption($shipToStoreOption)
+    {
+        $this->shipToStoreOption = $shipToStoreOption;
+        return $this;
+    }
 
     /**
      * @inheritDoc
@@ -94,7 +124,8 @@ class TaxData implements TaxDataInterface, \JsonSerializable
     {
         return [
             'tax_result' => $this->taxResult,
-            'shipping_option' => $this->shippingOption
+            'shipping_option' => $this->shippingOption,
+            'ship_to_store_option' => $this->shipToStoreOption
         ];
     }
 }

--- a/Test/Unit/Model/Api/Data/ShipToStoreOptionTest.php
+++ b/Test/Unit/Model/Api/Data/ShipToStoreOptionTest.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Test\Unit\Model\Api\Data;
+
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
+use Bolt\Boltpay\Model\Api\Data\ShipToStoreOption;
+use Bolt\Boltpay\Model\Api\Data\StoreAddress;
+
+/**
+ * Class ShipToStoreOptionTest
+ * @package Bolt\Boltpay\Test\Unit\Model\Api\Data
+ * @coversDefaultClass \Bolt\Boltpay\Model\Api\Data\ShipToStoreOption
+ */
+class ShipToStoreOptionTest extends BoltTestCase
+{
+    const REFERENCE = 'INSTOREPICKUPREFERENCE';
+    const COST = 10;
+    const TAX_AMOUNT = 123;
+    const STORE_NAME = 'INSTOREPICKUP_STORE';
+    const DISTANCE = 6.6;
+    const DISTANCE_UNIT = 'km';
+
+    /**
+     * @var ShipToStoreOption
+     */
+    protected $shipToStoreOption;
+    
+    /**
+     * @var StoreAddress
+     */
+    protected $storeAddress;
+
+    protected function setUpInternal()
+    {
+        $this->storeAddress =  new StoreAddress();
+        $this->shipToStoreOption = new ShipToStoreOption();
+        $this->shipToStoreOption->setReference(self::REFERENCE);
+        $this->shipToStoreOption->setCost(self::COST);
+        $this->shipToStoreOption->setStoreName(self::STORE_NAME);
+        $this->shipToStoreOption->setAddress($this->storeAddress);
+        $this->shipToStoreOption->setDistance(self::DISTANCE);
+        $this->shipToStoreOption->setDistanceUnit(self::DISTANCE_UNIT);
+        $this->shipToStoreOption->setTaxAmount(self::TAX_AMOUNT);
+    }
+
+    /**
+     * @test
+     * that getReference would return reference
+     * @covers ::getReference
+     */
+    public function getReference_always_returnsReference()
+    {
+        $this->assertEquals(self::REFERENCE, $this->shipToStoreOption->getReference());
+    }
+
+    /**
+     * @test
+     * that getCost would return cost
+     * @covers ::getCost
+     */
+    public function getCost_always_returnsCost()
+    {
+        $this->assertEquals(self::COST, $this->shipToStoreOption->getCost());
+    }
+    
+    /**
+     * @test
+     * that getStoreName would return store name
+     * @covers ::getStoreName
+     */
+    public function getStoreName_always_returnsStoreName()
+    {
+        $this->assertEquals(self::STORE_NAME, $this->shipToStoreOption->getStoreName());
+    }
+    
+    /**
+     * @test
+     * that getAddress would return store address
+     * @covers ::getAddress
+     */
+    public function getAddress_always_returnsAddress()
+    {
+        $this->assertEquals($this->storeAddress, $this->shipToStoreOption->getAddress());
+    }
+    
+    /**
+     * @test
+     * that getDistance would return distance
+     * @covers ::getDistance
+     */
+    public function getDistance_always_returnsDistance()
+    {
+        $this->assertEquals(self::DISTANCE, $this->shipToStoreOption->getDistance());
+    }
+    
+    /**
+     * @test
+     * that getDistanceUnit would return distance unit
+     * @covers ::getDistanceUnit
+     */
+    public function getDistanceUnit_always_returnsDistanceUnit()
+    {
+        $this->assertEquals(self::DISTANCE_UNIT, $this->shipToStoreOption->getDistanceUnit());
+    }
+
+    /**
+     * @test
+     * that getTaxAmount would return tax amount
+     * @covers ::getTaxAmount
+     */
+    public function getTaxAmount_always_returnsTaxAmount()
+    {
+        $this->assertEquals(self::TAX_AMOUNT, $this->shipToStoreOption->getTaxAmount());
+    }
+
+    /**
+     * @test
+     * that jsonSerialize would return an associative array of values
+     * @covers ::jsonSerialize
+     */
+    public function jsonSerialize_always_returnsValues()
+    {
+        $result = $this->shipToStoreOption->jsonSerialize();
+        $this->assertEquals([
+            'reference' => self::REFERENCE,
+            'cost' => self::COST,
+            'store_name' => self::STORE_NAME,
+            'address' => $this->storeAddress,
+            'distance' => self::DISTANCE,
+            'distance_unit' => self::DISTANCE_UNIT,
+            'tax_amount' =>self::TAX_AMOUNT
+        ], $result);
+    }
+}

--- a/Test/Unit/Model/Api/Data/ShippingDataTest.php
+++ b/Test/Unit/Model/Api/Data/ShippingDataTest.php
@@ -19,7 +19,9 @@ namespace Bolt\Boltpay\Test\Unit\Model\Api\Data;
 
 use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Model\Api\Data\ShippingOption;
+use Bolt\Boltpay\Model\Api\Data\ShipToStoreOption;
 use Bolt\Boltpay\Api\Data\ShippingDataInterface;
+use Bolt\Boltpay\Api\Data\ShipToStoreOptionInterface;
 use Bolt\Boltpay\Model\Api\Data\ShippingData;
 
 /**
@@ -38,12 +40,19 @@ class ShippingDataTest extends BoltTestCase
      * @var ShippingOption[]
      */
     private $shippingOptions;
+    
+    /**
+     * @var ShipToStoreOption[]
+     */
+    private $shipToStoreOptions = [];
 
     protected function setUpInternal()
     {
         $this->shippingOptions = [new ShippingOption];
+        $this->shipToStoreOptions = [new ShipToStoreOption];
         $this->shippingData = new ShippingData;
         $this->shippingData->setShippingOptions($this->shippingOptions);
+        $this->shippingData->setShipToStoreOptions($this->shipToStoreOptions);
     }
 
     /**
@@ -66,6 +75,27 @@ class ShippingDataTest extends BoltTestCase
         $result = $this->shippingData->setShippingOptions($this->shippingOptions);
         $this->assertInstanceOf(ShippingData::class, $result);
     }
+    
+    /**
+     * @test
+     * that getShipToStoreOptions would return ship to store options
+     * @covers ::getShipToStoreOptions
+     */
+    public function getShipToStoreOptions()
+    {
+        $this->assertEquals($this->shipToStoreOptions, $this->shippingData->getShipToStoreOptions());
+    }
+
+    /**
+     * @test
+     * that setShipToStoreOptions would set instances of ship to store options
+     * @covers ::setShipToStoreOptions
+     */
+    public function setShipToStoreOptions()
+    {
+        $result = $this->shippingData->setShipToStoreOptions($this->shipToStoreOptions);
+        $this->assertInstanceOf(ShippingData::class, $result);
+    }
 
     /**
      * @test
@@ -76,7 +106,8 @@ class ShippingDataTest extends BoltTestCase
     {
         $result = $this->shippingData->jsonSerialize();
         $this->assertEquals([
-            'shipping_options' => $this->shippingOptions
+            'shipping_options' => $this->shippingOptions,
+            'ship_to_store_options' => $this->shipToStoreOptions
         ], $result);
     }
 }

--- a/Test/Unit/Model/Api/Data/StoreAddressTest.php
+++ b/Test/Unit/Model/Api/Data/StoreAddressTest.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Test\Unit\Model\Api\Data;
+
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
+use Bolt\Boltpay\Model\Api\Data\StoreAddress;
+
+/**
+ * Class StoreAddressTest
+ * @package Bolt\Boltpay\Test\Unit\Model\Api\Data
+ * @coversDefaultClass \Bolt\Boltpay\Model\Api\Data\StoreAddress
+ */
+class StoreAddressTest extends BoltTestCase
+{
+    const STREET_ADDRESS_1 = '2233 Flatbush Ave';
+    const STREET_ADDRESS_2 = '#6';
+    const LOCALITY = 'Brooklyn';
+    const REGION = 'New York';
+    const POSTALCODE = '11234';
+    const COUNTRYCODE = 'US';
+
+    /**
+     * @var StoreAddress
+     */
+    protected $storeAddress;
+
+    protected function setUpInternal()
+    {
+        $this->storeAddress = new StoreAddress();
+        $this->storeAddress->setStreetAddress1(self::STREET_ADDRESS_1);
+        $this->storeAddress->setStreetAddress2(self::STREET_ADDRESS_2);
+        $this->storeAddress->setLocality(self::LOCALITY);
+        $this->storeAddress->setRegion(self::REGION);
+        $this->storeAddress->setPostalCode(self::POSTALCODE);
+        $this->storeAddress->setCountryCode(self::COUNTRYCODE);
+    }
+
+    /**
+     * @test
+     * that getStreetAddress1 would return region.
+     * @covers ::getStreetAddress1
+     */
+    public function getStreetAddress1_always_returnsStreetAddress1()
+    {
+        $this->assertEquals(self::STREET_ADDRESS_1, $this->storeAddress->getStreetAddress1());
+    }
+    
+    /**
+     * @test
+     * that getStreetAddress2 would return region.
+     * @covers ::getStreetAddress2
+     */
+    public function getStreetAddress2_always_returnsStreetAddress2()
+    {
+        $this->assertEquals(self::STREET_ADDRESS_2, $this->storeAddress->getStreetAddress2());
+    }
+    
+    /**
+     * @test
+     * that getLocality would return region.
+     * @covers ::getLocality
+     */
+    public function getLocality_always_returnsLocality()
+    {
+        $this->assertEquals(self::LOCALITY, $this->storeAddress->getLocality());
+    }
+    
+    /**
+     * @test
+     * that getRegion would return region.
+     * @covers ::getRegion
+     */
+    public function getRegion_always_returnsRegion()
+    {
+        $this->assertEquals(self::REGION, $this->storeAddress->getRegion());
+    }
+    
+    /**
+     * @test
+     * that getPostalCode would return postal code.
+     * @covers ::getPostalCode
+     */
+    public function getPostalCode_always_returnsPostalCode()
+    {
+        $this->assertEquals(self::POSTALCODE, $this->storeAddress->getPostalCode());
+    }
+    
+    /**
+     * @test
+     * that getCountryCode would return country code
+     * @covers ::getCountryCode
+     */
+    public function getCountryCode_always_returnsCountryCode()
+    {
+        $this->assertEquals(self::COUNTRYCODE, $this->storeAddress->getCountryCode());
+    }
+
+    /**
+     * @test
+     * that jsonSerialize would return an associative array of values
+     * @covers ::jsonSerialize
+     */
+    public function jsonSerialize_always_returnsValues()
+    {
+        $result = $this->storeAddress->jsonSerialize();
+        $this->assertEquals([
+            'street_address1' => self::STREET_ADDRESS_1,
+            'street_address2' => self::STREET_ADDRESS_2,
+            'locality' => self::LOCALITY,
+            'region' => self::REGION,
+            'postal_code' => self::POSTALCODE,
+            'country_code' => self::COUNTRYCODE
+        ], $result);
+    }
+}

--- a/Test/Unit/Model/Api/Data/TaxDataTest.php
+++ b/Test/Unit/Model/Api/Data/TaxDataTest.php
@@ -19,6 +19,7 @@ namespace Bolt\Boltpay\Test\Unit\Model\Api\Data;
 
 use Bolt\Boltpay\Api\Data\TaxDataInterface;
 use Bolt\Boltpay\Model\Api\Data\ShippingOption;
+use Bolt\Boltpay\Model\Api\Data\ShipToStoreOption;
 use Bolt\Boltpay\Model\Api\Data\TaxData;
 use Bolt\Boltpay\Model\Api\Data\TaxResult;
 use Bolt\Boltpay\Test\Unit\BoltTestCase;
@@ -44,14 +45,21 @@ class TaxDataTest extends BoltTestCase
      * @var ShippingOption
      */
     private $shippingOption;
+    
+    /**
+     * @var ShipToStoreOption
+     */
+    private $shipToStoreOption;
 
     public function setUpInternal()
     {
         $this->taxResult = new TaxResult;
         $this->shippingOption = new ShippingOption;
+        $this->shipToStoreOption = new ShipToStoreOption;
         $this->taxData = new TaxData;
         $this->taxData->setTaxResult($this->taxResult);
         $this->taxData->setShippingOption($this->shippingOption);
+        $this->taxData->setShipToStoreOption($this->shipToStoreOption);
     }
 
     /**
@@ -99,6 +107,29 @@ class TaxDataTest extends BoltTestCase
         $result = $this->taxData->setShippingOption($this->shippingOption);
         $this->assertInstanceOf(TaxData::class, $result);
     }
+    
+    /**
+     * @test
+     * that getShipToStoreOption would return ship to store option
+     *
+     * @covers ::getShipToStoreOption
+     */
+    public function getShipToStoreOption()
+    {
+        $this->assertEquals($this->shipToStoreOption, $this->taxData->getShipToStoreOption());
+    }
+
+    /**
+     * @test
+     * that setShipToStoreOption would set ship to store option and return tax data instance
+     *
+     * @covers ::setShipToStoreOption
+     */
+    public function setShipToStoreOption()
+    {
+        $result = $this->taxData->setShipToStoreOption($this->shipToStoreOption);
+        $this->assertInstanceOf(TaxData::class, $result);
+    }
 
     /**
      * @test
@@ -111,7 +142,8 @@ class TaxDataTest extends BoltTestCase
         $result = $this->taxData->jsonSerialize();
         $this->assertEquals([
             'tax_result' => $this->taxResult,
-            'shipping_option' => $this->shippingOption
+            'shipping_option' => $this->shippingOption,
+            'ship_to_store_option' => $this->shipToStoreOption
         ], $result);
     }
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -55,6 +55,8 @@
 
     <preference for="Bolt\Boltpay\Api\ShippingInterface"          type="Bolt\Boltpay\Model\Api\Shipping" />
     <preference for="Bolt\Boltpay\Api\Data\ShippingDataInterface" type="Bolt\Boltpay\Model\Api\Data\ShippingData" />
+    <preference for="Bolt\Boltpay\Api\Data\StoreAddressInterface" type="Bolt\Boltpay\Model\Api\Data\StoreAddress" />
+    <preference for="Bolt\Boltpay\Api\Data\ShipToStoreOptionInterface" type="Bolt\Boltpay\Model\Api\Data\ShipToStoreOption" />
 
     <preference for="Bolt\Boltpay\Api\TaxInterface"            type="Bolt\Boltpay\Model\Api\Tax" />
     <preference for="Bolt\Boltpay\Api\Data\TaxDataInterface"   type="Bolt\Boltpay\Model\Api\Data\TaxData" />


### PR DESCRIPTION
# Description

As we decide to add support BOPIS Spilt shipping to M2, and In-store delivery method is supported with version 2.4.0 of Magento (https://devdocs.magento.com/guides/v2.4/inventory/release-notes.html#v120) , this PR is for adding support for this feature.

Step 1 : Create/Update related api data interfaces and classes.

Fixes: https://boltpay.atlassian.net/browse/M2P-537

#changelog Add support for Magento native In-Store Pickup step 1

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
