### PR TITLE
M2P-596 Bugfix: shipping address of backoffice order is overridden by billing address

### DIFF
--- a/Block/Js.php
+++ b/Block/Js.php
@@ -342,6 +342,16 @@ class Js extends Template
     {
         return $this->configHelper->getModuleVersion();
     }
+    
+    /**
+     * Get Magento version
+     *
+     * @return string
+     */
+    public function getMagentoVersion()
+    {
+        return $this->configHelper->getStoreVersion();
+    }
 
     /**
      * Takes a string containing javascript and removes unneeded characters in

--- a/view/adminhtml/templates/boltpay/js/replacejs.phtml
+++ b/view/adminhtml/templates/boltpay/js/replacejs.phtml
@@ -554,6 +554,19 @@ require([
             }
             return result;
         }
+        <?php
+        if (version_compare($block->getMagentoVersion(), '2.4.0') >= 0) {
+        ?>
+        onElementReady("#order-shipping_same_as_billing", function(element) {
+            if (document.getElementById('order-shipping_same_as_billing').checked) {
+                order.disableShippingAddress(true); 
+            } else {
+                order.disableShippingAddress(false); 
+            }
+        });
+        <?php
+        }
+        ?>
     });
 });
 


### PR DESCRIPTION
# Description
Root cause : from magento 2.4.x, some behaviors of creating backoffice order changes: 
1. In the step "select a customer", there is already a quote created and its billing&shipping address are both created as well, all the fields of shipping address are null expect "same_as_billing" and its value is true by default. 

![image](https://user-images.githubusercontent.com/3198527/118433808-a84b8700-b690-11eb-87c6-14ee37d21b27.png)

2. Therefore, the js variable shippingAsBilling is set to true (link to related code [order.disableShippingAddress(true);](https://github.com/magento/magento2/blob/2.4.0/app/code/Magento/Sales/view/adminhtml/templates/order/create/form/address.phtml#L139)and [disableShippingAddress: function](https://github.com/magento/magento2/blob/2.4.0/app/code/Magento/Sales/view/adminhtml/web/order/create/scripts.js#L379))

3. On the other hand, when processing to order creation form, the **Same As Billing Address** is unchecked by default cause the customer has separate billing&shipping addresses. 
![image](https://user-images.githubusercontent.com/3198527/118435004-e21d8d00-b692-11eb-98fa-46ac91916b64.png)

4. Then the shop manager would consider to add different billing&shipping addresses, but actually the related quote still use same billing address as shipping address 

![image](https://user-images.githubusercontent.com/3198527/118435264-80115780-b693-11eb-92f9-df0c82ae5f8c.png)

5. As a result, Bolt plugin still get the billing address as shipping address when creating order.

Solution: Call the function [disableShippingAddress](https://github.com/magento/magento2/blob/2.4.0/app/code/Magento/Sales/view/adminhtml/web/order/create/scripts.js#L378) when loading the order creation form for Bolt checkout.

BTW. I am not sure if this is a bug of Magento 2.4.x or a intended behavior, but it seems to only affect Bolt checkout. Then it is hard to explain to the merchant about the root cause, I think we would better fix it in our side.


Fixes: https://boltpay.atlassian.net/browse/M2P-596

#changelog Bugfix: shipping address of backoffice order is overridden by billing address
 
# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
