### PR TITLE
M2P-570 - Don't create carts for quotes with error

### DIFF
--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -329,4 +329,14 @@ class Decider extends AbstractHelper
     {
         return $this->isSwitchEnabled(Definitions::M2_SHOW_ORDER_COMMENT_IN_ADMIN);
     }
+
+    /**
+     * Checks whether the feature switch for preventing bolt cart for quotes with error is enabled
+     *
+     * @return bool
+     */
+    public function isPreventBoltCartForQuotesWithError()
+    {
+        return $this->isSwitchEnabled(Definitions::M2_PREVENT_BOLT_CART_FOR_QUOTES_WITH_ERROR);
+    }
 }

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -182,6 +182,11 @@ class Definitions
      */
     const M2_SHOW_ORDER_COMMENT_IN_ADMIN = 'M2_SHOW_ORDER_COMMENT_IN_ADMIN';
 
+    /**
+     * Prevent bolt cart creation for quotes with error
+     */
+    const M2_PREVENT_BOLT_CART_FOR_QUOTES_WITH_ERROR = 'M2_PREVENT_BOLT_CART_FOR_QUOTES_WITH_ERROR';
+
     const DEFAULT_SWITCH_VALUES = [
         self::M2_SAMPLE_SWITCH_NAME => [
             self::NAME_KEY        => self::M2_SAMPLE_SWITCH_NAME,
@@ -353,6 +358,12 @@ class Definitions
         ],
         self::M2_SHOW_ORDER_COMMENT_IN_ADMIN => [
             self::NAME_KEY        => self::M2_SHOW_ORDER_COMMENT_IN_ADMIN,
+            self::VAL_KEY         => true,
+            self::DEFAULT_VAL_KEY => false,
+            self::ROLLOUT_KEY     => 100
+        ],
+        self::M2_PREVENT_BOLT_CART_FOR_QUOTES_WITH_ERROR => [
+            self::NAME_KEY        => self::M2_PREVENT_BOLT_CART_FOR_QUOTES_WITH_ERROR,
             self::VAL_KEY         => true,
             self::DEFAULT_VAL_KEY => false,
             self::ROLLOUT_KEY     => 100

--- a/Model/Api/CreateOrder.php
+++ b/Model/Api/CreateOrder.php
@@ -567,7 +567,10 @@ class CreateOrder implements CreateOrderInterface
         $errorInfos = $quoteItem->getErrorInfos();
         $message = '';
         foreach ($errorInfos as $errorInfo) {
-            $message .= '(' . $errorInfo['origin'] . '): ' . (is_string($errorInfo['message']) ?  $errorInfo['message'] : $errorInfo['message']->render()) . PHP_EOL;
+            // origin, code, message, additionalData keys always set but can equal null
+            if (isset($errorInfo['origin']) || isset($errorInfo['message'])) {
+                $message .= sprintf("(%s): %s%s", (string)$errorInfo['origin'], (string)$errorInfo['message'], PHP_EOL);
+            }
         }
         $errorCode = isset($errorInfos[0]['code']) ? $errorInfos[0]['code'] : 0;
 

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -2826,7 +2826,27 @@ ORDER
         static::assertEquals([], $boltHelperCart->getCartData(false, '', null));
     }
 
-        /**
+    /**
+     * @test
+     * that getCartData returns empty array if the quote has an error and the feature switch is enabled
+     *
+     * @covers ::getCartData
+     *
+     * @throws Exception from tested method
+     */
+    public function getCartData_withQuoteErrorAndFSEnabled_returnsEmptyArray()
+    {
+
+        $boltHelperCart = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
+        $quote = Bootstrap::getObjectManager()->create(Quote::class);
+        TestUtils::setQuoteToSession($quote);
+        $quote->setQuoteCurrencyCode('USD');
+        TestUtils::saveFeatureSwitch(Definitions::M2_PREVENT_BOLT_CART_FOR_QUOTES_WITH_ERROR, true);
+        $quote->addErrorInfo('error', null, null, 'Quote error');
+        static::assertEquals([], $boltHelperCart->getCartData(false, '', null));
+    }
+
+    /**
          * @test
          * that getCartData returns empty array if immutable quote has no items
          *
@@ -4910,10 +4930,10 @@ ORDER
         $quantity = 2;
 
         $order = TestUtils::createDumpyOrder([], [], [TestUtils::createOrderItemByProduct($product, $quantity)]);
-        
+
         $this->imageHelper->method('init')->willReturnSelf();
         $this->imageHelper->method('getUrl')->willReturn('no-image');
-        
+
         list($products, $totalAmount, $diff) = $this->currentMock->getCartItemsForOrder($order, self::STORE_ID);
 
         static::assertCount(1, $products);
@@ -4921,7 +4941,7 @@ ORDER
         static::assertEquals($products[0]['name'], $product->getName());
         static::assertEquals($products[0]['unit_price'], CurrencyUtils::toMinor($product->getPrice(), self::CURRENCY_CODE));
         static::assertEquals($products[0]['total_amount'], CurrencyUtils::toMinor($product->getPrice() * $quantity, self::CURRENCY_CODE));
-        static::assertEquals($products[0]['quantity'], $quantity);        
+        static::assertEquals($products[0]['quantity'], $quantity);
         static::assertEquals($products[0]['sku'], $product->getSku());
 
         TestUtils::cleanupSharedFixtures([$order]);

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -446,11 +446,12 @@ class CartTest extends BoltTestCase
         $this->customerMock = $this->createPartialMock(Customer::class, ['getEmail']);
         $this->coreRegistry = $this->createMock(Registry::class);
         $this->metricsClient = $this->createMock(MetricsClient::class);
-        $this->deciderHelper = $this->createPartialMock(DeciderHelper::class, ['ifShouldDisablePrefillAddressForLoggedInCustomer']);
         $this->serialize = (new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this))->getObject(Serialize::class);
         $this->deciderHelper = $this->createPartialMock(
             DeciderHelper::class,
-            ['ifShouldDisablePrefillAddressForLoggedInCustomer', 'handleVirtualProductsAsPhysical', 'isIncludeUserGroupIntoCart', 'isAddSessionIdToCartMetadata', 'isCustomizableOptionsSupport']
+            ['ifShouldDisablePrefillAddressForLoggedInCustomer', 'handleVirtualProductsAsPhysical',
+             'isIncludeUserGroupIntoCart', 'isAddSessionIdToCartMetadata', 'isCustomizableOptionsSupport',
+             'isPreventBoltCartForQuotesWithError']
         );
         $this->eventsForThirdPartyModules = $this->createPartialMock(EventsForThirdPartyModules::class, ['runFilter','dispatchEvent']);
         $this->eventsForThirdPartyModules->method('runFilter')->will($this->returnArgument(1));


### PR DESCRIPTION
# Description
Some (custom) themes, and the theme this merchant is using is heavily customized, as well as the whole store, don't verify the item integrity and allow showing of the checkout button on the shopping cart page even if not all options are selected for some of the products. In conjunction with (presumed) pre-auth timeout (Bolt acts like it had succeeded), this may result in crating the order on Bolt end but failing hooks and no (orphaned) order created in Magento.
This PR adds pre-check in plugin before order request is sent to Bolt and prevents the request if some mandatory options are not chosen. The feature switch is added and set to on by default.

Fixes: https://boltpay.atlassian.net/browse/M2P-570

![image](https://user-images.githubusercontent.com/37150717/119012647-80ad3500-b996-11eb-82cd-6d87f33c995d.png)


#changelog M2P-570 - Don't create carts for quotes with error

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
