### PR TITLE
CI - fix nodejs version for integration tests

### DIFF
--- a/Test/scripts/ci-integration.sh
+++ b/Test/scripts/ci-integration.sh
@@ -4,6 +4,11 @@ set -e
 set -u
 set -x
 
+npm cache clean -f
+npm install -g n
+sudo npm install -g n
+sudo n 14.17.3
+
 trap '>&2 echo Error: Command \`$BASH_COMMAND\` on line $LINENO failed with exit code $?' ERR
 
 git clone --depth 1 git@github.com:BoltApp/integration-tests.git


### PR DESCRIPTION
#changelog CI - fix nodejs version for integration tests
Fix nodejs error for `integration-php72-magento23`. node 10 -> 14

![image](https://user-images.githubusercontent.com/6696821/125631112-000fb9e5-58cb-437b-b299-79d310fadf9e.png)
