### PR TITLE
MA-709: fix the M2 config generation type name mismatch

### DIFF
--- a/Helper/AutomatedTesting.php
+++ b/Helper/AutomatedTesting.php
@@ -203,11 +203,14 @@ class AutomatedTesting extends AbstractHelper
                 ->setName($simpleStoreItem->getName())
                 ->setPrice($simpleStoreItem->getPrice())
                 ->setQuantity(1);
+            $tax = $this->pricePropertyFactory->create()
+                ->setName("tax")
+                ->setPrice($this->formatPrice($quote->getShippingAddress()->getTaxAmount()));
             $cart = $this->cartFactory->create()
                 ->setItems([$simpleCartItem])
                 ->setShipping(reset($shippingMethods))
                 ->setExpectedShippingMethods($shippingMethods)
-                ->setTax($this->formatPrice($quote->getShippingAddress()->getTaxAmount()))
+                ->setTax($tax)
                 ->setSubTotal($this->formatPrice($quote->getSubtotal()));
             $this->quoteRepository->delete($quote);
 

--- a/Test/Unit/Helper/AutomatedTestingTest.php
+++ b/Test/Unit/Helper/AutomatedTestingTest.php
@@ -245,6 +245,10 @@ class AutomatedTestingTest extends BoltTestCase
         $cartItem->expects(static::once())->method('setPrice')->willReturnSelf();
         $cartItem->expects(static::once())->method('setQuantity')->willReturnSelf();
         $this->cartItemFactory->expects(static::once())->method('create')->willReturn($cartItem);
+        $tax = $this->createMock(PriceProperty::class);
+        $tax->expects(static::once())->method('setName')->willReturnSelf();
+        $tax->expects(static::once())->method('setPrice')->willReturnSelf();
+        $this->pricePropertyFactory->expects(static::once())->method('create')->willReturn($tax);
         $cart = $this->createMock(Cart::class);
         $cart->expects(static::once())->method('setItems')->willReturnSelf();
         $cart->expects(static::once())->method('setShipping')->willReturnSelf();
@@ -283,6 +287,10 @@ class AutomatedTestingTest extends BoltTestCase
         $cartItem->expects(static::once())->method('setPrice')->willReturnSelf();
         $cartItem->expects(static::once())->method('setQuantity')->willReturnSelf();
         $this->cartItemFactory->expects(static::once())->method('create')->willReturn($cartItem);
+        $tax = $this->createMock(PriceProperty::class);
+        $tax->expects(static::once())->method('setName')->willReturnSelf();
+        $tax->expects(static::once())->method('setPrice')->willReturnSelf();
+        $this->pricePropertyFactory->expects(static::once())->method('create')->willReturn($tax);
         $cart = $this->createMock(Cart::class);
         $cart->expects(static::once())->method('setItems')->willReturnSelf();
         $cart->expects(static::once())->method('setShipping')->willReturnSelf();


### PR DESCRIPTION
# Description
Please include a summary of the change and which issue is fixed. Include the motivation for the changes, and comment on your PR if necessary for clarity.

fix tax for cart (make it a priceproperty object instead of a string) i need it to properly merge json with storeconfig for integration tests

https://boltpay.atlassian.net/browse/MA-709

Fixes: (link Jira ticket)

#changelog MA-709: fix the M2 config generation type name mismatch

# Type of change
- [] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
