### PR TITLE
M2P-629 Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Plugin\MageVision\FreeShippingAdmin\MethodPluginTest

### DIFF
--- a/Test/Unit/Plugin/MageVision/FreeShippingAdmin/MethodPluginTest.php
+++ b/Test/Unit/Plugin/MageVision/FreeShippingAdmin/MethodPluginTest.php
@@ -20,21 +20,17 @@ namespace Bolt\Boltpay\Test\Unit\Plugin\MageVision\FreeShippingAdmin;
 use Bolt\Boltpay\Test\Unit\TestHelper;
 use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Magento\Framework\App\State;
-use Magento\Shipping\Model\Rate\ResultFactory;
 use Magento\Quote\Model\Quote\Address\RateResult\MethodFactory;
 use Magento\Framework\Webapi\Rest\Request;
 use Bolt\Boltpay\Plugin\MageVision\FreeShippingAdmin\MethodPlugin;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\ObjectManager;
 
 /**
  * @coversDefaultClass \Bolt\Boltpay\Plugin\MageVision\FreeShippingAdmin\MethodPlugin
  */
 class MethodPluginTest extends BoltTestCase
 {
-    /**
-     * @var ResultFactory
-     */
-    private $rateResultFactory;
-
     /**
      * @var MethodFactory
      */
@@ -53,57 +49,49 @@ class MethodPluginTest extends BoltTestCase
     /**
      * @var MethodPlugin
      */
-    private $currentMock;
+    private $methodPlugin;
 
     private $subject;
 
+    /**
+     * @var ObjectManager
+     */
+    private $objectManager;
+
     public function setUpInternal()
     {
-        $this->rateResultFactory = $this->createPartialMock(ResultFactory::class, ['create', 'append']);
-        $this->resultMethodFactory = $this->createPartialMock(MethodFactory::class, [
-            'create', 'setCarrier',
-            'setCarrierTitle', 'setMethod',
-            'setMethodTitle', 'setPrice', 'setCost'
-        ]);
-        $this->appState = $this->createPartialMock(State::class, ['getAreaCode']);
-        $this->restRequest = $this->createPartialMock(Request::class, ['getContent']);
-
         $this->subject = $this->getMockBuilder('\MageVision\FreeShippingAdmin\Model\Carrier\Method')
             ->disableOriginalConstructor()
             ->setMethods(['getConfigFlag', 'getConfigData'])
             ->getMock();
 
-        $this->currentMock = $this->getMockBuilder(MethodPlugin::class)
-            ->enableOriginalConstructor()
-            ->setConstructorArgs(
-                [
-                    $this->rateResultFactory,
-                    $this->resultMethodFactory,
-                    $this->appState,
-                    $this->restRequest,
-                ]
-            )
-            ->enableProxyingToOriginalMethods()
-            ->getMock();
+        if (!class_exists('\Magento\TestFramework\Helper\Bootstrap')) {
+            return;
+        }
+        $this->objectManager = Bootstrap::getObjectManager();
+        $this->methodPlugin = $this->objectManager->create(MethodPlugin::class);
+        $this->appState = $this->objectManager->create(State::class);
+        $this->restRequest = $this->objectManager->create(Request::class);
     }
-
 
     /**
      * @test
      * @dataProvider dataProvider_isBoltCalculation
      * @covers ::isBoltCalculation
+     *
      * @param $appState
      * @param $content
      * @param $expected
-     *
-     *
+     * @throws \Magento\Framework\Exception\LocalizedException
      * @throws \ReflectionException
      */
     public function isBoltCalculation($appState, $content, $expected)
     {
-        $this->restRequest->method('getContent')->willReturn($content);
-        $this->appState->expects(self::once())->method('getAreaCode')->willReturn($appState);
-        $this->assertEquals($expected, TestHelper::invokeMethod($this->currentMock, 'isBoltCalculation'));
+        $this->restRequest->setContent($content);
+        $this->appState->setAreaCode($appState);
+        TestHelper::setProperty($this->methodPlugin, '_appState', $this->appState);
+        TestHelper::setProperty($this->methodPlugin, '_restRequest', $this->restRequest);
+        $this->assertEquals($expected, TestHelper::invokeMethod($this->methodPlugin, 'isBoltCalculation'));
     }
 
     public function dataProvider_isBoltCalculation()
@@ -121,7 +109,7 @@ class MethodPluginTest extends BoltTestCase
      */
     public function afterCollectRates_withResultIsTrue_returnResultObject()
     {
-        $this->assertTrue($this->currentMock->afterCollectRates($this->subject, true));
+        $this->assertTrue($this->methodPlugin->afterCollectRates($this->subject, true));
     }
 
     /**
@@ -131,7 +119,7 @@ class MethodPluginTest extends BoltTestCase
     public function afterCollectRates_withSubjectConfigFlagIsFalse_returnFalse()
     {
         $this->subject->expects(self::once())->method('getConfigFlag')->with('active')->willReturn(false);
-        $this->assertFalse($this->currentMock->afterCollectRates($this->subject, false));
+        $this->assertFalse($this->methodPlugin->afterCollectRates($this->subject, false));
     }
 
     /**
@@ -140,10 +128,12 @@ class MethodPluginTest extends BoltTestCase
      */
     public function afterCollectRates_withBoltCalculationIsFalse_returnFalse()
     {
-        $this->restRequest->method('getContent')->willReturn('{"order":{"cart":{"shipments":[{"reference":"freeshippingadmin_freeshippingadmin"}]}}}');
-        $this->appState->expects(self::once())->method('getAreaCode')->willReturn('non_webapi_rest');
+        $this->restRequest->setContent('{"order":{"cart":{"shipments":[{"reference":"freeshippingadmin_freeshippingadmin"}]}}}');
+        $this->appState->setAreaCode('non_webapi_rest');
+        TestHelper::setProperty($this->methodPlugin, '_appState', $this->appState);
+        TestHelper::setProperty($this->methodPlugin, '_restRequest', $this->restRequest);
         $this->subject->expects(self::once())->method('getConfigFlag')->with('active')->willReturn(true);
-        $this->assertFalse($this->currentMock->afterCollectRates($this->subject, false));
+        $this->assertFalse($this->methodPlugin->afterCollectRates($this->subject, false));
     }
 
     /**
@@ -152,8 +142,8 @@ class MethodPluginTest extends BoltTestCase
      */
     public function afterCollectRates_willResetRateResult()
     {
-        $this->restRequest->method('getContent')->willReturn('{"order":{"cart":{"shipments":[{"reference":"freeshippingadmin_freeshippingadmin"}]}}}');
-        $this->appState->expects(self::once())->method('getAreaCode')->willReturn('webapi_rest');
+        $this->restRequest->setContent('{"order":{"cart":{"shipments":[{"reference":"freeshippingadmin_freeshippingadmin"}]}}}');
+        $this->appState->setAreaCode('webapi_rest');
         $this->subject->expects(self::once())->method('getConfigFlag')->with('active')->willReturn(true);
 
         $this->subject->expects(self::any())->method('getConfigData')
@@ -161,22 +151,16 @@ class MethodPluginTest extends BoltTestCase
                 ['title'],
                 ['name']
             )
-            ->willReturnOnConsecutiveCalls(
-                'title',
-                'name'
-            );
-
-        $this->rateResultFactory->expects(self::once())->method('create')->willReturnSelf();
-
-        $this->resultMethodFactory->expects(self::once())->method('create')->willReturnSelf();
-        $this->resultMethodFactory->expects(self::once())->method('setCarrier')->willReturnSelf();
-        $this->resultMethodFactory->expects(self::once())->method('setCarrierTitle')->willReturnSelf();
-        $this->resultMethodFactory->expects(self::once())->method('setMethod')->willReturnSelf();
-        $this->resultMethodFactory->expects(self::once())->method('setMethodTitle')->willReturnSelf();
-        $this->resultMethodFactory->expects(self::once())->method('setPrice')->willReturnSelf();
-        $this->resultMethodFactory->expects(self::once())->method('setCost')->willReturnSelf();
-
-        $this->rateResultFactory->expects(self::once())->method('append')->willReturnSelf();
-        $this->currentMock->afterCollectRates($this->subject, false);
+            ->willReturnOnConsecutiveCalls('title', 'name');
+        TestHelper::setProperty($this->methodPlugin, '_appState', $this->appState);
+        TestHelper::setProperty($this->methodPlugin, '_restRequest', $this->restRequest);
+        $result = $this->methodPlugin->afterCollectRates($this->subject, false);
+        $rate = $result->getAllRates()[0];
+        $this->assertEquals('freeshippingadmin', $rate->getData('carrier'));
+        $this->assertEquals('title', $rate->getData('carrier_title'));
+        $this->assertEquals('0.00', $rate->getData('cost'));
+        $this->assertEquals('freeshippingadmin', $rate->getData('method'));
+        $this->assertEquals('name', $rate->getData('method_title'));
+        $this->assertEquals(0, $rate->getData('price'));
     }
 }


### PR DESCRIPTION
# Description
Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Plugin\MageVision\FreeShippingAdmin\MethodPluginTest

Fixes: https://boltpay.atlassian.net/browse/M2P-629

#changelog M2P-629 Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Plugin\MageVision\FreeShippingAdmin\MethodPluginTest

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
