### PR TITLE
[WIP] Use configuration inputs to specify the location of SSO buttons

### DIFF
--- a/Block/Js.php
+++ b/Block/Js.php
@@ -183,6 +183,18 @@ class Js extends Template
     }
 
     /**
+     * Get SSO ButtonSelectors.
+     *
+     * @return string
+     */
+    public function getSsoButtonSelectors()
+    {
+        $subject = trim($this->configHelper->getSsoButtonSelectors());
+
+        return array_filter(explode(',', preg_replace('/\s+/', ' ', $subject)));
+    }
+
+    /**
      * Get Additional button class.
      *
      * @return string
@@ -298,6 +310,7 @@ class Js extends Template
             'always_present_checkout'               => $this->enableAlwaysPresentCheckoutButton(),
             'account_url'                           => $this->getAccountJsUrl(),
             'order_management_selector'             => $this->getOrderManagementSelector(),
+            'sso_button_selectors'                  => $this->getSsoButtonSelectors(),
         ]);
     }
 
@@ -383,7 +396,7 @@ class Js extends Template
     {
         return $this->configHelper->getMinicartSupport();
     }
-    
+
     /**
      * Return true if bolt product page checkout is enabled
      */
@@ -399,7 +412,7 @@ class Js extends Template
     {
         return $this->isOnProductPage() && $this->isBoltPPCEnabled();
     }
-    
+
     /**
      * Return true if customer is on cart page
      */
@@ -408,7 +421,7 @@ class Js extends Template
         $currentPage = $this->getRequest()->getFullActionName();
         return $currentPage == 'checkout_cart_index';
     }
-    
+
     /**
      * Return true if customer is on product page
      */
@@ -417,7 +430,7 @@ class Js extends Template
         $currentPage = $this->getRequest()->getFullActionName();
         return $currentPage == 'catalog_product_view';
     }
-    
+
     /**
      * If feature switch M2_LOAD_CONNECT_JS_ON_SPECIFIC_PAGE is enabled,
      * then we only fetch Bolt connect js on page load for the product page (PPC is enabled) and cart page.
@@ -431,10 +444,10 @@ class Js extends Template
                 return false;
             }
         }
-        
+
         return true;
     }
-    
+
     /**
      * If feature switch M2_LOAD_CONNECT_JS_ON_SPECIFIC_PAGE is enabled,
      * then on the product page, with PPC disabled and minicart enabled,
@@ -449,7 +462,7 @@ class Js extends Template
                 return true;
             }
         }
-        
+
         return false;
     }
 

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -88,6 +88,11 @@ class Config extends AbstractHelper
     const XML_PATH_TOTALS_CHANGE_SELECTORS = 'payment/boltpay/totals_change_selectors';
 
     /**
+     * Path for Bolt SSO Selectors
+     */
+    const XML_PATH_BOLT_SSO_SELECTORS = 'payment/boltpay/bolt_sso_selectors';
+
+    /**
      * Path for Global CSS
      */
     const XML_PATH_GLOBAL_CSS = 'payment/boltpay/global_css';
