### PR TITLE
M2P-557 Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Cron\DeleteOldWebHookLogsTest

### DIFF
--- a/Test/Unit/Cron/DeleteOldWebHookLogsTest.php
+++ b/Test/Unit/Cron/DeleteOldWebHookLogsTest.php
@@ -18,8 +18,12 @@
 namespace Bolt\Boltpay\Test\Unit\Helper;
 
 use Bolt\Boltpay\Test\Unit\BoltTestCase;
-use Bolt\Boltpay\Model\ResourceModel\WebhookLogFactory;
+use Bolt\Boltpay\Model\WebhookLogFactory;
 use Bolt\Boltpay\Cron\DeleteOldWebHookLogs;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Stdlib\DateTime\DateTime;
+use Bolt\Boltpay\Model\ResourceModel\WebhookLog\CollectionFactory;
+use Magento\TestFramework\Helper\Bootstrap;
 
 /**
  * Class DeleteOldWebHookLogsTest
@@ -27,30 +31,41 @@ use Bolt\Boltpay\Cron\DeleteOldWebHookLogs;
  */
 class DeleteOldWebHookLogsTest extends BoltTestCase
 {
+    /**
+     * @var ObjectManager
+     */
+    private $objectManager;
 
     /**
      * @var DeleteOldWebHookLogs
      */
-    private $currentMock;
+    private $deleteOldWebHookLogs;
 
     /**
      * @var WebhookLogFactory
      */
     private $webhookLogFactory;
 
+    /**
+     * @var CollectionFactory
+     */
+    private $collectionFactory;
+
+    /**
+     * @var DateTime
+     */
+    private $coreDate;
+
     public function setUpInternal()
     {
-        $this->webhookLogFactory = $this->createPartialMock(
-            WebhookLogFactory::class,
-            ['create', 'deleteOldAttempts']
-        );
-
-        $this->currentMock = $this->getMockBuilder(DeleteOldWebHookLogs::class)
-            ->setConstructorArgs([
-               $this->webhookLogFactory
-            ])
-            ->enableProxyingToOriginalMethods()
-            ->getMock();
+        if (!class_exists('\Magento\TestFramework\Helper\Bootstrap')) {
+            return;
+        }
+        $this->objectManager = Bootstrap::getObjectManager();
+        $this->deleteOldWebHookLogs = $this->objectManager->create(DeleteOldWebHookLogs::class);
+        $this->webhookLogFactory = $this->objectManager->create(WebhookLogFactory::class);
+        $this->collectionFactory = $this->objectManager->create(CollectionFactory::class);
+        $this->coreDate = $this->objectManager->create(DateTime::class);
     }
 
     /**
@@ -58,8 +73,14 @@ class DeleteOldWebHookLogsTest extends BoltTestCase
      */
     public function execute()
     {
-        $this->webhookLogFactory->expects(self::once())->method('create')->willReturnSelf();
-        $this->webhookLogFactory->expects(self::once())->method('deleteOldAttempts')->willReturnSelf();
-        $this->currentMock->execute();
+        $this->webhookLogFactory->create()->setTransactionId('XXXX')
+            ->setHookType('pending')
+            ->setNumberOfMissingQuoteFailedHooks(1)
+            ->setUpdatedAt($this->coreDate->gmtDate(null, time() - 86400 * 31))
+            ->save();
+
+        $this->deleteOldWebHookLogs->execute();
+
+        self::assertEquals(0, $this->collectionFactory->create()->getSize());
     }
 }


### PR DESCRIPTION
# Description
Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Cron\DeleteOldWebHookLogsTest

Fixes: https://boltpay.atlassian.net/browse/M2P-557

#changelog ON-386 Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Cron\DeleteOldWebHookLogsTest

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
