### PR TITLE
M2P-549 Bugfix: Tax endpoint error when the cart is  virtual

### DIFF
--- a/Model/Api/Tax.php
+++ b/Model/Api/Tax.php
@@ -207,7 +207,7 @@ class Tax extends ShippingTax implements TaxInterface
         if (!empty($shipping_option)) {
             $shippingOption = $this->createShippingOption($totalsInformation, $currencyCode, $shipping_option);
             $taxData->setShippingOption($shippingOption);
-        } else {
+        } elseif (!empty($ship_to_store_option)) {
             $ship_to_store_option = $this->createInstorePickOption($totalsInformation, $currencyCode, $ship_to_store_option);
             $taxData->setShipToStoreOption($ship_to_store_option);
         }


### PR DESCRIPTION
# Description
This is because for virtual cart, the split tax api hook does not send any shipping_option or ship_to_store_option, for this case, we should not call setShippingOption or setShipToStoreOption for setting shipping info to the response, instead the response just returns "shipping_option":null,"ship_to_store_option":null

Tested with Magento v2.4.1-p1/v2.3.5/v2.2.2

Fixes: https://boltpay.atlassian.net/browse/M2P-549

#changelog Bugfix: Tax endpoint error when the cart is  virtual

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
