### PR TITLE
Bugfix: Fixed amount discount errors

### DIFF
--- a/Plugin/SalesRuleActionDiscountPlugin.php
+++ b/Plugin/SalesRuleActionDiscountPlugin.php
@@ -39,16 +39,10 @@ class SalesRuleActionDiscountPlugin
     ) {
         $checkoutSession = $this->sessionHelper->getCheckoutSession();
 
-        // If the sale rule has no coupon, its discount amount can not be retrieved directly,
-        // so we store the discount amount in the checkout session with the rule id as key.
-        $boltCollectSaleRuleDiscounts = $checkoutSession->getBoltCollectSaleRuleDiscounts([]);
+        // Save the sale rule id into session,
+        // so we can get the applied rule id in after method which is to save discount amount. (@see Bolt\Boltpay\Plugin\SalesRuleModelUtilityPlugin::afterMinFix)
         $ruleId = $rule->getId();
-        if (!isset($boltCollectSaleRuleDiscounts[$ruleId])) {
-            $boltCollectSaleRuleDiscounts[$ruleId] = $result->getAmount();
-        } else {
-            $boltCollectSaleRuleDiscounts[$ruleId] += $result->getAmount();
-        }
-        $checkoutSession->setBoltCollectSaleRuleDiscounts($boltCollectSaleRuleDiscounts);
+        $checkoutSession->setBoltNeedCollectSaleRuleDiscounts($ruleId);
 
         return $result;
     }

--- a/Plugin/SalesRuleModelUtilityPlugin.php
+++ b/Plugin/SalesRuleModelUtilityPlugin.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2018 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+namespace Bolt\Boltpay\Plugin;
+
+use Bolt\Boltpay\Helper\Session as SessionHelper;
+
+class SalesRuleModelUtilityPlugin
+{    
+    /** @var SessionHelper */
+    private $sessionHelper;
+    
+    public function __construct(
+        SessionHelper $sessionHelper
+    ) {
+        $this->sessionHelper = $sessionHelper;
+    }
+    
+    public function afterMinFix(\Magento\SalesRule\Model\Utility $subject,
+                                   $result, $discountData, $item, $qty)
+    {
+        $checkoutSession = $this->sessionHelper->getCheckoutSession();
+        $savedRuleId = $checkoutSession->getBoltNeedCollectSaleRuleDiscounts('');      
+        if (!empty($savedRuleId)) {
+            // If the sale rule has no coupon, its discount amount can not be retrieved directly,
+            // so we store the discount amount in the checkout session with the rule id as key.
+            $boltCollectSaleRuleDiscounts = $checkoutSession->getBoltCollectSaleRuleDiscounts([]);            
+            if (!isset($boltCollectSaleRuleDiscounts[$savedRuleId])) {
+            $boltCollectSaleRuleDiscounts[$savedRuleId] = $discountData->getAmount();            
+            } else {
+                $boltCollectSaleRuleDiscounts[$savedRuleId] += $discountData->getAmount();
+            }
+            $checkoutSession->setBoltCollectSaleRuleDiscounts($boltCollectSaleRuleDiscounts);
+            $checkoutSession->setBoltNeedCollectSaleRuleDiscounts(''); 
+        }
+
+        return $result;
+    }
+}
+

--- a/Plugin/SalesRuleModelUtilityPlugin.php
+++ b/Plugin/SalesRuleModelUtilityPlugin.php
@@ -39,7 +39,7 @@ class SalesRuleModelUtilityPlugin
             // so we store the discount amount in the checkout session with the rule id as key.
             $boltCollectSaleRuleDiscounts = $checkoutSession->getBoltCollectSaleRuleDiscounts([]);            
             if (!isset($boltCollectSaleRuleDiscounts[$savedRuleId])) {
-            $boltCollectSaleRuleDiscounts[$savedRuleId] = $discountData->getAmount();            
+                $boltCollectSaleRuleDiscounts[$savedRuleId] = $discountData->getAmount();            
             } else {
                 $boltCollectSaleRuleDiscounts[$savedRuleId] += $discountData->getAmount();
             }

