### PR TITLE
Custom Fields: Fix newsletter feature flag name

### DIFF
--- a/Helper/CustomFieldsHandler.php
+++ b/Helper/CustomFieldsHandler.php
@@ -29,9 +29,8 @@ use Magento\Newsletter\Model\SubscriberFactory;
  */
 class CustomFieldsHandler extends AbstractHelper
 {
-    const CATEGORY_NEWSLETTER = 'NEWSLETTER';
     const COMMENT_PREFIX_TEXT = 'BOLTPAY INFO :: customfields';
-    const FEATURE_SUBSCRIBE_TO_PLATFORM_NEWSLETTER = 'subscribe_to_platform_newsletter';
+    const FEATURE_SUBSCRIBE_TO_NEWSLETTER = 'subscribe_to_newsletter';
     const TYPE_CHECKBOX = 'CHECKBOX';
     const TYPE_DROPDOWN = 'DROPDOWN';
 
@@ -78,7 +77,7 @@ class CustomFieldsHandler extends AbstractHelper
                 $comment .= '<br>' . $customField['label'] . ': ' . $customField['value'];
             }
 
-            $needSubscribe = isset($customField['features']) && in_array(self::FEATURE_SUBSCRIBE_TO_PLATFORM_NEWSLETTER, $customField['features']);
+            $needSubscribe = isset($customField['features']) && in_array(self::FEATURE_SUBSCRIBE_TO_NEWSLETTER, $customField['features']);
         }
 
         if ($comment) {

--- a/Test/Unit/Helper/CustomFieldsHandlerTest.php
+++ b/Test/Unit/Helper/CustomFieldsHandlerTest.php
@@ -183,7 +183,7 @@ class CustomFieldsHandlerTest extends BoltTestCase
         $customField2 = ['label' => 'Question', 'type' => 'DROPDOWN', 'is_custom_field' => true, 'value' => 'Answer'];
         $comment2 = '<br>Question: Answer';
 
-        $customField3 = ['label' => 'Subscription', 'type' => 'CHECKBOX', 'is_custom_field' => true, 'value' => true, 'features' => ['subscribe_to_platform_newsletter']];
+        $customField3 = ['label' => 'Subscription', 'type' => 'CHECKBOX', 'is_custom_field' => true, 'value' => true, 'features' => ['subscribe_to_newsletter']];
         $comment3 = '<br>Subscription: Yes';
 
         return [


### PR DESCRIPTION
# Description
Farm & Home supply reported that custom fields where `subscribe to newsletter` feature was enabled did not trigger newsletter subscription logic in M2. Upon investigation, we found that we look for `subscribe_to_platform_newsletter` in custom fields payload. This is incorrect we should be looking for `subscribe_to_newsletter` instead.

The [spec](https://docs.google.com/document/d/1SrxeAf5ISwhEsWx7-Je_JJJp7GXjqCMR1fA54dfk5Fs/edit#) is here.

Fixes: (link Jira ticket)

#changelog Custom Fields: Fix newsletter feature flag name

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
