### PR TITLE
M2P-583 Bugfix: shipping coupon not applying

### DIFF
--- a/Model/Api/Tax.php
+++ b/Model/Api/Tax.php
@@ -198,15 +198,20 @@ class Tax extends ShippingTax implements TaxInterface
     /**
      * @param TotalsInterface $totalsInformation
      * @param string $currencyCode
-     * @param array $shipping_option
+     * @param array $shippingOption
      * @return array
      * @throws \Exception
      */
-    protected function getShippingDiscount($totalsInformation, $currencyCode, $shipping_option)
+    protected function getShippingDiscount($totalsInformation, $currencyCode, $shippingOption)
     {
-        $shippingDiscountAmount = $this->eventsForThirdPartyModules->runFilter("collectShippingDiscounts", $totalsInformation->getShippingDiscountAmount(), $this->quote, $this->quote->getShippingAddress());
+        $shippingDiscountAmount = $this->eventsForThirdPartyModules->runFilter(
+            "collectShippingDiscounts",
+            $totalsInformation->getShippingDiscountAmount(),
+            $this->quote,
+            $this->quote->getShippingAddress()
+        );
         if ($shippingDiscountAmount >= DiscountHelper::MIN_NONZERO_VALUE) {
-            $service = $shipping_option['service'] ?? '';
+            $service = $shippingOption['service'] ?? '';
             $shippingCost = $totalsInformation->getShippingAmount() - $shippingDiscountAmount;
             $shippingRoundedCost = CurrencyUtils::toMinor($shippingCost, $currencyCode);
             $diff = CurrencyUtils::toMinorWithoutRounding($shippingCost, $currencyCode) - $shippingRoundedCost;
@@ -217,16 +222,16 @@ class Tax extends ShippingTax implements TaxInterface
                 $discount = $this->priceHelper->currency($shippingDiscountAmount, true, false);
                 $service .= " [$discount" . "&nbsp;discount]";
             }
-            $shipping_option['service'] = html_entity_decode($service);
+            $shippingOption['service'] = html_entity_decode($service);
         } else {
             $shippingRoundedCost = CurrencyUtils::toMinor($totalsInformation->getShippingAmount(), $currencyCode);
             $taxAmount = CurrencyUtils::toMinor($totalsInformation->getShippingTaxAmount(), $currencyCode);
         }
         
-        $shipping_option['cost'] = $shippingRoundedCost;
-        $shipping_option['tax_amount'] = $taxAmount;
+        $shippingOption['cost'] = $shippingRoundedCost;
+        $shippingOption['tax_amount'] = $taxAmount;
         
-        return $shipping_option;
+        return $shippingOption;
     }
 
     /**

--- a/Model/Api/Tax.php
+++ b/Model/Api/Tax.php
@@ -23,9 +23,11 @@ use Bolt\Boltpay\Api\Data\TaxDataInterfaceFactory;
 use Bolt\Boltpay\Api\Data\TaxResultInterfaceFactory;
 use Bolt\Boltpay\Api\Data\TaxResultInterface;
 use Bolt\Boltpay\Helper\Shared\CurrencyUtils;
+use Bolt\Boltpay\Helper\Discount as DiscountHelper;
 use Magento\Checkout\Api\TotalsInformationManagementInterface;
 use Magento\Checkout\Api\Data\TotalsInformationInterface;
 use Magento\Quote\Api\Data\TotalsInterface;
+use Magento\Framework\Pricing\Helper\Data as PriceHelper;
 
 /**
  * Class Tax
@@ -63,6 +65,11 @@ class Tax extends ShippingTax implements TaxInterface
      * @var TotalsInformationInterface
      */
     protected $addressInformation;
