### PR TITLE
EN-4581 Bugfix: back office needs to be refreshed for button to show

### DIFF
--- a/Block/BlockTrait.php
+++ b/Block/BlockTrait.php
@@ -81,7 +81,7 @@ trait BlockTrait
     public function isEnabled()
     {
         $storeId = $this->getStoreId();
-        return $this->configHelper->isActive($storeId);
+        return ($this->_appState->getAreaCode() == \Magento\Framework\App\Area::AREA_ADMINHTML) || $this->configHelper->isActive($storeId);
     }
 
     /**

--- a/Block/Form.php
+++ b/Block/Form.php
@@ -180,7 +180,7 @@ class Form extends PaymentForm
      */
     public function getPublishableKeyBackOffice()
     {
-        return $this->configHelper->getPublishableKeyBackOffice();
+        return $this->configHelper->getPublishableKeyBackOffice($this->getQuoteData()->getStoreId());
     }
 
     /**
@@ -188,7 +188,7 @@ class Form extends PaymentForm
      */
     public function getPublishableKeyPaymentOnly()
     {
-        return $this->configHelper->getPublishableKeyPayment();
+        return $this->configHelper->getPublishableKeyPayment($this->getQuoteData()->getStoreId());
     }
 
     /**

--- a/Controller/Adminhtml/Cart/Data.php
+++ b/Controller/Adminhtml/Cart/Data.php
@@ -142,9 +142,10 @@ class Data extends \Magento\Sales\Controller\Adminhtml\Order\Create
             $quote = $this->_getOrderCreateModel()->getQuote();
             $this->storeManager->setCurrentStore($storeId);
 
-            $backOfficeKey = $this->configHelper->getPublishableKeyBackOffice();
-            $paymentOnlyKey = $this->configHelper->getPublishableKeyPayment();
-            $isPreAuth = $this->configHelper->getIsPreAuth();
+            $backOfficeKey = $this->configHelper->getPublishableKeyBackOffice($storeId);
+            $paymentOnlyKey = $this->configHelper->getPublishableKeyPayment($storeId);
+            $isPreAuth = $this->configHelper->getIsPreAuth($storeId);
+            $connectUrl = $this->configHelper->getCdnUrl($storeId) . '/connect.js';
 
             $customerEmail = $quote->getCustomerEmail();
             if (!$quote->getCustomerId() && $this->cartHelper->getCustomerByEmail($customerEmail)) {
@@ -185,6 +186,7 @@ class Data extends \Magento\Sales\Controller\Adminhtml\Order\Create
                         'paymentOnlyKey' => $paymentOnlyKey,
                         'storeId'        => $storeId,
                         'isPreAuth'      => $isPreAuth,
+                        'connectUrl'     => $connectUrl
                     ]
                 );
         } catch (LocalizedException $e) {
@@ -196,6 +198,7 @@ class Data extends \Magento\Sales\Controller\Adminhtml\Order\Create
                     'paymentOnlyKey' => $paymentOnlyKey ?? '',
                     'storeId'        => $storeId ?? '',
                     'isPreAuth'      => $isPreAuth ?? '',
+                    'connectUrl'     => $connectUrl ?? '',
                 ]
             );
         } catch (Exception $e) {

--- a/Helper/Api.php
+++ b/Helper/Api.php
@@ -272,10 +272,10 @@ class Api extends AbstractHelper
      *
      * @return Request
      */
