### PR TITLE
FP-751 Add token_type to payment data

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -2157,7 +2157,10 @@ class Order extends AbstractHelper
             'transaction_state' => $transactionState,
             'authorized' => $paymentAuthorized || in_array($transactionState, [self::TS_AUTHORIZED, self::TS_CAPTURED]),
             'refunds' => implode(',', $processedRefunds),
-            'processor' => $transaction->processor
+            'processor' => $transaction->processor,
+            'token_type' => isset($transaction->from_credit_card->token_type)
+                            ? $transaction->from_credit_card->token_type
+                            : $transaction->processor
         ];
 
         $message = __(

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -2158,9 +2158,7 @@ class Order extends AbstractHelper
             'authorized' => $paymentAuthorized || in_array($transactionState, [self::TS_AUTHORIZED, self::TS_CAPTURED]),
             'refunds' => implode(',', $processedRefunds),
             'processor' => $transaction->processor,
-            'token_type' => isset($transaction->from_credit_card->token_type)
-                            ? $transaction->from_credit_card->token_type
-                            : $transaction->processor
+            'token_type' => $transaction->from_credit_card->token_type ?? $transaction->processor
         ];
 
         $message = __(

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -108,6 +108,7 @@ class OrderTest extends BoltTestCase
     const REFERENCE_ID = '1123123123';
     const PROCESSOR_VANTIV = 'vantiv';
     const PROCESSOR_PAYPAL = 'paypal';
+    const TOKEN_BOLT = 'bolt';
     const STORE_ID = 1;
     const API_KEY = 'aaaabbbbcccc';
     const BOLT_TRACE_ID = 'aaaabbbbcccc';
@@ -2922,6 +2923,7 @@ class OrderTest extends BoltTestCase
                 'real_transaction_id' => self::TRANSACTION_ID,
                 'captures' => null,
                 'processor' => self::PROCESSOR_VANTIV,
+                'token_type' => self::TOKEN_BOLT,
             ]
         );
 
@@ -3005,6 +3007,7 @@ class OrderTest extends BoltTestCase
                 'real_transaction_id' => null,
                 'captures' => null,
                 'processor' => self::PROCESSOR_VANTIV,
+                'token_type' => self::TOKEN_BOLT,
             ]
         );
 
@@ -3684,6 +3687,9 @@ class OrderTest extends BoltTestCase
                                 'amount' => 10
                             ]
                         ]
+                    ],
+                    'from_credit_card' => [
+                        'token_type' => self::TOKEN_BOLT
                     ]
                 ]
             )
@@ -3730,7 +3736,8 @@ class OrderTest extends BoltTestCase
                 ['real_transaction_id'],
                 ['authorized'],
                 ['captures'],
-                ['processor']
+                ['processor'],
+                ['token_type']
             )
             ->willReturnOnConsecutiveCalls(
                 $prevTransactionState,
@@ -3738,7 +3745,8 @@ class OrderTest extends BoltTestCase
                 self::TRANSACTION_ID,
                 true,
                 '',
-                self::PROCESSOR_VANTIV
+                self::PROCESSOR_VANTIV,
+                self::TOKEN_BOLT
             );
 
         $this->currentMock->updateOrderPayment($this->orderMock, $transaction);


### PR DESCRIPTION
# Description
Create a new filed `token_type` in the AdditionalInformation of payment, so the merchant can read it to determine what APM the order went through. For its value, the plugin retrieves $transaction->from_credit_card->token_type by default, and if $transaction->from_credit_card->token_type does not exist, we use $transaction->processor instead.


Fixes: https://boltpay.atlassian.net/browse/FP-751

#changelog FP-751 Add token_type to payment data

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
