### PR TITLE
MA-688 Improve error message for out of stock item

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1337,6 +1337,7 @@ class Cart extends AbstractHelper
      * @param null $storeId
      * @param int $totalAmount
      * @param int $diff
+     * @param bool $ifOnlyVisibleItems
      * @return array
      * @throws \Exception
      */

--- a/Model/Api/CreateOrder.php
+++ b/Model/Api/CreateOrder.php
@@ -313,7 +313,7 @@ class CreateOrder implements CreateOrderInterface
         $this->eventsForThirdPartyModules->dispatchEvent("beforePrepareQuote", $immutableQuote);
         /** @var Quote $quote */
         $quote = $this->orderHelper->prepareQuote($immutableQuote, $transaction);
-
+        $this->cartHelper->checkCartItemStockState($quote, self::E_BOLT_ITEM_OUT_OF_INVENTORY);
         /** @var \Magento\Sales\Model\Order $createdOrder */
         $createdOrder = $this->orderHelper->processExistingOrder($quote, $transaction);
 

--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -57,6 +57,9 @@ class ShippingMethods implements ShippingMethodsInterface
     const NO_SHIPPING_SERVICE = 'No Shipping Required';
     const NO_SHIPPING_REFERENCE = 'noshipping';
     const BOLT_SHIPPING_TAX_CACHE_TAG = 'BOLT_SHIPPING_TAX_CACHE_TAG';
+    
+    const E_BOLT_CUSTOM_ERROR = 6103;
+    const E_BOLT_GENERAL_ERROR = 6009;
 
     /**
      * @var HookHelper
@@ -300,7 +303,7 @@ class ShippingMethods implements ShippingMethodsInterface
             throw new BoltException(
                 __('The cart is empty. Please reload the page and checkout again.'),
                 null,
-                6103
+                self::E_BOLT_CUSTOM_ERROR
             );
         }
 
@@ -325,13 +328,13 @@ class ShippingMethods implements ShippingMethodsInterface
                 throw new BoltException(
                     __('The quantity of items in your cart has changed and needs to be revised. Please reload the page and checkout again.'),
                     null,
-                    6103
+                    self::E_BOLT_CUSTOM_ERROR
                 );
             } else {
                 throw new BoltException(
                     __('Your cart total has changed and needs to be revised. Please reload the page and checkout again.'),
                     null,
-                    6103
+                    self::E_BOLT_CUSTOM_ERROR
                 );
             }
         }
@@ -397,7 +400,7 @@ class ShippingMethods implements ShippingMethodsInterface
         } catch (\Exception $e) {
             $this->metricsClient->processMetric("ship_tax.failure", 1, "ship_tax.latency", $startTime);
             $msg = __('Unprocessable Entity') . ': ' . $e->getMessage();
-            $this->catchExceptionAndSendError($e, $msg, 6009, 422);
+            $this->catchExceptionAndSendError($e, $msg, self::E_BOLT_GENERAL_ERROR, 422);
         }
     }
 
@@ -419,7 +422,7 @@ class ShippingMethods implements ShippingMethodsInterface
             throw new BoltException(
                 __('Unknown quote id: %1.', $immutableQuoteId),
                 null,
-                6103
+                self::E_BOLT_CUSTOM_ERROR
             );
         }
 
@@ -431,6 +434,7 @@ class ShippingMethods implements ShippingMethodsInterface
         $this->quote = $parentQuote;
         $this->quote->getStore()->setCurrentCurrencyCode($this->quote->getQuoteCurrencyCode());
         $this->checkCartItems($cart);
+        $this->cartHelper->checkCartItemStockState($this->quote, self::E_BOLT_CUSTOM_ERROR);
         // Load logged in customer checkout and customer sessions from cached session id.
         // Replace parent quote with immutable quote in checkout session.
         $this->sessionHelper->loadSession($this->quote, $cart['metadata'] ?? []);
@@ -470,7 +474,7 @@ class ShippingMethods implements ShippingMethodsInterface
      * @param int    $code
      * @param int    $httpStatusCode
      */
