### PR TITLE
M2P-621 Use integration test instead of unit test for  all methods in class Bolt\Boltpay\Test\Unit\Model\FeatureSwitchTest

### DIFF
--- a/Test/Unit/Model/FeatureSwitchTest.php
+++ b/Test/Unit/Model/FeatureSwitchTest.php
@@ -21,23 +21,31 @@ use Bolt\Boltpay\Model\FeatureSwitch;
 use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Test\Unit\TestHelper;
 use Bolt\Boltpay\Model\ResourceModel;
+use Magento\Framework\App\ObjectManager;
+use Magento\TestFramework\Helper\Bootstrap;
 
 class FeatureSwitchTest extends BoltTestCase
 {
     /**
      * @var \Bolt\Boltpay\Model\FeatureSwitch
      */
-    private $mockFeatureSwitch;
+    private $featureSwitch;
+
+    /**
+     * @var ObjectManager
+     */
+    private $objectManager;
 
     /**
      * Setup for FeatureSwitchTest Class
      */
     public function setUpInternal()
     {
-        $this->mockFeatureSwitch = $this->getMockBuilder(FeatureSwitch::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['_init'])
-            ->getMock();
+        if (!class_exists('\Magento\TestFramework\Helper\Bootstrap')) {
+            return;
+        }
+        $this->objectManager = Bootstrap::getObjectManager();
+        $this->featureSwitch = $this->objectManager->create(FeatureSwitch::class);
     }
 
     /**
@@ -45,11 +53,8 @@ class FeatureSwitchTest extends BoltTestCase
      */
     public function testConstruct()
     {
-        $this->mockFeatureSwitch->expects($this->once())->method('_init')
-            ->with(ResourceModel\FeatureSwitch::class)
-            ->willReturnSelf();
-
-        TestHelper::invokeMethod($this->mockFeatureSwitch, '_construct');
+        TestHelper::invokeMethod($this->featureSwitch, '_construct');
+        self::assertEquals(ResourceModel\FeatureSwitch::class,$this->featureSwitch->getResourceName());
     }
 
     /**
@@ -57,8 +62,8 @@ class FeatureSwitchTest extends BoltTestCase
      */
     public function setAndGetName()
     {
-        $this->mockFeatureSwitch->setName('name');
-        $this->assertEquals('name', $this->mockFeatureSwitch->getName());
+        $this->featureSwitch->setName('name');
+        $this->assertEquals('name', $this->featureSwitch->getName());
     }
 
     /**
@@ -66,8 +71,8 @@ class FeatureSwitchTest extends BoltTestCase
      */
     public function setAndGetValue()
     {
-        $this->mockFeatureSwitch->setValue(true);
-        $this->assertEquals(true, $this->mockFeatureSwitch->getValue());
+        $this->featureSwitch->setValue(true);
+        $this->assertEquals(true, $this->featureSwitch->getValue());
     }
 
     /**
@@ -75,8 +80,8 @@ class FeatureSwitchTest extends BoltTestCase
      */
     public function setAndGetDefaultValue()
     {
-        $this->mockFeatureSwitch->setDefaultValue(false);
-        $this->assertEquals(false, $this->mockFeatureSwitch->getDefaultValue());
+        $this->featureSwitch->setDefaultValue(false);
+        $this->assertEquals(false, $this->featureSwitch->getDefaultValue());
     }
 
     /**
@@ -84,7 +89,7 @@ class FeatureSwitchTest extends BoltTestCase
      */
     public function setAndGetRolloutPercentage()
     {
-        $this->mockFeatureSwitch->setRolloutPercentage('rolloutPercentage');
-        $this->assertEquals('rolloutPercentage', $this->mockFeatureSwitch->getRolloutPercentage());
+        $this->featureSwitch->setRolloutPercentage('rolloutPercentage');
+        $this->assertEquals('rolloutPercentage', $this->featureSwitch->getRolloutPercentage());
     }
 }


### PR DESCRIPTION
# Description
Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Model\FeatureSwitchTest.

Fixes: https://boltpay.atlassian.net/browse/M2P-621

#changelog M2P-621 Use integration test instead of unit test for  all methods in class Bolt\Boltpay\Test\Unit\Model\FeatureSwitchTest

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
