### PR TITLE
Prevent overwriting quote customer IP with Bolt (AWS) one in pre-auth call

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1120,7 +1120,7 @@ class Cart extends AbstractHelper
         $child,
         $save = true,
         $emailFields = ['customer_email', 'email'],
-        $excludeFields = ['entity_id', 'address_id', 'reserved_order_id',
+        $excludeFields = ['entity_id', 'address_id', 'reserved_order_id', 'remote_ip',
             'address_sales_rule_id', 'cart_fixed_rules', 'cached_items_all', 'customer_note']
     ) {
         foreach ($parent->getData() as $key => $value) {

--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -382,4 +382,12 @@ class Decider extends AbstractHelper
     {
         return $this->isSwitchEnabled(Definitions::M2_IGNORE_TOTAL_VALIDATION_WHEN_CREDIT_HOOK_IS_SENT_TO_MAGENTO);
     }
+
+    /**
+     * Checks whether the feature switch to prevent setting Bolt IPs as customer IP on quote is enabled
+     */
+    public function isPreventSettingBoltIpsAsCustomerIpOnQuote()
+    {
+        return $this->isSwitchEnabled(Definitions::M2_PREVENT_SETTING_BOLT_IPS_AS_CUSTOMER_IP_ON_QUOTE);
+    }
 }

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -217,6 +217,11 @@ class Definitions
      */
     const M2_IGNORE_TOTAL_VALIDATION_WHEN_CREDIT_HOOK_IS_SENT_TO_MAGENTO = 'M2_IGNORE_TOTAL_VALIDATION_WHEN_CREDIT_HOOK_IS_SENT_TO_MAGENTO';
 
+    /**
+     * Prevent Bolt IPs from being saved as customer IP on quote
+     */
+    const M2_PREVENT_SETTING_BOLT_IPS_AS_CUSTOMER_IP_ON_QUOTE = 'M2_PREVENT_SETTING_BOLT_IPS_AS_CUSTOMER_IP_ON_QUOTE';
+
     const DEFAULT_SWITCH_VALUES = [
         self::M2_SAMPLE_SWITCH_NAME => [
             self::NAME_KEY        => self::M2_SAMPLE_SWITCH_NAME,
@@ -430,6 +435,12 @@ class Definitions
         ],
         self::M2_SET_CUSTOMER_NAME_TO_ORDER_FOR_GUESTS => [
             self::NAME_KEY        => self::M2_SET_CUSTOMER_NAME_TO_ORDER_FOR_GUESTS,
+            self::VAL_KEY         => true,
+            self::DEFAULT_VAL_KEY => false,
+            self::ROLLOUT_KEY     => 0
+        ],
+        self::M2_PREVENT_SETTING_BOLT_IPS_AS_CUSTOMER_IP_ON_QUOTE => [
+            self::NAME_KEY        => self::M2_PREVENT_SETTING_BOLT_IPS_AS_CUSTOMER_IP_ON_QUOTE,
             self::VAL_KEY         => true,
             self::DEFAULT_VAL_KEY => false,
             self::ROLLOUT_KEY     => 0

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -443,7 +443,7 @@ class Definitions
             self::NAME_KEY        => self::M2_PREVENT_SETTING_BOLT_IPS_AS_CUSTOMER_IP_ON_QUOTE,
             self::VAL_KEY         => true,
             self::DEFAULT_VAL_KEY => false,
-            self::ROLLOUT_KEY     => 0
+            self::ROLLOUT_KEY     => 100
         ],
     ];
 }