--- a/Test/Unit/Plugin/SalesRuleActionDiscountPluginTest.php
+++ b/Test/Unit/Plugin/SalesRuleActionDiscountPluginTest.php
@@ -55,7 +55,7 @@ class SalesRuleActionDiscountPluginTest extends BoltTestCase
         );
         $this->checkoutSession = $this->createPartialMock(
             CheckoutSession::class,
-            ['getBoltCollectSaleRuleDiscounts', 'setBoltCollectSaleRuleDiscounts']
+            ['setBoltNeedCollectSaleRuleDiscounts']
         );
         $this->plugin = (new ObjectManager($this))->getObject(
             SalesRuleActionDiscountPlugin::class,
@@ -69,7 +69,7 @@ class SalesRuleActionDiscountPluginTest extends BoltTestCase
      * @test
      * @covers ::afterCalculate
      */
-    public function afterCalculate_saveSaleRuleDiscountsToCheckoutSession_sessionExists()
+    public function afterCalculate_saveSaleRuleIdToCheckoutSession()
     {
         $rule = $this->getMockBuilder(DataObject::class)
             ->setMethods(['getId'])
@@ -78,56 +78,12 @@ class SalesRuleActionDiscountPluginTest extends BoltTestCase
         $rule->expects(self::once())
             ->method('getId')
             ->willReturn(2);
-        $result = $this->getMockBuilder(DataObject::class)
-            ->setMethods(['getAmount'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $result->expects(self::once())
-            ->method('getAmount')
-            ->willReturn(20.0);
-        $boltCollectSaleRuleDiscounts = [2 => 106.0,];
         $this->checkoutSession->expects(self::once())
-                            ->method('getBoltCollectSaleRuleDiscounts')
-                            ->willReturn($boltCollectSaleRuleDiscounts);
-        $this->checkoutSession->expects(self::once())
-                            ->method('setBoltCollectSaleRuleDiscounts')
-                            ->with([2 => 126.0,]);
+                            ->method('setBoltNeedCollectSaleRuleDiscounts')
+                            ->with(2);
         $this->sessionHelper->expects(self::once())
                             ->method('getCheckoutSession')
                             ->willReturn($this->checkoutSession);
-        $this->plugin->afterCalculate($this->subject, $result, $rule, null, null);
-    }
-
-    /**
-     * @test
-     * @covers ::afterCalculate
-     */
-    public function afterCalculate_saveSaleRuleDiscountsToCheckoutSession_sessionNotExists()
-    {
-        $rule = $this->getMockBuilder(DataObject::class)
-            ->setMethods(['getId'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $rule->expects(self::once())
-            ->method('getId')
-            ->willReturn(2);
-        $result = $this->getMockBuilder(DataObject::class)
-            ->setMethods(['getAmount'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $result->expects(self::once())
-            ->method('getAmount')
-            ->willReturn(20.0);
-        $boltCollectSaleRuleDiscounts = [];
-        $this->checkoutSession->expects(self::once())
-                            ->method('getBoltCollectSaleRuleDiscounts')
-                            ->willReturn($boltCollectSaleRuleDiscounts);
-        $this->checkoutSession->expects(self::once())
-                            ->method('setBoltCollectSaleRuleDiscounts')
-                            ->with([2 => 20.0,]);
-        $this->sessionHelper->expects(self::once())
-                            ->method('getCheckoutSession')
-                            ->willReturn($this->checkoutSession);
-        $this->plugin->afterCalculate($this->subject, $result, $rule, null, null);
+        $this->plugin->afterCalculate($this->subject, null, $rule, null, null);
     }
 }

--- a/Test/Unit/Plugin/SalesRuleModelUtilityPluginTest.php
+++ b/Test/Unit/Plugin/SalesRuleModelUtilityPluginTest.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Test\Unit\Plugin;
+
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
+use Bolt\Boltpay\Plugin\SalesRuleModelUtilityPlugin;
+use Magento\Framework\DataObject;
+use Magento\Checkout\Model\Session as CheckoutSession;
+use Magento\SalesRule\Model\Utility;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Bolt\Boltpay\Helper\Session as SessionHelper;
+use Magento\SalesRule\Model\Rule\Action\Discount\Data as DiscountData;
+
+/**
+ * Class SalesRuleModelUtilityPluginTest
+ * @package Bolt\Boltpay\Test\Unit\Plugin
+ * @coversDefaultClass \Bolt\Boltpay\Plugin\SalesRuleModelUtilityPlugin
+ */
+class SalesRuleModelUtilityPluginTest extends BoltTestCase
+{
+    /**
+     * @var SalesRuleModelUtilityPlugin
+     */
+    protected $plugin;
+    
+    /** @var CheckoutSession */
+    protected $checkoutSession;
+
+    /** @var SessionHelper */
+    protected $sessionHelper;
+    
+    /** @var AbstractDiscount */
+    protected $subject;
+
+    public function setUpInternal()
+    {
+        $this->subject = $this->createMock(Utility::class);
+        $this->sessionHelper = $this->createPartialMock(
+            SessionHelper::class,
+            ['getCheckoutSession']
+        );
+        $this->checkoutSession = $this->createPartialMock(
+            CheckoutSession::class,
+            ['getBoltNeedCollectSaleRuleDiscounts',
+             'setBoltNeedCollectSaleRuleDiscounts',
+             'getBoltCollectSaleRuleDiscounts',
+             'setBoltCollectSaleRuleDiscounts']
+        );
+        $this->plugin = (new ObjectManager($this))->getObject(
+            SalesRuleModelUtilityPlugin::class,
+            [
+                'sessionHelper' => $this->sessionHelper
+            ]
+        );
+    }
+
+    /**
+     * @test
+     * @covers ::afterMinFix
+     */
+    public function afterMinFix_saveSaleRuleDiscountsToCheckoutSession_sessionExists()
+    {
+        $discountData = $this->getMockBuilder(DiscountData::class)
+            ->setMethods(['getAmount'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $discountData->expects(self::once())
+            ->method('getAmount')
+            ->willReturn(20.0);
+        $this->checkoutSession->expects(self::once())
+                            ->method('getBoltNeedCollectSaleRuleDiscounts')
+                            ->willReturn(2);
+        $boltCollectSaleRuleDiscounts = [2 => 106.0,];
+        $this->checkoutSession->expects(self::once())
+                            ->method('getBoltCollectSaleRuleDiscounts')
+                            ->willReturn($boltCollectSaleRuleDiscounts);
+        $this->checkoutSession->expects(self::once())
+                            ->method('setBoltCollectSaleRuleDiscounts')
+                            ->with([2 => 126.0,]);
+        $this->checkoutSession->expects(self::once())
+                            ->method('setBoltNeedCollectSaleRuleDiscounts')
+                            ->with('');
+        $this->sessionHelper->expects(self::once())
+                            ->method('getCheckoutSession')
+                            ->willReturn($this->checkoutSession);
+        $this->plugin->afterMinFix($this->subject, null, $discountData, null, null);
+    }
+
+    /**
+     * @test
+     * @covers ::afterMinFix
+     */
+    public function afterMinFix_saveSaleRuleDiscountsToCheckoutSession_sessionNotExists()
+    {
+        $this->checkoutSession->expects(self::once())
+                            ->method('getBoltNeedCollectSaleRuleDiscounts')
+                            ->willReturn('');
+        $this->checkoutSession->expects(self::never())
+                            ->method('getBoltCollectSaleRuleDiscounts');
+        $this->checkoutSession->expects(self::never())
+                            ->method('setBoltCollectSaleRuleDiscounts');
+        $this->checkoutSession->expects(self::never())
+                            ->method('setBoltNeedCollectSaleRuleDiscounts');
+        $this->sessionHelper->expects(self::once())
+                            ->method('getCheckoutSession')
+                            ->willReturn($this->checkoutSession);
+        $this->plugin->afterMinFix($this->subject, null, null, null, null);
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -198,6 +198,12 @@
                 type="Bolt\Boltpay\Plugin\SalesRuleQuoteDiscountPlugin"
                 sortOrder="1"/>
     </type>
+    
+    <type name="Magento\SalesRule\Model\Utility">
+        <plugin name="Bolt_Boltpay_SalesRule_Model_Utility_Plugin"
+                type="Bolt\Boltpay\Plugin\SalesRuleModelUtilityPlugin"
+                sortOrder="20"/>
+    </type>
 
     <type name="Magento\Quote\Observer\Frontend\Quote\Address\CollectTotalsObserver">
         <plugin name="bolt_boltpay_magento_quote_observer_frontend_quote_address_collect_totals_observer_plugin"


### PR DESCRIPTION
# Description
If the unit price of cart item is zero, the discount amount of this item is zero too. In the Magento core, after calculating sale rule on the item, it would do some extra fixes on the discount data, such as eventFix, deltaRoundingFix and minFix (refer to https://github.com/magento/magento2/blob/7c6b6365a3c099509d6f6e6c306cb1821910aab0/app/code/Magento/SalesRule/Model/RulesApplier.php#L238), so the solution to fix this issue is saving discount info after minFix.

Fixes: https://boltpay.atlassian.net/browse/EN-4540

#changelog Bugfix: Fixed amount discount errors

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