-    protected function catchExceptionAndSendError($exception, $msg = '', $code = 6009, $httpStatusCode = 422)
+    protected function catchExceptionAndSendError($exception, $msg = '', $code = self::E_BOLT_GENERAL_ERROR, $httpStatusCode = 422)
     {
         $this->bugsnag->notifyException($exception);
 

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -7011,6 +7011,9 @@ ORDER
         $this->stockState->method('verifyStock')->willReturn(true);
         $checkQtyResult->expects(static::once())->method('getHasError')->willReturn(true);
         $this->stockState->method('checkQuoteItemQty')->willReturn($checkQtyResult);
+        $storeMock = $this->createMock(\Magento\Store\Model\Store::class);
+        $storeMock->method('getWebsiteId')->willReturn(self::WEBSITE_ID);
+        $this->quoteMock->method('getStore')->willReturn($storeMock);
         $this->expectException(BoltException::class);
         $this->expectExceptionCode(2001005);
         $this->expectExceptionMessage('The requested qty of [Test Product] is not available');

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -390,7 +390,7 @@ class CartTest extends BoltTestCase
         $this->quoteShippingAddress = $this->createPartialMock(Quote\Address::class, $addressMethods);
         $this->quoteBillingAddress = $this->createPartialMock(Quote\Address::class, $addressMethods);
 
-        $this->productMock = $this->createPartialMock(Product::class, ['getDescription', 'getTypeInstance']);
+        $this->productMock = $this->createPartialMock(Product::class, ['getDescription', 'getTypeInstance', 'getTypeId']);
         $this->productMock->method('getTypeInstance')->willReturnSelf();
         $this->contextHelper = $this->createMock(ContextHelper::class);
         $this->quoteMock = $this->createPartialMock(Quote::class, [

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -390,7 +390,7 @@ class CartTest extends BoltTestCase
         $this->quoteShippingAddress = $this->createPartialMock(Quote\Address::class, $addressMethods);
         $this->quoteBillingAddress = $this->createPartialMock(Quote\Address::class, $addressMethods);
 
-        $this->productMock = $this->createPartialMock(Product::class, ['getDescription', 'getTypeInstance', 'getTypeId']);
+        $this->productMock = $this->createPartialMock(Product::class, ['getDescription', 'getTypeInstance', 'getTypeId', 'isAvailable']);
         $this->productMock->method('getTypeInstance')->willReturnSelf();
         $this->contextHelper = $this->createMock(ContextHelper::class);
         $this->quoteMock = $this->createPartialMock(Quote::class, [

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -6966,6 +6966,9 @@ ORDER
             ]
         );
         $currentMock->expects(static::once())->method('getCartItems')->willReturn($getCartItemsResult);
+        $this->productMock->method('getTypeId')->willReturn('simple');
+        $this->productRepository->expects(static::once())->method('getById')->with(self::PRODUCT_ID)
+            ->willReturn($this->productMock);
         $this->stockState->method('verifyStock')->willReturn(false);
         $this->expectException(BoltException::class);
         $this->expectExceptionCode(2001005);
@@ -7008,6 +7011,9 @@ ORDER
             ]
         );
         $currentMock->expects(static::once())->method('getCartItems')->willReturn($getCartItemsResult);
+        $this->productMock->method('getTypeId')->willReturn('simple');
+        $this->productRepository->expects(static::once())->method('getById')->with(self::PRODUCT_ID)
+            ->willReturn($this->productMock);
         $this->stockState->method('verifyStock')->willReturn(true);
         $checkQtyResult->expects(static::once())->method('getHasError')->willReturn(true);
         $this->stockState->method('checkQuoteItemQty')->willReturn($checkQtyResult);


### PR DESCRIPTION
# Description
1. Add validation on the stock status of cart items for legacy shipping&tax api endpoint and separate shipping&tax api endpoint.
2. Add validation on the stock status of quote items before order creation, so the plugin can respond with proper error code if any specific exception related to stock status.

Fixes: https://boltpay.atlassian.net/browse/MA-688

#changelog Improve error message for out of stock item

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