@@ -780,6 +785,22 @@ class Config extends AbstractHelper
     {
         return $this->getScopeConfig()->getValue(
             self::XML_PATH_TOTALS_CHANGE_SELECTORS,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+    }
+
+    /**
+     * Get SSO Button Selectors from config
+     *
+     * @param int|string $storeId
+     *
+     * @return string
+     */
+    public function getSsoButtonSelectors($storeId = null)
+    {
+        return $this->getScopeConfig()->getValue(
+            self::XML_PATH_BOLT_SSO_SELECTORS,
             ScopeInterface::SCOPE_STORE,
             $storeId
         );
@@ -1813,6 +1834,10 @@ class Config extends AbstractHelper
         $boltSettings[] = $this->boltConfigSettingFactory->create()
             ->setName('show_cc_type_in_order_grid')
             ->setValue($this->getShowCcTypeInOrderGrid());
+        // Bolt SSO Selectors
+        $boltSettings[] = $this->boltConfigSettingFactory->create()
+            ->setName('bolt_sso_selectors')
+            ->setValue($this->getSsoButtonSelectors());
         // Enable Bolt SSO
         $boltSettings[] = $this->boltConfigSettingFactory->create()
             ->setName('bolt_sso')

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -1310,7 +1310,7 @@ JS;
         $this->currentMock->expects(static::once())
             ->method('getFullActionName')
             ->willReturn($fullActionName);
-            
+
         $this->configHelper->expects(($fullActionName == 'catalog_product_view') ? static::once() : static::never())
             ->method('getProductPageCheckoutFlag')
             ->willReturn($productPageCheckoutFlag);
@@ -2158,7 +2158,7 @@ function(arg) {
             )
             ->getMock();
     }
-    
+
     /**
      * @test
      *
@@ -2267,7 +2267,7 @@ function(arg) {
             ],
         ];
     }
-    
+
     /**
      * @test
      *
@@ -2301,7 +2301,7 @@ function(arg) {
         $this->configHelper->expects($isLoadConnectJsOnSpecificPageFeatureSwitchEnabled ? static::once() : static::never())
                            ->method('getMinicartSupport')
                            ->willReturn($minicartSupport);
-                           
+
         $this->configHelper->expects(($isLoadConnectJsOnSpecificPageFeatureSwitchEnabled && $minicartSupport)
                                     ? static::once() : static::never())
                            ->method('getProductPageCheckoutFlag')
@@ -2309,7 +2309,7 @@ function(arg) {
 
         static::assertEquals($expectedResult, $this->currentMock->isLoadConnectJsDynamic());
     }
-    
+
     /**
      * Data provider for
      *

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -767,6 +767,7 @@ JSON;
             ['getButtonColor', BoltConfig::XML_PATH_BUTTON_COLOR],
             ['getReplaceSelectors', BoltConfig::XML_PATH_REPLACE_SELECTORS],
             ['getTotalsChangeSelectors', BoltConfig::XML_PATH_TOTALS_CHANGE_SELECTORS, 'tr.grand.totals td.amount span.price'],
+            ['getSsoButtonSelectors', BoltConfig::XML_PATH_BOLT_SSO_SELECTORS, '.authorization-link'],
             ['getSuccessPageRedirect', BoltConfig::XML_PATH_SUCCESS_PAGE_REDIRECT, 'checkout/onepage/success'],
             ['getjavascriptSuccess', BoltConfig::XML_PATH_JAVASCRIPT_SUCCESS],
             ['getAdditionalJS', BoltConfig::XML_PATH_ADDITIONAL_JS],
@@ -1132,6 +1133,7 @@ JSON;
             'shouldMinifyJavascript',
             'shouldCaptureMetrics',
             'shouldTrackCheckoutFunnel',
+            'getSsoButtonSelectors',
             'isBoltSSOEnabled',
             'isBoltDebugUniversalEnabled',
         ]);
@@ -1149,6 +1151,7 @@ JSON;
         $this->currentMock->method('getGeolocationApiKey')->willReturn('geolocation api key');
         $this->currentMock->method('getReplaceSelectors')->willReturn('#replace');
         $this->currentMock->method('getTotalsChangeSelectors')->willReturn('.totals');
+        $this->currentMock->method('getSsoButtonSelectors')->willReturn('.authorization-link');
         $this->currentMock->method('getGlobalCSS')->willReturn('#customerbalance-placer {width: 210px;}');
         $this->currentMock->method('getAdditionalCheckoutButtonClass')->willReturn('with-cards');
         $this->currentMock->method('getSuccessPageRedirect')->willReturn('checkout/onepage/success');
@@ -1224,6 +1227,7 @@ JSON;
             ['should_minify_javascript', 'true'],
             ['capture_merchant_metrics', 'false'],
             ['track_checkout_funnel', 'false'],
+            ['sso_button_selectors', '.authorization-link'],
             ['bolt_sso', 'false'],
             ['universal_debug', 'true']
         ];

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -161,6 +161,10 @@
                         <label>Totals Monitor Selectors</label>
                         <config_path>payment/boltpay/totals_change_selectors</config_path>
                     </field>
+                    <field id="bolt_sso_selectors" translate="label" type="textarea" sortOrder="96" showInDefault="1" showInWebsite="1" showInStore="0">
+                        <label>Bolt SSO Selectors</label>
+                        <config_path>payment/boltpay/bolt_sso_selectors</config_path>
+                    </field>
 
                     <field id="additional_checkout_button_class" translate="label" type="text" sortOrder="105" showInDefault="1" showInWebsite="1" showInStore="0">
                         <label>Additional Checkout Button Class</label>

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -86,6 +86,7 @@ $isLoadConnectJsDynamic = $block->isLoadConnectJsDynamic();
                 elements = doc.querySelectorAll(listener.selector);
                 for (var j = 0, jLen = elements.length, element; j < jLen; j++) {
                     element = elements[j];
+
                     // Make sure the callback isn't invoked with the
                     // same element more than once
                     if (!element.ready) {
@@ -417,7 +418,7 @@ $isLoadConnectJsDynamic = $block->isLoadConnectJsDynamic();
                 scriptTag.setAttribute('src', settings.connect_url);
             }
         };
-        
+
         var insertConnectScriptWithoutSrc = function() {
             var scriptTag = document.getElementById('bolt-connect');
             var publishableKey = getCheckoutKey();
@@ -818,7 +819,7 @@ $isLoadConnectJsDynamic = $block->isLoadConnectJsDynamic();
                     invalidateBoltCart();
                 }
             }
-            
+
             <?= /* @noEscape */ $block->getAdditionalInvalidateBoltCartJavascript(); ?>
         }
 
