### PR TITLE
[M2P-587] Flips in_array args to be correct

### DIFF
--- a/Helper/CustomFieldsHandler.php
+++ b/Helper/CustomFieldsHandler.php
@@ -78,7 +78,7 @@ class CustomFieldsHandler extends AbstractHelper
                 $comment .= '<br>' . $customField['label'] . ': ' . $customField['value'];
             }
 
-            $needSubscribe = isset($customField['features']) && in_array($customField['features'], self::FEATURE_SUBSCRIBE_TO_PLATFORM_NEWSLETTER);
+            $needSubscribe = isset($customField['features']) && in_array($self::FEATURE_SUBSCRIBE_TO_PLATFORM_NEWSLETTER, customField['features']);
         }
 
         if ($comment) {

--- a/Helper/CustomFieldsHandler.php
+++ b/Helper/CustomFieldsHandler.php
@@ -78,7 +78,7 @@ class CustomFieldsHandler extends AbstractHelper
                 $comment .= '<br>' . $customField['label'] . ': ' . $customField['value'];
             }
 
-            $needSubscribe = isset($customField['features']) && in_array($self::FEATURE_SUBSCRIBE_TO_PLATFORM_NEWSLETTER, customField['features']);
+            $needSubscribe = isset($customField['features']) && in_array(self::FEATURE_SUBSCRIBE_TO_PLATFORM_NEWSLETTER, $customField['features']);
         }
 
         if ($comment) {

--- a/Test/Unit/Helper/CustomFieldsHandlerTest.php
+++ b/Test/Unit/Helper/CustomFieldsHandlerTest.php
@@ -177,7 +177,7 @@ class CustomFieldsHandlerTest extends BoltTestCase
 
     public function handleCustomFieldsDataProvider()
     {
-        $customField1 = ['label' => 'Gift', 'type'=>'CHECKBOX', 'is_custom_field' => true, 'value' => false];
+        $customField1 = ['label' => 'Gift', 'type' => 'CHECKBOX', 'is_custom_field' => true, 'value' => false];
         $comment1 = '<br>Gift: No';
       
         $customField2 = ['label' => 'Question', 'type' => 'DROPDOWN', 'is_custom_field' => true, 'value' => 'Answer'];

--- a/Test/Unit/Helper/CustomFieldsHandlerTest.php
+++ b/Test/Unit/Helper/CustomFieldsHandlerTest.php
@@ -182,10 +182,15 @@ class CustomFieldsHandlerTest extends BoltTestCase
       
         $customField2 = ['label' => 'Question', 'type' => 'DROPDOWN', 'is_custom_field' => true, 'value' => 'Answer'];
         $comment2 = '<br>Question: Answer';
+
+        $customField3 = ['label' => 'Subscription', 'type' => 'CHECKBOX', 'is_custom_field' => true, 'value' => true, 'features' => ['subscribe_to_platform_newsletter']];
+        $comment3 = '<br>Subscription: Yes';
+
         return [
             [[], '', false],
             [[$customField1], $comment1, false],
-            [[$customField2], $comment2, false]
+            [[$customField2], $comment2, false],
+            [[$customField3], $comment3, true]
         ];
     }
 }


### PR DESCRIPTION
# Description
Flips `in_array` args.

Test case added for unit tests. Fails when I flipped the arguments back around.

Fixes: https://boltpay.atlassian.net/browse/M2P-587

#changelog WIP [M2P-587] Flips in_array args to be correct

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
