### PR TITLE
M2P-541 Bugfix: No such entity with cartId

### DIFF
--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -431,7 +431,6 @@ class ShippingMethods implements ShippingMethodsInterface
         $this->quote = $parentQuote;
         $this->quote->getStore()->setCurrentCurrencyCode($this->quote->getQuoteCurrencyCode());
         $this->checkCartItems($cart);
-
         // Load logged in customer checkout and customer sessions from cached session id.
         // Replace parent quote with immutable quote in checkout session.
         $this->sessionHelper->loadSession($this->quote, $cart['metadata']);


### PR DESCRIPTION
# Description
Refer to the task https://boltpay.atlassian.net/browse/EN-4217 for contexts, and for v1 shipping&tax endpoint, we load immutable quote into checkout session and get shipping and tax options, but usually the immutable quote in not active, if any other plugins try to call

`$this->quoteRepository->getActive($this->checkoutSession->getQuoteId());`

it would cause an error No such entity with cartId = xxx

Solution: Load parent quote instead of immutable quote into the checkout session, as same as we do for split shipping tax endpoint.

Fixes: https://boltpay.atlassian.net/browse/M2P-541

#changelog Bugfix: No such entity with cartId

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
