### PR TITLE
M2P-575 Create global JS field for injecting JS on all Magento pages

### DIFF
--- a/Block/Js.php
+++ b/Block/Js.php
@@ -211,6 +211,17 @@ class Js extends Template
     {
         return $this->configHelper->getGlobalCSS();
     }
+    
+    /**
+     * Get the global javascript to be added to any page.
+     *
+     * @return string global javascript
+     */
+    public function getGlobalJS()
+    {
+        $storeId = $this->getStoreId();
+        return $this->configHelper->getGlobalJS($storeId);
+    }
 
     /**
      * Get Javascript function call on success.

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -91,6 +91,11 @@ class Config extends AbstractHelper
      * Path for Global CSS
      */
     const XML_PATH_GLOBAL_CSS = 'payment/boltpay/global_css';
+    
+    /**
+     * Path for Global Javascript
+     */
+    const XML_PATH_GLOBAL_JS = 'payment/boltpay/global_js';
 
     /**
      * Path for show card type in the order grid
@@ -411,6 +416,7 @@ class Config extends AbstractHelper
         'replace_selectors'                  => self::XML_PATH_REPLACE_SELECTORS,
         'totals_change_selectors'            => self::XML_PATH_TOTALS_CHANGE_SELECTORS,
         'global_css'                         => self::XML_PATH_GLOBAL_CSS,
+        'global_js'                          => self::XML_PATH_GLOBAL_JS,
         'additional_checkout_button_class'   => self::XML_PATH_ADDITIONAL_CHECKOUT_BUTTON_CLASS,
         'success_page'                       => self::XML_PATH_SUCCESS_PAGE_REDIRECT,
         'prefetch_shipping'                  => self::XML_PATH_PREFETCH_SHIPPING,
@@ -798,6 +804,22 @@ class Config extends AbstractHelper
     {
         return $this->getScopeConfig()->getValue(
             self::XML_PATH_GLOBAL_CSS,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+    }
+    
+    /**
+     * Get Global Javascript from config
+     *
+     * @param int|string $storeId
+     *
+     * @return string
+     */
+    public function getGlobalJS($storeId = null)
+    {
+        return $this->getScopeConfig()->getValue(
+            self::XML_PATH_GLOBAL_JS,
             ScopeInterface::SCOPE_STORE,
             $storeId
         );
@@ -1703,6 +1725,10 @@ class Config extends AbstractHelper
         $boltSettings[] = $this->boltConfigSettingFactory->create()
             ->setName('global_css')
             ->setValue($this->getGlobalCSS());
+        // Global CSS
+        $boltSettings[] = $this->boltConfigSettingFactory->create()
+            ->setName('global_js')
+            ->setValue($this->getGlobalJS());
         // Additional Checkout Button Class
         $boltSettings[] = $this->boltConfigSettingFactory->create()
             ->setName('additional_checkout_button_class')

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -570,6 +570,30 @@ class JsTest extends BoltTestCase
 
         static::assertEquals($value, $result, 'getGlobalCSS() method: not working properly');
     }
