### PR TITLE
M2P-567 Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Model\ResourceModel\FeatureSwitchTest

### DIFF
--- a/Test/Unit/Model/ResourceModel/FeatureSwitchTest.php
+++ b/Test/Unit/Model/ResourceModel/FeatureSwitchTest.php
@@ -19,35 +19,35 @@ namespace Bolt\Boltpay\Test\Unit\Model\ResourceModel;
 
 use Bolt\Boltpay\Model\ResourceModel\FeatureSwitch;
 use Bolt\Boltpay\Test\Unit\BoltTestCase;
-use Bolt\Boltpay\Test\Unit\TestHelper;
+use Magento\TestFramework\Helper\Bootstrap;
 
 class FeatureSwitchTest extends BoltTestCase
 {
     /**
-     * @var \Bolt\Boltpay\Model\ResourceModel\FeatureSwitch
+     * @var FeatureSwitch
      */
-    private $mockFeatureSwitch;
+    private $featureSwitch;
+
+    private $objectManager;
 
     /**
-     * Setup for CustomerCreditCardTest Class
+     * @inheritdoc
      */
     public function setUpInternal()
     {
-        $this->mockFeatureSwitch = $this->getMockBuilder(FeatureSwitch::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['_init'])
-            ->getMock();
+        if (!class_exists('\Magento\TestFramework\Helper\Bootstrap')) {
+            return;
+        }
+        $this->objectManager = Bootstrap::getObjectManager();
+        $this->featureSwitch = $this->objectManager->create(FeatureSwitch::class);
     }
 
     /**
      * @test
      */
-    public function testConstruct()
+    public function construct()
     {
-        $this->mockFeatureSwitch->expects($this->once())->method('_init')
-            ->with('bolt_feature_switches', 'id')
-            ->willReturnSelf();
-
-        TestHelper::invokeMethod($this->mockFeatureSwitch, '_construct');
+        self::assertEquals('bolt_feature_switches', $this->featureSwitch->getMainTable());
+        self::assertEquals('id', $this->featureSwitch->getIdFieldName());
     }
 }


### PR DESCRIPTION
# Description
Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Model\ResourceModel\FeatureSwitchTest

Fixes: https://boltpay.atlassian.net/browse/M2P-567

#changelog M2P-566 Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Model\ResourceModel\FeatureSwitchTest

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
