### PR TITLE
Custom Order Note field support

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -380,6 +380,9 @@ class Config extends AbstractHelper
 
     const XML_PATH_PRODUCT_ATTRIBUTES_LIST = 'payment/boltpay/product_attributes_list';
 
+    /** @var string  */
+    const XML_PATH_ORDER_COMMENT_FIELD = 'payment/boltpay/order_comment_field';
+
     /**
      * Default whitelisted shopping cart and checkout pages "Full Action Name" identifiers, <router_controller_action>
      * Pages allowed to load Bolt javascript / show checkout button
@@ -1811,7 +1814,7 @@ class Config extends AbstractHelper
         // Show card type in the order grid
         $boltSettings[] = $this->boltConfigSettingFactory->create()
             ->setName('show_cc_type_in_order_grid')
-            ->setValue($this->getShowCcTypeInOrderGrid());
+            ->setValue(var_export($this->getShowCcTypeInOrderGrid(), true));
         // Enable Bolt SSO
         $boltSettings[] = $this->boltConfigSettingFactory->create()
             ->setName('bolt_sso')
@@ -1820,6 +1823,10 @@ class Config extends AbstractHelper
         $boltSettings[] = $this->boltConfigSettingFactory->create()
             ->setName('universal_debug')
             ->setValue(var_export($this->isBoltDebugUniversalEnabled(), true));
+        // Order comment field
+        $boltSettings[] = $this->boltConfigSettingFactory->create()
+            ->setName('order_comment_field')
+            ->setValue(var_export($this->getOrderCommentField(), true));
 
         return $boltSettings;
     }
@@ -2085,6 +2092,22 @@ class Config extends AbstractHelper
             return [];
         }
         return explode(',', $commaSeparateList);
+    }
+
+    /**
+     * Gets order field configured to store comment, if not set defaults to customer_note
+     *
+     * @param null|string $storeId
+     *
+     * @return string either the configured field or 'customer_note'
+     */
+    public function getOrderCommentField($storeId = null)
+    {
+        return $this->getScopeConfig()->getValue(
+            self::XML_PATH_ORDER_COMMENT_FIELD,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        ) ?: 'customer_note';
     }
 
     /**

--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -298,19 +298,27 @@ class Decider extends AbstractHelper
     {
         return $this->isSwitchEnabled(Definitions::M2_ENABLE_BOLT_SSO);
     }
-    
+
     public function isCustomizableOptionsSupport()
     {
         return $this->isSwitchEnabled(Definitions::M2_CUSTOMIZABLE_OPTIONS_SUPPORT);
     }
-    
+
     public function isLoadConnectJsOnSpecificPage()
     {
         return $this->isSwitchEnabled(Definitions::M2_LOAD_CONNECT_JS_ON_SPECIFIC_PAGE);
     }
-  
+
     public function isReturnErrWhenRunFilter()
     {
         return $this->isSwitchEnabled(Definitions::M2_RETURN_ERR_WHEN_RUN_FILTER);
+    }
+
+    /**
+     * Checks whether the feature switch for displaying order comment in admin is enabled
+     */
+    public function isShowOrderCommentInAdmin()
+    {
+        return $this->isSwitchEnabled(Definitions::M2_SHOW_ORDER_COMMENT_IN_ADMIN);
     }
 }

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -161,7 +161,7 @@ class Definitions
      * Support Customizable Options
      */
     const M2_CUSTOMIZABLE_OPTIONS_SUPPORT = 'M2_CUSTOMIZABLE_OPTIONS_SUPPORT';
-    
+
     /**
      * Enable connect.js on cart page or product page (if PPC enabled) only
      */
@@ -171,6 +171,11 @@ class Definitions
      * Enable always return error if there is any exception when running filter.
      */
     const M2_RETURN_ERR_WHEN_RUN_FILTER = 'M2_RETURN_ERR_WHEN_RUN_FILTER';
+
+    /**
+     * Display order comment block in admin
+     */
+    const M2_SHOW_ORDER_COMMENT_IN_ADMIN = 'M2_SHOW_ORDER_COMMENT_IN_ADMIN';
 
     const DEFAULT_SWITCH_VALUES = [
         self::M2_SAMPLE_SWITCH_NAME => [
@@ -334,6 +339,12 @@ class Definitions
             self::VAL_KEY         => true,
             self::DEFAULT_VAL_KEY => false,
             self::ROLLOUT_KEY     => 100
-        ]
+        ],
+        self::M2_SHOW_ORDER_COMMENT_IN_ADMIN => [
+            self::NAME_KEY        => self::M2_SHOW_ORDER_COMMENT_IN_ADMIN,
+            self::VAL_KEY         => true,
+            self::DEFAULT_VAL_KEY => false,
+            self::ROLLOUT_KEY     => 100
+        ],
     ];
 }

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -1584,6 +1584,7 @@ class Order extends AbstractHelper
             ->addStatusHistoryComment($userNote)
             ->setIsVisibleOnFront(true)
             ->setIsCustomerNotified(false);
