### PR TITLE
M2P-566 Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Model\ResourceModel\ExternalCustomerEntityTest

### DIFF
--- a/Test/Unit/Model/ResourceModel/ExternalCustomerEntityTest.php
+++ b/Test/Unit/Model/ResourceModel/ExternalCustomerEntityTest.php
@@ -19,34 +19,35 @@ namespace Bolt\Boltpay\Test\Unit\Model\ResourceModel;
 
 use Bolt\Boltpay\Model\ResourceModel\ExternalCustomerEntity;
 use Bolt\Boltpay\Test\Unit\BoltTestCase;
-use Bolt\Boltpay\Test\Unit\TestHelper;
+use Magento\TestFramework\Helper\Bootstrap;
 
 class ExternalCustomerEntityTest extends BoltTestCase
 {
     /**
      * @var ExternalCustomerEntity
      */
-    private $externalCustomerEntityMock;
+    private $externalCustomerEntity;
+
+    private $objectManager;
 
     /**
      * @inheritdoc
      */
     public function setUpInternal()
     {
-        $this->externalCustomerEntityMock = $this->getMockBuilder(ExternalCustomerEntity::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['_init'])
-            ->getMock();
+        if (!class_exists('\Magento\TestFramework\Helper\Bootstrap')) {
+            return;
+        }
+        $this->objectManager = Bootstrap::getObjectManager();
+        $this->externalCustomerEntity = $this->objectManager->create(ExternalCustomerEntity::class);
     }
 
     /**
      * @test
      */
-    public function testConstruct()
+    public function construct()
     {
-        $this->externalCustomerEntityMock->expects($this->once())->method('_init')
-            ->with('bolt_external_customer_entity', 'id')
-            ->willReturnSelf();
-        TestHelper::invokeMethod($this->externalCustomerEntityMock, '_construct');
+        self::assertEquals('bolt_external_customer_entity', $this->externalCustomerEntity->getMainTable());
+        self::assertEquals('id', $this->externalCustomerEntity->getIdFieldName());
     }
 }


### PR DESCRIPTION


# Description
M2P-566 Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Model\ResourceModel\ExternalCustomerEntityTest

Fixes: https://boltpay.atlassian.net/browse/M2P-566

#changelog M2P-566 Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Model\ResourceModel\ExternalCustomerEntityTest

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
