### PR TITLE
EN-4862 - Get the Last 4 card digits in the checkout success event

### DIFF
--- a/Controller/ReceivedUrlTrait.php
+++ b/Controller/ReceivedUrlTrait.php
@@ -98,7 +98,7 @@ trait ReceivedUrlTrait
                             $this->cartHelper->getFeatureSwitchDeciderHelper()->isSetOrderPaymentInfoDataOnSuccessPage()
                             && ($orderPayment = $order->getPayment())
                             && ($transaction = $this->orderHelper->fetchTransactionInfo($reference))) {
-                            $this->orderHelper->setOrderPaymentInfoData($order->getPayment(), $transaction);
+                            $this->orderHelper->setOrderPaymentInfoData($orderPayment, $transaction);
                         }
                     } catch (LocalizedException $e) {
                         $this->bugsnag->notifyException($e);

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -2745,4 +2745,12 @@ class Cart extends AbstractHelper
         $quote->setCartFixedRules([]);
         $this->totalsCollector->collectAddressTotals($quote, $address);
     }
+
+    /**
+     * @return DeciderHelper
+     */
+    public function getFeatureSwitchDeciderHelper()
+    {
+        return $this->deciderHelper;
+    }
 }

--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -339,4 +339,14 @@ class Decider extends AbstractHelper
     {
         return $this->isSwitchEnabled(Definitions::M2_PREVENT_BOLT_CART_FOR_QUOTES_WITH_ERROR);
     }
+
+    /**
+     * Checks whether the feature switch for setting order payment info data on success page is enabled
+     *
+     * @return bool
+     */
+    public function isSetOrderPaymentInfoDataOnSuccessPage()
+    {
+        return $this->isSwitchEnabled(Definitions::M2_SET_ORDER_PAYMENT_INFO_DATA_ON_SUCCESS_PAGE);
+    }
 }

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -187,6 +187,11 @@ class Definitions
      */
     const M2_PREVENT_BOLT_CART_FOR_QUOTES_WITH_ERROR = 'M2_PREVENT_BOLT_CART_FOR_QUOTES_WITH_ERROR';
 
+    /**
+     * Set order payment info data on success page
+     */
+    const M2_SET_ORDER_PAYMENT_INFO_DATA_ON_SUCCESS_PAGE = 'M2_SET_ORDER_PAYMENT_INFO_DATA_ON_SUCCESS_PAGE';
+
     const DEFAULT_SWITCH_VALUES = [
         self::M2_SAMPLE_SWITCH_NAME => [
             self::NAME_KEY        => self::M2_SAMPLE_SWITCH_NAME,
@@ -367,6 +372,12 @@ class Definitions
             self::VAL_KEY         => true,
             self::DEFAULT_VAL_KEY => false,
             self::ROLLOUT_KEY     => 100
+        ],
+        self::M2_SET_ORDER_PAYMENT_INFO_DATA_ON_SUCCESS_PAGE => [
+            self::NAME_KEY        => self::M2_SET_ORDER_PAYMENT_INFO_DATA_ON_SUCCESS_PAGE,
+            self::VAL_KEY         => true,
+            self::DEFAULT_VAL_KEY => false,
+            self::ROLLOUT_KEY     => 0
         ],
     ];
 }

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -767,7 +767,7 @@ class Order extends AbstractHelper
      * @param \stdClass $transaction
      * @return void
      */