+        $order->setData($this->configHelper->getOrderCommentField($order->getStoreId()), $userNote);
     }
 
     /**

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -2734,21 +2734,20 @@ ORDER
         static::assertNull($currentMock->getBoltpayOrder(false, ''));
     }
 
-        /**
-         * @test
-         * @dataProvider dataProvider_sessionIdToCartMetadataSwitch
-         * @covers ::getCartData
-         */
+    /**
+     * @test
+     * @dataProvider dataProvider_sessionIdToCartMetadataSwitch
+     * @covers ::getCartData
+     */
     public function getCartData_inMultistepWithNoDiscount_returnsCartData(
         $addSessionIdToMetadataValue,
         $metadataSessionIdAssertMethod
     ) {
-
         $boltHelperCart = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
         $quote = TestUtils::createQuote();
         $product = TestUtils::getSimpleProduct();
         $this->objectsToClean[] = $product;
-        $quote->addProduct($product, 1);
+        $quote->addProduct($product,1);
         TestUtils::setQuoteToSession($quote);
 
         $sessionToMetadataSwitch = TestUtils::saveFeatureSwitch(
@@ -2765,7 +2764,7 @@ ORDER
 
         // check image url
         static::assertMatchesRegularExpression(
-            "|http://localhost/(pub\/)?static/version\d+/frontend/Magento/luma/en_US/Magento_Catalog/images/product/placeholder/small_image.jpg|",
+            "|https?://localhost/(pub\/)?static/version\d+/frontend/Magento/luma/en_US/Magento_Catalog/images/product/placeholder/small_image.jpg|",
             $result['items'][0]['image_url']
         );
         unset($result['items'][0]['image_url']);
@@ -2902,8 +2901,8 @@ ORDER
 
         // check image url
         static::assertMatchesRegularExpression(
-            "|http://localhost/(pub\/)?static/version\d+/frontend/Magento/luma/en_US/Magento_Catalog/images/product/placeholder/small_image.jpg|",
-            $result['items'][0]['image_url']
+            "|https?://localhost/(pub\/)?static/version\d+/frontend/Magento/luma/en_US/Magento_Catalog/images/product/placeholder/small_image.jpg|",
+                $result['items'][0]['image_url']
         );
         unset($result['items'][0]['image_url']);
 
@@ -4424,7 +4423,7 @@ ORDER
         static::assertEquals($expectedDiscountAmount, $discounts[0]['amount']);
         static::assertEquals($expectedTotalAmount, $totalAmountResult);
     }
-        
+
         /**
          * @test
          * that collectDiscounts properly handles gift voucher discount by subtracting it from regular discount
@@ -4452,9 +4451,9 @@ ORDER
         $this->discountHelper->expects(static::never())->method('getUnirgyGiftCertBalanceByCode');
         $appliedDiscount = 0; // $
         $shippingAddress->expects(static::once())->method('getDiscountAmount')->willReturn($appliedDiscount);
-    
+
         $quote->method('getAppliedRuleIds')->willReturn('2');
-    
+
         $rule2 = $this->getMockBuilder(DataObject::class)
             ->setMethods(['getCouponType', 'getDescription', 'getSimpleFreeShipping'])
             ->disableOriginalConstructor()
@@ -4465,7 +4464,7 @@ ORDER
             ->willReturn(self::COUPON_DESCRIPTION);
         $rule2->expects(static::once())->method('getSimpleFreeShipping')
             ->willReturn(2);
-    
+
         $this->ruleRepository->expects(static::once())
             ->method('getById')
             ->with(2)
@@ -4480,8 +4479,8 @@ ORDER
                         ->willReturn([2 => $appliedDiscount]);
         $this->sessionHelper->expects(static::once())->method('getCheckoutSession')
              ->willReturn($checkoutSession);
-    
-    
+
+
         $totalAmount = 10000; // cents
         $diff = 0;
         $paymentOnly = false;
@@ -4491,7 +4490,7 @@ ORDER
             $paymentOnly,
             $quote
         );
-    
+
         static::assertEquals($diffResult, $diff);
         $expectedDiscountAmount = 100 * $appliedDiscount;
         $expectedTotalAmount = $totalAmount - $expectedDiscountAmount;

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -2747,7 +2747,7 @@ ORDER
         $quote = TestUtils::createQuote();
         $product = TestUtils::getSimpleProduct();
         $this->objectsToClean[] = $product;
-        $quote->addProduct($product,1);
+        $quote->addProduct($product, 1);
         TestUtils::setQuoteToSession($quote);
 
         $sessionToMetadataSwitch = TestUtils::saveFeatureSwitch(
@@ -2902,7 +2902,7 @@ ORDER
         // check image url
         static::assertMatchesRegularExpression(
             "|https?://localhost/(pub\/)?static/version\d+/frontend/Magento/luma/en_US/Magento_Catalog/images/product/placeholder/small_image.jpg|",
-                $result['items'][0]['image_url']
+            $result['items'][0]['image_url']
         );
         unset($result['items'][0]['image_url']);
 

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -1135,8 +1135,10 @@ JSON;
             'shouldMinifyJavascript',
             'shouldCaptureMetrics',
             'shouldTrackCheckoutFunnel',
+            'getShowCcTypeInOrderGrid',
             'isBoltSSOEnabled',
             'isBoltDebugUniversalEnabled',
+            'getOrderCommentField',
         ]);
         $this->currentMock->method('isActive')->willReturn(true);
         $this->currentMock->method('getTitle')->willReturn('bolt test title');
@@ -1180,8 +1182,10 @@ JSON;
         $this->currentMock->method('shouldMinifyJavascript')->willReturn(true);
         $this->currentMock->method('shouldCaptureMetrics')->willReturn(false);
         $this->currentMock->method('shouldTrackCheckoutFunnel')->willReturn(false);
+        $this->currentMock->method('getShowCcTypeInOrderGrid')->willReturn(false);
         $this->currentMock->method('isBoltSSOEnabled')->willReturn(false);
         $this->currentMock->method('isBoltDebugUniversalEnabled')->willReturn(true);
+        $this->currentMock->method('getOrderCommentField')->willReturn('customer_note');
 
         // check bolt settings
         $expected = [
@@ -1227,12 +1231,14 @@ JSON;
             ['should_minify_javascript', 'true'],
             ['capture_merchant_metrics', 'false'],
             ['track_checkout_funnel', 'false'],
+            ['show_cc_type_in_order_grid', 'false'],
             ['bolt_sso', 'false'],
-            ['universal_debug', 'true']
+            ['universal_debug', 'true'],
+            ['order_comment_field', "'customer_note'"],
         ];
         $actual = $this->currentMock->getAllConfigSettings();
-        $this->assertEquals(45, count($actual));
-        for ($i = 0; $i < 2; $i++) {
+        $this->assertEquals(46, count($actual));
+        for ($i = 0; $i < 46; $i++) {
             $this->assertEquals($expected[$i][0], $actual[$i]->getName());
             $this->assertEquals($expected[$i][1], $actual[$i]->getValue(), 'actual value for ' . $expected[$i][0] . ' is not equals to expected');
         }
@@ -1854,5 +1860,38 @@ Room 4000',
             ->method('getValue')
             ->with(BoltConfig::XML_PATH_ADDITIONAL_CONFIG, \Magento\Store\Model\ScopeInterface::SCOPE_STORE, null)
             ->willReturn($additionalConfig);
+    }
+
+    /**
+     * @test
+     * that getOrderCommentField returns order comment field from the configuration if set
+     *
+     * @covers ::getOrderCommentField
+     */
+    public function getOrderCommentField_ifSetInConfiguration_returnsCommentField()
+    {
+        $customCommentField = 'custom_comment_field';
+        $this->scopeConfig
+            ->expects(self::once())
+            ->method('getValue')
+            ->with(BoltConfig::XML_PATH_ORDER_COMMENT_FIELD, \Magento\Store\Model\ScopeInterface::SCOPE_STORE, null)
+            ->willReturn($customCommentField);
+        $this->assertEquals($customCommentField, $this->currentMock->getOrderCommentField());
+    }
+
+    /**
+     * @test
+     * that getOrderCommentField returns 'customer_note' field if a field is not set in the configuration
+     *
+     * @covers ::getOrderCommentField
+     */
+    public function getOrderCommentField_ifNotSetInConfiguration_returnsCustomerNote()
+    {
+        $this->scopeConfig
+            ->expects(self::once())
+            ->method('getValue')
+            ->with(BoltConfig::XML_PATH_ORDER_COMMENT_FIELD, \Magento\Store\Model\ScopeInterface::SCOPE_STORE, null)
+            ->willReturn(null);
+        $this->assertEquals('customer_note', $this->currentMock->getOrderCommentField());
     }
 }

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -132,7 +132,7 @@ class OrderTest extends BoltTestCase
     const HOOK_TYPE_AUTH = 'auth';
     const HOOK_PAYLOAD = ['checkboxes' => ['text'=>'Subscribe for our newsletter','category'=>'NEWSLETTER','value'=>true, 'is_custom_field'=>false],
                           'custom_fields' =>  ['label'=>'Gift', 'type'=>'CHECKBOX', 'is_custom_field'=>true,'value'=>true]];