--- a/Plugin/WebapiRest/Magento/Quote/Model/QuotePlugin.php
+++ b/Plugin/WebapiRest/Magento/Quote/Model/QuotePlugin.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Plugin\WebapiRest\Magento\Quote\Model;
+
+/**
+ * Plugin for {@see \Magento\Quote\Model\Quote}
+ */
+class QuotePlugin
+{
+    /**
+     * @var \Bolt\Boltpay\Helper\FeatureSwitch\Decider
+     */
+    private $featureSwitches;
+
+    /**
+     * @var bool
+     */
+    private $isPreventSettingBoltIpsAsCustomerIpOnQuote;
+
+    /**
+     * QuotePlugin constructor.
+     *
+     * @param \Bolt\Boltpay\Helper\FeatureSwitch\Decider $featureSwitches
+     */
+    public function __construct(\Bolt\Boltpay\Helper\FeatureSwitch\Decider $featureSwitches = null)
+    {
+        $this->featureSwitches = $featureSwitches ?? \Magento\Framework\App\ObjectManager::getInstance()
+                ->get(\Bolt\Boltpay\Helper\FeatureSwitch\Decider::class);
+        $this->isPreventSettingBoltIpsAsCustomerIpOnQuote = $this->featureSwitches->isPreventSettingBoltIpsAsCustomerIpOnQuote();
+    }
+
+    /**
+     * Prevent IP from being set when requests are coming from Bolt, except initially
+     *
+     * @param \Magento\Quote\Model\Quote $subject intercepted quote object
+     * @param array|string               $key 
+     * @param mixed                      $value
+     *
+     * @return array|void
+     */
+    public function beforeSetData(\Magento\Quote\Model\Quote $subject, $key, $value = null)
+    {
+        if ($this->isPreventSettingBoltIpsAsCustomerIpOnQuote
+            && $key === 'remote_ip'
+            && \Bolt\Boltpay\Helper\Hook::$fromBolt) {
+            return [$key, ($subject->getData('remote_ip') ?: $subject->getOrigData('remote_ip')) ?: $value];
+        }
+    }
+}