+    
+    /**
+     * @test
+     * that getGlobalJS returns global javascript from config to be added to any page
+     *
+     * @see \Bolt\Boltpay\Helper\Config::getGlobalJS
+     *
+     * @covers ::getGlobalJS
+     */
+    public function getGlobalJS_always_returnsJSCode()
+    {
+        $value = 'require([
+            "jquery"
+        ], function ($) {       
+        });';
+
+        $this->configHelper->expects(static::once())
+            ->method('getGlobalJS')
+            ->willReturn($value);
+
+        $result = $this->currentMock->getGlobalJS();
+
+        static::assertEquals($value, $result, 'getGlobalJS() method: not working properly');
+    }
 
     /**
      * @test
@@ -2074,6 +2098,7 @@ function(arg) {
             'getPublishableKeyBackOffice',
             'getReplaceSelectors',
             'getGlobalCSS',
+            'getGlobalJS',
             'getPrefetchShipping',
             'getQuoteIsVirtual',
             'getTotalsChangeSelectors',

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -1241,8 +1241,8 @@ JSON;
             ['order_comment_field', "'customer_note'"],
         ];
         $actual = $this->currentMock->getAllConfigSettings();
-        $this->assertEquals(46, count($actual));
-        for ($i = 0; $i < 46; $i++) {
+        $this->assertEquals(47, count($actual));
+        for ($i = 0; $i < 47; $i++) {
             $this->assertEquals($expected[$i][0], $actual[$i]->getName());
             $this->assertEquals($expected[$i][1], $actual[$i]->getValue(), 'actual value for ' . $expected[$i][0] . ' is not equals to expected');
         }

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -1207,6 +1207,7 @@ JSON;
             ['replace_selectors', '#replace'],
             ['totals_change_selectors', '.totals'],
             ['global_css', '#customerbalance-placer {width: 210px;}'],
+            ['global_js', 'require(["jquery"], function ($) {});'],
             ['additional_checkout_button_class', 'with-cards'],
             ['success_page', 'checkout/onepage/success'],
             ['prefetch_shipping', 'true'],

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -764,6 +764,7 @@ JSON;
     {
         return [
             ['getGlobalCSS', BoltConfig::XML_PATH_GLOBAL_CSS, '.replaceable-example-selector1 {color: black;}]'],
+            ['getGlobalJS', BoltConfig::XML_PATH_GLOBAL_JS, 'require(["jquery"], function ($) {});'],
             ['getShowCcTypeInOrderGrid', BoltConfig::XML_PATH_SHOW_CC_TYPE_IN_ORDER_GRID, '1'],
             ['getAdditionalCheckoutButtonClass', BoltConfig::XML_PATH_ADDITIONAL_CHECKOUT_BUTTON_CLASS, 'with-cards'],
             ['getPrefetchAddressFields', BoltConfig::XML_PATH_PREFETCH_ADDRESS_FIELDS, 'address_field1, address_field2'],
@@ -1107,6 +1108,7 @@ JSON;
             'getReplaceSelectors',
             'getTotalsChangeSelectors',
             'getGlobalCSS',
+            'getGlobalJS',
             'getAdditionalCheckoutButtonClass',
             'getAdditionalCheckoutButtonAttributes',
             'getSuccessPageRedirect',
@@ -1155,6 +1157,7 @@ JSON;
         $this->currentMock->method('getReplaceSelectors')->willReturn('#replace');
         $this->currentMock->method('getTotalsChangeSelectors')->willReturn('.totals');
         $this->currentMock->method('getGlobalCSS')->willReturn('#customerbalance-placer {width: 210px;}');
+        $this->currentMock->method('getGlobalJS')->willReturn('require(["jquery"], function ($) {});');
         $this->currentMock->method('getAdditionalCheckoutButtonClass')->willReturn('with-cards');
         $this->currentMock->method('getSuccessPageRedirect')->willReturn('checkout/onepage/success');
         $this->currentMock->method('getPrefetchShipping')->willReturn(true);

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -129,6 +129,11 @@
                         <comment>This CSS will be added to any page that displays the Bolt Checkout button.</comment>
                         <config_path>payment/boltpay/global_css</config_path>
                     </field>
+                    <field id="global_js" translate="label" type="textarea" sortOrder="101" showInDefault="1" showInWebsite="1" showInStore="0">
+                        <label>Global Javascript</label>
+                        <comment>This Javascript will be added to any page.</comment>
+                        <config_path>payment/boltpay/global_js</config_path>
+                    </field>
                     <field id="show_cc_type_in_order_grid" translate="label" type="select" sortOrder="110" showInDefault="1" showInWebsite="1" showInStore="0">
                         <label>Show card type in the order grid</label>
                         <config_path>payment/boltpay/show_cc_type_in_order_grid</config_path>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -53,6 +53,7 @@ tr.shipping.totals td.amount span.price,
 .cart-container #customerbalance-placer .payment-option-title {display: none;}
 .cart-container #customerbalance-placer #use-customer-balance {width: 284px;}
 .payment-method-boltpay .payment-method-title img.payment-icon {padding: 8px; border: 1px solid #cccccc; width: 200px;}</global_css>
+                <global_js></global_js>
                 <show_cc_type_in_order_grid>0</show_cc_type_in_order_grid>
                 <additional_checkout_button_class>with-cards</additional_checkout_button_class>
                 <success_page>checkout/onepage/success</success_page>

--- a/view/frontend/templates/js/boltglobaljs.phtml
+++ b/view/frontend/templates/js/boltglobaljs.phtml
@@ -24,7 +24,11 @@
  */
 if ($block->shouldDisableBoltCheckout()) { return;
 }
-
+?>
+<script type="text/javascript">
+    <?= /* @noEscape */ $block->getGlobalJS(); ?>
+</script>
+<?php
 //check if we need Bolt on this page
 if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled() && !$block->isBoltProductPage()) { return;
 }


### PR DESCRIPTION
# Description
Currently the additionalJS field only injects on pages where BoltCheckout can appear. This will let us globally inject JS to deal with things like errant buttons or fields.

Fixes: https://boltpay.atlassian.net/browse/M2P-575

#changelog Create global JS field for injecting JS on all Magento pages

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
