### PR TITLE
EN-5280 Exclude "useless" cart price rule from Bolt cart

### DIFF
--- a/Plugin/SalesRuleModelUtilityPlugin.php
+++ b/Plugin/SalesRuleModelUtilityPlugin.php
@@ -17,6 +17,7 @@
 namespace Bolt\Boltpay\Plugin;
 
 use Bolt\Boltpay\Helper\Session as SessionHelper;
+use Bolt\Boltpay\Helper\Discount as DiscountHelper;
 
 class SalesRuleModelUtilityPlugin
 {    
@@ -29,6 +30,26 @@ class SalesRuleModelUtilityPlugin
         $this->sessionHelper = $sessionHelper;
     }
     
+    /**
+     * Save the discount amount of item into checkout session, so we can get actual discount amount of coupon.
+     */
+    public function beforeMinFix(\Magento\SalesRule\Model\Utility $subject, $discountData, $item, $qty)
+    {
+        $checkoutSession = $this->sessionHelper->getCheckoutSession();
+        $savedRuleId = $checkoutSession->getBoltNeedCollectSaleRuleDiscounts('');      
+        if (!empty($savedRuleId)) {
+            $checkoutSession->setBoltDiscountBreakdown( [
+                'item_discount' => $item->getDiscountAmount(),
+                'rule_id' => $savedRuleId,
+            ]);
+        }
+        
+        return [$discountData, $item, $qty];
+    }
+    
+    /**
+     * Save actual discount amount of coupon into checkout session.
+     */
     public function afterMinFix(\Magento\SalesRule\Model\Utility $subject,
                                    $result, $discountData, $item, $qty)
     {
@@ -37,15 +58,22 @@ class SalesRuleModelUtilityPlugin
         if (!empty($savedRuleId)) {
             // If the sale rule has no coupon, its discount amount can not be retrieved directly,
             // so we store the discount amount in the checkout session with the rule id as key.
-            $boltCollectSaleRuleDiscounts = $checkoutSession->getBoltCollectSaleRuleDiscounts([]);            
-            if (!isset($boltCollectSaleRuleDiscounts[$savedRuleId])) {
-                $boltCollectSaleRuleDiscounts[$savedRuleId] = $discountData->getAmount();            
-            } else {
-                $boltCollectSaleRuleDiscounts[$savedRuleId] += $discountData->getAmount();
+            $boltDiscountBreakdown = $checkoutSession->getBoltDiscountBreakdown([]);
+            if (!empty($boltDiscountBreakdown) && $boltDiscountBreakdown['rule_id'] == $savedRuleId) {
+                $discountAmount = $discountData->getAmount() - $boltDiscountBreakdown['item_discount'];
+                if ($discountAmount >= DiscountHelper::MIN_NONZERO_VALUE) {
+                    $boltCollectSaleRuleDiscounts = $checkoutSession->getBoltCollectSaleRuleDiscounts([]);
+                    if (!isset($boltCollectSaleRuleDiscounts[$savedRuleId])) {
+                        $boltCollectSaleRuleDiscounts[$savedRuleId] = $discountAmount;            
+                    } else {
+                        $boltCollectSaleRuleDiscounts[$savedRuleId] += $discountAmount;
+                    }
+                    $checkoutSession->setBoltCollectSaleRuleDiscounts($boltCollectSaleRuleDiscounts);
+                }
             }
-            $checkoutSession->setBoltCollectSaleRuleDiscounts($boltCollectSaleRuleDiscounts);
-            $checkoutSession->setBoltNeedCollectSaleRuleDiscounts(''); 
         }
+        $checkoutSession->setBoltNeedCollectSaleRuleDiscounts('');
+        $checkoutSession->setBoltDiscountBreakdown([]);
 
         return $result;
     }

--- a/Test/Unit/Plugin/SalesRuleModelUtilityPluginTest.php
+++ b/Test/Unit/Plugin/SalesRuleModelUtilityPluginTest.php
@@ -91,7 +91,7 @@ class SalesRuleModelUtilityPluginTest extends BoltTestCase
         $this->sessionHelper->expects(self::once())
                             ->method('getCheckoutSession')
                             ->willReturn($this->checkoutSession);
-        $this->plugin->beforeMinFix($this->subject, null, null, $item, null);
+        $this->plugin->beforeMinFix($this->subject, null, $item, null);
     }
 
     /**

--- a/Test/Unit/Plugin/SalesRuleModelUtilityPluginTest.php
+++ b/Test/Unit/Plugin/SalesRuleModelUtilityPluginTest.php
@@ -88,6 +88,9 @@ class SalesRuleModelUtilityPluginTest extends BoltTestCase
         $item->expects(self::once())
             ->method('getDiscountAmount')
             ->willReturn(20.0);
+        $this->sessionHelper->expects(self::once())
+                            ->method('getCheckoutSession')
+                            ->willReturn($this->checkoutSession);
         $this->plugin->beforeMinFix($this->subject, null, null, $item, null);
     }
 
@@ -143,17 +146,14 @@ class SalesRuleModelUtilityPluginTest extends BoltTestCase
         $this->checkoutSession->expects(self::once())
                             ->method('getBoltNeedCollectSaleRuleDiscounts')
                             ->willReturn(2);
-        $boltCollectSaleRuleDiscounts = [2 => 106.0,];
-        $this->checkoutSession->expects(self::once())
-                            ->method('getBoltCollectSaleRuleDiscounts')
-                            ->willReturn($boltCollectSaleRuleDiscounts);
         $boltDiscountBreakdown = ['item_discount' => 20.0,'rule_id' => 2,];
         $this->checkoutSession->expects(self::once())
                             ->method('getBoltDiscountBreakdown')
                             ->willReturn($boltDiscountBreakdown);
-        $this->checkoutSession->expects(self::once())
-                            ->method('setBoltCollectSaleRuleDiscounts')
-                            ->with([2 => 106.0,]);
+        $this->checkoutSession->expects(self::never())
+                            ->method('getBoltCollectSaleRuleDiscounts');
+        $this->checkoutSession->expects(self::never())
+                            ->method('setBoltCollectSaleRuleDiscounts');
         $this->checkoutSession->expects(self::once())
                             ->method('setBoltNeedCollectSaleRuleDiscounts')
                             ->with('');
@@ -178,8 +178,9 @@ class SalesRuleModelUtilityPluginTest extends BoltTestCase
                             ->method('getBoltDiscountBreakdown');
         $this->checkoutSession->expects(self::never())
                             ->method('setBoltCollectSaleRuleDiscounts');
-        $this->checkoutSession->expects(self::never())
-                            ->method('setBoltNeedCollectSaleRuleDiscounts');
+        $this->checkoutSession->expects(self::once())
+                            ->method('setBoltNeedCollectSaleRuleDiscounts')
+                            ->with('');
         $this->sessionHelper->expects(self::once())
                             ->method('getCheckoutSession')
                             ->willReturn($this->checkoutSession);


### PR DESCRIPTION
# Description
If the merchant create a cart price rule that:
1. Zero discount amount
2. No free shipping
For such a rule, M2 native cart does not calculate it in.
But when the customer apply another coupon to cart, the Bolt plugin would take the "useless" rule and apply a discount to the cart by mistake.
We need to fix this bug.

Fixes: https://boltpay.atlassian.net/browse/EN-5280

#changelog Exclude "useless" cart price rule from Bolt cart

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
