### PR TITLE
Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Block\Checkout\ComponentSwitcherProcessorTest

### DIFF
--- a/Test/Unit/Block/Checkout/ComponentSwitcherProcessorTest.php
+++ b/Test/Unit/Block/Checkout/ComponentSwitcherProcessorTest.php
@@ -19,8 +19,9 @@
 namespace Bolt\Boltpay\Test\Unit\Block\Checkout;
 
 use Bolt\Boltpay\Block\Checkout\ComponentSwitcherProcessor;
-use Bolt\Boltpay\Helper\Config as ConfigHelper;
 use Bolt\Boltpay\Test\Unit\BoltTestCase;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\ObjectManager;
 
 /**
  * @coversDefaultClass \Bolt\Boltpay\Block\Checkout\ComponentSwitcherProcessor
@@ -28,26 +29,27 @@ use Bolt\Boltpay\Test\Unit\BoltTestCase;
 class ComponentSwitcherProcessorTest extends BoltTestCase
 {
     /**
-     * @var ConfigHelper
-     */
-    private $configHelper;
-
-    /**
      * @var ComponentSwitcherProcessor
      */
-    private $componentSwitcherProcessor;
+    protected $componentSwitcherProcessor;
 
-    public function setUpInternal()
+    /**
+     * @var ObjectManager
+     */
+    protected $objectManager;
+
+    /**
+     * Setup test dependencies
+     *
+     * @return void
+     */
+    protected function setUpInternal()
     {
-        $this->configHelper = $this->createPartialMock(ConfigHelper::class, ['isPaymentOnlyCheckoutEnabled']);
-        $this->componentSwitcherProcessor = $this->getMockBuilder(ComponentSwitcherProcessor::class)
-            ->setConstructorArgs(
-                [
-                    $this->configHelper
-                ]
-            )
-            ->enableProxyingToOriginalMethods()
-            ->getMock();
+        if (!class_exists('\Magento\TestFramework\Helper\Bootstrap')) {
+            return;
+        }
+        $this->objectManager = Bootstrap::getObjectManager();
+        $this->componentSwitcherProcessor = $this->objectManager->create(ComponentSwitcherProcessor::class);
     }
 
     /**
@@ -56,10 +58,8 @@ class ComponentSwitcherProcessorTest extends BoltTestCase
      */
     public function process()
     {
-        $this->configHelper->method('isPaymentOnlyCheckoutEnabled')->willReturn(true);
         $jsLayout = $this->componentSwitcherProcessor->process([]);
-
-        $this->assertFalse(
+        $this->assertTrue(
             $jsLayout['components']['checkout']['children']['steps']['children']['billing-step']['children']['payment']['children']['renders']['children']['boltpay-payments']['config']['componentDisabled']
         );
     }


### PR DESCRIPTION
# Description
Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Block\Checkout\ComponentSwitcherProcessorTest

Fixes: (link Jira ticket)

#changelog Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Block\Checkout\ComponentSwitcherProcessorTest

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
