### PR TITLE
[Orders] Update orders on Bolt when orders are edited on the plugin side

### DIFF
--- a/Helper/Api.php
+++ b/Helper/Api.php
@@ -61,6 +61,11 @@ class Api extends AbstractHelper
     const API_CREATE_ORDER = 'merchant/orders';
 
     /**
+     * Api update order
+     */
+    const API_UPDATE_ORDER = 'merchant/orders/update';
+
+    /**
      * Api create non-Bolt order
      */
     const API_CREATE_NON_BOLT_ORDER = 'non_bolt_order';

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1353,7 +1353,7 @@ class Cart extends AbstractHelper
             $product['sku']          = trim($giftWrapping->getCode());
             $product['type']         =  self::ITEM_TYPE_PHYSICAL;
 
-            $totalAmount +=  $product['total_amount'];
+            $data[1] +=  $product['total_amount'];
             $data[0][] = $product;
         }
 

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1337,7 +1337,7 @@ class Cart extends AbstractHelper
         $currencyCode = $quote->getQuoteCurrencyCode();
 
         // $data is of the form [products[], totalAmount, diff]
-        $data = getCartItemsFromItems($items, $currencyCode, $storeId, $totalAmount, $diff);
+        $data = $this->getCartItemsFromItems($items, $currencyCode, $storeId, $totalAmount, $diff);
 
         // getTotals is only available on a quote
         $total = $quote->getTotals();
@@ -1363,7 +1363,8 @@ class Cart extends AbstractHelper
     /**
      * Create cart data items array, given an array of items
      * fetched from either a quote or an order
-     * @param $quote
+     * @param $items
+     * @param $currencyCode
      * @param null $storeId
      * @param int $totalAmount
      * @param int $diff

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1336,8 +1336,7 @@ class Cart extends AbstractHelper
         $items = $quote->getAllVisibleItems();
         $currencyCode = $quote->getQuoteCurrencyCode();
 
-        // $data is of the form [products[], totalAmount, diff]
-        $data = $this->getCartItemsFromItems($items, $currencyCode, $storeId, $totalAmount, $diff);
+        list($products, $totalAmount, $diff) = $this->getCartItemsFromItems($items, $currencyCode, $storeId, $totalAmount, $diff);
 
         // getTotals is only available on a quote
         $total = $quote->getTotals();
@@ -1351,13 +1350,13 @@ class Cart extends AbstractHelper
             $product['unit_price']   = CurrencyUtils::toMinor($totalPrice, $currencyCode);
             $product['quantity']     = 1;
             $product['sku']          = trim($giftWrapping->getCode());
-            $product['type']         =  self::ITEM_TYPE_PHYSICAL;
+            $product['type']         = self::ITEM_TYPE_PHYSICAL;
 
-            $data[1] +=  $product['total_amount'];
-            $data[0][] = $product;
+            $totalAmount += $product['total_amount'];
+            $products[] = $product;
         }
 
-        return $data;
+        return [$products, $totalAmount, $diff];
     }
 
     /**

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1374,7 +1374,7 @@ class Cart extends AbstractHelper
     public function getCartItemsFromItems($items, $currencyCode, $storeId = null, $totalAmount = 0, $diff = 0)
     {
         /////////////////////////////////////////////////////////////////////////////////////////////////////////
-        // The "appEmulation" is necessary for geting correct image url from an API call.
+        // The "appEmulation" is necessary for getting correct image url from an API call.
         /////////////////////////////////////////////////////////////////////////////////////////////////////////
         $this->appEmulation->startEnvironmentEmulation(
             $storeId,

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1356,7 +1356,12 @@ class Cart extends AbstractHelper
             $products[] = $product;
         }
 
-        return [$products, $totalAmount, $diff];
+        return $this->eventsForThirdPartyModules->runFilter(
+            'filterCartItems',
+            [$products, $totalAmount, $diff],
+            $quote,
+            $storeId
+        );
     }
 
     /**
@@ -1548,12 +1553,7 @@ class Cart extends AbstractHelper
         $this->appEmulation->stopEnvironmentEmulation();
         /////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-        return $this->eventsForThirdPartyModules->runFilter(
-            'filterCartItems',
-            [$products, $totalAmount, $diff],
-            $quote,
-            $storeId
-        );
+        return [$products, $totalAmount, $diff];
     }
 
     /**

--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -207,6 +207,14 @@ class Decider extends AbstractHelper
     }
 
     /**
+     * Checks whether the feature switch for updating orders is enabled
+     */
+    public function isOrderUpdateEnabled()
+    {
+        return $this->isSwitchEnabled(Definitions::M2_ORDER_UPDATE);
+    }
+
+    /**
      * Checks whether the feature switch for ingesting Non-Bolt order information is enabled
      */
     public function isNonBoltTrackingEnabled()

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -68,6 +68,11 @@ class Definitions
     const M2_TRACK_SHIPMENT = 'M2_TRACK_SHIPMENT';
 
     /**
+     * Enable order updates
+     */
+    const M2_ORDER_UPDATE = 'M2_ORDER_UPDATE';
+
+    /**
      * Enable non-Bolt order tracking
      */
     const M2_TRACK_NON_BOLT = 'M2_TRACK_NON_BOLT';