--- a/Test/Unit/Plugin/WebapiRest/Magento/Quote/Model/QuotePluginTest.php
+++ b/Test/Unit/Plugin/WebapiRest/Magento/Quote/Model/QuotePluginTest.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+namespace Bolt\Boltpay\Test\Unit\Plugin\WebapiRest\Magento\Quote\Model;
+
+/**
+ * Test for {@see \Bolt\Boltpay\Plugin\WebapiRest\Magento\Quote\Model\QuotePlugin}
+ *
+ * @coversDefaultClass \Bolt\Boltpay\Plugin\WebapiRest\Magento\Quote\Model\QuotePlugin
+ */
+class QuotePluginTest extends \Bolt\Boltpay\Test\Unit\BoltTestCase
+{
+
+    /**
+     * @var \Bolt\Boltpay\Helper\FeatureSwitch\Decider|\PHPUnit\Framework\MockObject\MockObject|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $featureSwitchesMock;
+
+    /**
+     * Setup test dependencies
+     */
+    protected function setUp(): void
+    {
+        $this->featureSwitchesMock = $this->createMock(\Bolt\Boltpay\Helper\FeatureSwitch\Decider::class);
+        parent::setUp();
+    }
+
+    /**
+     * @test
+     * that beforeSetData prevents setting Bolt as remote IP
+     *
+     * @covers ::beforeSetData
+     *
+     * @dataProvider beforeSetData_ifPreconditionsAreMetProvider
+     */
+    public function beforeSetData_ifPreconditionsAreMet_preventsSettingBoltIP(
+        $key,
+        $value,
+        $originalRemoteIp,
+        $currentRemoteIp,
+        $fromBolt,
+        $isPreventSettingBoltIpsAsCustomerIpOnQuote,
+        $changedArguments
+    ) {
+        $om = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        $this->featureSwitchesMock->method('isPreventSettingBoltIpsAsCustomerIpOnQuote')
+            ->willReturn($isPreventSettingBoltIpsAsCustomerIpOnQuote);
+        $pluginInstance = $om->create(
+            \Bolt\Boltpay\Plugin\WebapiRest\Magento\Quote\Model\QuotePlugin::class,
+            [
+                'featureSwitches' => $this->featureSwitchesMock
+            ]
+        );
+        $quote = $om->create(\Magento\Quote\Model\Quote::class);
+        $quote->setOrigData('remote_ip', $originalRemoteIp);
+        $quote->setData('remote_ip', $currentRemoteIp);
+        \Bolt\Boltpay\Helper\Hook::$fromBolt = $fromBolt;
+        static::assertEquals($changedArguments, $pluginInstance->beforeSetData($quote, $key, $value));
+    }
+
+    /**
+     * Data provider for {@see beforeSetData_ifPreconditionsAreMet_preventsSettingBoltIP}
+     *
+     * @return array[]
+     */
+    public function beforeSetData_ifPreconditionsAreMetProvider()
+    {
+        $boltIP = '52.53.112.98';
+        $customerIP1 = '127.0.0.1';
+        $customerIP2 = '172.20.10.1';
+        return [
+            'Happy path' => [
+                'key'                                        => 'remote_ip',
+                'value'                                      => $boltIP,
+                'originalRemoteIp'                           => $customerIP1,
+                'currentRemoteIp'                            => $customerIP1,
+                'fromBolt'                                   => true,
+                'isPreventSettingBoltIpsAsCustomerIpOnQuote' => true,
+                'changedArguments'                           => ['remote_ip', $customerIP1],
+            ],
+            'Initial setting of the IP' => [
+                'key'                                        => 'remote_ip',
+                'value'                                      => $customerIP1,
+                'originalRemoteIp'                           => null,
+                'currentRemoteIp'                            => null,
+                'fromBolt'                                   => true,
+                'isPreventSettingBoltIpsAsCustomerIpOnQuote' => true,
+                'changedArguments'                           => ['remote_ip', $customerIP1],
+            ],
+            'Read IP from Current Data' => [
+                'key'                                        => 'remote_ip',
+                'value'                                      => $boltIP,
+                'originalRemoteIp'                           => $customerIP1,
+                'currentRemoteIp'                            => $customerIP2,
+                'fromBolt'                                   => true,
+                'isPreventSettingBoltIpsAsCustomerIpOnQuote' => true,
+                'changedArguments'                           => ['remote_ip', $customerIP2],
+            ],
+            'Read IP from Original Data' => [
+                'key'                                        => 'remote_ip',
+                'value'                                      => $boltIP,
+                'originalRemoteIp'                           => $customerIP1,
+                'currentRemoteIp'                            => null,
+                'fromBolt'                                   => true,
+                'isPreventSettingBoltIpsAsCustomerIpOnQuote' => true,
+                'changedArguments'                           => ['remote_ip', $customerIP1],
+            ],
+            'Non IP data change - nothing happens' => [
+                'key'                                        => 'test',
+                'value'                                      => true,
+                'originalRemoteIp'                           => $customerIP1,
+                'currentRemoteIp'                            => $customerIP2,
+                'fromBolt'                                   => false,
+                'isPreventSettingBoltIpsAsCustomerIpOnQuote' => false,
+                'changedArguments'                           => null,
+            ],
+            'Key is array - nothing happens' => [
+                'key'                                        => ['test' => 1, 'test2' => 2],
+                'value'                                      => true,
+                'originalRemoteIp'                           => $customerIP1,
+                'currentRemoteIp'                            => $customerIP2,
+                'fromBolt'                                   => false,
+                'isPreventSettingBoltIpsAsCustomerIpOnQuote' => false,
+                'changedArguments'                           => null,
+            ],
+            'Hook not from Bolt - nothing happens' => [
+                'key'                                        => 'remote_ip',
+                'value'                                      => $boltIP,
+                'originalRemoteIp'                           => $customerIP1,
+                'currentRemoteIp'                            => $customerIP1,
+                'fromBolt'                                   => false,
+                'isPreventSettingBoltIpsAsCustomerIpOnQuote' => true,
+                'changedArguments'                           => null,
+            ],
+            'FS disabled - nothing happens' => [
+                'key'                                        => 'remote_ip',
+                'value'                                      => $boltIP,
+                'originalRemoteIp'                           => $customerIP1,
+                'currentRemoteIp'                            => $customerIP1,
+                'fromBolt'                                   => true,
+                'isPreventSettingBoltIpsAsCustomerIpOnQuote' => false,
+                'changedArguments'                           => null,
+            ],
+        ];
+    }
+}

--- a/etc/webapi_rest/di.xml
+++ b/etc/webapi_rest/di.xml
@@ -27,4 +27,9 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Quote\Model\Quote">
+        <plugin name="bolt_boltpay_webapirest_magento_quote_model_quote"
+                type="Bolt\Boltpay\Plugin\WebapiRest\Magento\Quote\Model\QuotePlugin"
+                sortOrder="1"/>
+    </type>
 </config>


### PR DESCRIPTION
# Description
Merchant requires customer IP but we are only sending AWS IPs in our requests.
Merchant is reporting that as of 29/01/2020 they haven't received the customer IP in their DB when orders are created via Bolt.
This is a generic, although not so common, case - some 3party modules may trigger totals collection in pre-auth processing and get and store the IP from the session. This PR prevents that in our calls, leaving the initial, customer session IP in place.

Fixes: https://boltpay.atlassian.net/browse/EN-5023

#changelog Prevent overwriting quote customer IP with Bolt (AWS) one in pre-auth call

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
