### PR TITLE
M2P-537 Add support for Magento native In-Store Pickup step 2

### DIFF
--- a/Model/Api/Shipping.php
+++ b/Model/Api/Shipping.php
@@ -86,17 +86,21 @@ class Shipping extends ShippingTax implements ShippingInterface
     /**
      * @param array $addressData
      * @param null $shipping_option
+     * @param null $ship_to_store_option
      * @return ShippingDataInterface
      * @throws LocalizedException
      */
-    public function generateResult($addressData, $shipping_option)
+    public function generateResult($addressData, $shipping_option, $ship_to_store_option)
     {
         $shippingOptions = $this->getShippingOptions($addressData);
+        // Get ship to store options
+        list($shipToStoreOptions, $shippingOptions) = $this->eventsForThirdPartyModules->runFilter("getShipToStoreOptions", [[],$shippingOptions], $this->quote, $shippingOptions, $addressData);
         /**
          * @var ShippingDataInterface $shippingData
          */
         $shippingData = $this->shippingDataFactory->create();
         $shippingData->setShippingOptions($shippingOptions);
+        $shippingData->setShipToStoreOptions($shipToStoreOptions);
         return $shippingData;
     }
 

--- a/Model/Api/ShippingTax.php
+++ b/Model/Api/ShippingTax.php
@@ -419,6 +419,8 @@ abstract class ShippingTax
     }
 
     /**
+     * For the shipping api hook, it only has $addressData.
+     * For the tax api hook, besides the $addressData, it also has $shipping_option or $ship_to_store_option.
      * @param array $addressData
      * @param array|null $shipping_option
      * @param array|null $ship_to_store_option

--- a/Model/Api/ShippingTax.php
+++ b/Model/Api/ShippingTax.php
@@ -115,6 +115,21 @@ abstract class ShippingTax
      * @var ShippingOptionInterfaceFactory
      */
     protected $shippingOptionFactory;
+    
+    /**
+     * @var ShipToStoreOptionInterfaceFactory
+     */
+    protected $shipToStoreOptionFactory;
+    
+    /**
+     * @var StoreAddressInterfaceFactory
+     */
+    protected $storeAddressFactory;
+    
+    /**
+     * @var EventsForThirdPartyModules
+     */
+    protected $eventsForThirdPartyModules;
 
     /**
      * Assigns local references to global resources
@@ -136,6 +151,9 @@ abstract class ShippingTax
         $this->regionModel = $shippingTaxContext->getRegionModel();
         $this->response = $shippingTaxContext->getResponse();
         $this->shippingOptionFactory = $shippingTaxContext->getShippingOptionFactory();
+        $this->shipToStoreOptionFactory = $shippingTaxContext->getShipToStoreOptionFactory();
+        $this->storeAddressFactory = $shippingTaxContext->getStoreAddressFactory();
+        $this->eventsForThirdPartyModules = $shippingTaxContext->getEventsForThirdPartyModules();
     }
 
     /**
@@ -298,16 +316,17 @@ abstract class ShippingTax
      * @param mixed $cart cart details
      * @param mixed $shipping_address shipping address
      * @param mixed $shipping_option selected shipping option
+     * @param mixed $ship_to_store_option selected ship to store option
      * @return ShippingTaxDataInterface
      */