@@ -208,6 +213,12 @@ class Definitions
             self::VAL_KEY         => true,
             self::DEFAULT_VAL_KEY => false,
             self::ROLLOUT_KEY     => 100
+        ],
+        self::M2_ORDER_UPDATE => [
+            self::NAME_KEY        => self::M2_ORDER_UPDATE,
+            self::VAL_KEY         => true,
+            self::DEFAULT_VAL_KEY => false,
+            self::ROLLOUT_KEY     => 0
         ],
         self::M2_TRACK_NON_BOLT => [
             self::NAME_KEY        => self::M2_TRACK_NON_BOLT,

--- a/Observer/OrderSaveObserver.php
+++ b/Observer/OrderSaveObserver.php
@@ -23,7 +23,6 @@ use Bolt\Boltpay\Helper\Bugsnag;
 use Bolt\Boltpay\Helper\Config as ConfigHelper;
 use Bolt\Boltpay\Helper\Cart as CartHelper;
 use Bolt\Boltpay\Helper\FeatureSwitch\Decider;
-use Bolt\Boltpay\Helper\Log as LogHelper;
 use Bolt\Boltpay\Helper\MetricsClient;
 use Bolt\Boltpay\Helper\Shared\CurrencyUtils;
 use Exception;
@@ -37,11 +36,6 @@ class OrderSaveObserver implements ObserverInterface
      * @var ConfigHelper
      */
     private $configHelper;
-
-    /**
-     * @var LogHelper
-     */
-    protected $logHelper;
 
     /**
      * @var DataObjectFactory
@@ -75,7 +69,6 @@ class OrderSaveObserver implements ObserverInterface
 
     /**
      * @param ConfigHelper      $configHelper
-     * @param LogHelper         $logHelper
      * @param DataObjectFactory $dataObjectFactory
      * @param ApiHelper         $apiHelper
      * @param CartHelper        $cartHelper
@@ -85,7 +78,6 @@ class OrderSaveObserver implements ObserverInterface
      */
     public function __construct(
         ConfigHelper $configHelper,
-        LogHelper $logHelper,
         DataObjectFactory $dataObjectFactory,
         ApiHelper $apiHelper,
         CartHelper $cartHelper,
@@ -94,7 +86,6 @@ class OrderSaveObserver implements ObserverInterface
         Decider $decider
     ) {
         $this->configHelper = $configHelper;
-        $this->logHelper = $logHelper;
         $this->dataObjectFactory = $dataObjectFactory;
         $this->apiHelper = $apiHelper;
         $this->cartHelper = $cartHelper;
@@ -120,7 +111,7 @@ class OrderSaveObserver implements ObserverInterface
 
             $currencyCode = $order->getOrderCurrencyCode();
             $items = $order->getAllVisibleItems();
-            $itemData = $this->cartHelper->getCartItemsFromItems($items, $currencyCode, $storeId); 
+            $itemData = $this->cartHelper->getCartItemsFromItems($items, $currencyCode, $storeId);
 
             // TODO: Before this goes into production, we should hash and cache
             // the resulting itemData to avoid sending updates for unchanged carts.
@@ -134,7 +125,6 @@ class OrderSaveObserver implements ObserverInterface
                     'items' => $itemData[0],
                 ]
             ];
-            $this->logHelper->addInfoLog(json_encode($orderUpdateData));
 
             $requestData = $this->dataObjectFactory->create();
             $requestData->setApiData($orderUpdateData);