-    
+
     const CUSTOMER_ID = 1111;
 
     /** @var string test cart network */
@@ -678,7 +678,7 @@ class OrderTest extends BoltTestCase
      */
     public function setShippingMethod_withVirtualQuote_doesNothing()
     {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         $quote = Bootstrap::getObjectManager()->create(Quote::class);
         $product = TestUtils::createVirtualProduct();
@@ -704,7 +704,7 @@ class OrderTest extends BoltTestCase
      */
     public function setShippingMethod_withPhysicalQuote()
     {
-        
+
         $quote = TestUtils::createQuote();
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
 
@@ -738,9 +738,7 @@ class OrderTest extends BoltTestCase
      */
     public function setAddress()
     {
-        
         $addressObject = (object) self::ADDRESS_DATA;
-        ;
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         $quote = TestUtils::createQuote();
         $quoteAddress = $quote->getShippingAddress();
@@ -826,7 +824,7 @@ class OrderTest extends BoltTestCase
      */
     public function checkExistingOrder_orderAlreadyExists_notifiesError()
     {
-        
+
         $order = TestUtils::createDumpyOrder(['quote_id' => self::QUOTE_ID]);
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
 
@@ -850,7 +848,7 @@ class OrderTest extends BoltTestCase
      */
     public function checkExistingOrder_orderDoesntExist_returnsFalse()
     {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
 
         static::assertFalse(
@@ -1131,7 +1129,7 @@ class OrderTest extends BoltTestCase
      */
     public function setOrderPaymentInfoData_ifPaymentIsMissingLastFourOrType_theyAreUpdated()
     {
-        
+
         $order = TestUtils::createDumpyOrder();
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         $payment = $order->getPayment();
@@ -1179,7 +1177,7 @@ class OrderTest extends BoltTestCase
      */
     public function resetOrderState()
     {
-        
+
         $order = TestUtils::createDumpyOrder();
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         $boltHelperOrder->resetOrderState($order);
@@ -1199,7 +1197,7 @@ class OrderTest extends BoltTestCase
      */
     public function getOrderByQuoteId()
     {
-        
+
         $order = TestUtils::createDumpyOrder(['quote_id' => self::QUOTE_ID]);
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         static::assertEquals($order->getId(), $boltHelperOrder->getOrderByQuoteId(self::QUOTE_ID)->getId());
@@ -1681,7 +1679,7 @@ class OrderTest extends BoltTestCase
      */
     public function processExistingOrder_noOrder()
     {
-        
+
         $quote = TestUtils::createQuote();
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         self::assertFalse($boltHelperOrder->processExistingOrder($quote, new stdClass()));
@@ -1725,7 +1723,7 @@ class OrderTest extends BoltTestCase
      */
     public function processExistingOrder_pendingOrder()
     {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
 
         $quote = Bootstrap::getObjectManager()->create(Quote::class);
@@ -1758,7 +1756,7 @@ class OrderTest extends BoltTestCase
      */
     public function processExistingOrder_samePriceOrder()
     {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
 
         $quote = Bootstrap::getObjectManager()->create(Quote::class);
@@ -1798,7 +1796,7 @@ class OrderTest extends BoltTestCase
      */
     public function processExistingOrder_deleteOrder()
     {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
 
         $quote = Bootstrap::getObjectManager()->create(Quote::class);
@@ -2357,7 +2355,7 @@ class OrderTest extends BoltTestCase
      */
     public function deleteOrder()
     {
-        
+
         $order = TestUtils::createDumpyOrder();
         $orderId = $order->getId();
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
@@ -2408,7 +2406,7 @@ class OrderTest extends BoltTestCase
      */
     public function tryDeclinedPaymentCancelation_noOrder()
     {
-        
+
 
         $this->expectException(BoltException::class);
         $this->expectExceptionMessage(
@@ -2433,7 +2431,7 @@ class OrderTest extends BoltTestCase
      */
     public function tryDeclinedPaymentCancelation_pendingOrder()
     {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
 
         $order = TestUtils::createDumpyOrder();
@@ -2452,7 +2450,7 @@ class OrderTest extends BoltTestCase
      */
     public function tryDeclinedPaymentCancelation_canceledOrder()
     {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
 
         $order = TestUtils::createDumpyOrder(
@@ -2472,7 +2470,7 @@ class OrderTest extends BoltTestCase
      */
     public function tryDeclinedPaymentCancelation_completeOrder()
     {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
 
         $order = TestUtils::createDumpyOrder(
@@ -2492,7 +2490,7 @@ class OrderTest extends BoltTestCase
      */
     public function deleteOrderByIncrementId_noOrder()
     {
-        
+
         $this->bugsnag->expects(self::once())->method('notifyError');
         $this->currentMock->deleteOrderByIncrementId(self::INCREMENT_ID, self::IMMUTABLE_QUOTE_ID);
     }
@@ -2533,7 +2531,7 @@ class OrderTest extends BoltTestCase
      */
     public function deleteOrderByIncrementId_ifParentQuoteIdIsNotEqualToImmutableQuoteId_reactivateSessionQuote()
     {
-        
+
 
         $quote = Bootstrap::getObjectManager()->create(Quote::class);
         $quote->setQuoteCurrencyCode("USD");
@@ -2555,7 +2553,7 @@ class OrderTest extends BoltTestCase
      */
     public function deleteOrderByIncrementId_ifBoltCheckoutTypeIsComplete_changesCheckoutTypeToPPC()
     {
-        
+
 
         $quote = Bootstrap::getObjectManager()->create(Quote::class);
         $quote->setBoltCheckoutType(CartHelper::BOLT_CHECKOUT_TYPE_PPC_COMPLETE);
@@ -2581,7 +2579,7 @@ class OrderTest extends BoltTestCase
      */
     public function getExistingOrder()
     {
-        
+
         $order = TestUtils::createDumpyOrder();
 
         $incrementId = $order->getIncrementId();
@@ -2602,7 +2600,7 @@ class OrderTest extends BoltTestCase
      */
     public function quoteAfterChange()
     {
-        
+
         $quote = TestUtils::createQuote();
         $quoteId = $quote->getId();
         $orderHelper = Bootstrap::getObjectManager()->create(OrderHelper::class);
@@ -2757,18 +2755,48 @@ class OrderTest extends BoltTestCase
 
     /**
      * @test
+     * that setOrderUserNote will both add a new status history containing the user note, and set the configured order
+     * order field
      *
      * @covers ::setOrderUserNote
+     *
+     * @dataProvider setOrderUserNote_withVariousCommentFieldsConfiguredProvider
      */
-    public function setOrderUserNote()
-    {
-        
+    public function setOrderUserNote_withVariousCommentFieldsConfigured_setsOrderFieldAndAddsStatusHistory(
+        $configuredField,
+        $expectedField
+    ) {
+        TestUtils::setupBoltConfig(
+            [
+                [
+                    'path'    => \Bolt\Boltpay\Helper\Config::XML_PATH_ORDER_COMMENT_FIELD,
+                    'value'   => $configuredField,
+                    'scope'   => ScopeInterface::SCOPE_STORE,
+                    'scopeId' => 0,
+                ]
+            ]
+        );
         $userNote = 'Test note';
         $order = TestUtils::createDumpyOrder();
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         $boltHelperOrder->setOrderUserNote($order, $userNote);
         self::assertEquals($userNote, $order->getStatusHistories()[0]->getComment());
+        self::assertEquals($userNote, $order->getData($expectedField));
         TestUtils::cleanupSharedFixtures([$order]);
+    }
+
+    public function setOrderUserNote_withVariousCommentFieldsConfiguredProvider()
+    {
+        return [
+            'Not configured - defaults to `customer_note`' => [
+                'configuredField' => null,
+                'expectedField'   => 'customer_note'
+            ],
+            'Custom field configured' => [
+                'configuredField' => 'custom_comment_field',
+                'expectedField'   => 'custom_comment_field'
+            ],
+        ];
     }
 
     /**
@@ -2778,7 +2806,7 @@ class OrderTest extends BoltTestCase
      */
     public function formatReferenceUrl()
     {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         static::assertEquals(
             sprintf(
@@ -2807,7 +2835,7 @@ class OrderTest extends BoltTestCase
         $itemTypeAdditionalInformation,
         $expectedResult
     ) {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         $payment = Bootstrap::getObjectManager()->create(Payment::class);
         $payment->setAdditionalInformation(
@@ -2855,7 +2883,7 @@ class OrderTest extends BoltTestCase
      */
     public function getProcessedRefunds()
     {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         $payment = Bootstrap::getObjectManager()->create(Payment::class);
         $payment->setAdditionalInformation(
@@ -2882,7 +2910,7 @@ class OrderTest extends BoltTestCase
      */
     public function getTransactionState_CreditCardAuthorize()
     {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         $payment = Bootstrap::getObjectManager()->create(Payment::class);
 
@@ -2913,7 +2941,7 @@ class OrderTest extends BoltTestCase
      */
     public function getTransactionState_PaypalCompleted()
     {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         $payment = Bootstrap::getObjectManager()->create(Payment::class);
         $payment->setAdditionalInformation(
@@ -2941,7 +2969,7 @@ class OrderTest extends BoltTestCase
      */
     public function getTransactionState_APMInitialAuthorized()
     {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         list($paymentMock, $transaction) = $this->getTransactionStateSetUp(
             null,
@@ -2994,7 +3022,7 @@ class OrderTest extends BoltTestCase
      */
     public function getTransactionState_TSCreditCompleted()
     {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         list($payment, $transaction) = $this->getTransactionStateSetUp(
             null,
@@ -3014,7 +3042,7 @@ class OrderTest extends BoltTestCase
      */
     public function getTransactionState_TSAuthorized()
     {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         list($payment, $transaction) = $this->getTransactionStateSetUp(
             OrderHelper::TS_PENDING,
@@ -3035,7 +3063,7 @@ class OrderTest extends BoltTestCase
      */
     public function getTransactionState_TSAuthorizedFromPending()
     {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         list($payment, $transaction) = $this->getTransactionStateSetUp(
             OrderHelper::TS_PENDING,
@@ -3056,7 +3084,7 @@ class OrderTest extends BoltTestCase
      */
     public function getTransactionState_TSCaptured()
     {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         list($payment, $transaction) = $this->getTransactionStateSetUp(
             OrderHelper::TS_AUTHORIZED,
@@ -3077,7 +3105,7 @@ class OrderTest extends BoltTestCase
      */
     public function getTransactionState_TSCapturedFromAuthorized()
     {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         list($payment, $transaction) = $this->getTransactionStateSetUp(
             OrderHelper::TS_AUTHORIZED,
@@ -3098,7 +3126,7 @@ class OrderTest extends BoltTestCase
      */
     public function getTransactionState_TSCapturedFromACompleted()
     {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         list($payment, $transaction) = $this->getTransactionStateSetUp(
             OrderHelper::TS_CREDIT_COMPLETED,
@@ -3119,7 +3147,7 @@ class OrderTest extends BoltTestCase
      */
     public function getTransactionState_TSPartialVoided()
     {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         list($paymentMock, $transaction) = $this->getTransactionStateSetUp(
             OrderHelper::TS_CAPTURED,
@@ -3325,7 +3353,7 @@ class OrderTest extends BoltTestCase
         $orderState,
         $isHookFromBolt = false
     ) {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         Hook::$fromBolt = $isHookFromBolt;
         static::assertEquals(
@@ -3362,7 +3390,7 @@ class OrderTest extends BoltTestCase
      */
     public function formatTransactionData()
     {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         $order = TestUtils::createDumpyOrder();
 
@@ -3396,7 +3424,7 @@ class OrderTest extends BoltTestCase
      */
     public function setOrderState_holdedOrder()
     {
-        
+
         $order = TestUtils::createDumpyOrder();
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         $boltHelperOrder->setOrderState($order, Order::STATE_HOLDED);
@@ -3432,9 +3460,9 @@ class OrderTest extends BoltTestCase
      */
     public function setOrderState_canceledOrder()
     {
-        
+
         $state = Order::STATE_CANCELED;
-        
+
         $order = TestUtils::createDumpyOrder();
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         $boltHelperOrder->setOrderState($order, $state);
@@ -3481,7 +3509,7 @@ class OrderTest extends BoltTestCase
      */
     public function setOrderState_nonSpecialStateOrder()
     {
-        
+
         $state = Order::STATE_PAYMENT_REVIEW;
         $order = TestUtils::createDumpyOrder();
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
@@ -3499,7 +3527,7 @@ class OrderTest extends BoltTestCase
      */
     public function cancelOrder()
     {
-        
+
         $order = TestUtils::createDumpyOrder();
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         TestHelper::invokeMethod($boltHelperOrder, 'cancelOrder', [$order]);
@@ -3536,7 +3564,7 @@ class OrderTest extends BoltTestCase
      */
     public function checkPaymentMethod()
     {
-        
+
         $orderPayment = Bootstrap::getObjectManager()->create(OrderPayment::class);
         $orderPayment->setMethod(Payment::METHOD_CODE);
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
@@ -3553,7 +3581,7 @@ class OrderTest extends BoltTestCase
      */
     public function checkPaymentMethod_notBolt_throwsException()
     {
-        
+
         $orderPayment = Bootstrap::getObjectManager()->create(OrderPayment::class);
         $orderPayment->setMethod('checkmo');
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
@@ -3755,7 +3783,7 @@ class OrderTest extends BoltTestCase
          */
     public function updateOrderPayment_handleCustomFields()
     {
-       
+
         list($transaction, $paymentMock) = $this->updateOrderPaymentSetUp(OrderHelper::TS_AUTHORIZED);
         $paymentMock->expects(self::atLeastOnce())->method('getAdditionalInformation')
             ->withConsecutive(['transaction_state'])
@@ -4457,7 +4485,7 @@ class OrderTest extends BoltTestCase
         $transactionState,
         $expectedResult
     ) {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         Hook::$fromBolt = $isHookFromBolt;
         static::assertEquals($expectedResult, $boltHelperOrder->isZeroAmountHook($transactionState));
@@ -4491,7 +4519,7 @@ class OrderTest extends BoltTestCase
      */
     public function isCaptureHookRequest($isHookFromBolt, $newCapture, $expectedResult)
     {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         Hook::$fromBolt = $isHookFromBolt;
         static::assertEquals(
@@ -4522,7 +4550,7 @@ class OrderTest extends BoltTestCase
      */
     public function validateCaptureAmount_invalidCaptureAmount_throwsException()
     {
-        
+
         $order = TestUtils::createDumpyOrder();
         TestUtils::cleanupSharedFixtures([$order]);
         $this->expectException(Exception::class);
@@ -4539,7 +4567,7 @@ class OrderTest extends BoltTestCase
      */
     public function validateCaptureAmount_captureAmountAndGrandTotalMismatch_throwsException()
     {
-        
+
         $order = TestUtils::createDumpyOrder([
             'total_invoiced' => 200,
             'grand_total' => 100,
@@ -4566,7 +4594,7 @@ class OrderTest extends BoltTestCase
      */
     public function validateCaptureAmount_captureAmountAndGrandTotalMatch_doesNothing()
     {
-        
+
         $order = TestUtils::createDumpyOrder([
             'total_invoiced' => 50,
             'grand_total' => 100,
@@ -4597,7 +4625,7 @@ class OrderTest extends BoltTestCase
         $orderState,
         $expectedResult
     ) {
-        
+
         $order = TestUtils::createDumpyOrder(['state' => $orderState]);
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         Hook::$fromBolt = $isHookFromBolt;
@@ -4692,7 +4720,7 @@ class OrderTest extends BoltTestCase
      */
     public function formatAmountForDisplay_withValidAmount_returnsFormattedAmount()
     {
-        
+
         $order = TestUtils::createDumpyOrder();
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         static::assertEquals("$1.23", $boltHelperOrder->formatAmountForDisplay($order, 1.23));
@@ -4706,7 +4734,7 @@ class OrderTest extends BoltTestCase
      */
     public function getStoreIdByQuoteId_withValidQuote_returnsStoreIdFromQuote()
     {
-        
+
         $quote = TestUtils::createQuote(['store_id' => self::STORE_ID]);
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         static::assertEquals(self::STORE_ID, $boltHelperOrder->getStoreIdByQuoteId($quote->getId()));
@@ -4719,7 +4747,7 @@ class OrderTest extends BoltTestCase
      */
     public function getStoreIdByQuoteId_withEmptyQuoteId_returnsNull()
     {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         static::assertNull($boltHelperOrder->getStoreIdByQuoteId(''));
     }
@@ -4731,7 +4759,7 @@ class OrderTest extends BoltTestCase
      */
     public function getOrderStoreIdByDisplayId_withEmptyDisplayId_returnsNull()
     {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         static::assertNull($boltHelperOrder->getOrderStoreIdByDisplayId(''));
     }
@@ -4743,7 +4771,7 @@ class OrderTest extends BoltTestCase
      */
     public function getOrderStoreIdByDisplayId_withInvalidDisplayId_returnsNull()
     {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         static::assertNull($boltHelperOrder->getOrderStoreIdByDisplayId(' / '));
     }
@@ -4756,7 +4784,7 @@ class OrderTest extends BoltTestCase
      */
     public function getOrderStoreIdByDisplayId_withValidDisplayId_returnsStoreId()
     {
-        
+
         $order = TestUtils::createDumpyOrder(['store_id'=>self::STORE_ID]);
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         static::assertEquals(self::STORE_ID, $boltHelperOrder->getOrderStoreIdByDisplayId($order->getIncrementId()));
@@ -4770,7 +4798,7 @@ class OrderTest extends BoltTestCase
      */
     public function setBillingAddress()
     {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         $transaction = json_decode(
             json_encode(
@@ -4804,7 +4832,7 @@ class OrderTest extends BoltTestCase
      */
     public function setShippingAddress()
     {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         $transaction = json_decode(
             json_encode(
@@ -4917,7 +4945,7 @@ class OrderTest extends BoltTestCase
         $hookType,
         $expectException
     ) {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         Hook::$fromBolt = $hookFromBolt;
         if ($expectException) {
@@ -4966,7 +4994,7 @@ class OrderTest extends BoltTestCase
      */
     public function getOrderByQuoteId_withVariousQuoteIds_returnsOrder()
     {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         $order = TestUtils::createDumpyOrder(['quote_id' => self::QUOTE_ID]);
         $this->assertEquals($order->getId(), $boltHelperOrder->getOrderByQuoteId(self::QUOTE_ID)->getId());
@@ -5228,7 +5256,7 @@ class OrderTest extends BoltTestCase
      */
     public function validateRefundAmount_withInvalidRefundAmount($refundAmount)
     {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         $order = Bootstrap::getObjectManager()->create(OrderModel::class);
         $this->expectException(\Exception::class);
@@ -5252,7 +5280,7 @@ class OrderTest extends BoltTestCase
      */
     public function validateRefundAmount_withRefundAmountIsMoreThanAvailableRefund()
     {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         $order = TestUtils::createDumpyOrder(
             [
@@ -5281,7 +5309,7 @@ class OrderTest extends BoltTestCase
      */
     public function validateRefundAmount_withRefundAmountValidAndLowerThanAvailable_succeeds()
     {
-        
+
         $boltHelperOrder = Bootstrap::getObjectManager()->create(OrderHelper::class);
         $order = TestUtils::createDumpyOrder(
             [
@@ -5316,7 +5344,7 @@ class OrderTest extends BoltTestCase
         $grandTotal,
         $priceFaultTolerance
     ) {
-        
+
         $orderHelper = Bootstrap::getObjectManager()->create(OrderHelper::class);
         $quote = TestUtils::createQuote();
         $quoteId = $quote->getId();
@@ -5389,7 +5417,6 @@ class OrderTest extends BoltTestCase
      */
     public function getExistingOrder_byParenQuoteId()
     {
-        
         $order = TestUtils::createDumpyOrder(['quote_id' => self::QUOTE_ID]);
 
         $orderHelper = Bootstrap::getObjectManager()->create(\Bolt\Boltpay\Helper\Order::class);
@@ -5489,7 +5516,7 @@ class OrderTest extends BoltTestCase
      */
     public function deleteOrCancelFailedPaymentOrder_deleteOrderByIncrementId()
     {
-        
+
         $quote = TestUtils::createQuote();
         $order = TestUtils::createDumpyOrder(
             [
@@ -5512,7 +5539,6 @@ class OrderTest extends BoltTestCase
      */
     public function deleteOrCancelFailedPaymentOrder_cancelFailedPaymentOrder()
     {
-        
         $this->featureSwitches->method('isCancelFailedPaymentOrderInsteadOfDeleting')
             ->willReturn(true);
         $quote = TestUtils::createQuote();
@@ -5523,7 +5549,7 @@ class OrderTest extends BoltTestCase
             ]
         );
         $displayId = $order->getIncrementId();
-        
+
         self::assertEquals(
             'Order was canceled: '.$displayId,
             $this->currentMock->deleteOrCancelFailedPaymentOrder($displayId, $quote->getId())
@@ -5542,7 +5568,7 @@ class OrderTest extends BoltTestCase
      */
     public function cancelFailedPaymentOrder_ifOrderStateIsNotPendingPayment_throwsBoltException()
     {
-        
+
         $order = TestUtils::createDumpyOrder(['state' => OrderModel::STATE_PROCESSING]);
         $incrementId = $order->getIncrementId();
         $orderHelper = Bootstrap::getObjectManager()->create(\Bolt\Boltpay\Helper\Order::class);

--- a/Test/Unit/ViewModel/OrderCommentTest.php
+++ b/Test/Unit/ViewModel/OrderCommentTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Test\Unit\ViewModel;
+
+use Bolt\Boltpay\Helper\Config;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
+use Bolt\Boltpay\ViewModel\OrderComment;
+use Magento\Sales\Model\Order;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class OrderCommentTest
+ *
+ * @package Bolt\Boltpay\Test\Unit\ViewModel
+ */
+class OrderCommentTest extends BoltTestCase
+{
+    const STORE_ID = 1;
+
+    /**
+     * @var MockObject|Config
+     */
+    protected $configHelperMock;
+
+    /**
+     * @var MockObject|OrderComment
+     */
+    protected $currentMock;
+
+    /**
+     * Setup test dependencies, called before each test
+     */
+    protected function setUpInternal()
+    {
+        $this->configHelperMock = $this->createMock(Config::class);
+        $this->currentMock = $this->getMockBuilder(OrderComment::class)
+            ->setMethods(null)
+            ->setConstructorArgs([$this->configHelperMock])
+            ->getMock();
+    }
+
+    /**
+     * @test
+     * that constructor will populate the expected properties with the provided arguments
+     */
+    public function __construct_always_populatesInternalProperties()
+    {
+        $instance = new OrderComment($this->configHelperMock);
+        static::assertAttributeEquals($this->configHelperMock, 'configHelper', $instance);
+    }
+
+    /**
+     * @test
+     * that getCommentForOrder returns order data stored under the field configured to be used for comment storage
+     * @see \Bolt\Boltpay\Helper\Config::getOrderCommentField
+     */
+    public function getCommentForOrder_withCommentFieldSet_returnsOrderCommentFromTheConfiguredField()
+    {
+        $orderMock = $this->createMock(Order::class);
+        $orderMock->expects(static::once())->method('getStoreId')->willReturn(self::STORE_ID);
+        $orderMock->expects(static::once())->method('getData')->with('user_note')->willReturn('test note');
+        $this->configHelperMock->expects(static::once())->method('getOrderCommentField')->with(self::STORE_ID)
+            ->willReturn('user_note');
+        static::assertEquals('test note', $this->currentMock->getCommentForOrder($orderMock));
+    }
+}

--- a/ViewModel/OrderComment.php
+++ b/ViewModel/OrderComment.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Bolt magento2 plugin
  *
@@ -18,8 +19,13 @@
 namespace Bolt\Boltpay\ViewModel;
 
 use Bolt\Boltpay\Helper\Config;
+use Bolt\Boltpay\Helper\FeatureSwitch\Decider;
+use Bolt\Boltpay\Model\Payment;
 use Magento\Sales\Model\Order;
 
+/**
+ * Order Comment view model
+ */
 class OrderComment implements \Magento\Framework\View\Element\Block\ArgumentInterface
 {
     /**
@@ -28,21 +34,55 @@ class OrderComment implements \Magento\Framework\View\Element\Block\ArgumentInte
     private $configHelper;
 
     /**
+     * @var Decider
+     */
+    private $featureSwitches;
+
+    /**
      * OrderComment constructor.
      *
-     * @param Config $config
+     * @param Config  $config          Bolt configuration helper
+     * @param Decider $featureSwitches Bolt Feature Switch decider
      */
-    public function __construct(Config $config)
+    public function __construct(Config $config, Decider $featureSwitches)
     {
         $this->configHelper = $config;
+        $this->featureSwitches = $featureSwitches;
     }
 
     /**
-     * @param Order $order
+     * Returns comment for the provided order, stored in the configured field returned by
+     *
+     * @see \Bolt\Boltpay\Helper\Config::getOrderCommentField
+     *
+     * @param Order $order for which to retrieve the comment
+     *
+     * @return string|null
      */
     public function getCommentForOrder($order)
     {
         $commentField = $this->configHelper->getOrderCommentField($order->getStoreId());
         return $order->getData($commentField);
+    }
+
+    /**
+     * Determines whether the order comment block should be displayed.
+     * Requirements:
+     * 1. M2_SHOW_ORDER_COMMENT_IN_ADMIN feature switch is enabled
+     * 2. Order comment field is not empty
+     * 3. Order payment method is Bolt
+     *
+     * @param Order $order being displayed in the admin
+     *
+     * @return bool true if the order comment block should be displayed, otherwise false
+     *
+     * @throws \Magento\Framework\Exception\LocalizedException if the feature switch is undefined
+     */
+    public function shouldDisplayForOrder($order)
+    {
+        return $this->featureSwitches->isShowOrderCommentInAdmin()
+            && $this->getCommentForOrder($order)
+            && $order->getPayment()
+            && $order->getPayment()->getMethod() == Payment::METHOD_CODE;
     }
 }

--- a/ViewModel/OrderComment.php
+++ b/ViewModel/OrderComment.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\ViewModel;
+
+use Bolt\Boltpay\Helper\Config;
+use Magento\Sales\Model\Order;
+
+class OrderComment implements \Magento\Framework\View\Element\Block\ArgumentInterface
+{
+    /**
+     * @var Config
+     */
+    private $configHelper;
+
+    /**
+     * OrderComment constructor.
+     *
+     * @param Config $config
+     */
+    public function __construct(Config $config)
+    {
+        $this->configHelper = $config;
+    }
+
+    /**
+     * @param Order $order
+     */
+    public function getCommentForOrder($order)
+    {
+        $commentField = $this->configHelper->getOrderCommentField($order->getStoreId());
+        return $order->getData($commentField);
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -362,6 +362,12 @@
                         <config_path>payment/boltpay/product_attributes_list</config_path>
                         <comment>Comma separated list of product attributes that we send to bolt server. Leave empty for include only standard attributes.</comment>
                     </field>
+                    <field id="order_comment_field" translate="label" type="text" sortOrder="390" showInDefault="1"
+                           showInWebsite="1" showInStore="1">
+                        <label>Order Comment DB field</label>
+                        <config_path>payment/boltpay/order_comment_field</config_path>
+                        <comment>Defaults to customer_note, if not set</comment>
+                    </field>
                 </group>
                 <group id="third_party_modules" translate="label" type="text" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Third Party Modules Support</label>

--- a/view/adminhtml/layout/sales_order_view.xml
+++ b/view/adminhtml/layout/sales_order_view.xml
@@ -23,5 +23,14 @@
                    name="bolt.transaction.target"
                    template="Bolt_Boltpay::boltpay/js/transaction.phtml"/>
         </referenceContainer>
+        <referenceContainer name="order_additional_info">
+            <block name="bolt_order_comment"
+                   class="Magento\Sales\Block\Adminhtml\Order\AbstractOrder"
+                   template="Bolt_Boltpay::order/comment.phtml">
+                <arguments>
+                    <argument name="order_comment" xsi:type="object">Bolt\Boltpay\ViewModel\OrderComment</argument>
+                </arguments>
+            </block>
+        </referenceContainer>
     </body>
 </page>

--- a/view/adminhtml/templates/order/comment.phtml
+++ b/view/adminhtml/templates/order/comment.phtml
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/** @var \Magento\Sales\Block\Adminhtml\Order\AbstractOrder $block */
+
+use Bolt\Boltpay\Model\Payment;
+
+$order = $block->getOrder();
+/** @var \Bolt\Boltpay\ViewModel\OrderComment $orderCommentModel */
+$orderCommentModel = $block->getOrderComment();
+$comment = $orderCommentModel->getCommentForOrder($order);
+if (!$comment || !$order->getPayment() || $order->getPayment()->getMethod() !== Payment::METHOD_CODE) {
+    return;
+}
+?>
+<section class="admin__page-section">
+    <div class="admin__page-section-title">
+        <span class='title'><?= $block->escapeHtml(__('Order Comment')) ?></span>
+    </div>
+    <div class="admin__page-section-content">
+        <div class="admin__page-section-item">
+            <?php echo nl2br($block->escapeHtml($comment)); ?>
+        </div>
+    </div>
+</section>

--- a/view/adminhtml/templates/order/comment.phtml
+++ b/view/adminhtml/templates/order/comment.phtml
@@ -22,18 +22,17 @@ use Bolt\Boltpay\Model\Payment;
 $order = $block->getOrder();
 /** @var \Bolt\Boltpay\ViewModel\OrderComment $orderCommentModel */
 $orderCommentModel = $block->getOrderComment();
-$comment = $orderCommentModel->getCommentForOrder($order);
-if (!$comment || !$order->getPayment() || $order->getPayment()->getMethod() !== Payment::METHOD_CODE) {
+if (!$orderCommentModel->shouldDisplayForOrder($order)) {
     return;
 }
 ?>
 <section class="admin__page-section">
     <div class="admin__page-section-title">
-        <span class='title'><?= $block->escapeHtml(__('Order Comment')) ?></span>
+        <span class="title"><?php echo $block->escapeHtml(__('Order Comment')) ?></span>
     </div>
     <div class="admin__page-section-content">
         <div class="admin__page-section-item">
-            <?php echo nl2br($block->escapeHtml($comment)); ?>
+            <?php echo nl2br($block->escapeHtml($orderCommentModel->getCommentForOrder($order))); ?>
         </div>
     </div>
 </section>


### PR DESCRIPTION
# Description
Passing the order note to whatever field is configured. Defaults to customer_note.
Adding a Order Comment section to the admin order view.

Fixes: https://boltpay.atlassian.net/browse/M2P-388

## Order View
![image](https://user-images.githubusercontent.com/37150717/113754322-67666700-970f-11eb-949d-b86bf9d1219f.png)

## Plugin Configuration
![image](https://user-images.githubusercontent.com/37150717/113754405-7baa6400-970f-11eb-9c72-97d4dc812c34.png)

#changelog Custom Order Note field support

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