-    public function execute($cart, $shipping_address, $shipping_option = null)
+    public function execute($cart, $shipping_address, $shipping_option = null, $ship_to_store_option = null)
     {
         // echo statement initially
         $startTime = $this->metricsClient->getCurrentTime();
         $this->logHelper->addInfoLog('[-= Shipping / Tax request =-]');
         $this->logHelper->addInfoLog(file_get_contents('php://input'));
         try {
-            $result = $this->handleRequest($cart, $shipping_address, $shipping_option);
+            $result = $this->handleRequest($cart, $shipping_address, $shipping_option, $ship_to_store_option);
             $this->metricsClient->processMetric(static::METRICS_SUCCESS_KEY, 1, static::METRICS_LATENCY_KEY, $startTime);
             return $result;
         } catch (\Magento\Framework\Webapi\Exception $e) {
@@ -330,10 +349,11 @@ abstract class ShippingTax
      * @param mixed $cart cart details
      * @param mixed $shipping_address shipping address
      * @param mixed $shipping_option selected shipping option
+     * @param mixed $ship_to_store_option selected pick up in store option
      * @return ShippingTaxDataInterface
      * @throws BoltException
      */
-    public function handleRequest($cart = null, $shipping_address = null, $shipping_option = null)
+    public function handleRequest($cart = null, $shipping_address = null, $shipping_option = null, $ship_to_store_option = null)
     {
         // get immutable quote id stored with transaction
         $immutableQuoteId = $this->cartHelper->getImmutableQuoteIdFromBoltCartArray($cart);
@@ -361,7 +381,7 @@ abstract class ShippingTax
             $this->validateAddressData($addressData);
         }
 
-        $result = $this->getResult($addressData, $shipping_option);
+        $result = $this->getResult($addressData, $shipping_option, $ship_to_store_option);
 
         $this->logHelper->addInfoLog('[-= Shipping / Tax result =-]');
         $this->logHelper->addInfoLog(json_encode($result, JSON_PRETTY_PRINT));
@@ -373,15 +393,16 @@ abstract class ShippingTax
      *
      * @param array $addressData
      * @param array|null $shipping_option
+     * @param array|null $ship_to_store_option
      *
      * @return ShippingTaxDataInterface
      * @throws LocalizedException
      */
-    public function getResult($addressData, $shipping_option)
+    public function getResult($addressData, $shipping_option, $ship_to_store_option)
     {
         // Take into account external data applied to quote in thirt party modules
         $this->applyExternalQuoteData();
-        $result = $this->generateResult($addressData, $shipping_option);
+        $result = $this->generateResult($addressData, $shipping_option, $ship_to_store_option);
         return $result;
     }
 
@@ -400,8 +421,9 @@ abstract class ShippingTax
     /**
      * @param array $addressData
      * @param array|null $shipping_option
+     * @param array|null $ship_to_store_option
      * @return ShippingTaxDataInterface
      * @throws \Exception
      */
-    abstract public function generateResult($addressData, $shipping_option);
+    abstract public function generateResult($addressData, $shipping_option, $ship_to_store_option);
 }

--- a/Model/Api/ShippingTaxContext.php
+++ b/Model/Api/ShippingTaxContext.php
@@ -29,6 +29,9 @@ use Bolt\Boltpay\Model\ErrorResponse as BoltErrorResponse;
 use Magento\Directory\Model\Region as RegionModel;
 use Magento\Framework\Webapi\Rest\Response;
 use Bolt\Boltpay\Api\Data\ShippingOptionInterfaceFactory;
+use Bolt\Boltpay\Api\Data\ShipToStoreOptionInterfaceFactory;
+use Bolt\Boltpay\Api\Data\StoreAddressInterfaceFactory;
+use Bolt\Boltpay\Model\EventsForThirdPartyModules;
 
 /**
  * Class ShippingTaxContext
@@ -97,6 +100,21 @@ class ShippingTaxContext
      * @var ShippingOptionInterfaceFactory
      */
     protected $shippingOptionFactory;
+    
+    /**
+     * @var ShipToStoreOptionInterfaceFactory
+     */
+    protected $shipToStoreOptionFactory;
+    
+    /**
+     * @var StoreAddressInterfaceFactory
+     */
+    protected $storeAddressFactory;
+    
+    /**
+     * @var EventsForThirdPartyModules
+     */
+    protected $eventsForThirdPartyModules;
 
     /**
      * Assigns local references to global resources
@@ -113,6 +131,9 @@ class ShippingTaxContext
      * @param RegionModel $regionModel
      * @param Response $response
      * @param ShippingOptionInterfaceFactory $shippingOptionFactory
+     * @param ShipToStoreOptionInterfaceFactory $shipToStoreOptionFactory
+     * @param StoreAddressInterfaceFactory $storeAddressFactory
+     * @param EventsForThirdPartyModules $eventsForThirdPartyModules
      */
     public function __construct(
         HookHelper $hookHelper,
@@ -126,7 +147,10 @@ class ShippingTaxContext
         BoltErrorResponse $errorResponse,
         RegionModel $regionModel,
         Response $response,
-        ShippingOptionInterfaceFactory $shippingOptionFactory
+        ShippingOptionInterfaceFactory $shippingOptionFactory,
+        ShipToStoreOptionInterfaceFactory $shipToStoreOptionFactory,
+        StoreAddressInterfaceFactory $storeAddressFactory,
+        EventsForThirdPartyModules $eventsForThirdPartyModules
     ) {
         $this->hookHelper = $hookHelper;
         $this->cartHelper = $cartHelper;
@@ -140,6 +164,9 @@ class ShippingTaxContext
         $this->regionModel = $regionModel;
         $this->response = $response;
         $this->shippingOptionFactory = $shippingOptionFactory;
+        $this->shipToStoreOptionFactory = $shipToStoreOptionFactory;
+        $this->storeAddressFactory = $storeAddressFactory;
+        $this->eventsForThirdPartyModules = $eventsForThirdPartyModules;
     }
 
     /**
@@ -236,5 +263,29 @@ class ShippingTaxContext
     public function getShippingOptionFactory()
     {
         return $this->shippingOptionFactory;
+    }
+    
+    /**
+     * @return ShipToStoreOptionInterfaceFactory
+     */
+    public function getShipToStoreOptionFactory()
+    {
+        return $this->shipToStoreOptionFactory;
+    }
+    
+    /**
+     * @return StoreAddressInterfaceFactory
+     */
+    public function getStoreAddressFactory()
+    {
+        return $this->storeAddressFactory;
+    }
+    
+    /**
+     * @return EventsForThirdPartyModules
+     */
+    public function getEventsForThirdPartyModules()
+    {
+        return $this->eventsForThirdPartyModules;
     }
 }

