### PR TITLE
M2P-609 - Save customer_firstname, customer_lastname in sales_order table

### DIFF
--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -349,4 +349,14 @@ class Decider extends AbstractHelper
     {
         return $this->isSwitchEnabled(Definitions::M2_SET_ORDER_PAYMENT_INFO_DATA_ON_SUCCESS_PAGE);
     }
+
+    /**
+     * Checks whether the feature switch for seting customer name to order for guests is enabled
+     *
+     * @return bool
+     */
+    public function isSetCustomerNameToOrderForGuests()
+    {
+        return $this->isSwitchEnabled(Definitions::M2_SET_CUSTOMER_NAME_TO_ORDER_FOR_GUESTS);
+    }
 }

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -192,6 +192,11 @@ class Definitions
      */
     const M2_SET_ORDER_PAYMENT_INFO_DATA_ON_SUCCESS_PAGE = 'M2_SET_ORDER_PAYMENT_INFO_DATA_ON_SUCCESS_PAGE';
 
+    /**
+     * Set customer name to order for guests
+     */
+    const M2_SET_CUSTOMER_NAME_TO_ORDER_FOR_GUESTS = 'M2_SET_CUSTOMER_NAME_TO_ORDER_FOR_GUESTS';
+
     const DEFAULT_SWITCH_VALUES = [
         self::M2_SAMPLE_SWITCH_NAME => [
             self::NAME_KEY        => self::M2_SAMPLE_SWITCH_NAME,
@@ -375,6 +380,12 @@ class Definitions
         ],
         self::M2_SET_ORDER_PAYMENT_INFO_DATA_ON_SUCCESS_PAGE => [
             self::NAME_KEY        => self::M2_SET_ORDER_PAYMENT_INFO_DATA_ON_SUCCESS_PAGE,
+            self::VAL_KEY         => true,
+            self::DEFAULT_VAL_KEY => false,
+            self::ROLLOUT_KEY     => 0
+        ],
+        self::M2_SET_CUSTOMER_NAME_TO_ORDER_FOR_GUESTS => [
+            self::NAME_KEY        => self::M2_SET_CUSTOMER_NAME_TO_ORDER_FOR_GUESTS,
             self::VAL_KEY         => true,
             self::DEFAULT_VAL_KEY => false,
             self::ROLLOUT_KEY     => 0

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -437,7 +437,7 @@ class Order extends AbstractHelper
         if ($quote->isVirtual()) {
             return;
         }
-        
+
         if (isset($transaction->order->cart->in_store_shipments)) {
             $this->eventsForThirdPartyModules->dispatchEvent("setInStoreShippingMethodForPrepareQuote", $quote, $transaction);
         } else {
@@ -547,19 +547,26 @@ class Order extends AbstractHelper
     /**
      * Set quote customer email and guest checkout parameters
      *
-     * @param Quote $quote
+     * @param Quote  $quote
      * @param string $email
+     * @param \stdClass $transaction
      *
      * @return void
      */
-    private function addCustomerDetails($quote, $email)
+    protected function addCustomerDetails($quote, $email, $transaction)
     {
         $quote->setCustomerEmail($email);
-        if (!$quote->getCustomerId() && $quote->getData('bolt_checkout_type') != CartHelper::BOLT_CHECKOUT_TYPE_BACKOFFICE) {
-            $quote->setCustomerId(null);
-            $quote->setCheckoutMethod('guest');
-            $quote->setCustomerIsGuest(true);
-            $quote->setCustomerGroupId(GroupInterface::NOT_LOGGED_IN_ID);
+        if (!$quote->getCustomerId()) {
+            if ($this->featureSwitches->isSetCustomerNameToOrderForGuests()) {
+                $quote->setCustomerFirstname($transaction->order->cart->billing_address->first_name);
+                $quote->setCustomerLastname($transaction->order->cart->billing_address->last_name);
+            }
+            if ($quote->getData('bolt_checkout_type') != CartHelper::BOLT_CHECKOUT_TYPE_BACKOFFICE) {
+                $quote->setCustomerId(null);
+                $quote->setCheckoutMethod('guest');
+                $quote->setCustomerIsGuest(true);
+                $quote->setCustomerGroupId(GroupInterface::NOT_LOGGED_IN_ID);
+            }
         }
     }
 
@@ -1542,8 +1549,8 @@ class Order extends AbstractHelper
             $email = $transaction->order->cart->billing_address->email_address ??
                 $transaction->order->cart->shipments[0]->shipping_address->email_address ?? null;
         }
-        
-        $this->addCustomerDetails($quote, $email);
+
+        $this->addCustomerDetails($quote, $email, $transaction);
 
         $this->cartHelper->quoteResourceSave($quote);
 

--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -404,8 +404,8 @@ class ShippingMethods implements ShippingMethodsInterface
     /**
      * Get shipping and tax options
      *
-     * @param $cart
-     * @param $shipping_address
+     * @param array $cart
+     * @param array $shipping_address
      * @return ShippingOptionsInterface
      * @throws BoltException
      */
@@ -423,8 +423,18 @@ class ShippingMethods implements ShippingMethodsInterface
             );
         }
 
+        if (!$immutableQuote->getCustomerId()
+            && $this->cartHelper->getFeatureSwitchDeciderHelper()->isSetCustomerNameToOrderForGuests()) {
+            $immutableQuote->addData(
+                [
+                    \Magento\Sales\Api\Data\OrderInterface::CUSTOMER_FIRSTNAME => $shipping_address['first_name'],
+                    \Magento\Sales\Api\Data\OrderInterface::CUSTOMER_LASTNAME  => $shipping_address['last_name'],
+                ]
+            );
+        }
+
         $this->preprocessHook($immutableQuote->getStoreId());
-        
+
         $parentQuoteId = $cart['order_reference'];
         $parentQuote = $this->getQuoteById($parentQuoteId);
         $this->cartHelper->replicateQuoteData($immutableQuote, $parentQuote);
@@ -696,6 +706,7 @@ class ShippingMethods implements ShippingMethodsInterface
      */
     public function getShippingOptions($quote, $addressData)
     {
+
         if ($quote->isVirtual()) {
             $billingAddress = $quote->getBillingAddress();
             $billingAddress->addData($addressData);


### PR DESCRIPTION
M2P-609 - Save customer_firstname, customer_lastname in sales_order table

For the logged in customer it is done automatically by Magento by copying the data from customer billing address.
This PR does it for guests.

# Description
Please include a summary of the change and which issue is fixed. Include the motivation for the changes, and comment on your PR if necessary for clarity.

Fixes: https://boltpay.atlassian.net/browse/M2P-609

#changelog M2P-609 - Save customer_firstname, customer_lastname in sales_order table

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
