### PR TITLE
Integration tests - Update sql db for tests

### DIFF
--- a/Test/scripts/ci-integration.sh
+++ b/Test/scripts/ci-integration.sh
@@ -13,7 +13,7 @@ sudo service mysql start -- --initialize-insecure --skip-grant-tables --skip-net
 cd integration-tests/operations/docker/m2
 gzip -d basic240.sql.gz
 ls 
-sudo mysql magento2 < basic240.sql.gz
+sudo mysql magento2 < basic240.sql
 cd /home/circleci/project
 cp Test/scripts/CouponCode.php ../$MAGENTO_DIR
 cp Test/scripts/FreeShipping.php ../$MAGENTO_DIR

--- a/Test/scripts/ci-integration.sh
+++ b/Test/scripts/ci-integration.sh
@@ -11,9 +11,9 @@ git clone --depth 1 git@github.com:BoltApp/integration-tests.git
 sudo service mysql start -- --initialize-insecure --skip-grant-tables --skip-networking --protocol=socket
 
 cd integration-tests/operations/docker/m2
-gzip -d create_test_data.sql.gz
+gzip -d basic240.sql.gz
 ls 
-sudo mysql magento2 < create_test_data.sql
+sudo mysql magento2 < basic240.sql.gz
 cd /home/circleci/project
 cp Test/scripts/CouponCode.php ../$MAGENTO_DIR
 cp Test/scripts/FreeShipping.php ../$MAGENTO_DIR


### PR DESCRIPTION
Integration tests use newer m2 images with smaller DB dumb after https://github.com/BoltApp/integration-tests/pull/2859.

If this PR doesn't fix m2 ci tests @njfaries please close it and merge https://github.com/BoltApp/integration-tests/pull/2900 which recovers original SQL dump

#changelog Use newer db dump for tests