@@ -1116,12 +1117,12 @@ $isLoadConnectJsDynamic = $block->isLoadConnectJsDynamic();
                         // We haven't seen magento cart yet. If Magento cart isn't set it means that bolt cart is unactual
                         return;
                     }
-                    
+
                     if (data.hints === undefined) {
                         // In some contexts, the data only has data_id.
                         return;
                     }
-                    
+
                     boltCartDataID = data.data_id;
                     if (BoltState.magentoCart.data_id > boltCartDataID) {
                         // bolt cart is unactual
@@ -1377,9 +1378,9 @@ $isLoadConnectJsDynamic = $block->isLoadConnectJsDynamic();
             var state_selectors = ['div[name="billingAddressboltpay.region_id"] select[name=region_id]','div[name="shippingAddress.region_id"] select[name=region_id]','.payment-method-boltpay select[name=region_id]'];
         } else {
             var country_selectors = ['select[name=country_id]'];
-            var state_selectors = ['select[name=region_id]'];                
+            var state_selectors = ['select[name=region_id]'];
         }
-        
+
         ///////////////////////////////////////////////////////////
         // Monitor Country DOM element change and update hints
         ///////////////////////////////////////////////////////////
@@ -1395,7 +1396,7 @@ $isLoadConnectJsDynamic = $block->isLoadConnectJsDynamic();
             configureHints();
         }, true);
         ///////////////////////////////////////////////////////////
-            
+
         ///////////////////////////////////////////////////////////
         // Monitor State DOM element change and update hints
         ///////////////////////////////////////////////////////////
@@ -1501,6 +1502,83 @@ $isLoadConnectJsDynamic = $block->isLoadConnectJsDynamic();
             setupOrderManagementReplacement();
         }
 
