### PR TITLE
M2P-556 Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Cron\DeactivateQuoteTest

### DIFF
--- a/Test/Unit/Cron/DeactivateQuoteTest.php
+++ b/Test/Unit/Cron/DeactivateQuoteTest.php
@@ -19,10 +19,10 @@ namespace Bolt\Boltpay\Test\Unit\Helper;
 
 use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Cron\DeactivateQuote;
-use Magento\Framework\App\ResourceConnection;
-use Magento\Framework\DB\Adapter\Pdo\Mysql;
-use Zend\Http\Header\Connection;
-use Bolt\Boltpay\Helper\Bugsnag;
+use Bolt\Boltpay\Test\Unit\TestUtils;
+use Magento\Quote\Model\Quote;
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Payment;
 
 /**
  * Class DeactivateQuoteTest
@@ -30,102 +30,41 @@ use Bolt\Boltpay\Helper\Bugsnag;
  */
 class DeactivateQuoteTest extends BoltTestCase
 {
-    /**
-     * @var DeactivateQuote
-     */
+    private $objectManager;
     private $deactivateQuote;
-
-    /**
-     * @var ResourceConnection
-     */
-    private $resourceConnection;
-
-    /**
-     * @var Bugsnag
-     */
-    private $bugsnag;
-
-    /**
-     * @var Connection
-     */
-    private $connection;
 
     public function setUpInternal()
     {
-        $this->resourceConnection = $this->createPartialMock(
-            ResourceConnection::class,
-            ['getConnection', 'getTableName']
-        );
-
-        $this->bugsnag = $this->createPartialMock(
-            Bugsnag::class,
-            ['notifyException']
-        );
-
-        $this->deactivateQuote = $this->getMockBuilder(DeactivateQuote::class)
-            ->setConstructorArgs(
-                [
-                    $this->resourceConnection,
-                    $this->bugsnag
-                ]
-            )
-            ->enableProxyingToOriginalMethods()
-            ->getMock();
-
-        $this->connection = $this->createPartialMock(Mysql::class, ['query']);
+        if (!class_exists('\Magento\TestFramework\Helper\Bootstrap')) {
+            return;
+        }
+        $this->objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        $this->deactivateQuote = $this->objectManager->create(DeactivateQuote::class);
     }
 
     /**
      * @test
-     * @param $data
-     * @dataProvider execute_dataProvider
      */
-    public function execute($data)
+    public function execute()
     {
-        $this->resourceConnection->expects(self::once())->method('getConnection')->willReturn($this->connection);
+        $quote = TestUtils::createQuote(['is_active' => true]);
+        $quoteId = $quote->getId();
+        $payment = $this->objectManager->create(Payment::class);
+        $payment->setMethod(\Bolt\Boltpay\Model\Payment::METHOD_CODE);
 
-        $this->resourceConnection->method('getTableName')->withConsecutive(
-            ['quote'],
-            ['sales_order'],
-            ['sales_order_payment']
-        )->willReturnOnConsecutiveCalls('quote', 'sales_order', 'sales_order_payment');
+        $paymentData = [
+            'transaction_reference' => 'XXXXX',
+            'transaction_state' => 'cc_payment:pending',
+        ];
+        $payment->setAdditionalInformation(array_merge((array)$payment->getAdditionalInformation(), $paymentData));
 
-        $this->connection->expects(self::once())->method('query')->will($this->returnCallback(
-            function ($data) {
-                $this->assertEquals(
-                    'UPDATE quote SET is_active = 0 WHERE is_active = 1 AND entity_id IN (SELECT so.quote_id FROM sales_order AS so INNER JOIN sales_order_payment AS sop ON so.entity_id = sop.parent_id WHERE sop.method = "boltpay")',
-                    $data
-                );
-            }
-        ));
-
-        if ($data['exception']) {
-            $this->connection->expects(self::once())->method('query')->willThrowException(new \Exception($data['exception']));
-            $this->bugsnag->expects(self::once())->method('notifyException')->will(
-                $this->returnCallback(
-                    function ($data) {
-                        $this->assertEquals(__('Error when run query'), $data->getMessage());
-                    }
-                )
-            );
-        } else {
-            $this->connection->expects(self::once())->method('query')->willReturnSelf();
-        }
+        $order = TestUtils::createDumpyOrder(['quote_id' => $quoteId], [], [], Order::STATE_PENDING_PAYMENT, Order::STATE_PENDING_PAYMENT, $payment);
 
         $this->deactivateQuote->execute();
+
+        self::assertEquals('0',$this->objectManager->create(Quote::class)->loadByIdWithoutStore($quoteId)->getIsActive());
+        TestUtils::cleanupSharedFixtures([$order]);
     }
 
-    public function execute_dataProvider()
-    {
-        return [
-            ['data' => [
-                'exception' => __('Error when run query'),
-            ]
-            ],
-            ['data' => [
-                'exception' => false,
-            ]
-            ]
-        ];
-    }
+
 }


### PR DESCRIPTION
# Description
M2P-556 Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Cron\DeactivateQuoteTest

Fixes: https://boltpay.atlassian.net/browse/M2P-556

#changelog M2P-556 Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Cron\DeactivateQuoteTest

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
