### PR TITLE
FP-746 Bugfix: item price mismatch error when checkout with non-usd currency

### DIFF
--- a/Model/Api/CreateOrder.php
+++ b/Model/Api/CreateOrder.php
@@ -544,7 +544,7 @@ class CreateOrder implements CreateOrderInterface
         foreach ($quoteItems as $item) {
             /** @var QuoteItem $item */
             $sku = trim($item->getSku());
-            $itemPrice = CurrencyUtils::toMinor($item->getPrice(), $quote->getQuoteCurrencyCode());
+            $itemPrice = CurrencyUtils::toMinor($item->getCalculationPrice(), $quote->getQuoteCurrencyCode());
 
             $this->hasItemErrors($item);
             $this->validateItemPrice($sku, $itemPrice, $transactionItems);


### PR DESCRIPTION
# Description
When multi currencies are enabled in M2 store, the function getPrice just returns price of base currency while getCalculationPrice returns actual price of current currency. So we need to use getCalculationPrice instead

Fixes: https://boltpay.atlassian.net/browse/FP-746

#changelog Bugfix: item price mismatch error when checkout with non-usd currency

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [x] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
