### PR TITLE
M2P-623 Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Model\ExternalCustomerEntityTest

### DIFF
--- a/Test/Unit/Model/ExternalCustomerEntityTest.php
+++ b/Test/Unit/Model/ExternalCustomerEntityTest.php
@@ -21,24 +21,32 @@ use Bolt\Boltpay\Model\ExternalCustomerEntity;
 use Bolt\Boltpay\Model\ResourceModel;
 use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Test\Unit\TestHelper;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use Magento\Framework\App\ObjectManager;
+use Magento\TestFramework\Helper\Bootstrap;
 
 class ExternalCustomerEntityTest extends BoltTestCase
 {
+
     /**
-     * @var ExternalCustomerEntity|MockObject
+     * @var \Bolt\Boltpay\Model\ExternalCustomerEntity
      */
-    private $externalCustomerEntityMock;
+    private $externalCustomerEntity;
+
+    /**
+     * @var ObjectManager
+     */
+    private $objectManager;
 
     /**
      * @inheritdoc
      */
     public function setUpInternal()
     {
-        $this->externalCustomerEntityMock = $this->getMockBuilder(ExternalCustomerEntity::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['_init'])
-            ->getMock();
+        if (!class_exists('\Magento\TestFramework\Helper\Bootstrap')) {
+            return;
+        }
+        $this->objectManager = Bootstrap::getObjectManager();
+        $this->externalCustomerEntity = $this->objectManager->create(ExternalCustomerEntity::class);
     }
 
     /**
@@ -46,10 +54,8 @@ class ExternalCustomerEntityTest extends BoltTestCase
      */
     public function testConstruct()
     {
-        $this->externalCustomerEntityMock->expects($this->once())->method('_init')
-            ->with(ResourceModel\ExternalCustomerEntity::class)
-            ->willReturnSelf();
-        TestHelper::invokeMethod($this->externalCustomerEntityMock, '_construct');
+        TestHelper::invokeMethod($this->externalCustomerEntity, '_construct');
+        self::assertEquals(ResourceModel\ExternalCustomerEntity::class, $this->externalCustomerEntity->getResourceName());
     }
 
     /**
@@ -57,8 +63,8 @@ class ExternalCustomerEntityTest extends BoltTestCase
      */
     public function setAndGetExternalID()
     {
-        $this->externalCustomerEntityMock->setExternalID('test_external_id');
-        $this->assertEquals('test_external_id', $this->externalCustomerEntityMock->getExternalID());
+        $this->externalCustomerEntity->setExternalID('test_external_id');
+        $this->assertEquals('test_external_id', $this->externalCustomerEntity->getExternalID());
     }
 
     /**
@@ -66,7 +72,7 @@ class ExternalCustomerEntityTest extends BoltTestCase
      */
     public function setAndGetCustomerID()
     {
-        $this->externalCustomerEntityMock->setCustomerID(123);
-        $this->assertEquals(123, $this->externalCustomerEntityMock->getCustomerID());
+        $this->externalCustomerEntity->setCustomerID(123);
+        $this->assertEquals(123, $this->externalCustomerEntity->getCustomerID());
     }
 }


### PR DESCRIPTION
# Description
Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Model\ExternalCustomerEntityTest

Fixes: https://boltpay.atlassian.net/browse/M2P-623

#changelog M2P-623 Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Model\ExternalCustomerEntityTest

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