--- a/Model/Api/Tax.php
+++ b/Model/Api/Tax.php
@@ -149,11 +149,12 @@ class Tax extends ShippingTax implements TaxInterface
 
     /**
      * @param array $addressData
-     * @param array $shipping_option
+     * @param array|null $shipping_option
+     * @param array|null $ship_to_store_option
      * @return TaxDataInterface
      * @throws \Exception
      */
-    public function generateResult($addressData, $shipping_option)
+    public function generateResult($addressData, $shipping_option, $ship_to_store_option)
     {
         $this->setAddressInformation($addressData, $shipping_option);
 

--- a/Model/EventsForThirdPartyModules.php
+++ b/Model/EventsForThirdPartyModules.php
@@ -37,6 +37,7 @@ use Bolt\Boltpay\ThirdPartyModules\Magento\SalesRuleStaging as Magento_SalesRule
 use Bolt\Boltpay\ThirdPartyModules\Zonos\DutyTax as Zonos_DutyTax;
 use Bolt\Boltpay\ThirdPartyModules\Mageside\CustomShippingPrice as Mageside_CustomShippingPrice;
 use Bolt\Boltpay\ThirdPartyModules\MageWorld\Affiliate as MW_Affiliate;
+use Bolt\Boltpay\ThirdPartyModules\Magento\InStorePickupShipping as Magento_InStorePickupShipping;
 use Bolt\Boltpay\Helper\Bugsnag;
 use Exception;
 
@@ -770,6 +771,21 @@ class EventsForThirdPartyModules
                     "module" => "MW_Affiliate",
                     "checkClasses" => ["MW\Affiliate\Helper\Data"],
                     "boltClass" => MW_Affiliate::class,
+                ],
+            ],
+        ],
+        "getShipToStoreOptions" => [
+            "listeners" => [
+                [
+                    "module" => "Magento_InventoryInStorePickup",
+                    "sendClasses" => ["Magento\InventoryInStorePickupApi\Model\SearchRequestBuilderInterface",
+                                      "Magento\InventoryInStorePickupApi\Api\GetPickupLocationsInterface",
+                                      "Magento\InventoryInStorePickupApi\Api\Data\SearchRequest\ProductInfoInterfaceFactory",
+                                      "Magento\InventoryInStorePickupApi\Api\Data\SearchRequestExtensionFactory",
+                                      "Magento\InventoryInStorePickup\Model\SearchRequest\Area\GetDistanceToSources"],
+                    "checkClasses" => ["Magento\InventoryInStorePickupShippingApi\Model\Carrier\InStorePickup",
+                                       "Magento\InventorySalesApi\Api\Data\SalesChannelInterface"],
+                    "boltClass" => Magento_InStorePickupShipping::class,
                 ],
             ],
         ]

