### PR TITLE
EN-4706 MW_RewardPoints: Fix mismatch total amount issue if customers redeem their maximum reward points when enabling split shipping and tax

### DIFF
--- a/Model/Api/Tax.php
+++ b/Model/Api/Tax.php
@@ -159,7 +159,12 @@ class Tax extends ShippingTax implements TaxInterface
         $shippingOption = $this->shippingOptionFactory->create();
         $shippingOption->setTaxAmount($shipping_option['tax_amount']);
         $shippingOption->setService($shipping_option['service'] ?? null);
-        $shippingOption->setCost($shipping_option['cost']);
+        $shippingAmount = $this->eventsForThirdPartyModules->runFilter(
+            "adjustShippingAmountInTaxEndPoint",
+            $shipping_option['cost'],
+            $this->quote
+        );
+        $shippingOption->setCost($shippingAmount);
         $shippingOption->setReference($shipping_option['reference'] ?? null);
 
         return $shippingOption;

--- a/Model/EventsForThirdPartyModules.php
+++ b/Model/EventsForThirdPartyModules.php
@@ -848,6 +848,18 @@ class EventsForThirdPartyModules
                 ],
             ],
         ],
+        "adjustShippingAmountInTaxEndPoint" => [
+            'listeners' => [
+                'MW_RewardPoints' => [
+                    'module'      => 'MW_RewardPoints',
+                    "sendClasses" => [
+                        "MW\RewardPoints\Helper\Data",
+                        "MW\RewardPoints\Model\CustomerFactory"
+                    ],
+                    'boltClass'   => MW_RewardPoints::class,
+                ],
+            ],
+        ],
         "getAdditionalInvalidateBoltCartJavascript" => [
             "listeners" => [
                 [


### PR DESCRIPTION
# Description

Fix mismatch total amount issue if customers redeem their maximum reward points when enabling split shipping and tax

Fixes: https://boltpay.atlassian.net/browse/EN-4706

#changelog EN-4706 Fix mismatch total amount issue if customers redeem their maximum reward points when enabling split shipping and tax

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