-    public function buildRequest($requestData)
+    public function buildRequest($requestData, $storeId = null)
     {
         $apiData = $requestData->getApiData();
-        $apiUrl = $this->configHelper->getApiUrl() . self::API_CURRENT_VERSION . $requestData->getDynamicApiUrl();
+        $apiUrl = $this->configHelper->getApiUrl($storeId) . self::API_CURRENT_VERSION . $requestData->getDynamicApiUrl();
         $apiKey = $requestData->getApiKey();
         $requestMethod = $requestData->getRequestMethod() ?: 'POST';
         $contentType = $requestData->getContentType() ?: 'application/json';

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -415,7 +415,7 @@ class Order extends AbstractHelper
         $requestData->setApiKey($this->configHelper->getApiKey($storeId));
         $requestData->setRequestMethod('GET');
         //Build Request
-        $request = $this->apiHelper->buildRequest($requestData);
+        $request = $this->apiHelper->buildRequest($requestData, $storeId);
 
         $result = $this->apiHelper->sendRequest($request);
         $response = $result->getResponse();
@@ -1007,7 +1007,7 @@ class Order extends AbstractHelper
         $requestData->setDynamicApiUrl(ApiHelper::API_VOID_TRANSACTION);
         $requestData->setApiKey($apiKey);
         //Build Request
-        $request = $this->apiHelper->buildRequest($requestData);
+        $request = $this->apiHelper->buildRequest($requestData, $storeId);
         $result = $this->apiHelper->sendRequest($request);
         $response = $result->getResponse();
 

--- a/Test/Unit/Block/FormTest.php
+++ b/Test/Unit/Block/FormTest.php
@@ -95,7 +95,7 @@ class FormTest extends BoltTestCase
 
         $this->quoteMock = $this->getMockBuilder(BackendQuote::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getBillingAddress'])
+            ->setMethods(['getBillingAddress','getStoreId'])
             ->getMock();
 
         $this->addressMock = $this->getMockBuilder(Address::class)
@@ -188,11 +188,29 @@ class FormTest extends BoltTestCase
      */
     public function getPublishableKeyBackOfficeShouldReturnConfigValue()
     {
+        $this->quoteMock->expects(self::once())->method('getStoreId')->willReturn(1);
+        $this->block->expects(self::once())->method('getQuoteData')->willReturn($this->quoteMock);        
         $this->configHelperMock
             ->method('getPublishableKeyBackOffice')
+            ->with(1)
             ->willReturn("backoffice-key");
 
         $this->assertEquals("backoffice-key", $this->block->getPublishableKeyBackOffice());
+    }
+    
+    /**
+     * @test
+     */
+    public function getPublishableKeyPaymentOnlyShouldReturnConfigValue()
+    {
+        $this->quoteMock->expects(self::once())->method('getStoreId')->willReturn(1);
+        $this->block->expects(self::once())->method('getQuoteData')->willReturn($this->quoteMock);        
+        $this->configHelperMock
+            ->method('getPublishableKeyPayment')
+            ->with(1)
+            ->willReturn("payment-key");
+
+        $this->assertEquals("payment-key", $this->block->getPublishableKeyPaymentOnly());
     }
 
     /**

--- a/Test/Unit/Controller/Adminhtml/Cart/DataTest.php
+++ b/Test/Unit/Controller/Adminhtml/Cart/DataTest.php
@@ -51,6 +51,7 @@ class DataTest extends BoltTestCase
     const HINT = 'hint!';
     const RESPONSE_TOKEN = 'response_token';
     const CUSTOMER_EMAIL = 'test@bolt.com';
+    const CDN_URL_SANDBOX = 'https://connect-sandbox.bolt.com';
 
     /**
      * @var Context
@@ -171,7 +172,8 @@ class DataTest extends BoltTestCase
             'storeId'        => self::STORE_ID,
             'isPreAuth'      => self::IS_PREAUTH,
             'backOfficeKey'  => self::PUBLISHABLE_KEY,
-            'paymentOnlyKey' => null
+            'paymentOnlyKey' => null,
+            'connectUrl'     => self::CDN_URL_SANDBOX,
         ];
 
         $this->noTokenCartArray = ['orderToken' => ''];
@@ -184,6 +186,7 @@ class DataTest extends BoltTestCase
             'isPreAuth'      => self::IS_PREAUTH,
             'backOfficeKey'  => self::PUBLISHABLE_KEY,
             'paymentOnlyKey' => '',
+            'connectUrl'     => self::CDN_URL_SANDBOX,
         ];
 
         $this->map = [
@@ -210,9 +213,14 @@ class DataTest extends BoltTestCase
 
         $this->configHelperMock = $this->createMock(Config::class);
         $this->configHelperMock->method('getPublishableKeyBackOffice')
+            ->with(self::STORE_ID)
             ->willReturn(self::PUBLISHABLE_KEY);
         $this->configHelperMock->method('getIsPreAuth')
+            ->with(self::STORE_ID)
             ->willReturn(self::IS_PREAUTH);
+        $this->configHelperMock->method('getCdnUrl')
+            ->with(self::STORE_ID)
+            ->willReturn(self::CDN_URL_SANDBOX);
 
         $this->quoteMock = $this->createPartialMock(
             \Magento\Quote\Model\Quote::class,
@@ -440,6 +448,7 @@ class DataTest extends BoltTestCase
                 'paymentOnlyKey' => '',
                 'storeId'        => '',
                 'isPreAuth'      => '',
+                'connectUrl'     => '',
             ]
         );
 
@@ -477,6 +486,7 @@ class DataTest extends BoltTestCase
                 'paymentOnlyKey' => '',
                 'storeId'        => self::STORE_ID,
                 'isPreAuth'      => self::IS_PREAUTH,
+                'connectUrl'     => self::CDN_URL_SANDBOX,
             ]
         );
 

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -645,7 +645,7 @@ class OrderTest extends BoltTestCase
 
         $request = $this->createMock(Request::class);
 
-        $this->apiHelper->expects(static::once())->method('buildRequest')->with($requestObject)
+        $this->apiHelper->expects(static::once())->method('buildRequest')->with($requestObject, self::STORE_ID)
             ->willReturn($request);
 
         /** @var MockObject|Response $result */
@@ -5019,7 +5019,7 @@ class OrderTest extends BoltTestCase
         $this->dataObjectFactory->expects(self::once())->method('setApiKey')->willReturnSelf();
 
         $this->apiHelper->expects(self::once())->method('buildRequest')
-            ->with($this->dataObjectFactory)->willReturn($this->boltRequest);
+            ->with($this->dataObjectFactory, self::STORE_ID)->willReturn($this->boltRequest);
         $this->apiHelper->expects(self::once())->method('sendRequest')
             ->withAnyParameters()->willReturn($this->responseFactory);
 

--- a/view/adminhtml/templates/boltpay/js/replacejs.phtml
+++ b/view/adminhtml/templates/boltpay/js/replacejs.phtml
@@ -221,7 +221,7 @@ require([
      * Inject connect.js
      * return void
      */
-    var insertConnectScript = function(publishableKey) {
+    var insertConnectScript = function(publishableKey, connectUrl) {
         var scriptTag = document.getElementById('bolt-connect');
         if (scriptTag) {
             BoltCheckout.configure(cart, hints, callbacks);
@@ -231,9 +231,13 @@ require([
             console.error('No publishable key set');
             return;
         }
+        if (!connectUrl) {
+            console.error('No connect url set');
+            return;
+        }
         scriptTag = document.createElement('script');
         scriptTag.setAttribute('type', 'text/javascript');
-        scriptTag.setAttribute('src', settings.connect_url);
+        scriptTag.setAttribute('src', connectUrl);
         scriptTag.setAttribute('id', 'bolt-connect');
         scriptTag.setAttribute('data-publishable-key', publishableKey);
         scriptTag.onload = function() {BoltCheckout.configure(cart, hints, callbacks);}
@@ -394,8 +398,8 @@ require([
             settings.storeId = data.storeId;
             settings.isPreAuth = data.isPreAuth;
 
-            if (data.backOfficeKey) {
-                insertConnectScript(data.backOfficeKey);
+            if (data.backOfficeKey && data.connectUrl) {
+                insertConnectScript(data.backOfficeKey, data.connectUrl);
             }
             if (data.paymentOnlyKey && settings.pay_by_link_url && cart.orderToken) {
                 $(".bolt-checkout-options-separator").toggle(!!data.backOfficeKey);


### PR DESCRIPTION
# Description
Root cause: if the merchant site enables multi stores and the default store does not have Bolt enabled, the related JS and Bolt keys are not loaded on the backoffice order creation page. 

Solution:
1. We always load replacejs.phtml for the backoffice order creation.
2. Loads Bolt keys and connect url by current store id instead of default store id.
3. Builds api request content by current store id.

Fixes: https://boltpay.atlassian.net/browse/EN-4581

#changelog Bugfix: back office needs to be refreshed for button to show

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