@@ -148,7 +138,7 @@ class OrderSaveObserver implements ObserverInterface
                 $success = true;
             }
         } catch (Exception $e) {
-            $this->logHelper->addInfoLog($e);
+            print($e);
             $this->bugsnag->notifyException($e);
         } finally {
             $this->metricsClient->processMetric(

--- a/Observer/OrderSaveObserver.php
+++ b/Observer/OrderSaveObserver.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ *
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Observer;
+
+use Bolt\Boltpay\Helper\Api as ApiHelper;
+use Bolt\Boltpay\Helper\Bugsnag;
+use Bolt\Boltpay\Helper\Config as ConfigHelper;
+use Bolt\Boltpay\Helper\Cart as CartHelper;
+use Bolt\Boltpay\Helper\FeatureSwitch\Decider;
+use Bolt\Boltpay\Helper\Log as LogHelper;
+use Bolt\Boltpay\Helper\MetricsClient;
+use Bolt\Boltpay\Helper\Shared\CurrencyUtils;
+use Exception;
+use Magento\Framework\DataObjectFactory;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+class OrderSaveObserver implements ObserverInterface
+{
+    /**
+     * @var ConfigHelper
+     */
+    private $configHelper;
+
+    /**
+     * @var LogHelper
+     */
+    protected $logHelper;
+
+    /**
+     * @var DataObjectFactory
+     */
+    private $dataObjectFactory;
+
+    /**
+     * @var ApiHelper
+     */
+    private $apiHelper;
+
+    /**
+     * @var CartHelper
+     */
+    private $cartHelper;
+
+    /**
+     * @var Bugsnag
+     */
+    private $bugsnag;
+
+    /**
+     * @var MetricsClient
+     */
+    private $metricsClient;
+
+    /**
+     * @var Decider
+     */
+    private $decider;
+
+    /**
+     * @param ConfigHelper      $configHelper
+     * @param LogHelper         $logHelper
+     * @param DataObjectFactory $dataObjectFactory
+     * @param ApiHelper         $apiHelper
+     * @param CartHelper        $cartHelper
+     * @param Bugsnag           $bugsnag
+     * @param MetricsClient     $metricsClient
+     * @param Decider           $decider
+     */
+    public function __construct(
+        ConfigHelper $configHelper,
+        LogHelper $logHelper,
+        DataObjectFactory $dataObjectFactory,
+        ApiHelper $apiHelper,
+        CartHelper $cartHelper,
+        Bugsnag $bugsnag,
+        MetricsClient $metricsClient,
+        Decider $decider
+    ) {
+        $this->configHelper = $configHelper;
+        $this->logHelper = $logHelper;
+        $this->dataObjectFactory = $dataObjectFactory;
+        $this->apiHelper = $apiHelper;
+        $this->cartHelper = $cartHelper;
+        $this->bugsnag = $bugsnag;
+        $this->metricsClient = $metricsClient;
+        $this->decider = $decider;
+    }
+
+    /**
+     * @param Observer $observer
+     */
+    public function execute(Observer $observer)
+    {
+        // TODO: Add new switch
+        // if (!$this->decider->isTrackShipmentEnabled()) {
+        //     return;
+        // }
+
+
+        // generate cart (no order token yet)
+        // convert it to string and hash it (md5) to generate a cache key
+        // look it up in cache
+        // if found - skip it, already sent to Bolt in some previous attempt before caching
+        // if not found - fetch transaction, get the order token, add it to the cart object, send it to Bolt, on success (200 OK) store it in cache with the above key
+        // additionally you can also store the order token in cache, with the transaction_reference as key, so you reduce the number of fetch calls to only one per order (during the cache lifetime of course)
+
+// to create a refund: credit memo, select item
+
+        $success = false;
+        try {
+            $startTime = $this->metricsClient->getCurrentTime();
+            $order = $observer->getEvent()->getOrder();
+            $storeId = $order->getStoreId();
+
+            $currencyCode = $order->getOrderCurrencyCode();
+            $items = $order->getAllVisibleItems();
+            $itemData = $this->cartHelper->getCartItemsFromItems($items, $currencyCode, $storeId); 
+            // hash and cache itemData to detect changes           
+            $orderUpdateData = [
+                'cart' => [
+                    'display_id' => $order->getIncrementId(),
+                    'order_reference' => $order->getQuoteId(),
+                    'total_amount' => CurrencyUtils::toMinor($order->getGrandTotal(), $currencyCode),
+                    'tax_amount' => CurrencyUtils::toMinor($order->getTaxAmount(), $currencyCode),
+                    'items' => $itemData[0],
+                ]
+            ];
+            $this->logHelper->addInfoLog(json_encode($orderUpdateData));
+
+            //Request Data
+            $requestData = $this->dataObjectFactory->create();
+            $requestData->setApiData($orderUpdateData);
+            $requestData->setDynamicApiUrl(ApiHelper::API_UPDATE_ORDER);
+            $apiKey = $this->configHelper->getApiKey($storeId);
+            $requestData->setApiKey($apiKey);
+
+            //Build Request
+            $request = $this->apiHelper->buildRequest($requestData);
+            $result = $this->apiHelper->sendRequest($request);
+            if ($result == 200) {
+                $success = true;
+            }
+        } catch (Exception $e) {
+            $this->logHelper->addInfoLog($e);
+            $this->bugsnag->notifyException($e);
+        } finally {
+            $this->metricsClient->processMetric(
+                $success ? 'order_update.success' : 'order_update.failure',
+                1,
+                'order_update.latency',
+                $startTime
+            );
+        }
+    }
+}

--- a/Observer/OrderSaveObserver.php
+++ b/Observer/OrderSaveObserver.php
@@ -134,7 +134,7 @@ class OrderSaveObserver implements ObserverInterface
                     'items' => $itemData[0],
                 ]
             ];