--- a/Test/Unit/Model/Api/ShippingTaxContextTest.php
+++ b/Test/Unit/Model/Api/ShippingTaxContextTest.php
@@ -32,6 +32,9 @@ use Magento\Directory\Model\Region as RegionModel;
 use Magento\Framework\Webapi\Rest\Response;
 use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
+use Bolt\Boltpay\Api\Data\ShipToStoreOptionInterfaceFactory;
+use Bolt\Boltpay\Api\Data\StoreAddressInterfaceFactory;
+use Bolt\Boltpay\Model\EventsForThirdPartyModules;
 
 /**
  * Class ShippingTaxContextTest
@@ -99,6 +102,21 @@ class ShippingTaxContextTest extends BoltTestCase
      * @var ShippingOptionInterfaceFactory|MockObject
      */
     private $shippingOptionFactory;
+    
+    /**
+     * @var ShipToStoreOptionInterfaceFactory
+     */
+    private $shipToStoreOptionFactory;
+    
+    /**
+     * @var StoreAddressInterfaceFactory
+     */
+    private $storeAddressFactory;
+    
+    /**
+     * @var EventsForThirdPartyModules
+     */
+    private $eventsForThirdPartyModules;
 
     /**
      * @var ShippingTaxContext|MockObject
@@ -119,6 +137,9 @@ class ShippingTaxContextTest extends BoltTestCase
         $this->regionModel = $this->createMock(RegionModel::class);
         $this->response = $this->createMock(Response::class);
         $this->shippingOptionFactory = $this->createMock(ShippingOptionInterfaceFactory::class);
+        $this->shipToStoreOptionFactory = $this->createMock(ShipToStoreOptionInterfaceFactory::class);
+        $this->storeAddressFactory = $this->createMock(StoreAddressInterfaceFactory::class);
+        $this->eventsForThirdPartyModules = $this->createMock(EventsForThirdPartyModules::class);
 
         $this->currentMock = $this->getMockBuilder(ShippingTaxContext::class)
             ->setConstructorArgs(
@@ -134,7 +155,10 @@ class ShippingTaxContextTest extends BoltTestCase
                     $this->errorResponse,
                     $this->regionModel,
                     $this->response,
-                    $this->shippingOptionFactory
+                    $this->shippingOptionFactory,
+                    $this->shipToStoreOptionFactory,
+                    $this->storeAddressFactory,
+                    $this->eventsForThirdPartyModules
                 ]
             )
             ->enableProxyingToOriginalMethods()
@@ -162,7 +186,10 @@ class ShippingTaxContextTest extends BoltTestCase
             $this->errorResponse,
             $this->regionModel,
             $this->response,
-            $this->shippingOptionFactory
+            $this->shippingOptionFactory,
+            $this->shipToStoreOptionFactory,
+            $this->storeAddressFactory,
+            $this->eventsForThirdPartyModules
         );
 
         static::assertAttributeInstanceOf(HookHelper::class, 'hookHelper', $instance);
@@ -179,6 +206,21 @@ class ShippingTaxContextTest extends BoltTestCase
         static::assertAttributeInstanceOf(
             ShippingOptionInterfaceFactory::class,
             'shippingOptionFactory',
+            $instance
+        );
+        static::assertAttributeInstanceOf(
+            ShipToStoreOptionInterfaceFactory::class,
+            'shipToStoreOptionFactory',
+            $instance
+        );
+        static::assertAttributeInstanceOf(
+            StoreAddressInterfaceFactory::class,
+            'storeAddressFactory',
+            $instance
+        );
+        static::assertAttributeInstanceOf(
+            EventsForThirdPartyModules::class,
+            'eventsForThirdPartyModules',
             $instance
         );
     }
@@ -315,6 +357,48 @@ class ShippingTaxContextTest extends BoltTestCase
         $this->assertEquals(
             $this->shippingOptionFactory,
             $this->currentMock->getShippingOptionFactory()
+        );
+    }
+    
+    /**
+     * @test
+     * that getShipToStoreOptionFactory would returns ship to store option factory instance
+     *
+     * @covers ::getShipToStoreOptionFactory
+     */
+    public function getShipToStoreOptionFactory_always_returnsShipToStoreOptionFactory()
+    {
+        $this->assertEquals(
+            $this->shipToStoreOptionFactory,
+            $this->currentMock->getShipToStoreOptionFactory()
+        );
+    }
+    
+    /**
+     * @test
+     * that getStoreAddressFactory would returns store address factory instance
+     *
+     * @covers ::getStoreAddressFactory
+     */
+    public function getStoreAddressFactory_always_returnsStoreAddressFactory()
+    {
+        $this->assertEquals(
+            $this->storeAddressFactory,
+            $this->currentMock->getStoreAddressFactory()
+        );
+    }
+    
+    /**
+     * @test
+     * that getEventsForThirdPartyModules would returns eventsForThirdPartyModules instance
+     *
+     * @covers ::getEventsForThirdPartyModules
+     */
+    public function getEventsForThirdPartyModules_always_returnsEventsForThirdPartyModules()
+    {
+        $this->assertEquals(
+            $this->eventsForThirdPartyModules,
+            $this->currentMock->getEventsForThirdPartyModules()
         );
     }
 }

