### PR TITLE
Create feature switch for saving the customer credit card when the pending hook is sent to Magento

### DIFF
--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -359,4 +359,12 @@ class Decider extends AbstractHelper
     {
         return $this->isSwitchEnabled(Definitions::M2_SET_CUSTOMER_NAME_TO_ORDER_FOR_GUESTS);
     }
+
+    /**
+     * Checks whether the feature switch for saving customer credit card is enabled
+     */
+    public function isSaveCustomerCreditCardEnabled()
+    {
+        return $this->isSwitchEnabled(Definitions::M2_SAVE_CUSTOMER_CREDIT_CARD);
+    }
 }

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -188,6 +188,11 @@ class Definitions
     const M2_PREVENT_BOLT_CART_FOR_QUOTES_WITH_ERROR = 'M2_PREVENT_BOLT_CART_FOR_QUOTES_WITH_ERROR';
 
     /**
+     * Save customer credit card
+     */
+    const M2_SAVE_CUSTOMER_CREDIT_CARD = 'M2_SAVE_CUSTOMER_CREDIT_CARD';
+
+    /**
      * Set order payment info data on success page
      */
     const M2_SET_ORDER_PAYMENT_INFO_DATA_ON_SUCCESS_PAGE = 'M2_SET_ORDER_PAYMENT_INFO_DATA_ON_SUCCESS_PAGE';
@@ -206,6 +211,12 @@ class Definitions
         ],
         self::M2_BOLT_ENABLED => [
             self::NAME_KEY        => self::M2_BOLT_ENABLED,
+            self::VAL_KEY         => true,
+            self::DEFAULT_VAL_KEY => false,
+            self::ROLLOUT_KEY     => 100
+        ],
+        self::M2_SAVE_CUSTOMER_CREDIT_CARD => [
+            self::NAME_KEY        => self::M2_SAVE_CUSTOMER_CREDIT_CARD,
             self::VAL_KEY         => true,
             self::DEFAULT_VAL_KEY => false,
             self::ROLLOUT_KEY     => 100

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -1038,6 +1038,10 @@ class Order extends AbstractHelper
     public function saveCustomerCreditCard($reference, $storeId)
     {
         try {
+            if (!$this->featureSwitches->isSaveCustomerCreditCardEnabled()){
+                return false;
+            }
+
             $transaction = $this->fetchTransactionInfo($reference, $storeId);
             $parentQuoteId = $transaction->order->cart->order_reference ?? false;
             $quote = $this->cartHelper->getQuoteById($parentQuoteId);

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -533,6 +533,7 @@ class OrderTest extends BoltTestCase
                 'isIgnoreHookForInvoiceCreationEnabled',
                 'isCancelFailedPaymentOrderInsteadOfDeleting',
                 'isSetCustomerNameToOrderForGuests',
+                'isSaveCustomerCreditCardEnabled',
             ]
         );
         $this->creditmemoFactory = $this->createPartialMock(CreditmemoFactory::class, ['createByOrder']);
@@ -5087,7 +5088,7 @@ class OrderTest extends BoltTestCase
 
         $this->customerCreditCardFactory->expects(static::never())->method('create');
         $this->customerCreditCardFactory->expects(static::never())->method('saveCreditCard');
-
+        $this->featureSwitches->method('isSaveCustomerCreditCardEnabled')->willReturn(true);
         $result = $this->currentMock->saveCustomerCreditCard(self::REFERENCE, self::STORE_ID);
         $this->assertFalse($result);
     }
@@ -5151,7 +5152,7 @@ class OrderTest extends BoltTestCase
 
         $this->customerCreditCardFactory->expects(static::once())->method('create')->willReturnSelf();
         $this->customerCreditCardFactory->expects(static::once())->method('saveCreditCard')->willReturnSelf();
-
+        $this->featureSwitches->method('isSaveCustomerCreditCardEnabled')->willReturn(true);
         $result = $this->currentMock->saveCustomerCreditCard(self::REFERENCE, self::STORE_ID);
         $this->assertTrue($result);
     }
@@ -5179,7 +5180,7 @@ class OrderTest extends BoltTestCase
 
         $this->customerCreditCardFactory->expects(static::once())->method('create')->willReturnSelf();
         $this->customerCreditCardFactory->expects(static::once())->method('saveCreditCard')->willReturnSelf();
-
+        $this->featureSwitches->method('isSaveCustomerCreditCardEnabled')->willReturn(true);
         $result = $this->currentMock->saveCustomerCreditCard(self::REFERENCE, self::STORE_ID);
         $this->assertTrue($result);
     }
@@ -5200,7 +5201,7 @@ class OrderTest extends BoltTestCase
         $this->cartHelper->expects(self::exactly(2))->method('getQuoteById')
             ->withConsecutive([self::QUOTE_ID], [self::IMMUTABLE_QUOTE_ID])
             ->willReturnOnConsecutiveCalls(null, null);
-
+        $this->featureSwitches->method('isSaveCustomerCreditCardEnabled')->willReturn(true);
 
         $result = $this->currentMock->saveCustomerCreditCard(self::REFERENCE, self::STORE_ID);
         $this->assertFalse($result);
@@ -5227,7 +5228,7 @@ class OrderTest extends BoltTestCase
 
         $this->customerCreditCardFactory->expects(static::once())->method('create')->willReturnSelf();
         $this->customerCreditCardFactory->expects(static::once())->method('saveCreditCard')->willThrowException(new \Exception());
-
+        $this->featureSwitches->method('isSaveCustomerCreditCardEnabled')->willReturn(true);
         $result = $this->currentMock->saveCustomerCreditCard(self::REFERENCE, self::STORE_ID);
         $this->assertFalse($result);
     }
@@ -5254,7 +5255,7 @@ class OrderTest extends BoltTestCase
 
         $this->customerCreditCardFactory->expects(static::never())->method('create');
         $this->customerCreditCardFactory->expects(static::never())->method('saveCreditCard');
-
+        $this->featureSwitches->method('isSaveCustomerCreditCardEnabled')->willReturn(true);
         $result = $this->currentMock->saveCustomerCreditCard(self::REFERENCE, self::STORE_ID);
         $this->assertFalse($result);
     }


### PR DESCRIPTION
# Description
Create feature switch for saving the customer credit card when the pending hook is sent to Magento

Fixes: (link Jira ticket)

#changelog Create feature switch for saving the customer credit card when the pending hook is sent to Magento

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