-            // $this->logHelper->addInfoLog(json_encode($orderUpdateData));
+            $this->logHelper->addInfoLog(json_encode($orderUpdateData));
 
             $requestData = $this->dataObjectFactory->create();
             $requestData->setApiData($orderUpdateData);
@@ -148,7 +148,7 @@ class OrderSaveObserver implements ObserverInterface
                 $success = true;
             }
         } catch (Exception $e) {
-            // $this->logHelper->addInfoLog($e);
+            $this->logHelper->addInfoLog($e);
             $this->bugsnag->notifyException($e);
         } finally {
             $this->metricsClient->processMetric(

--- a/Observer/OrderSaveObserver.php
+++ b/Observer/OrderSaveObserver.php
@@ -117,13 +117,12 @@ class OrderSaveObserver implements ObserverInterface
         $result = self::RESULT_FAILURE;
         try {
             $startTime = $this->metricsClient->getCurrentTime();
+            
             $order = $observer->getEvent()->getOrder();
             $storeId = $order->getStoreId();
-
             $currencyCode = $order->getOrderCurrencyCode();
-            $items = $order->getAllVisibleItems();
-            $itemData = $this->cartHelper->getCartItemsFromItems($items, $currencyCode, $storeId);
 
+            $itemData = $this->cartHelper->getCartItemsForOrder($order, $storeId);
             $orderUpdateData = [
                 'order_reference' => $order->getQuoteId(),
                 'cart' => [

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -4933,7 +4933,7 @@ ORDER
         list($products, $totalAmount, $diff) = $this->currentMock->getCartItemsFromItems(
             [$this->getQuoteItemMock()],
             self::CURRENCY_CODE,
-            self::STORE_ID,
+            self::STORE_ID
         );
 
         $resultProductProperties = $products[0]['properties'];

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -4919,6 +4919,8 @@ ORDER
         static::assertEquals($products[0]['total_amount'], CurrencyUtils::toMinor($product->getPrice() * $quantity, self::CURRENCY_CODE));
         static::assertEquals($products[0]['quantity'], $quantity);        
         static::assertEquals($products[0]['sku'], $product->getSku());
+
+        TestUtils::cleanupSharedFixtures([$order]);
     }
 
         /**

--- a/Test/Unit/Observer/OrderSaveObserverTest.php
+++ b/Test/Unit/Observer/OrderSaveObserverTest.php
@@ -136,8 +136,8 @@ class OrderSaveObserverTest extends BoltTestCase
             ->willReturn($order);
 
         $this->cartHelper->expects($this->once())
-            ->method('getCartItemsFromItems')
-            ->with(null, self::ORDER_CURRENCY_CODE, self::ORDER_STORE_ID, 0, 0)
+            ->method('getCartItemsForOrder')
+            ->with($order, self::ORDER_STORE_ID, 0, 0)
             ->willReturn(['item_data', 0, 0]);
 
         $expectedData = [
@@ -198,8 +198,8 @@ class OrderSaveObserverTest extends BoltTestCase
         $event->method('getOrder')->willReturn($order);
 
         $this->cartHelper
-            ->method('getCartItemsFromItems')
-            ->with(null, self::ORDER_CURRENCY_CODE, self::ORDER_STORE_ID, 0, 0)
+            ->method('getCartItemsForOrder')
+            ->with($order, self::ORDER_STORE_ID, 0, 0)
             ->willReturn(['item_data', 0, 0]);
         
         $this->cache->expects($this->exactly(2))->method('load')->willReturnOnConsecutiveCalls(false, true);

--- a/Test/Unit/Observer/OrderSaveObserverTest.php
+++ b/Test/Unit/Observer/OrderSaveObserverTest.php
@@ -1,0 +1,198 @@
+<?php
+
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ *
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Test\Unit\Observer;
+
+use Bolt\Boltpay\Helper\Api as ApiHelper;
+use Bolt\Boltpay\Helper\Bugsnag;
+use Bolt\Boltpay\Helper\Cart;
+use Bolt\Boltpay\Helper\Config as ConfigHelper;
+use Bolt\Boltpay\Helper\FeatureSwitch\Decider;
+use Bolt\Boltpay\Helper\MetricsClient;
+use Bolt\Boltpay\Helper\Shared\CurrencyUtils;
+use Bolt\Boltpay\Model\Request;
+use Bolt\Boltpay\Observer\OrderSaveObserver as Observer;
+use Bolt\Boltpay\Test\Unit\BoltTestCase;
+use Exception;
+use Magento\Framework\DataObject;
+use Magento\Framework\DataObjectFactory;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+
+/**
+ * Class OrderSaveObserverTest
+ *
+ * @coversDefaultClass \Bolt\Boltpay\Observer\OrderSaveObserverTest
+ */
+class OrderSaveObserverTest extends BoltTestCase
+{
+    const ORDER_CURRENCY_CODE = 'USD';
+    const ORDER_INCREMENT_ID = '1235';
+    const ORDER_STORE_ID = '4321';
+    const ORDER_QUOTE_ID = '1357';
+    const ORDER_TOTAL_AMOUNT = '1000';
+    const ORDER_TAX_AMOUNT = '100';
+
+    /**
+     * @var Observer
+     */
+    protected $observer;
+
+    /**
+     * @var ConfigHelper
+     */
+    private $configHelper;
+
+    /**
+     * @var DataObjectFactory
+     */
+    private $dataObjectFactory;
+
+    /**
+     * @var DataObject
+     */
+    private $dataObject;
+
+    /**
+     * @var ApiHelper
+     */
+    private $apiHelper;
+
+    /**
+     * @var MockObject|Bugsnag
+     */
+    private $bugsnag;
+
+    /**
+     * @var MetricsClient
+     */
+    private $metricsClient;
+
+    /**
+     * @var Decider
+     */
+    private $decider;
+
+    /**
+     * @test
+     */
+    public function testExecute()
+    {
+        $this->decider->expects($this->once())->method('isOrderUpdateEnabled')->willReturn(true);
+        
+        $order = $this->getMockBuilder(\Magento\Sales\Model\Order::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $order->expects($this->once())
+            ->method('getStoreId')
+            ->willReturn(self::ORDER_STORE_ID);
+        $order->expects($this->once())
+            ->method('getOrderCurrencyCode')
+            ->willReturn(self::ORDER_CURRENCY_CODE);
+        $order->expects($this->once())
+            ->method('getQuoteId')
+            ->willReturn(self::ORDER_QUOTE_ID);
+        $order->expects($this->once())
+            ->method('getIncrementId')
+            ->willReturn(self::ORDER_INCREMENT_ID);
+        $order->expects($this->once())
+            ->method('getGrandTotal')
+            ->willReturn(self::ORDER_TOTAL_AMOUNT);
+        $order->expects($this->once())
+            ->method('getTaxAmount')
+            ->willReturn(self::ORDER_TAX_AMOUNT);
+
+        $eventObserver = $this->getMockBuilder(\Magento\Framework\Event\Observer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $event = $this->getMockBuilder(\Magento\Framework\Event::class)
+            ->setMethods(['getOrder'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $eventObserver->expects($this->once())
+            ->method('getEvent')
+            ->willReturn($event);
+        $event->expects($this->once())
+            ->method('getOrder')
+            ->willReturn($order);
+
+        $this->cartHelper->expects($this->once())
+            ->method('getCartItemsFromItems')
+            ->with(null, self::ORDER_CURRENCY_CODE, self::ORDER_STORE_ID, 0, 0)
+            ->willReturn(['item_data', 0, 0]);
+
+        $expectedData = [
+            'order_reference' => self::ORDER_QUOTE_ID,
+            'cart' => [
+                'display_id' => self::ORDER_INCREMENT_ID,
+                'total_amount' => CurrencyUtils::toMinor(self::ORDER_TOTAL_AMOUNT, self::ORDER_CURRENCY_CODE),
+                'tax_amount' => CurrencyUtils::toMinor(self::ORDER_TAX_AMOUNT, self::ORDER_CURRENCY_CODE),
+                'items' => 'item_data',
+            ],
+        ];
+        $this->dataObject->expects($this->once())
+            ->method('setApiData')
+            ->with($expectedData);
+
+        $this->apiHelper->expects($this->once())->method('buildRequest')->willReturn(new Request());
+        $this->apiHelper->expects($this->once())->method('sendRequest')->willReturn(200);
+
+        $this->metricsClient->expects($this->once())->method('getCurrentTime')->willReturn(5000);
+        $this->metricsClient->expects($this->once())->method('processMetric')->with(
+            'order_update.success',
+            1,
+            'order_update.latency',
+            5000
+        );
+                
+        $this->observer->execute($eventObserver);
+    }
+
+    protected function setUpInternal()
+    {
+        $this->initRequiredMocks();
+    }
+
+    private function initRequiredMocks()
+    {
+        $this->configHelper = $this->createMock(ConfigHelper::class);
+        
+        $this->dataObject = $this->getMockBuilder(DataObject::class)
+            ->setMethods(['setApiData'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->dataObjectFactory = $this->createMock(DataObjectFactory::class);
+        $this->dataObjectFactory->method('create')->willReturn($this->dataObject);
+
+        $this->bugsnag = $this->createMock(Bugsnag::class);
+        $this->apiHelper = $this->createMock(ApiHelper::class);
+        $this->cartHelper = $this->createMock(Cart::class);
+        $this->metricsClient = $this->createMock(MetricsClient::class);
+        $this->decider = $this->createMock(Decider::class);
+
+        $this->observer = new Observer(
+            $this->configHelper,
+            $this->dataObjectFactory,
+            $this->apiHelper,
+            $this->cartHelper,
+            $this->bugsnag,
+            $this->metricsClient,
+            $this->decider
+        );
+    }
+}

--- a/Test/Unit/Observer/OrderSaveObserverTest.php
+++ b/Test/Unit/Observer/OrderSaveObserverTest.php
@@ -38,7 +38,7 @@ use PHPUnit_Framework_MockObject_MockObject as MockObject;
 /**
  * Class OrderSaveObserverTest
  *
- * @coversDefaultClass \Bolt\Boltpay\Observer\OrderSaveObserverTest
+ * @coversDefaultClass \Bolt\Boltpay\Observer\OrderSaveObserver
  */
 class OrderSaveObserverTest extends BoltTestCase
 {

--- a/Test/Unit/TestUtils.php
+++ b/Test/Unit/TestUtils.php
@@ -530,6 +530,8 @@ class TestUtils
         $orderItem->setRowTotalInclTax($product->getPrice());
         $orderItem->setBaseRowTotalInclTax($product->getPrice());
         $orderItem->setProductType($product->getTypeId());
+        $orderItem->setName($product->getName());
+        $orderItem->setSku($product->getSku());
 
         return $orderItem;
     }

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
     <!-- When adding any observer, you MUST wrap the observer in a feature switch -->
+    <event name="sales_order_save_after">
+        <observer name="boltOrderSaveObserver" instance="Bolt\Boltpay\Observer\OrderSaveObserver" />
+    </event>
     <event name="sales_order_shipment_track_save_after">
         <observer name="boltTrackSaveObserver" instance="Bolt\Boltpay\Observer\TrackingSaveObserver" />
     </event>


### PR DESCRIPTION
# Description
* We'd like for order/cart information to be in sync between M2 and Bolt, even post-purchase. See [this spec](https://docs.google.com/document/d/1BcV_yGw2Itk0Q_T4xaiTbG_ppliC_cZ87kP_PlIyvXI/edit#heading=h.cunzcjjb9kz).
* We listen to the `sales_order_save_after` to invoke this functionality. This event triggers, for example, when refunds are issued. There are also paid plugins that allow order items to be added or edited.
* The functionality is gated behind a feature switch.

#changelog Update orders in Bolt when orders are saved

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [X] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [X] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [X] New and existing unit tests pass locally with my changes.
- [X] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
