### PR TITLE
M2P-636 Conditionally load trackjs

### DIFF
--- a/Block/Js.php
+++ b/Block/Js.php
@@ -500,7 +500,7 @@ class Js extends Template
      * If feature switch M2_DISABLE_TRACK_ON_NON_BOLT_PAGES is enabled,
      * then the Bolt track.js would be loaded only on pages where we have Bolt connect.js.
      */
-    public function isLoadTrackJsOnBoltPagesOnly()
+    public function isDisableTrackJsFromNonBoltPage()
     {
         if ($this->featureSwitches->isDisableTrackJsFromNonBoltPage()) {
             return true;

--- a/Block/Js.php
+++ b/Block/Js.php
@@ -489,7 +489,7 @@ class Js extends Template
      */
     public function isDisableTrackJsOnHomePage()
     {
-        if ($this->featureSwitches->isDisableTrackJsFromHomePage()) {
+        if ($this->featureSwitches->isDisableTrackJsOnHomePage()) {
             return true;
         }
         
@@ -500,9 +500,9 @@ class Js extends Template
      * If feature switch M2_DISABLE_TRACK_ON_NON_BOLT_PAGES is enabled,
      * then the Bolt track.js would be loaded only on pages where we have Bolt connect.js.
      */
-    public function isDisableTrackJsFromNonBoltPage()
+    public function isDisableTrackJsOnNonBoltPages()
     {
-        if ($this->featureSwitches->isDisableTrackJsFromNonBoltPage()) {
+        if ($this->featureSwitches->isDisableTrackJsOnNonBoltPages()) {
             return true;
         }
         

--- a/Block/Js.php
+++ b/Block/Js.php
@@ -284,6 +284,7 @@ class Js extends Template
     {
         return json_encode([
             'connect_url'                           => $this->getConnectJsUrl(),
+            'track_url'                             => $this->getTrackJsUrl(),
             'publishable_key_payment'               => $this->configHelper->getPublishableKeyPayment(),
             'publishable_key_checkout'              => $this->configHelper->getPublishableKeyCheckout(),
             'publishable_key_back_office'           => $this->configHelper->getPublishableKeyBackOffice(),
@@ -440,6 +441,14 @@ class Js extends Template
     }
     
     /**
+     * Return true if customer is on home page
+     */
+    public function isOnHomePage()
+    {
+        return $this->getRequest()->getFullActionName() == Config::HOME_PAGE_ACTION;
+    }
+    
+    /**
      * If feature switch M2_LOAD_CONNECT_JS_ON_SPECIFIC_PAGE is enabled,
      * then we only fetch Bolt connect js on page load for the product page (PPC is enabled) and cart page.
      */
@@ -469,6 +478,32 @@ class Js extends Template
             if ($this->isMinicartEnabled() && !$this->isBoltPPCEnabled() && $this->isOnProductPage()) {
                 return true;
             }
+        }
+        
+        return false;
+    }
+    
+    /**
+     * If feature switch M2_DISABLE_TRACK_ON_HOME_PAGE is enabled,
+     * then the Bolt track.js should be disabled on the home page.
+     */
+    public function isDisableTrackJsOnHomePage()
+    {
+        if ($this->featureSwitches->isDisableTrackJsFromHomePage()) {
+            return true;
+        }
+        
+        return false;
+    }
+    
+    /**
+     * If feature switch M2_DISABLE_TRACK_ON_NON_BOLT_PAGES is enabled,
+     * then the Bolt track.js would be loaded only on pages where we have Bolt connect.js.
+     */
+    public function isLoadTrackJsOnBoltPagesOnly()
+    {
+        if ($this->featureSwitches->isDisableTrackJsFromNonBoltPage()) {
+            return true;
         }
         
         return false;

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -395,6 +395,7 @@ class Config extends AbstractHelper
     const SHOPPING_CART_PAGE_ACTION = 'checkout_cart_index';
     const CHECKOUT_PAGE_ACTION = 'checkout_index_index';
     const SUCCESS_PAGE_ACTION = 'checkout_onepage_success';
+    const HOME_PAGE_ACTION = 'cms_index_index';
 
     /**
      * Map of human-readable config names to their XML paths

--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -317,12 +317,12 @@ class Decider extends AbstractHelper
         return $this->isSwitchEnabled(Definitions::M2_LOAD_CONNECT_JS_ON_SPECIFIC_PAGE);
     }
     
-    public function isDisableTrackJsFromHomePage()
+    public function isDisableTrackJsOnHomePage()
     {
         return $this->isSwitchEnabled(Definitions::M2_DISABLE_TRACK_ON_HOME_PAGE);
     }
     
-    public function isDisableTrackJsFromNonBoltPage()
+    public function isDisableTrackJsOnNonBoltPages()
     {
         return $this->isSwitchEnabled(Definitions::M2_DISABLE_TRACK_ON_NON_BOLT_PAGES);
     }

--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -316,6 +316,16 @@ class Decider extends AbstractHelper
     {
         return $this->isSwitchEnabled(Definitions::M2_LOAD_CONNECT_JS_ON_SPECIFIC_PAGE);
     }
+    
+    public function isDisableTrackJsFromHomePage()
+    {
+        return $this->isSwitchEnabled(Definitions::M2_DISABLE_TRACK_ON_HOME_PAGE);
+    }
+    
+    public function isDisableTrackJsFromNonBoltPage()
+    {
+        return $this->isSwitchEnabled(Definitions::M2_DISABLE_TRACK_ON_NON_BOLT_PAGES);
+    }
 
     public function isReturnErrWhenRunFilter()
     {

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -171,6 +171,16 @@ class Definitions
      * Enable connect.js on cart page or product page (if PPC enabled) only
      */
     const M2_LOAD_CONNECT_JS_ON_SPECIFIC_PAGE = 'M2_LOAD_CONNECT_JS_ON_SPECIFIC_PAGE';
+    
+    /**
+     * Remove track.js from home page of the site
+     */
+    const M2_DISABLE_TRACK_ON_HOME_PAGE = 'M2_DISABLE_TRACK_ON_HOME_PAGE';
+    
+    /**
+     * Include track.js only on pages where we have connect.js
+     */
+    const M2_DISABLE_TRACK_ON_NON_BOLT_PAGES = 'M2_DISABLE_TRACK_ON_NON_BOLT_PAGES';
 
     /**
      * Enable always return error if there is any exception when running filter.
@@ -367,6 +377,18 @@ class Definitions
         ],
         self::M2_LOAD_CONNECT_JS_ON_SPECIFIC_PAGE => [
             self::NAME_KEY        => self::M2_LOAD_CONNECT_JS_ON_SPECIFIC_PAGE,
+            self::VAL_KEY         => true,
+            self::DEFAULT_VAL_KEY => false,
+            self::ROLLOUT_KEY     => 0
+        ],
+        self::M2_DISABLE_TRACK_ON_HOME_PAGE => [
+            self::NAME_KEY        => self::M2_DISABLE_TRACK_ON_HOME_PAGE,
+            self::VAL_KEY         => true,
+            self::DEFAULT_VAL_KEY => false,
+            self::ROLLOUT_KEY     => 0
+        ],
+        self::M2_DISABLE_TRACK_ON_NON_BOLT_PAGES => [
+            self::NAME_KEY        => self::M2_DISABLE_TRACK_ON_NON_BOLT_PAGES,
             self::VAL_KEY         => true,
             self::DEFAULT_VAL_KEY => false,
             self::ROLLOUT_KEY     => 0

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -663,6 +663,7 @@ class JsTest extends BoltTestCase
 
         $message = 'Cannot find following key in the Settings: ';
         static::assertArrayHasKey('connect_url', $array, $message . 'connect_url');
+        static::assertArrayHasKey('track_url', $array, $message . 'track_url');
         static::assertArrayHasKey('publishable_key_payment', $array, $message . 'publishable_key_payment');
         static::assertArrayHasKey('publishable_key_checkout', $array, $message . 'publishable_key_checkout');
         static::assertArrayHasKey('publishable_key_back_office', $array, $message . 'publishable_key_back_office');
@@ -2442,6 +2443,80 @@ function(arg) {
                 'productPageCheckoutFlag'                           => false,
                 'isLoadConnectJsOnSpecificPageFeatureSwitchEnabled' => true,
                 'expectedResult'                                    => false
+            ],
+        ];
+    }
+    
+    /**
+     * @test
+     *
+     * @dataProvider isDisableTrackJsOnHomePage_withVariousConfigsProvider
+     *
+     * @param bool $isDisableTrackJsFromHomePage
+     * @param bool $expectedResult
+     */
+    public function isDisableTrackJsOnHomePage_withVariousConfigs_returnsCorrectResult($isDisableTrackJsFromHomePage, $expectedResult)
+    {
+        $this->deciderMock->expects(static::once())
+            ->method('isDisableTrackJsFromHomePage')
+            ->willReturn($isDisableTrackJsFromHomePage);
+        static::assertEquals($expectedResult, $this->currentMock->isDisableTrackJsOnHomePage());
+    }
+    
+    /**
+     * Data provider for
+     *
+     * @see isDisableTrackJsOnHomePage_withVariousConfigs_returnsCorrectResult
+     *
+     * @return array
+     */
+    public function isDisableTrackJsOnHomePage_withVariousConfigsProvider()
+    {
+        return [
+            [
+                'isDisableTrackJsFromHomePage' => true,
+                'expectedResult'               => true
+            ],
+            [
+                'isDisableTrackJsFromHomePage' => false,
+                'expectedResult'               => false
+            ],
+        ];
+    }
+    
+    /**
+     * @test
+     *
+     * @dataProvider isDisableTrackJsFromNonBoltPage_withVariousConfigsProvider
+     *
+     * @param bool $isDisableTrackJsFromNonBoltPage
+     * @param bool $expectedResult
+     */
+    public function isDisableTrackJsFromNonBoltPage_withVariousConfigs_returnsCorrectResult($isDisableTrackJsFromNonBoltPage, $expectedResult)
+    {
+        $this->deciderMock->expects(static::once())
+            ->method('isDisableTrackJsFromNonBoltPage')
+            ->willReturn($isDisableTrackJsFromNonBoltPage);
+        static::assertEquals($expectedResult, $this->currentMock->isDisableTrackJsFromNonBoltPage());
+    }
+    
+    /**
+     * Data provider for
+     *
+     * @see isDisableTrackJsFromNonBoltPage_withVariousConfigs_returnsCorrectResult
+     *
+     * @return array
+     */
+    public function isDisableTrackJsFromNonBoltPage_withVariousConfigsProvider()
+    {
+        return [
+            [
+                'isDisableTrackJsFromNonBoltPage' => true,
+                'expectedResult'                  => true
+            ],
+            [
+                'isDisableTrackJsFromNonBoltPage' => false,
+                'expectedResult'                  => false
             ],
         ];
     }

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -61,7 +61,7 @@ class JsTest extends BoltTestCase
     /**
      * @var int expected number of settings returned by {@see \Bolt\Boltpay\Block\Js::getSettings}
      */
-    const SETTINGS_NUMBER = 26;
+    const SETTINGS_NUMBER = 27;
 
     /**
      * @var int expeced number of tracking callback returned by {@see \Bolt\Boltpay\Block\Js::getTrackCallbacks}

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -2452,14 +2452,14 @@ function(arg) {
      *
      * @dataProvider isDisableTrackJsOnHomePage_withVariousConfigsProvider
      *
-     * @param bool $isDisableTrackJsFromHomePage
+     * @param bool $isDisableTrackJsOnHomePage
      * @param bool $expectedResult
      */
-    public function isDisableTrackJsOnHomePage_withVariousConfigs_returnsCorrectResult($isDisableTrackJsFromHomePage, $expectedResult)
+    public function isDisableTrackJsOnHomePage_withVariousConfigs_returnsCorrectResult($isDisableTrackJsOnHomePage, $expectedResult)
     {
         $this->deciderMock->expects(static::once())
-            ->method('isDisableTrackJsFromHomePage')
-            ->willReturn($isDisableTrackJsFromHomePage);
+            ->method('isDisableTrackJsOnHomePage')
+            ->willReturn($isDisableTrackJsOnHomePage);
         static::assertEquals($expectedResult, $this->currentMock->isDisableTrackJsOnHomePage());
     }
     
@@ -2474,11 +2474,11 @@ function(arg) {
     {
         return [
             [
-                'isDisableTrackJsFromHomePage' => true,
+                'isDisableTrackJsOnHomePage' => true,
                 'expectedResult'               => true
             ],
             [
-                'isDisableTrackJsFromHomePage' => false,
+                'isDisableTrackJsOnHomePage' => false,
                 'expectedResult'               => false
             ],
         ];
@@ -2487,35 +2487,35 @@ function(arg) {
     /**
      * @test
      *
-     * @dataProvider isDisableTrackJsFromNonBoltPage_withVariousConfigsProvider
+     * @dataProvider isDisableTrackJsOnNonBoltPages_withVariousConfigsProvider
      *
-     * @param bool $isDisableTrackJsFromNonBoltPage
+     * @param bool $isDisableTrackJsOnNonBoltPages
      * @param bool $expectedResult
      */
-    public function isDisableTrackJsFromNonBoltPage_withVariousConfigs_returnsCorrectResult($isDisableTrackJsFromNonBoltPage, $expectedResult)
+    public function isDisableTrackJsOnNonBoltPages_withVariousConfigs_returnsCorrectResult($isDisableTrackJsOnNonBoltPages, $expectedResult)
     {
         $this->deciderMock->expects(static::once())
-            ->method('isDisableTrackJsFromNonBoltPage')
-            ->willReturn($isDisableTrackJsFromNonBoltPage);
-        static::assertEquals($expectedResult, $this->currentMock->isDisableTrackJsFromNonBoltPage());
+            ->method('isDisableTrackJsOnNonBoltPages')
+            ->willReturn($isDisableTrackJsOnNonBoltPages);
+        static::assertEquals($expectedResult, $this->currentMock->isDisableTrackJsOnNonBoltPages());
     }
     
     /**
      * Data provider for
      *
-     * @see isDisableTrackJsFromNonBoltPage_withVariousConfigs_returnsCorrectResult
+     * @see isDisableTrackJsOnNonBoltPages_withVariousConfigs_returnsCorrectResult
      *
      * @return array
      */
-    public function isDisableTrackJsFromNonBoltPage_withVariousConfigsProvider()
+    public function isDisableTrackJsOnNonBoltPages_withVariousConfigsProvider()
     {
         return [
             [
-                'isDisableTrackJsFromNonBoltPage' => true,
+                'isDisableTrackJsOnNonBoltPages' => true,
                 'expectedResult'                  => true
             ],
             [
-                'isDisableTrackJsFromNonBoltPage' => false,
+                'isDisableTrackJsOnNonBoltPages' => false,
                 'expectedResult'                  => false
             ],
         ];

--- a/view/frontend/templates/js/boltjs.phtml
+++ b/view/frontend/templates/js/boltjs.phtml
@@ -23,16 +23,19 @@
 if ($block->shouldDisableBoltCheckout()) {
     return;
 }
-
-//check if we need Bolt on this page
-if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled() && !$block->isBoltProductPage()) {
-    return;
-}
-
-$trackJsUrl = $block->getTrackJsUrl();
-$checkoutKey = $block->getCheckoutKey();
 ?>
 <script>console.log("Bolt M2 Version: <?= /* @noEscape */ $block->getModuleVersion()?>");</script>
+<?php
+$checkoutKey = $block->getCheckoutKey();
+$isLoadTrackJsOnlyBoltPages = $block->isLoadTrackJsOnBoltPagesOnly();
+$isLoadConnectJs = $block->isLoadConnectJs();
+$isLoadBoltJs = $block->isOnPageFromWhiteList() || $block->isMinicartEnabled() || $block->isBoltProductPage();
+$isDisableTrackJs = ($block->isDisableTrackJsOnHomePage() && $block->isOnHomePage())
+                    || ($block->isLoadTrackJsOnBoltPagesOnly() && (!$isLoadBoltJs || !$isLoadConnectJs));
+
+if (!$isDisableTrackJs) {
+    $trackJsUrl = $block->getTrackJsUrl();
+?>
 <script
         id="bolt-track"
         type="text/javascript"
@@ -44,9 +47,10 @@ $checkoutKey = $block->getCheckoutKey();
         $checkoutKey; ?>">
 </script>
 <?php
-if ($block->isLoadConnectJs()) {
+}
+if ($isLoadBoltJs && $isLoadConnectJs) {
     $connectJsUrl = $block->getConnectJsUrl();
-    ?>
+?>
 <script
         id="bolt-connect"
         type="text/javascript"

--- a/view/frontend/templates/js/boltjs.phtml
+++ b/view/frontend/templates/js/boltjs.phtml
@@ -30,7 +30,7 @@ $checkoutKey = $block->getCheckoutKey();
 $isLoadConnectJs = $block->isLoadConnectJs();
 $isLoadBoltJs = $block->isOnPageFromWhiteList() || $block->isMinicartEnabled() || $block->isBoltProductPage();
 $isDisableTrackJs = ($block->isDisableTrackJsOnHomePage() && $block->isOnHomePage())
-                    || ($block->isDisableTrackJsFromNonBoltPage() && (!$isLoadBoltJs || !$isLoadConnectJs));
+                    || ($block->isDisableTrackJsOnNonBoltPages() && (!$isLoadBoltJs || !$isLoadConnectJs));
 
 if (!$isDisableTrackJs) {
     $trackJsUrl = $block->getTrackJsUrl();

--- a/view/frontend/templates/js/boltjs.phtml
+++ b/view/frontend/templates/js/boltjs.phtml
@@ -27,11 +27,10 @@ if ($block->shouldDisableBoltCheckout()) {
 <script>console.log("Bolt M2 Version: <?= /* @noEscape */ $block->getModuleVersion()?>");</script>
 <?php
 $checkoutKey = $block->getCheckoutKey();
-$isLoadTrackJsOnlyBoltPages = $block->isLoadTrackJsOnBoltPagesOnly();
 $isLoadConnectJs = $block->isLoadConnectJs();
 $isLoadBoltJs = $block->isOnPageFromWhiteList() || $block->isMinicartEnabled() || $block->isBoltProductPage();
 $isDisableTrackJs = ($block->isDisableTrackJsOnHomePage() && $block->isOnHomePage())
-                    || ($block->isLoadTrackJsOnBoltPagesOnly() && (!$isLoadBoltJs || !$isLoadConnectJs));
+                    || ($block->isDisableTrackJsFromNonBoltPage() && (!$isLoadBoltJs || !$isLoadConnectJs));
 
 if (!$isDisableTrackJs) {
     $trackJsUrl = $block->getTrackJsUrl();

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -1552,7 +1552,13 @@ $isLoadTrackJsDynamic = $block->isLoadTrackJsOnBoltPagesOnly() && $isLoadConnect
             ?>
         magentoCartDataListenerLoadConnectJs = function(data) {
             if (data.items !== undefined && data.items.length > 0) {
+                <?php
+                if ($isLoadTrackJsDynamic) {
+                ?>
                 insertTrackScript();
+                <?php
+                }
+                ?>                
                 insertConnectScript();
             }            
         }

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -33,7 +33,7 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
 
 $connectJsUrl = $block->getConnectJsUrl();
 $isLoadConnectJsDynamic = $block->isLoadConnectJsDynamic();
-$isLoadTrackJsDynamic = $block->isLoadTrackJsOnBoltPagesOnly() && $isLoadConnectJsDynamic;
+$isLoadTrackJsDynamic = $block->isDisableTrackJsFromNonBoltPage() && $isLoadConnectJsDynamic;
 ?>
 
 <script type="text/javascript">

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -33,6 +33,7 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
 
 $connectJsUrl = $block->getConnectJsUrl();
 $isLoadConnectJsDynamic = $block->isLoadConnectJsDynamic();
+$isLoadTrackJsDynamic = $block->isLoadTrackJsOnBoltPagesOnly() && $isLoadConnectJsDynamic;
 ?>
 
 <script type="text/javascript">
@@ -430,6 +431,23 @@ $isLoadConnectJsDynamic = $block->isLoadConnectJsDynamic();
             scriptTag.setAttribute('async', '');
             scriptTag.setAttribute('id', 'bolt-connect');
             scriptTag.setAttribute('data-publishable-key', publishableKey);
+            document.head.appendChild(scriptTag);
+            return true;
+        };
+        
+        var insertTrackScript = function() {
+            var scriptTag = document.getElementById('bolt-track');
+            var publishableKey = getCheckoutKey();
+            if (scriptTag) {
+                scriptTag.setAttribute('data-publishable-key', publishableKey);
+                return false;
+            }
+            scriptTag = document.createElement('script');
+            scriptTag.setAttribute('type', 'text/javascript');
+            scriptTag.setAttribute('async', '');
+            scriptTag.setAttribute('id', 'bolt-track');
+            scriptTag.setAttribute('data-publishable-key', publishableKey);
+            scriptTag.setAttribute('src', settings.track_url);
             document.head.appendChild(scriptTag);
             return true;
         };
@@ -1446,6 +1464,11 @@ $isLoadConnectJsDynamic = $block->isLoadConnectJsDynamic();
             }
             <?php
             if ($isLoadConnectJsDynamic) {
+                if ($isLoadTrackJsDynamic) {
+                ?>
+            insertTrackScript();    
+                <?php
+                }
                 ?>
             if (insertConnectScriptWithoutSrc()) {
                 $.getScript("<?= /* @noEscape */ $connectJsUrl; ?>", function(data, textStatus, jqxhr) {
@@ -1529,6 +1552,7 @@ $isLoadConnectJsDynamic = $block->isLoadConnectJsDynamic();
             ?>
         magentoCartDataListenerLoadConnectJs = function(data) {
             if (data.items !== undefined && data.items.length > 0) {
+                insertTrackScript();
                 insertConnectScript();
             }            
         }

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -33,7 +33,7 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
 
 $connectJsUrl = $block->getConnectJsUrl();
 $isLoadConnectJsDynamic = $block->isLoadConnectJsDynamic();
-$isLoadTrackJsDynamic = $block->isDisableTrackJsFromNonBoltPage() && $isLoadConnectJsDynamic;
+$isLoadTrackJsDynamic = $block->isDisableTrackJsOnNonBoltPages() && $isLoadConnectJsDynamic;
 ?>
 
 <script type="text/javascript">


### PR DESCRIPTION
# Description
add track.js to each page of the site

add feature switch M2_DISABLE_TRACK_ON_HOME_PAGE (disabled by default) that remove track.js from main page of the site

add feature switch M2_DISABLE_TRACK_ON_NON_BOLT_PAGES (disabled by default). With this feature switch, we include track.js only on pages where we have connect.js (actually the same as we have now)

Fixes: https://boltpay.atlassian.net/browse/M2P-636

#changelog Conditionally load trackjs

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