--- a/Test/Unit/Model/Api/ShippingTest.php
+++ b/Test/Unit/Model/Api/ShippingTest.php
@@ -111,7 +111,7 @@ class ShippingTest extends BoltTestCase
             ->setTaxAmount(0);
         $quote = TestUtils::createQuote(['store_id' => $this->storeId]);
         TestHelper::setProperty($this->shipping, 'quote', $quote);
-        $result = $this->shipping->generateResult($addressData,[]);
+        $result = $this->shipping->generateResult($addressData,[], null);
         $this->assertEquals(
             [$shippingOptionData],
             $result->getShippingOptions()

--- a/Test/Unit/Model/Api/TaxTest.php
+++ b/Test/Unit/Model/Api/TaxTest.php
@@ -302,6 +302,6 @@ class TaxTest extends BoltTestCase
         TestHelper::setProperty($this->tax, 'quote', $quote);
         TestHelper::setProperty($this->tax, 'addressInformation', $addressInformation);
 
-        $this->assertEquals($taxData, $this->tax->generateResult($addressData, $shipping_option));
+        $this->assertEquals($taxData, $this->tax->generateResult($addressData, $shipping_option, null));
     }
 }

--- a/ThirdPartyModules/Magento/InStorePickupShipping.php
+++ b/ThirdPartyModules/Magento/InStorePickupShipping.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\ThirdPartyModules\Magento;
+
+use Bolt\Boltpay\Helper\Bugsnag;
+use Bolt\Boltpay\Api\Data\StoreAddressInterfaceFactory;
+use Bolt\Boltpay\Api\Data\ShipToStoreOptionInterfaceFactory;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\ScopeInterface;
+use Magento\InventoryInStorePickupShippingApi\Model\Carrier\InStorePickup;
+use Magento\InventorySalesApi\Api\Data\SalesChannelInterface;
+
+/**
+ * Class InStorePickupShipping
+ * @package Bolt\Boltpay\ThirdPartyModules\Magento
+ */
+class InStorePickupShipping
+{
+    /**
+     * @var Bugsnag Bugsnag helper instance
+     */
+    private $bugsnagHelper;
+    
+    /**
+     * @var StoreAddressInterfaceFactory
+     */
+    protected $storeAddressFactory;
+    
+    /**
+     * @var ShipToStoreOptionInterfaceFactory
+     */
+    protected $shipToStoreOptionFactory;
+    
+    /**
+     * @var ScopeConfigInterface
+     */
+    private $config;
+    
+    /**
+     * @var Magento\InventoryInStorePickupApi\Model\SearchRequestBuilderInterface
+     */
+    protected $searchRequestBuilder;
+    
+    /**
+     * @var Magento\InventoryInStorePickupApi\Api\GetPickupLocationsInterface
+     */
+    protected $getPickupLocations;
+    
+    /**
+     * @var Magento\InventoryInStorePickupApi\Api\Data\SearchRequest\ProductInfoInterfaceFactory
+     */
+    protected $productInfo;
+    
+    /**
+     * @var Magento\InventoryInStorePickupApi\Api\Data\SearchRequestExtensionFactory
+     */
+    protected $searchRequestExtension;
+    
+    /**
+     * @var Magento\InventoryInStorePickup\Model\SearchRequest\Area\GetDistanceToSources
+     */
+    protected $getDistanceToSources;
+    
+    private const SEARCH_RADIUS = 'carriers/instore/search_radius';
+    
+    /**
+     * @param Bugsnag     $bugsnagHelper Bugsnag helper instance
+     * @param Discount    $discountHelper
+     * @param Cart        $cartHelper
+     * @param Decider     $featureSwitches
+     */
+    public function __construct(
+        Bugsnag  $bugsnagHelper,
+        StoreAddressInterfaceFactory $storeAddressFactory,
+        ShipToStoreOptionInterfaceFactory $shipToStoreOptionFactory,
+        ScopeConfigInterface $config
+    ) {
+        $this->bugsnagHelper = $bugsnagHelper;
+        $this->storeAddressFactory = $storeAddressFactory;
+        $this->shipToStoreOptionFactory = $shipToStoreOptionFactory;
+        $this->config = $config;
+    }
+    
+    /**
+     * @param array $result
+     * @param Magento\InventoryInStorePickupApi\Model\SearchRequestBuilderInterface $searchRequestBuilder
+     * @param Magento\InventoryInStorePickupApi\Api\GetPickupLocationsInterface     $getPickupLocations
+     * @param Magento\InventoryInStorePickupApi\Api\Data\SearchRequest\ProductInfoInterfaceFactory $productInfo
+     * @param Magento\InventoryInStorePickupApi\Api\Data\SearchRequestExtensionFactory $searchRequestExtension
+     * @param Magento\InventoryInStorePickup\Model\SearchRequest\Area\GetDistanceToSources $getDistanceToSources
+     * @param Magento\Quote\Model\Quote $quote
+     * @param array $shippingOptions
+     * @param array $addressData
+     * @return array
+     */
+    public function getShipToStoreOptions(
+        $result,
+        $searchRequestBuilder,
+        $getPickupLocations,
+        $productInfo,
+        $searchRequestExtension,
+        $getDistanceToSources,
+        $quote,
+        $shippingOptions,
+        $addressData
+    ) {
+        try {
+            if (empty($shippingOptions)) {
+                return $result;
+            }
+          
+            $tmpShippingOptions = [];
+            $inStorePickupCost = 0;
+            $hasInStorePickup = false;
+            foreach ($shippingOptions as $shippingOption) {
+                if ($shippingOption->getReference() == InStorePickup::DELIVERY_METHOD) {
+                    $hasInStorePickup = true;
+                    $inStorePickupCost = $shippingOption->getCost();
+                } else {
+                    $tmpShippingOptions[] = $shippingOption;
+                }
+            }
+             
+            if (!$hasInStorePickup) {
+                return $result;
+            }
+            
+            $this->searchRequestBuilder = $searchRequestBuilder;
+            $this->getPickupLocations = $getPickupLocations;
+            $this->productInfo = $productInfo;
+            $this->searchRequestExtension = $searchRequestExtension;
+            $this->getDistanceToSources = $getDistanceToSources;
+        
+            $productsInfo = [];
+            $items = $quote->getAllVisibleItems();
+            foreach ($items as $item) {
+                $itemSku = trim($item->getSku());
+                $productsInfo[] = $this->productInfo->create(['sku' => $itemSku]);
+            }
+            $extensionAttributes = $this->searchRequestExtension->create();
+            $extensionAttributes->setProductsInfo($productsInfo);
+            $searchRadius = (float)$this->config->getValue(self::SEARCH_RADIUS, ScopeInterface::SCOPE_WEBSITE);
+            $searchTerm = $addressData['postal_code'] . ':' . $addressData['country_code'];
+            $searchRequest = $this->searchRequestBuilder->setScopeCode($quote->getStore()->getWebsite()->getCode())
+                        ->setScopeType(SalesChannelInterface::TYPE_WEBSITE)
+                        ->setAreaRadius($searchRadius)
+                        ->setAreaSearchTerm($searchTerm)
+                        ->setSearchRequestExtension($extensionAttributes)
+                        ->setPageSize(50)
+                        ->create();                       
+            $searchResult = $this->getPickupLocations->execute($searchRequest);
+            $distanceToSources = $this->getDistanceToSources->execute($searchRequest->getArea());   
+            $shipToStoreOptions = [];
+            if ($searchResult->getTotalCount() !== 0) {
+                $items = $searchResult->getItems();
+                foreach ($items as $item) {
+                    $storeAddress = $this->storeAddressFactory->create();
+                    $storeAddress->setStreetAddress1($item->getStreet());
+                    $storeAddress->setStreetAddress2('');
+                    $storeAddress->setLocality($item->getCity());
+                    $storeAddress->setRegion($item->getRegion());
+                    $storeAddress->setPostalCode($item->getPostcode());
+                    $storeAddress->setCountryCode($item->getCountryId());
+                    
+                    $shipToStoreOption = $this->shipToStoreOptionFactory->create();
+                    $pickupLocationCode = $item->getPickupLocationCode();
+
+                    $shipToStoreOption->setReference(InStorePickup::DELIVERY_METHOD . '_' . $pickupLocationCode);
+                    $shipToStoreOption->setCost($inStorePickupCost);
+                    $shipToStoreOption->setStoreName($item->getName());
+                    $shipToStoreOption->setAddress($storeAddress);
+                    $shipToStoreOption->setDistance($distanceToSources[$pickupLocationCode]);
+                    $shipToStoreOption->setDistanceUnit('km');
+                    
+                    $shipToStoreOptions[] = $shipToStoreOption;
+                }
+            }
+            
+            $result = [$shipToStoreOptions, $tmpShippingOptions];
+        } catch (\Exception $e) {
+            $this->bugsnagHelper->notifyException($e);
+        } finally {
+            return $result;
+        }
+    }
+}


### PR DESCRIPTION
# Description

As we decide to add support BOPIS Spilt shipping to M2, and In-store delivery method is supported with version 2.4.0 of Magento (https://devdocs.magento.com/guides/v2.4/inventory/release-notes.html#v120) , this PR is for adding support for this feature.

Step 2 : Add in-store pickup options to split shipping endpoint if they are available.

Fixes: https://boltpay.atlassian.net/browse/M2P-537

#changelog Add support for Magento native In-Store Pickup step 2

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
