### PR TITLE
M2P-544 Bugfix: order status moves from processing back to pending payment

### DIFF
--- a/Test/Unit/Plugin/OrderPluginTest.php
+++ b/Test/Unit/Plugin/OrderPluginTest.php
@@ -118,6 +118,7 @@ class OrderPluginTest extends BoltTestCase
             ['', OrderHelper::TS_REJECTED_IRREVERSIBLE, [Order::STATE_PENDING_PAYMENT]],
             [Order::STATE_NEW, Order::STATE_NEW, [Order::STATE_PENDING_PAYMENT]],
             [Order::STATE_COMPLETE, Order::STATE_COMPLETE, [Order::STATE_COMPLETE]],
+            [Order::STATE_PROCESSING, Order::STATE_PENDING_PAYMENT, [Order::STATE_PROCESSING]],
         ];
     }
 
@@ -185,6 +186,8 @@ class OrderPluginTest extends BoltTestCase
             [Order::STATE_COMPLETE, OrderHelper::MAGENTO_ORDER_STATUS_PENDING, Order::STATE_PENDING_PAYMENT, [Order::STATE_COMPLETE]],
             [Order::STATE_COMPLETE, OrderHelper::MAGENTO_ORDER_STATUS_PENDING, Order::STATE_NEW, [Order::STATE_COMPLETE]],
             [Order::STATE_COMPLETE, OrderHelper::MAGENTO_ORDER_STATUS_PENDING, '', [Order::STATE_COMPLETE]],
+            [Order::STATE_COMPLETE, OrderHelper::MAGENTO_ORDER_STATUS_PENDING, '', [Order::STATE_COMPLETE]],
+            [Order::STATE_PENDING_PAYMENT, Order::STATE_PENDING_PAYMENT, Order::STATE_PROCESSING, [Order::STATE_PROCESSING]],
         ];
     }
 


### PR DESCRIPTION
# Description
In some contexts, when the create_order hook (thread 1) takes a lot of time to execute and returns a timeout, the authorize/payment hook (thread 2) is sent to Magento. It updates the order prior to the create_order hook (thread 1) process and change order status to processing. Then the create_order hook (thread 1) could change the order status back to pending payment which is unexpected behavior.

This PR is to compare previous status with new status and prevent such a behavior.

Fixes: https://boltpay.atlassian.net/browse/M2P-544

#changelog Bugfix: order status moves from processing back to pending payment

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
