### PR TITLE
M2P-661 Bugfix: Discount not applied to virtual quote when the feature switch M2_HANDLE_VIRTUAL_PRODUCTS_AS_PHYSICAL is enabled

### DIFF
--- a/Model/Api/DiscountCodeValidation.php
+++ b/Model/Api/DiscountCodeValidation.php
@@ -272,9 +272,7 @@ class DiscountCodeValidation extends UpdateCartCommon implements DiscountCodeVal
     private function getCartTotals($quote)
     {
         $is_has_shipment = !empty($this->requestArray['cart']['shipments'][0]['reference']);
-        $payload = isset($this->requestArray['cart']['billing_address'])
-                   ? $this->createPayloadForVirtualQuote($quote, $this->requestArray['cart']['billing_address'])
-                   : null;
+        $payload = $this->createPayloadForVirtualQuote($quote, $this->requestArray);
         $cart = $this->cartHelper->getCartData($is_has_shipment, $payload, $quote);
         if (empty($cart)) {
             throw new \Exception('Something went wrong when getting cart data.');

--- a/Model/Api/DiscountCodeValidation.php
+++ b/Model/Api/DiscountCodeValidation.php
@@ -272,25 +272,9 @@ class DiscountCodeValidation extends UpdateCartCommon implements DiscountCodeVal
     private function getCartTotals($quote)
     {
         $is_has_shipment = !empty($this->requestArray['cart']['shipments'][0]['reference']);
-        if ($quote->isVirtual() && $this->featureSwitches->handleVirtualProductsAsPhysical()) {
-            $payload = [
-                'billingAddress' => [
-                    'firstname' => $this->requestArray['cart']['billing_address']['first_name'] ?? '',
-                    'lastname'  => $this->requestArray['cart']['billing_address']['last_name'] ?? '',
-                    'company'   => $this->requestArray['cart']['billing_address']['company'] ?? '',
-                    'telephone' => $this->requestArray['cart']['billing_address']['phone_number'] ?? '',
-                    'street'    => [$this->requestArray['cart']['billing_address']['street_address1'] ?? '', $this->requestArray['cart']['billing_address']['street_address2'] ?? ''],
-                    'city'      => $this->requestArray['cart']['billing_address']['locality'] ?? '',
-                    'region'    => $this->requestArray['cart']['billing_address']['region'] ?? '',
-                    'postcode'  => $this->requestArray['cart']['billing_address']['postal_code'] ?? '',
-                    'countryId' => $this->requestArray['cart']['billing_address']['country_code'] ?? '',
-                    'email'     => $this->requestArray['cart']['billing_address']['email_address'] ?? '',
-                ],
-            ];
-            $payload = json_encode((object)$payload);
-        } else {
-            $payload = null;
-        }
+        $payload = isset($this->requestArray['cart']['billing_address'])
+                   ? $this->createPayloadForVirtualQuote($quote, $this->requestArray['cart']['billing_address'])
+                   : null;
         $cart = $this->cartHelper->getCartData($is_has_shipment, $payload, $quote);
         if (empty($cart)) {
             throw new \Exception('Something went wrong when getting cart data.');

--- a/Model/Api/DiscountCodeValidation.php
+++ b/Model/Api/DiscountCodeValidation.php
@@ -272,7 +272,26 @@ class DiscountCodeValidation extends UpdateCartCommon implements DiscountCodeVal
     private function getCartTotals($quote)
     {
         $is_has_shipment = !empty($this->requestArray['cart']['shipments'][0]['reference']);
-        $cart = $this->cartHelper->getCartData($is_has_shipment, null, $quote);
+        if ($quote->isVirtual() && $this->featureSwitches->handleVirtualProductsAsPhysical()) {
+            $payload = [
+                'billingAddress' => [
+                    'firstname' => $this->requestArray['cart']['billing_address']['first_name'] ?? '',
+                    'lastname'  => $this->requestArray['cart']['billing_address']['last_name'] ?? '',
+                    'company'   => $this->requestArray['cart']['billing_address']['company'] ?? '',
+                    'telephone' => $this->requestArray['cart']['billing_address']['phone_number'] ?? '',
+                    'street'    => [$this->requestArray['cart']['billing_address']['street_address1'] ?? '', $this->requestArray['cart']['billing_address']['street_address2'] ?? ''],
+                    'city'      => $this->requestArray['cart']['billing_address']['locality'] ?? '',
+                    'region'    => $this->requestArray['cart']['billing_address']['region'] ?? '',
+                    'postcode'  => $this->requestArray['cart']['billing_address']['postal_code'] ?? '',
+                    'countryId' => $this->requestArray['cart']['billing_address']['country_code'] ?? '',
+                    'email'     => $this->requestArray['cart']['billing_address']['email_address'] ?? '',
+                ],
+            ];
+            $payload = json_encode((object)$payload);
+        } else {
+            $payload = null;
+        }
+        $cart = $this->cartHelper->getCartData($is_has_shipment, $payload, $quote);
         if (empty($cart)) {
             throw new \Exception('Something went wrong when getting cart data.');
         }

--- a/Model/Api/UpdateCart.php
+++ b/Model/Api/UpdateCart.php
@@ -370,9 +370,7 @@ class UpdateCart extends UpdateCartCommon implements UpdateCartInterface
         $has_shipment = !empty($this->cartRequest['shipments'][0]['reference']);
         //make sure we recollect totals
         $quote->setTotalsCollectedFlag(false);
-        $payload = isset($this->cartRequest['billing_address'])
-                   ? $this->createPayloadForVirtualQuote($quote, $this->cartRequest['billing_address'])
-                   : null;
+        $payload = $this->createPayloadForVirtualQuote($quote, $this->cartRequest);
         $cart = $this->cartHelper->getCartData($has_shipment, $payload, $quote);
         if (empty($cart)) {
             throw new \Exception('Something went wrong when getting cart data.');

--- a/Model/Api/UpdateCart.php
+++ b/Model/Api/UpdateCart.php
@@ -370,7 +370,10 @@ class UpdateCart extends UpdateCartCommon implements UpdateCartInterface
         $has_shipment = !empty($this->cartRequest['shipments'][0]['reference']);
         //make sure we recollect totals
         $quote->setTotalsCollectedFlag(false);
-        $cart = $this->cartHelper->getCartData($has_shipment, null, $quote);
+        $payload = isset($this->cartRequest['billing_address'])
+                   ? $this->createPayloadForVirtualQuote($quote, $this->cartRequest['billing_address'])
+                   : null;
+        $cart = $this->cartHelper->getCartData($has_shipment, $payload, $quote);
         if (empty($cart)) {
             throw new \Exception('Something went wrong when getting cart data.');
         }

--- a/Model/Api/UpdateCartCommon.php
+++ b/Model/Api/UpdateCartCommon.php
@@ -364,6 +364,36 @@ abstract class UpdateCartCommon
         $this->sessionHelper->loadSession($quote, $metadata ?? []);
         $this->cartHelper->resetCheckoutSession($this->sessionHelper->getCheckoutSession());
     }
+    
+    /**
+     * When the feature switch M2_HANDLE_VIRTUAL_PRODUCTS_AS_PHYSICAL is enabled and the virtual quote has coupon applied,
+     * the billing address is required to get cart data.
+     *
+     * @param Quote $quote
+     * @param array $billingAddress
+     *
+     */
+    public function createPayloadForVirtualQuote($quote, $billingAddress)
+    {
+        if (!$quote->isVirtual() || !$this->featureSwitches->handleVirtualProductsAsPhysical()) {
+            return null;
+        }
+        $payload = [
+            'billingAddress' => [
+                'firstname' => $billingAddress['first_name'] ?? '',
+                'lastname'  => $billingAddress['last_name'] ?? '',
+                'company'   => $billingAddress['company'] ?? '',
+                'telephone' => $billingAddress['phone_number'] ?? '',
+                'street'    => [$billingAddress['street_address1'] ?? '', $billingAddress['street_address2'] ?? ''],
+                'city'      => $billingAddress['locality'] ?? '',
+                'region'    => $billingAddress['region'] ?? '',
+                'postcode'  => $billingAddress['postal_code'] ?? '',
+                'countryId' => $billingAddress['country_code'] ?? '',
+                'email'     => $billingAddress['email_address'] ?? '',
+            ],
+        ];
+        return json_encode((object)$payload);
+    }
 
     /**
      * @param int        $errCode

--- a/Model/Api/UpdateCartCommon.php
+++ b/Model/Api/UpdateCartCommon.php
@@ -370,12 +370,18 @@ abstract class UpdateCartCommon
      * the billing address is required to get cart data.
      *
      * @param Quote $quote
-     * @param array $billingAddress
+     * @param array $requestData
      *
      */
-    public function createPayloadForVirtualQuote($quote, $billingAddress)
+    public function createPayloadForVirtualQuote($quote, $requestData)
     {
         if (!$quote->isVirtual() || !$this->featureSwitches->handleVirtualProductsAsPhysical()) {
+            return null;
+        }
+        $billingAddress = $requestData['cart']['billing_address']
+                          ?? $requestData['billing_address']
+                          ?? null;
+        if (!$billingAddress) {
             return null;
         }
         $payload = [

--- a/Test/Unit/Model/Api/DiscountCodeValidationTest.php
+++ b/Test/Unit/Model/Api/DiscountCodeValidationTest.php
@@ -928,10 +928,10 @@ class DiscountCodeValidationTest extends BoltTestCase
             'discounts'    => [],
         ];
         
+        $this->parentQuoteMock->expects(static::once())->method('isVirtual')->willReturn(false);
         $this->cartHelper->expects(self::once())->method('getCartData')
             ->with(false, null, $this->parentQuoteMock)
             ->willReturn($cartData);
-        
         $result = TestHelper::invokeMethod($this->currentMock, 'getCartTotals', [$this->parentQuoteMock]);
         
         $this->assertEquals($cartData, $result);
@@ -946,7 +946,7 @@ class DiscountCodeValidationTest extends BoltTestCase
         $this->initCurrentMock();
         
         $cartData = [];
-        
+        $this->parentQuoteMock->expects(static::once())->method('isVirtual')->willReturn(false);
         $this->cartHelper->expects(self::once())->method('getCartData')
             ->with(false, null, $this->parentQuoteMock)
             ->willReturn($cartData);
@@ -1217,7 +1217,7 @@ class DiscountCodeValidationTest extends BoltTestCase
             ->getMock();
 
         $this->parentQuoteMock = $this->getMockBuilder(Quote::class)
-            ->setMethods(['getItemsCount', 'getCouponCode', 'getCustomerId'])
+            ->setMethods(['getItemsCount', 'getCouponCode', 'getCustomerId', 'isVirtual'])
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/Test/Unit/Model/Api/UpdateCartCommonTest.php
+++ b/Test/Unit/Model/Api/UpdateCartCommonTest.php
@@ -818,7 +818,7 @@ class UpdateCartCommonTest extends BoltTestCase
             'email_address'   => 'test@bolt.com',
         ];
         
-        $expected_result = '{"billingAddress":{"firstname":"","lastname":"","company":"","telephone":"","street":["",""],"city":"","region":"","postcode":"","countryId":"","email":""}}';
+        $expected_result = '{"billingAddress":{"firstname":"Test","lastname":"Bolt","company":"Bolt","telephone":"0123456789","street":["Test Street 1",""],"city":"Beverly Hills","region":"CA","postcode":"90210","countryId":"US","email":"test@bolt.com"}}';
         
         $result = $this->currentMock->createPayloadForVirtualQuote($quote, $billingAddress);
         

--- a/Test/Unit/Model/Api/UpdateCartCommonTest.php
+++ b/Test/Unit/Model/Api/UpdateCartCommonTest.php
@@ -803,7 +803,7 @@ class UpdateCartCommonTest extends BoltTestCase
         
         $this->featureSwitches->expects(self::once())->method('handleVirtualProductsAsPhysical')->willReturn(true);
         
-        $quote->expects(static::once())->method('isVirtual')->with(true)->willReturnSelf();
+        $quote->expects(static::once())->method('isVirtual')->willReturn(true);
         
         $billingAddress = [
             'first_name'      => 'Test',

--- a/Test/Unit/Model/Api/UpdateCartCommonTest.php
+++ b/Test/Unit/Model/Api/UpdateCartCommonTest.php
@@ -783,4 +783,45 @@ class UpdateCartCommonTest extends BoltTestCase
         
         $this->currentMock->updateSession($quote);
     }
+    
+    /**
+     * @test
+     * @covers ::createPayloadForVirtualQuote
+     *
+     */
+    public function createPayloadForVirtualQuote()
+    {
+        $this->initCurrentMock();
+        
+        $quote = $this->getQuoteMock(
+            self::PARENT_QUOTE_ID,
+            self::PARENT_QUOTE_ID,
+            [
+                'isVirtual',
+            ]
+        );
+        
+        $this->featureSwitches->expects(self::once())->method('handleVirtualProductsAsPhysical')->willReturn(true);
+        
+        $quote->expects(static::once())->method('isVirtual')->with(true)->willReturnSelf();
+        
+        $billingAddress = [
+            'first_name'      => 'Test',
+            'last_name'       => 'Bolt',
+            'street_address1' => "Test Street 1",
+            'locality'        => 'Beverly Hills',
+            'country_code'    => 'US',
+            'region'          => 'CA',
+            'postal_code'     => '90210',
+            'phone_number'    => '0123456789',
+            'company'         => 'Bolt',
+            'email_address'   => 'test@bolt.com',
+        ];
+        
+        $expected_result = '{"billingAddress":{"firstname":"","lastname":"","company":"","telephone":"","street":["",""],"city":"","region":"","postcode":"","countryId":"","email":""}}';
+        
+        $result = $this->currentMock->createPayloadForVirtualQuote($quote, $billingAddress);
+        
+        $this->assertEquals($expected_result, $result);
+    }
 }

--- a/Test/Unit/Model/Api/UpdateCartCommonTest.php
+++ b/Test/Unit/Model/Api/UpdateCartCommonTest.php
@@ -805,22 +805,24 @@ class UpdateCartCommonTest extends BoltTestCase
         
         $quote->expects(static::once())->method('isVirtual')->willReturn(true);
         
-        $billingAddress = [
-            'first_name'      => 'Test',
-            'last_name'       => 'Bolt',
-            'street_address1' => "Test Street 1",
-            'locality'        => 'Beverly Hills',
-            'country_code'    => 'US',
-            'region'          => 'CA',
-            'postal_code'     => '90210',
-            'phone_number'    => '0123456789',
-            'company'         => 'Bolt',
-            'email_address'   => 'test@bolt.com',
+        $requestData = [
+            'billing_address' => [
+                'first_name'      => 'Test',
+                'last_name'       => 'Bolt',
+                'street_address1' => "Test Street 1",
+                'locality'        => 'Beverly Hills',
+                'country_code'    => 'US',
+                'region'          => 'CA',
+                'postal_code'     => '90210',
+                'phone_number'    => '0123456789',
+                'company'         => 'Bolt',
+                'email_address'   => 'test@bolt.com',    
+            ]
         ];
         
         $expected_result = '{"billingAddress":{"firstname":"Test","lastname":"Bolt","company":"Bolt","telephone":"0123456789","street":["Test Street 1",""],"city":"Beverly Hills","region":"CA","postcode":"90210","countryId":"US","email":"test@bolt.com"}}';
         
-        $result = $this->currentMock->createPayloadForVirtualQuote($quote, $billingAddress);
+        $result = $this->currentMock->createPayloadForVirtualQuote($quote, $requestData);
         
         $this->assertEquals($expected_result, $result);
     }


### PR DESCRIPTION
# Description
Root cause: we do not set billing address for virtual quote while virtual cart item is handled as physical

Fixes: https://boltpay.atlassian.net/browse/M2P-661

#changelog Bugfix: Discount not applied to virtual quote when the feature switch M2_HANDLE_VIRTUAL_PRODUCTS_AS_PHYSICAL is enabled

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