+    
+    /**
+     * @var PriceHelper
+     */
+    protected $priceHelper;
 
     /**
      * Assigns local references to global resources
@@ -73,19 +80,22 @@ class Tax extends ShippingTax implements TaxInterface
      * @param TaxResultInterfaceFactory $taxResultFactory
      * @param TotalsInformationManagementInterface $totalsInformationManagement
      * @param TotalsInformationInterface $addressInformation
+     * @param PriceHelper $priceHelper
      */
     public function __construct(
         ShippingTaxContext $shippingTaxContext,
         TaxDataInterfaceFactory $taxDataFactory,
         TaxResultInterfaceFactory $taxResultFactory,
         TotalsInformationManagementInterface $totalsInformationManagement,
-        TotalsInformationInterface $addressInformation
+        TotalsInformationInterface $addressInformation,
+        PriceHelper $priceHelper
     ) {
         parent::__construct($shippingTaxContext);
         $this->taxDataFactory = $taxDataFactory;
         $this->taxResultFactory = $taxResultFactory;
         $this->totalsInformationManagement = $totalsInformationManagement;
         $this->addressInformation = $addressInformation;
+        $this->priceHelper = $priceHelper;
     }
 
     /**
@@ -144,10 +154,12 @@ class Tax extends ShippingTax implements TaxInterface
      */
     public function createShippingOption($totalsInformation, $currencyCode, $shipping_option)
     {
+        $shipping_option = $this->getShippingDiscount($totalsInformation, $currencyCode, $shipping_option);
+
         $shippingOption = $this->shippingOptionFactory->create();
-        $shippingOption->setTaxAmount(CurrencyUtils::toMinor($totalsInformation->getShippingTaxAmount(), $currencyCode));
+        $shippingOption->setTaxAmount($shipping_option['tax_amount']);
         $shippingOption->setService($shipping_option['service'] ?? null);
-        $shippingOption->setCost(CurrencyUtils::toMinor($totalsInformation->getShippingAmount(), $currencyCode));
+        $shippingOption->setCost($shipping_option['cost']);
         $shippingOption->setReference($shipping_option['reference'] ?? null);
 
         return $shippingOption;
@@ -169,16 +181,52 @@ class Tax extends ShippingTax implements TaxInterface
         $storeAddress->setRegion($ship_to_store_option['address']['region']);
         $storeAddress->setPostalCode($ship_to_store_option['address']['postal_code']);
         
+        $ship_to_store_option = $this->getShippingDiscount($totalsInformation, $currencyCode, $ship_to_store_option);
+        
         $shipToStoreOption = $this->shipToStoreOptionFactory->create();
         $shipToStoreOption->setReference($ship_to_store_option['reference']);
-        $shipToStoreOption->setCost(CurrencyUtils::toMinor($totalsInformation->getShippingAmount(), $currencyCode));
+        $shipToStoreOption->setCost($ship_to_store_option['cost']);
         $shipToStoreOption->setStoreName($ship_to_store_option['store_name']);
         $shipToStoreOption->setAddress($storeAddress);
         $shipToStoreOption->setDistance($ship_to_store_option['distance']);
         $shipToStoreOption->setDistanceUnit($ship_to_store_option['distance_unit']);
-        $shipToStoreOption->setTaxAmount(CurrencyUtils::toMinor($totalsInformation->getShippingTaxAmount(), $currencyCode));
+        $shipToStoreOption->setTaxAmount($ship_to_store_option['tax_amount']);
 
         return $shipToStoreOption;
+    }
+    
+    /**
+     * @param TotalsInterface $totalsInformation
+     * @param string $currencyCode
+     * @param array $shipping_option
+     * @return array
+     * @throws \Exception
+     */
+    protected function getShippingDiscount($totalsInformation, $currencyCode, $shipping_option)
+    {
+        $shippingDiscountAmount = $this->eventsForThirdPartyModules->runFilter("collectShippingDiscounts", $totalsInformation->getShippingDiscountAmount(), $this->quote, $this->quote->getShippingAddress());
+        if ($shippingDiscountAmount >= DiscountHelper::MIN_NONZERO_VALUE) {
+            $service = $shipping_option['service'] ?? '';
+            $shippingCost = $totalsInformation->getShippingAmount() - $shippingDiscountAmount;
+            $shippingRoundedCost = CurrencyUtils::toMinor($shippingCost, $currencyCode);
+            $diff = CurrencyUtils::toMinorWithoutRounding($shippingCost, $currencyCode) - $shippingRoundedCost;
+            $taxAmount = round(CurrencyUtils::toMinorWithoutRounding($totalsInformation->getShippingTaxAmount(), $currencyCode) + $diff);
+            if ($shippingRoundedCost == 0) {
+                $service .= ' [free&nbsp;shipping&nbsp;discount]';
+            } else {
+                $discount = $this->priceHelper->currency($shippingDiscountAmount, true, false);
+                $service .= " [$discount" . "&nbsp;discount]";
+            }
+            $shipping_option['service'] = html_entity_decode($service);
+        } else {
+            $shippingRoundedCost = CurrencyUtils::toMinor($totalsInformation->getShippingAmount(), $currencyCode);
+            $taxAmount = CurrencyUtils::toMinor($totalsInformation->getShippingTaxAmount(), $currencyCode);
+        }
+        
+        $shipping_option['cost'] = $shippingRoundedCost;
+        $shipping_option['tax_amount'] = $taxAmount;
+        
+        return $shipping_option;
     }
 
     /**

--- a/Test/Unit/Model/Api/TaxTest.php
+++ b/Test/Unit/Model/Api/TaxTest.php
@@ -26,9 +26,11 @@ use Bolt\Boltpay\Api\Data\TaxDataInterfaceFactory;
 use Bolt\Boltpay\Api\Data\TaxResultInterfaceFactory;
 use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Model\Api\Tax;
+use Bolt\Boltpay\Helper\Discount as DiscountHelper;
 use PHPUnit\Framework\MockObject\MockObject;
 use Magento\TestFramework\ObjectManager;
 use Magento\TestFramework\Helper\Bootstrap;
+use Magento\Framework\Pricing\Helper\Data as PriceHelper;
 
 /**
  * Class TaxTest
@@ -190,6 +192,13 @@ class TaxTest extends BoltTestCase
         $addressInformation = $this->objectManager->create(TotalsInformationInterface::class);
         $addressInformation->setShippingTaxAmount(10);
         $addressInformation->setShippingAmount(10);
+        $addressInformation->setShippingDiscountAmount(5);
+        
+        $priceHelper = $this->objectManager->create(PriceHelper::class);
+        TestHelper::setProperty($this->tax, 'priceHelper', $priceHelper);
+        
+        $quote = TestUtils::createQuote();
+        TestHelper::setProperty($this->tax, 'quote', $quote);
 
         $shipping_option = [
             'service' => 'carrierTitle - methodTitle',
@@ -198,8 +207,8 @@ class TaxTest extends BoltTestCase
 
         $shippingOptionData = new \Bolt\Boltpay\Model\Api\Data\ShippingOption();
         $shippingOptionData
-            ->setService('carrierTitle - methodTitle')
-            ->setCost(1000)
+            ->setService(html_entity_decode('carrierTitle - methodTitle [$5.00&nbsp;discount]'))
+            ->setCost(500)
             ->setReference('carrierCode_methodCode')
             ->setTaxAmount(1000);
 
@@ -224,6 +233,11 @@ class TaxTest extends BoltTestCase
     public function createShippingOption_noShippingOption()
     {
         $addressInformation = $this->objectManager->create(TotalsInformationInterface::class);
+        $addressInformation->setShippingDiscountAmount(0);
+        $addressInformation->setShippingTaxAmount(0);
+        $addressInformation->setShippingAmount(0);
+        $quote = TestUtils::createQuote();
+        TestHelper::setProperty($this->tax, 'quote', $quote);
         $shipping_option = null;
         $shippingOptionData = new \Bolt\Boltpay\Model\Api\Data\ShippingOption();
         $shippingOptionData


### PR DESCRIPTION
# Description
For split shipping and tax, we do not calculate the shipping discount if the coupon has **Apply to Shipping Amount** enabled, as a result, the order creation fails due to the total mismatch error.

Solution: In the tax endpoint, we have selected shipping option, then we can calculate shipping discount and return updated shipping cost.

Fixes: https://boltpay.atlassian.net/browse/M2P-583

#changelog Bugfix: shipping coupon not applying

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
