### PR TITLE
M2P-612 Bugfix: unable to checkout for BOPIS using Bolt PPC

### DIFF
--- a/ThirdPartyModules/Magento/InStorePickupShipping.php
+++ b/ThirdPartyModules/Magento/InStorePickupShipping.php
@@ -322,7 +322,7 @@ class InStorePickupShipping
                     $quote->getStore()->getWebsite()->getCode()
                 );
                 $extraData = ['telephone'=>$pickupLocation->getPhone()];
-                $shippingAddress = $addressConverter->convert($pickupLocation, $shippingAddress);
+                $shippingAddress = $addressConverter->convert($pickupLocation, $shippingAddress, $extraData);
                 $quote->setShippingAddress($shippingAddress)->save();
             }
         } catch (\Exception $e) {

--- a/ThirdPartyModules/Magento/InStorePickupShipping.php
+++ b/ThirdPartyModules/Magento/InStorePickupShipping.php
@@ -321,6 +321,7 @@ class InStorePickupShipping
                     SalesChannelInterface::TYPE_WEBSITE,
                     $quote->getStore()->getWebsite()->getCode()
                 );
+                $extraData = ['telephone'=>$pickupLocation->getPhone()];
                 $shippingAddress = $addressConverter->convert($pickupLocation, $shippingAddress);
                 $quote->setShippingAddress($shippingAddress)->save();
             }


### PR DESCRIPTION
# Description
When converting pickup location data and quote shipping address to Pickup Location Quote Address, it does not include phone info, so we need to add this field separately.

Fixes: https://boltpay.atlassian.net/browse/M2P-612

#changelog Bugfix: unable to checkout for BOPIS using Bolt PPC

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