+
+        // insert Bolt SSO buttons into DOM
+        if (settings.sso_button_selectors) {
+            let insertAccountScript = function () {
+                let scriptTag = document.getElementById('bolt-account');
+                if (scriptTag) {
+                    return;
+                }
+                let publishableKey = getCheckoutKey();
+                scriptTag = document.createElement('script');
+                scriptTag.setAttribute('type', 'text/javascript');
+                scriptTag.setAttribute('async', '');
+                scriptTag.setAttribute('src', settings.account_url);
+                scriptTag.setAttribute('id', 'bolt-account');
+                scriptTag.setAttribute('data-publishable-key', publishableKey);
+                document.head.appendChild(scriptTag);
+            }
+            let insertSsoButtonAfterElement = function(element) {
+                let isUserLoggedIn;
+                require(['Magento_Customer/js/model/customer'], function (customer) {
+                    isUserLoggedIn = customer.isLoggedIn();
+                });
+
+                let ssoButton = document.createElement('div');
+                ssoButton.setAttribute('class', 'bolt-account-sso');
+                ssoButton.setAttribute('data-logged-in', isUserLoggedIn ? 'true' : 'false');
+                element.parentNode.insertBefore(ssoButton, element.nextSibling);
+                insertAccountScript();
+            }
+            let replaceElementWithSsoButton = function(element) {
+                let isUserLoggedIn;
+                require(['Magento_Customer/js/model/customer'], function (customer) {
+                    isUserLoggedIn = customer.isLoggedIn();
+                });
+
+                let ssoButton = document.createElement('div');
+                ssoButton.setAttribute('class', 'bolt-account-sso');
+                ssoButton.setAttribute('data-logged-in', isUserLoggedIn ? 'true' : 'false');
+                element.parentNode.replaceChild(ssoButton, element);
+                insertAccountScript();
+            }
+            let addSsoOnClickToElement = function(element) {
+                element.setAttribute('id', 'bolt-custom-sso');
+                // cannot have an href since this will cause a redirect when the element is clicked
+                element.removeAttribute('href');
+                insertAccountScript();
+            }
+            let setupSsoButtonReplacement = function() {
+                for (let i = 0, length = settings.sso_button_selectors.length; i < length; i++) {
+                    const selector = settings.sso_button_selectors[i];
+                    const parts = selector.split('|');
+
+                    // the CSS selector
+                    const identifier = parts[0].trim();
+
+                    // button placement regarding the selector element: append, replace, onclick
+                    const position = parts[1];
+
+                    console.log(identifier);
+                    console.log(position);
+
+                    onElementReady(identifier, function(element) {
+                        console.log(identifier);
+                        console.log("ready");
+                        if (position.trim().toLowerCase() === 'append') {
+                            insertSsoButtonAfterElement(element);
+                        } else if (position.trim().toLowerCase() === 'replace') {
+                            replaceElementWithSsoButton(element);
+                        } else if (position.trim().toLowerCase() === 'onclick') {
+                            addSsoOnClickToElement(element);
+                        }
+                    });
+                }
+            }
+            setupSsoButtonReplacement();
+        }
+
         ////////////////////////////////////////////////////
         // Initially configures BoltCheckout.
         // Required for setting check callback which either
@@ -1509,14 +1587,14 @@ $isLoadConnectJsDynamic = $block->isLoadConnectJsDynamic();
         ////////////////////////////////////////////////////
         boltCheckoutSetup();
         ////////////////////////////////////////////////////
-        
+
         <?php
         if ($isLoadConnectJsDynamic) {
         ?>
         magentoCartDataListenerLoadConnectJs = function(data) {
             if (data.items !== undefined && data.items.length > 0) {
                 insertConnectScript();
-            }            
+            }
         }
         customerData.get('cart').subscribe(magentoCartDataListenerLoadConnectJs);
         <?php


### PR DESCRIPTION
Rather than relying on a single reference block, which may or may not be present
in a merchant's website, we will instead allow the merchant to configure any number
of custom selectors, along with a directive indicating whether to replace any
matching elements, insert after it, or add the SSO onclick functionality to it.

# Description
Previously, I thought that we would be able to modify the merchant's website HTML directly. Since this is not the case for M2, we will instead use this approach to allow merchants to add the SSO button/functionality wherever they want.

Fixes: (link Jira ticket)

#changelog [WIP] Use configuration inputs to specify the location of SSO buttons

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.