### PR TITLE
M2P-564 Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Model\CustomerCreditCardTest

### DIFF
--- a/Test/Unit/Model/CustomerCreditCardTest.php
+++ b/Test/Unit/Model/CustomerCreditCardTest.php
@@ -22,6 +22,7 @@ use Bolt\Boltpay\Model\CustomerCreditCardFactory;
 use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Test\Unit\TestHelper;
 use Bolt\Boltpay\Test\Unit\TestUtils;
+<<<<<<< HEAD
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\DataObjectFactory;
 use Bolt\Boltpay\Helper\Api as ApiHelper;
@@ -29,6 +30,17 @@ use Magento\Framework\App\ObjectManager;
 use Magento\TestFramework\Helper\Bootstrap;
 use Magento\Store\Api\WebsiteRepositoryInterface;
 use Magento\Store\Model\StoreManagerInterface;
+=======
+use Klarna\Core\Helper\ConfigHelper;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Exception\LocalizedException;
+use Bolt\Boltpay\Helper\Api as ApiHelper;
+use Magento\Sales\Model\Order;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Store\Api\WebsiteRepositoryInterface;
+use Magento\Framework\DataObjectFactory;
+>>>>>>> Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Model\CustomerCreditCardTest
 
 class CustomerCreditCardTest extends BoltTestCase
 {
@@ -48,16 +60,20 @@ class CustomerCreditCardTest extends BoltTestCase
     private $customerCreditCard;
 
     /**
+<<<<<<< HEAD
      * @var CustomerCreditCardFactory
      */
     private $customerCreditCardFactory;
 
     /**
+=======
+>>>>>>> Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Model\CustomerCreditCardTest
      * @var ObjectManager
      */
     private $objectManager;
 
     /**
+<<<<<<< HEAD
      * @var DataObjectFactory
      */
     private $dataObjectFactory;
@@ -65,6 +81,28 @@ class CustomerCreditCardTest extends BoltTestCase
     private $customer;
 
     private $order;
+=======
+     * @var StoreManagerInterface
+     */
+    private $storeId;
+
+    /**
+     * @var WebsiteRepositoryInterface
+     */
+    private $websiteId;
+
+    /**
+     * @var CustomerCreditCard
+     */
+    private $newCustomerCreditCard;
+
+    /**
+     * @var DataObjectFactory
+     */
+    private $dataObjectFactory;
+
+    private $customerId;
+>>>>>>> Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Model\CustomerCreditCardTest
 
     /**
      * Setup for CustomerCreditCardTest Class
@@ -75,6 +113,7 @@ class CustomerCreditCardTest extends BoltTestCase
             return;
         }
         $this->objectManager = Bootstrap::getObjectManager();
+<<<<<<< HEAD
         $this->customerCreditCard = $this->objectManager->create(CustomerCreditCard::class);
         $store = $this->objectManager->get(StoreManagerInterface::class);
         $storeId = $store->getStore()->getId();
@@ -82,6 +121,15 @@ class CustomerCreditCardTest extends BoltTestCase
         $websiteRepository = $this->objectManager->get(WebsiteRepositoryInterface::class);
         $websiteId = $websiteRepository->get('base')->getId();
         $this->customer = TestUtils::createCustomer($websiteId, $storeId, [
+=======
+        $this->mockCustomerCreditCard = $this->objectManager->create(CustomerCreditCardFactory::class);
+        $store = $this->objectManager->get(StoreManagerInterface::class);
+        $this->storeId = $store->getStore()->getId();
+
+        $websiteRepository = $this->objectManager->get(WebsiteRepositoryInterface::class);
+        $this->websiteId = $websiteRepository->get('base')->getId();
+        $customer = TestUtils::createCustomer($this->websiteId, $this->storeId, [
+>>>>>>> Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Model\CustomerCreditCardTest
             "street_address1" => "street",
             "street_address2" => "",
             "locality" => "Los Angeles",
@@ -95,6 +143,7 @@ class CustomerCreditCardTest extends BoltTestCase
             "first_name" => "firstname",
             "last_name" => "lastname",
             "phone_number" => "11111111",
+<<<<<<< HEAD
             "email_address" => "johntest@bolt.com",
         ]);
         $this->customerCreditCardFactory = $this->objectManager->create(CustomerCreditCardFactory::class)->create()
@@ -110,6 +159,19 @@ class CustomerCreditCardTest extends BoltTestCase
     {
         TestUtils::cleanupSharedFixtures([$this->order]);
         TestUtils::cleanupSharedFixtures([$this->customerCreditCardFactory]);
+=======
+            "email_address" => "john@bolt.com",
+        ]);
+        $this->customerId = $customer->getId();
+
+        $this->newCustomerCreditCard = $this->mockCustomerCreditCard->create()
+            ->setCustomerId($this->customerId)
+            ->setConsumerId('xxxx')
+            ->setCreditCardId('xxxxxx')
+            ->setCardInfo(self::CARD_INFO)
+            ->save();
+        $this->dataObjectFactory = $this->objectManager->create(DataObjectFactory::class);
+>>>>>>> Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Model\CustomerCreditCardTest
     }
 
     /**
@@ -117,9 +179,29 @@ class CustomerCreditCardTest extends BoltTestCase
      */
     public function recharge_withException()
     {
+<<<<<<< HEAD
         $this->expectException(LocalizedException::class);
         $this->expectExceptionMessage('Authentication error. Authorization required.');
         $this->customerCreditCard->recharge($this->order);
+=======
+        $order = $this->createPartialMock(
+            Order::class,
+            [
+                'getQuoteId',
+                'getOrderCurrencyCode',
+                'getGrandTotal',
+                'getIncrementId'
+            ]
+        );
+        $order->expects(self::any())->method('getQuoteId')->willReturn(self::QUOTE_ID);
+        $order->expects(self::once())->method('getIncrementId')->willReturn(self::INCREMENT_ID);
+        $order->expects(self::once())->method('getGrandTotal')->willReturn(self::QUOTE_GRAND_TOTAL);
+        $order->expects(self::once())->method('getOrderCurrencyCode')->willReturn(self::ORDER_CURRENCY_CODE);
+
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage('Authentication error. Authorization required.');
+        $this->mockCustomerCreditCard->create()->recharge($order);
+>>>>>>> Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Model\CustomerCreditCardTest
     }
 
     /**
@@ -127,18 +209,58 @@ class CustomerCreditCardTest extends BoltTestCase
      */
     public function recharge()
     {
+<<<<<<< HEAD
         $apiHelper = $this->createPartialMock(ApiHelper::class, ['buildRequest', 'sendRequest']);
         $apiHelper->expects(self::once())->method('buildRequest')->willReturnSelf();
         $apiHelper->expects(self::once())->method('sendRequest')->willReturn(true);
 
         TestHelper::setProperty($this->customerCreditCard, 'apiHelper', $apiHelper);
         $this->assertTrue($this->customerCreditCard->recharge($this->order));
+=======
+        $order = $this->createPartialMock(
+            Order::class,
+            [
+                'getQuoteId',
+                'getOrderCurrencyCode',
+                'getGrandTotal',
+                'getIncrementId'
+            ]
+        );
+        $order->expects(self::any())->method('getQuoteId')->willReturn(self::QUOTE_ID);
+        $order->expects(self::once())->method('getIncrementId')->willReturn(self::INCREMENT_ID);
+        $order->expects(self::once())->method('getGrandTotal')->willReturn(self::QUOTE_GRAND_TOTAL);
+        $order->expects(self::once())->method('getOrderCurrencyCode')->willReturn(self::ORDER_CURRENCY_CODE);
+        $apiHelper = $this->getMockBuilder(ApiHelper::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['buildRequest', 'sendRequest'])
+            ->getMock();
+
+        $apiHelper->expects(self::once())->method('buildRequest');
+        $apiHelper->expects(self::once())->method('sendRequest')->willReturn(true);
+        $mockCustomerCreditCard = $this->objectManager->create(CustomerCreditCard::class);
+        TestHelper::setProperty($mockCustomerCreditCard, 'apiHelper', $apiHelper);
+
+        $this->assertTrue($mockCustomerCreditCard->recharge($order));
+>>>>>>> Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Model\CustomerCreditCardTest
     }
 
     /**
      * @test
      */
+<<<<<<< HEAD
     public function getCardInfoObject()
+=======
+    public function getCardInfoObject($data)
+    {
+        $this->newCustomerCreditCard->setData('card_info', $data['info']);
+        $result = $this->newCustomerCreditCard->getCardInfoObject();
+        $cartInfo = $this->dataObjectFactory->create();
+        $cartInfo->setData($data['expected']);
+        $this->assertEquals($cartInfo, $result);
+    }
+
+    public function providerGetCardInfoObject()
+>>>>>>> Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Model\CustomerCreditCardTest
     {
         $cartInfo = $this->dataObjectFactory->create();
         $cartInfo->setData([
@@ -155,8 +277,12 @@ class CustomerCreditCardTest extends BoltTestCase
      */
     public function getCardType()
     {
+<<<<<<< HEAD
         $result = $this->customerCreditCardFactory->getCardType();
         $this->assertEquals('Visa', $result);
+=======
+        $this->assertEquals('Visa', $this->newCustomerCreditCard->getCardType());
+>>>>>>> Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Model\CustomerCreditCardTest
     }
 
     /**
@@ -164,7 +290,11 @@ class CustomerCreditCardTest extends BoltTestCase
      */
     public function getCardLast4Digit()
     {
+<<<<<<< HEAD
         $result = $this->customerCreditCardFactory->getCardLast4Digit();
+=======
+        $result = $this->newCustomerCreditCard->getCardLast4Digit();
+>>>>>>> Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Model\CustomerCreditCardTest
         $this->assertEquals('XXXX-1111', $result);
     }
 
@@ -173,8 +303,13 @@ class CustomerCreditCardTest extends BoltTestCase
      */
     public function getIdentities()
     {
+<<<<<<< HEAD
         $result = $this->customerCreditCardFactory->getIdentities();
         $this->assertEquals(['bolt_customer_credit_cards_' . $this->customerCreditCardFactory->getId()], $result);
+=======
+        $result = $this->newCustomerCreditCard->getIdentities();
+        $this->assertEquals([CustomerCreditCard::CACHE_TAG . '_' . $this->newCustomerCreditCard->getId()], $result);
+>>>>>>> Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Model\CustomerCreditCardTest
     }
 
     /**
@@ -182,6 +317,7 @@ class CustomerCreditCardTest extends BoltTestCase
      */
     public function saveCreditCard()
     {
+<<<<<<< HEAD
         $customerCreditCard = $this->objectManager->create(CustomerCreditCardFactory::class)->create()
             ->saveCreditCard(
                 $this->customer->getId(),
@@ -191,5 +327,14 @@ class CustomerCreditCardTest extends BoltTestCase
             );
         $this->assertNotNull($customerCreditCard->getId());
         TestUtils::cleanupSharedFixtures([$customerCreditCard]);
+=======
+        $customerCreditCardId = $this->mockCustomerCreditCard->create()->saveCreditCard(
+            $this->customerId,
+            self::CONSUMER_ID,
+            self::CREDIT_CARD_ID,
+            []
+        )->getId();
+        $this->assertNotNull($customerCreditCardId);
+>>>>>>> Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Model\CustomerCreditCardTest
     }
 }


### PR DESCRIPTION
# Description
Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Model\CustomerCreditCardTest

Fixes: https://boltpay.atlassian.net/browse/M2P-564

#changelog M2P-564 Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Model\CustomerCreditCardTest

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