-    protected function setOrderPaymentInfoData($payment, $transaction)
+    public function setOrderPaymentInfoData($payment, $transaction)
     {
         if (empty($payment->getCcLast4()) && ! empty($transaction->from_credit_card->last4)) {
             $payment->setCcLast4($transaction->from_credit_card->last4);

--- a/Test/Unit/Controller/Order/ReceivedUrlTest.php
+++ b/Test/Unit/Controller/Order/ReceivedUrlTest.php
@@ -202,11 +202,16 @@ class ReceivedUrlTest extends BoltTestCase
 
         $url = $this->createUrlMock();
 
+        $featureSwitchDeciderMock = $this->createMocK(\Bolt\Boltpay\Helper\FeatureSwitch\Decider::class);
+
         $cartHelper = $this->createMock(CartHelper::class);
         $cartHelper->expects($this->once())
             ->method('getQuoteById')
             ->with(self::QUOTE_ID)
             ->willReturn($quote);
+        $cartHelper->expects($this->once())
+            ->method('getFeatureSwitchDeciderHelper')
+            ->willReturn($featureSwitchDeciderMock);
 
         $checkoutSession = $this->getMockBuilder(CheckoutSession::class)
             ->disableOriginalConstructor()

--- a/Test/Unit/Controller/ReceivedUrlTraitTest.php
+++ b/Test/Unit/Controller/ReceivedUrlTraitTest.php
@@ -17,16 +17,16 @@
 
 namespace Bolt\Boltpay\Test\Unit\Controller;
 
+use Bolt\Boltpay\Controller\ReceivedUrlTrait;
 use Bolt\Boltpay\Helper\Cart;
 use Bolt\Boltpay\Helper\Config;
 use Bolt\Boltpay\Helper\Order as OrderHelper;
-use Bolt\Boltpay\Test\Unit\TestHelper;
-use Magento\Quote\Model\Quote;
-use Magento\Sales\Model\Order;
 use Bolt\Boltpay\Test\Unit\BoltTestCase;
-use Bolt\Boltpay\Controller\ReceivedUrlTrait;
+use Bolt\Boltpay\Test\Unit\TestHelper;
 use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Quote\Model\Quote;
+use Magento\Sales\Model\Order;
 
 /**
  * Class ReceivedUrlTraitTest
@@ -39,56 +39,83 @@ class ReceivedUrlTraitTest extends BoltTestCase
     const INCREMENT_ID = 3;
     const REDIRECT_URL = 'https://bolt-rediect.com';
     const TRANSACTION_REFERENCE = 'TRANSACTION_REFERENCE_TEST';
+    
+    const DECODED_BOLT_PAYLOAD = '{"display_id":"' .self::JSON_DISPLAY_ID. '", "transaction_reference":"' .self::TRANSACTION_REFERENCE. '"}';
+    const DISPLAY_ID = self::INCREMENT_ID;
+    const JSON_DISPLAY_ID = self::INCREMENT_ID;
+    const SIGNING_SECRET = 'signing secret';
+    const STORE_ID = 1;
 
     /**
-     * @var ReceivedUrlTrait
+     * @var ReceivedUrlTrait|\PHPUnit\Framework\MockObject\MockObject|\PHPUnit_Framework_MockObject_MockObject
      */
     private $currentMock;
 
     /**
-     * @var Cart
+     * @var Cart|\PHPUnit\Framework\MockObject\MockObject|\PHPUnit_Framework_MockObject_MockObject
      */
     private $cartHelper;
 
     /**
-     * @var CheckoutSession
+     * @var CheckoutSession|\PHPUnit\Framework\MockObject\MockObject|\PHPUnit_Framework_MockObject_MockObject
      */
     private $checkoutSession;
 
     /**
-     * @var Quote
+     * @var Quote|\PHPUnit\Framework\MockObject\MockObject|\PHPUnit_Framework_MockObject_MockObject
      */
     private $quote;
 
     /**
-     * @var Order
+     * @var Order|\PHPUnit\Framework\MockObject\MockObject|\PHPUnit_Framework_MockObject_MockObject
      */
     private $order;
 
     /**
-     * @var OrderHelper
+     * @var OrderHelper|\PHPUnit\Framework\MockObject\MockObject|\PHPUnit_Framework_MockObject_MockObject
      */
     private $orderHelper;
 
     /**
-     * @var Config
+     * @var Config|\PHPUnit\Framework\MockObject\MockObject|\PHPUnit_Framework_MockObject_MockObject
      */
     private $configHelper;
+
+    /**
+     * @var \Magento\Framework\HTTP\PhpEnvironment\Request|\PHPUnit\Framework\MockObject\MockObject|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $requestMock;
+
+    /**
+     * @var \Bolt\Boltpay\Helper\FeatureSwitch\Decider|\PHPUnit\Framework\MockObject\MockObject|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $deciderMock;
+
+    /**
+     * @var \Magento\Sales\Model\Order\Payment|\PHPUnit\Framework\MockObject\MockObject|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $paymentMock;
 
     public function setUpInternal()
     {
         $this->currentMock = $this->getMockBuilder(ReceivedUrlTrait::class)
             ->enableOriginalConstructor()
+            ->setMethods(['getRequest', 'redirectToAdminIfNeeded', 'getRedirectUrl', '_redirect'])
             ->getMockForTrait();
-        $this->cartHelper = $this->createPartialMock(Cart::class, ['getQuoteById']);
-        $this->orderHelper = $this->createPartialMock(OrderHelper::class, ['getExistingOrder']);
+        $this->cartHelper = $this->createPartialMock(Cart::class, ['getQuoteById', 'getFeatureSwitchDeciderHelper']);
+        $this->orderHelper = $this->createPartialMock(OrderHelper::class, ['getExistingOrder', 'fetchTransactionInfo', 'formatReferenceUrl', 'dispatchPostCheckoutEvents']);
         $this->configHelper = $this->createPartialMock(Config::class, ['getSigningSecret']);
         $this->checkoutSession = $this->createPartialMock(
             CheckoutSession::class,
             ['setLastQuoteId', 'setLastSuccessQuoteId', 'clearHelperData', 'setLastOrderId', 'setRedirectUrl', 'setLastRealOrderId', 'setLastOrderStatus']
         );
+        $this->requestMock = $this->createMock(\Magento\Framework\HTTP\PhpEnvironment\Request::class);
+        $this->currentMock->method('getRequest')->willReturn($this->requestMock);
+        $this->deciderMock = $this->createMock(\Bolt\Boltpay\Helper\FeatureSwitch\Decider::class);
+        $this->cartHelper->method('getFeatureSwitchDeciderHelper')->willReturn($this->deciderMock);
         $this->quote = $this->createPartialMock(Quote::class, ['getId']);
-        $this->order = $this->createPartialMock(Order::class, ['getId', 'getIncrementId', 'getStatus']);
+        $this->order = $this->createPartialMock(Order::class, ['getId', 'getIncrementId', 'getStatus', 'getState', 'getPayment', 'addStatusHistoryComment', 'save']);
+        $this->paymentMock = $this->createMock(\Magento\Sales\Model\Order\Payment::class);
         TestHelper::setProperty($this->currentMock, 'cartHelper', $this->cartHelper);
         TestHelper::setProperty($this->currentMock, 'checkoutSession', $this->checkoutSession);
         TestHelper::setProperty($this->currentMock, 'orderHelper', $this->orderHelper);
@@ -177,5 +204,58 @@ class ReceivedUrlTraitTest extends BoltTestCase
         $result = TestHelper::invokeMethod($this->currentMock, 'getReferenceFromPayload', [$payload]);
 
         $this->assertEquals(self::TRANSACTION_REFERENCE, $result);
+    }
+
+    /**
+     * @test
+     * that execute will use {@see \Bolt\Boltpay\Helper\Order::setOrderPaymentInfoData} to set credit card data to order
+     * if the M2_SET_ORDER_PAYMENT_INFO_DATA_ON_SUCCESS_PAGE feature switch is enabled
+     * order payment object is available and transaction is succesfully retrieved
+     *
+     * @covers \Bolt\Boltpay\Controller\ReceivedUrlTrait::execute
+     *      
+     * @dataProvider execute_ifFeatureSwitchIsEnabled_setsPaymentInfoDataProvider
+     */
+    public function execute_ifFeatureSwitchIsEnabled_setsPaymentInfoData(
+        $isSetOrderPaymentInfoDataOnSuccessPage,
+        $isPaymentAvailable,
+        $isTransactionAvailable
+    ) {
+        $encodedBoltPayload = base64_encode(self::DECODED_BOLT_PAYLOAD);
+        $hashBoltPayloadWithKey = hash_hmac('sha256', $encodedBoltPayload, self::SIGNING_SECRET, true);
+        $boltSignature = base64_encode(base64_encode($hashBoltPayloadWithKey));
+        $this->requestMock->expects(static::exactly(3))->method('getParam')->willReturnMap(
+            [
+                ['bolt_signature', null, $boltSignature],
+                ['bolt_payload', null, $encodedBoltPayload],
+                ['store_id', null, self::STORE_ID],
+            ]
+        );
+        
+        $this->checkoutSession->method(new \PHPUnit\Framework\Constraint\RegularExpression("/[setLastQuoteId|setLastSuccessQuoteId]/"))
+            ->willReturnSelf();
+        
+        $this->configHelper->expects(static::once())->method('getSigningSecret')->with(self::STORE_ID)->willReturn(self::SIGNING_SECRET);
+        $this->orderHelper->expects(static::once())->method('getExistingOrder')->willReturn($this->order);
+        $this->cartHelper->expects(static::once())->method('getQuoteById')->willReturn($this->quote);
+        $this->order->expects(static::once())->method('getState')->willReturn(\Magento\Sales\Model\Order::STATE_PENDING_PAYMENT);
+        $this->order->expects(static::once())->method('addStatusHistoryComment')->willReturnSelf();
+        
+        $this->deciderMock->method('isSetOrderPaymentInfoDataOnSuccessPage')
+            ->willReturn($isSetOrderPaymentInfoDataOnSuccessPage);
+        $this->order->method('getPayment')->willReturn($isPaymentAvailable ? $this->paymentMock : null);
+        $this->orderHelper->method('fetchTransactionInfo')->willReturn(json_decode(self::DECODED_BOLT_PAYLOAD));
+
+        $this->currentMock->execute();
+    }
+
+    /**
+     * Data provider for {@see execute_ifFeatureSwitchIsEnabled_setsPaymentInfoData}
+     *
+     * @return \bool[][]
+     */
+    public function execute_ifFeatureSwitchIsEnabled_setsPaymentInfoDataProvider()
+    {
+        return TestHelper::getAllBooleanCombinations(3);
     }
 }


### PR DESCRIPTION
# Description
With pre-auth, the payment info is passed back to Magento and order updated in a hook that happens after the checkout.
In this PR we do it in the checkout redirect process.

Fixes: https://boltpay.atlassian.net/browse/EN-4862

#changelog EN-4862 - Get the Last 4 card digits in the checkout success event

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
