### PR TITLE
Magento 2.4.3 support - replace Zend PhpSerialize with Magento Serialize

### DIFF
--- a/Helper/ArrayHelper.php
+++ b/Helper/ArrayHelper.php
@@ -63,4 +63,26 @@ class ArrayHelper
 
         return $default;
     }
+
+    /**
+     * Converts giver array to an object, recursively
+     *
+     * @param array $array to be converted
+     *
+     * @return \stdClass object
+     */
+    public static function arrayToObject($array)
+    {
+        $obj = new \stdClass;
+        foreach ($array as $k => $v) {
+            if (strlen($k)) {
+                if (is_array($v)) {
+                    $obj->{$k} = self::arrayToObject($v); //RECURSION
+                } else {
+                    $obj->{$k} = $v;
+                }
+            }
+        }
+        return $obj;
+    }
 }

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -884,7 +884,14 @@ class Cart extends AbstractHelper
             $cacheIdentifier = $this->getCartCacheIdentifier($cart);
 
             if ($boltOrderData = $this->loadFromCache($cacheIdentifier)) {
-                $boltOrder = new Response(['store_id' => $boltOrderData['store_id'], 'response'=>ArrayHelper::arrayToObject($boltOrderData['response'])]);
+                // re-create response object from the cached response
+                $boltOrder = new Response(
+                    [
+                        'store_id' => $boltOrderData['store_id'],
+                        // further in the code we expect the reponse as an object
+                        'response' => ArrayHelper::arrayToObject($boltOrderData['response'])
+                    ]
+                );
                 $immutableQuoteId = $this->getImmutableQuoteIdFromBoltOrder($boltOrder->getResponse());
 
                 // found in cache, check if the old immutable quote is still there

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -17,56 +17,55 @@
 
 namespace Bolt\Boltpay\Helper;
 
-use Bolt\Boltpay\Model\Response;
-use Magento\Framework\Registry;
-use Magento\Framework\Session\SessionManagerInterface as CheckoutSession;
-use Magento\Catalog\Model\ProductRepository;
+use Bolt\Boltpay\Exception\BoltException;
 use Bolt\Boltpay\Helper\Api as ApiHelper;
 use Bolt\Boltpay\Helper\Config as ConfigHelper;
+use Bolt\Boltpay\Helper\Discount as DiscountHelper;
+use Bolt\Boltpay\Helper\FeatureSwitch\Decider as DeciderHelper;
+use Bolt\Boltpay\Helper\Hook as HookHelper;
+use Bolt\Boltpay\Helper\Log as LogHelper;
+use Bolt\Boltpay\Helper\Session as SessionHelper;
+use Bolt\Boltpay\Helper\Shared\CurrencyUtils;
+use Bolt\Boltpay\Model\ErrorResponse as BoltErrorResponse;
+use Bolt\Boltpay\Model\EventsForThirdPartyModules;
+use Bolt\Boltpay\Model\Response;
+use Magento\Catalog\Helper\ImageFactory;
+use Magento\Catalog\Model\Config\Source\Product\Thumbnail as ThumbnailSource;
+use Magento\Catalog\Model\ProductRepository;
+use Magento\CatalogInventory\Api\StockStateInterface as StockState;
+use Magento\Checkout\Helper\Data as CheckoutHelper;
+use Magento\Customer\Api\CustomerRepositoryInterface as CustomerRepository;
+use Magento\Customer\Model\Address;
 use Magento\Customer\Model\Session as CustomerSession;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\App\CacheInterface;
 use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Framework\App\Helper\Context;
-use Magento\Framework\Exception\LocalizedException;
-use Magento\Quote\Model\Quote;
-use Magento\Quote\Model\Quote\Address\Total as AddressTotal;
-use Magento\Sales\Api\Data\OrderInterface;
-use Zend_Http_Client_Exception;
-use Bolt\Boltpay\Helper\Log as LogHelper;
-use Bolt\Boltpay\Helper\Shared\CurrencyUtils;
-use Magento\Framework\DataObjectFactory;
-use Magento\Catalog\Helper\ImageFactory;
-use Magento\Store\Model\App\Emulation;
-use Magento\Customer\Model\Address;
-use Magento\Quote\Model\QuoteFactory;
-use Magento\Quote\Model\Quote\TotalsCollector;
-use Magento\Quote\Api\CartRepositoryInterface as QuoteRepository;
-use Magento\Sales\Api\OrderRepositoryInterface as OrderRepository;
-use Magento\Framework\Api\SearchCriteriaBuilder;
-use Magento\Quote\Model\ResourceModel\Quote as QuoteResource;
-use Magento\Framework\Exception\NoSuchEntityException;
-use Bolt\Boltpay\Helper\Session as SessionHelper;
-use Magento\Checkout\Helper\Data as CheckoutHelper;
-use Magento\Quote\Model\Quote\Address as QuoteAddress;
-use Bolt\Boltpay\Helper\Discount as DiscountHelper;
-use Magento\Framework\App\CacheInterface;
-use Magento\Quote\Api\Data\CartInterface;
 use Magento\Framework\App\ResourceConnection;
-use Magento\Sales\Model\Order;
-use Magento\Store\Model\ScopeInterface;
-use Magento\Quote\Api\CartManagementInterface;
-use Bolt\Boltpay\Helper\Hook as HookHelper;
+use Magento\Framework\DataObjectFactory;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Registry;
+use Magento\Framework\Serialize\SerializerInterface as Serialize;
+use Magento\Framework\Session\SessionManagerInterface as CheckoutSession;
 use Magento\Framework\Webapi\Exception as WebapiException;
-use Magento\Customer\Api\CustomerRepositoryInterface as CustomerRepository;
-use Bolt\Boltpay\Exception\BoltException;
-use Bolt\Boltpay\Model\ErrorResponse as BoltErrorResponse;
-use Bolt\Boltpay\Helper\MetricsClient;
-use Bolt\Boltpay\Helper\FeatureSwitch\Decider as DeciderHelper;
-use Magento\Catalog\Model\Config\Source\Product\Thumbnail as ThumbnailSource;
-use Magento\Framework\Serialize\Serializer\Serialize as Serialize;
-use Bolt\Boltpay\Model\EventsForThirdPartyModules;
-use Magento\SalesRule\Model\RuleRepository;
+use Magento\Quote\Api\CartManagementInterface;
+use Magento\Quote\Api\CartRepositoryInterface as QuoteRepository;
+use Magento\Quote\Api\Data\CartInterface;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\Quote\Address as QuoteAddress;
+use Magento\Quote\Model\Quote\Address\Total as AddressTotal;
+use Magento\Quote\Model\Quote\TotalsCollector;
+use Magento\Quote\Model\QuoteFactory;
+use Magento\Quote\Model\ResourceModel\Quote as QuoteResource;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Api\OrderRepositoryInterface as OrderRepository;
+use Magento\Sales\Model\Order;
 use Magento\SalesRule\Api\Data\RuleInterface;
-use Magento\CatalogInventory\Api\StockStateInterface as StockState;
+use Magento\SalesRule\Model\RuleRepository;
+use Magento\Store\Model\App\Emulation;
+use Magento\Store\Model\ScopeInterface;
+use Zend_Http_Client_Exception;
 
 /**
  * Boltpay Cart helper
@@ -541,13 +540,18 @@ class Cart extends AbstractHelper
             return false;
         }
 
-        return $unserialize ? $this->serialize->unserialize($cached) : $cached;
+        try {
+            return $unserialize ? $this->serialize->unserialize($cached) : $cached;
+        } catch (\InvalidArgumentException $e) {
+            $this->bugsnag->notifyException($e);
+            return false;
+        }
     }
 
     /**
      * Save data to Magento cache
      *
-     * @param mixed $data
+     * @param array|object $data
      * @param string $identifier
      * @param int $lifeTime
      * @param bool $serialize
@@ -555,7 +559,9 @@ class Cart extends AbstractHelper
      */
     protected function saveToCache($data, $identifier, $tags = [], $lifeTime = null, $serialize = true)
     {
-        $data = $serialize ? $this->serialize->serialize($data) : $data;
+        if ($serialize) {
+            $data = $data instanceof \Magento\Framework\DataObject ? $data->toJson() : $this->serialize->serialize($data);
+        }
         $this->cache->save($data, $identifier, $tags, $lifeTime);
     }
 
@@ -877,8 +883,8 @@ class Cart extends AbstractHelper
 
             $cacheIdentifier = $this->getCartCacheIdentifier($cart);
 
-            if ($boltOrder = $this->loadFromCache($cacheIdentifier)) {
-
+            if ($boltOrderData = $this->loadFromCache($cacheIdentifier)) {
+                $boltOrder = new Response(['store_id' => $boltOrderData['store_id'], 'response'=>ArrayHelper::arrayToObject($boltOrderData['response'])]);
                 $immutableQuoteId = $this->getImmutableQuoteIdFromBoltOrder($boltOrder->getResponse());
 
                 // found in cache, check if the old immutable quote is still there

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -62,7 +62,7 @@ use Bolt\Boltpay\Model\ErrorResponse as BoltErrorResponse;
 use Bolt\Boltpay\Helper\MetricsClient;
 use Bolt\Boltpay\Helper\FeatureSwitch\Decider as DeciderHelper;
 use Magento\Catalog\Model\Config\Source\Product\Thumbnail as ThumbnailSource;
-use Zend\Serializer\Adapter\PhpSerialize as Serialize;
+use Magento\Framework\Serialize\Serializer\Serialize as Serialize;
 use Bolt\Boltpay\Model\EventsForThirdPartyModules;
 use Magento\SalesRule\Model\RuleRepository;
 use Magento\SalesRule\Api\Data\RuleInterface;

--- a/Helper/Session.php
+++ b/Helper/Session.php
@@ -30,7 +30,7 @@ use Magento\Framework\App\Area;
 use Magento\Framework\Data\Form\FormKey;
 use Bolt\Boltpay\Helper\Config as ConfigHelper;
 use Bolt\Boltpay\Model\EventsForThirdPartyModules;
-use Zend\Serializer\Adapter\PhpSerialize as Serialize;
+use Magento\Framework\Serialize\Serializer\Serialize as Serialize;
 
 /**
  * Boltpay Session helper

--- a/Helper/Session.php
+++ b/Helper/Session.php
@@ -30,7 +30,7 @@ use Magento\Framework\App\Area;
 use Magento\Framework\Data\Form\FormKey;
 use Bolt\Boltpay\Helper\Config as ConfigHelper;
 use Bolt\Boltpay\Model\EventsForThirdPartyModules;
-use Magento\Framework\Serialize\Serializer\Serialize as Serialize;
+use Magento\Framework\Serialize\SerializerInterface as Serialize;
 
 /**
  * Boltpay Session helper
@@ -207,7 +207,13 @@ class Session extends AbstractHelper
         }
         // @todo remove when update.cart hook starts supporting metadata
         elseif ($serialized = $this->cache->load($cacheIdentifier)) {
-            $sessionData = $this->serialize->unserialize($serialized);
+            try {
+                $sessionData = $this->serialize->unserialize($serialized);
+            } catch (\InvalidArgumentException $e) {
+                # temporary to ensure smooth transition to JSON
+                // phpcs:ignore Magento2.Security.InsecureFunction
+                $sessionData = unserialize($serialized);
+            }
             $sessionID = $sessionData["sessionID"];
             $storeId = $quote->getStoreId();
 

--- a/Helper/Session.php
+++ b/Helper/Session.php
@@ -207,17 +207,11 @@ class Session extends AbstractHelper
         }
         // @todo remove when update.cart hook starts supporting metadata
         elseif ($serialized = $this->cache->load($cacheIdentifier)) {
-            try {
-                $sessionData = $this->serialize->unserialize($serialized);
-            } catch (\InvalidArgumentException $e) {
-                # temporary to ensure smooth transition to JSON
-                // phpcs:ignore Magento2.Security.InsecureFunction
-                $sessionData = unserialize($serialized);
-            }
-            $sessionID = $sessionData["sessionID"];
+            $sessionData = $this->serialize->unserialize($serialized);
+            $sessionID = $sessionData['sessionID'];
             $storeId = $quote->getStoreId();
 
-            if ($sessionData["sessionType"] == "frontend") {
+            if ($sessionData['sessionType'] == 'frontend') {
                 // shipping and tax, orphaned transaction
                 // cart belongs to logged in customer?
                 $this->setSession($this->checkoutSession, $sessionID, $storeId);

--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -17,34 +17,34 @@
 
 namespace Bolt\Boltpay\Model\Api;
 
-use Bolt\Boltpay\Api\Data\ShippingOptionInterface;
-use Bolt\Boltpay\Api\Data\ShippingOptionInterfaceFactory;
 use Bolt\Boltpay\Api\Data\ShippingOptionsInterface;
+use Bolt\Boltpay\Api\ShippingMethodsInterface;
+use Bolt\Boltpay\Helper\Hook as HookHelper;
+use Bolt\Boltpay\Helper\Cart as CartHelper;
+use Magento\Directory\Model\Region as RegionModel;
+use Magento\Framework\Exception\LocalizedException;
 use Bolt\Boltpay\Api\Data\ShippingOptionsInterfaceFactory;
 use Bolt\Boltpay\Api\Data\ShippingTaxInterfaceFactory;
-use Bolt\Boltpay\Api\ShippingMethodsInterface;
-use Bolt\Boltpay\Exception\BoltException;
-use Bolt\Boltpay\Helper\Bugsnag;
-use Bolt\Boltpay\Helper\Cart as CartHelper;
-use Bolt\Boltpay\Helper\Config as ConfigHelper;
-use Bolt\Boltpay\Helper\Discount as DiscountHelper;
-use Bolt\Boltpay\Helper\Hook as HookHelper;
-use Bolt\Boltpay\Helper\Log as LogHelper;
-use Bolt\Boltpay\Helper\MetricsClient;
-use Bolt\Boltpay\Helper\Session as SessionHelper;
-use Bolt\Boltpay\Helper\Shared\CurrencyUtils;
-use Bolt\Boltpay\Model\ErrorResponse as BoltErrorResponse;
-use Bolt\Boltpay\Model\EventsForThirdPartyModules;
-use Magento\Directory\Model\Region as RegionModel;
-use Magento\Framework\App\CacheInterface;
-use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\Pricing\Helper\Data as PriceHelper;
-use Magento\Framework\Serialize\SerializerInterface as Serialize;
-use Magento\Framework\Webapi\Rest\Request;
-use Magento\Framework\Webapi\Rest\Response;
-use Magento\Quote\Model\Cart\ShippingMethodConverter;
 use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\Cart\ShippingMethodConverter;
+use Bolt\Boltpay\Api\Data\ShippingOptionInterface;
+use Bolt\Boltpay\Api\Data\ShippingOptionInterfaceFactory;
+use Bolt\Boltpay\Helper\Bugsnag;
+use Bolt\Boltpay\Helper\MetricsClient;
+use Bolt\Boltpay\Helper\Log as LogHelper;
+use Bolt\Boltpay\Helper\Shared\CurrencyUtils;
+use Magento\Framework\Webapi\Rest\Response;
+use Bolt\Boltpay\Helper\Config as ConfigHelper;
+use Magento\Framework\Webapi\Rest\Request;
+use Magento\Framework\App\CacheInterface;
+use Magento\Framework\Pricing\Helper\Data as PriceHelper;
+use Bolt\Boltpay\Model\ErrorResponse as BoltErrorResponse;
+use Bolt\Boltpay\Helper\Session as SessionHelper;
+use Bolt\Boltpay\Exception\BoltException;
+use Bolt\Boltpay\Helper\Discount as DiscountHelper;
 use Magento\SalesRule\Model\RuleFactory;
+use Magento\Framework\Serialize\SerializerInterface as Serialize;
+use Bolt\Boltpay\Model\EventsForThirdPartyModules;
 
 /**
  * Class ShippingMethods
@@ -597,6 +597,7 @@ class ShippingMethods implements ShippingMethodsInterface
                 $address->setShippingMethod(null)->save();
                 try {
                     $shippingOptionsData = $this->serialize->unserialize($serialized);
+                    //re-create the object expected as the return
                     return $this->shippingOptionsInterfaceFactory->create()
                         ->setShippingOptions(
                             array_map(

--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -43,7 +43,7 @@ use Bolt\Boltpay\Helper\Session as SessionHelper;
 use Bolt\Boltpay\Exception\BoltException;
 use Bolt\Boltpay\Helper\Discount as DiscountHelper;
 use Magento\SalesRule\Model\RuleFactory;
-use Zend\Serializer\Adapter\PhpSerialize as Serialize;
+use Magento\Framework\Serialize\Serializer\Serialize as Serialize;
 use Bolt\Boltpay\Model\EventsForThirdPartyModules;
 
 /**

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -87,7 +87,7 @@ use Bolt\Boltpay\Helper\FeatureSwitch\Decider as DeciderHelper;
 use Magento\Catalog\Model\Config\Source\Product\Thumbnail as ThumbnailSource;
 use Bolt\Boltpay\Test\Unit\TestUtils;
 use Magento\TestFramework\Helper\Bootstrap;
-use Zend\Serializer\Adapter\PhpSerialize as Serialize;
+use Magento\Framework\Serialize\Serializer\Serialize as Serialize;
 use Bolt\Boltpay\Model\EventsForThirdPartyModules;
 use Magento\SalesRule\Model\RuleRepository;
 use Bolt\Boltpay\Helper\FeatureSwitch\Definitions;
@@ -450,7 +450,7 @@ class CartTest extends BoltTestCase
         $this->customerMock = $this->createPartialMock(Customer::class, ['getEmail']);
         $this->coreRegistry = $this->createMock(Registry::class);
         $this->metricsClient = $this->createMock(MetricsClient::class);
-        $this->serialize = (new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this))->getObject(Serialize::class);
+        $this->serialize = (new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this))->getObject(\Magento\Framework\Serialize\Serializer\Serialize::class);
         $this->deciderHelper = $this->createPartialMock(
             DeciderHelper::class,
             ['ifShouldDisablePrefillAddressForLoggedInCustomer', 'handleVirtualProductsAsPhysical',

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -2451,6 +2451,7 @@ ORDER
         );
         $boltOrderResponse = new Response();
         $boltOrderResponse->setResponse($order);
+        $boltOrderResponse->setStoreId(1);
         return [$currentMock, $cart, $boltOrderResponse];
     }
 
@@ -2669,7 +2670,7 @@ ORDER
         ->with(self::STORE_ID)->willReturn(true);
         $currentMock->expects(static::once())->method('getCartCacheIdentifier')->willReturn(self::CACHE_IDENTIFIER);
         $currentMock->expects(static::once())->method('loadFromCache')->with(self::CACHE_IDENTIFIER)
-        ->willReturn($boltOrder);
+        ->willReturn($boltOrder->toArray());
         $currentMock->expects(static::once())->method('getImmutableQuoteIdFromBoltOrder')->with($boltOrder->getResponse())
         ->willReturn(self::IMMUTABLE_QUOTE_ID);
         $currentMock->expects(static::once())->method('isQuoteAvailable')->with(self::IMMUTABLE_QUOTE_ID)

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -87,7 +87,7 @@ use Bolt\Boltpay\Helper\FeatureSwitch\Decider as DeciderHelper;
 use Magento\Catalog\Model\Config\Source\Product\Thumbnail as ThumbnailSource;
 use Bolt\Boltpay\Test\Unit\TestUtils;
 use Magento\TestFramework\Helper\Bootstrap;
-use Magento\Framework\Serialize\Serializer\Serialize as Serialize;
+use Magento\Framework\Serialize\SerializerInterface as Serialize;
 use Bolt\Boltpay\Model\EventsForThirdPartyModules;
 use Magento\SalesRule\Model\RuleRepository;
 use Bolt\Boltpay\Helper\FeatureSwitch\Definitions;
@@ -450,7 +450,7 @@ class CartTest extends BoltTestCase
         $this->customerMock = $this->createPartialMock(Customer::class, ['getEmail']);
         $this->coreRegistry = $this->createMock(Registry::class);
         $this->metricsClient = $this->createMock(MetricsClient::class);
-        $this->serialize = (new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this))->getObject(\Magento\Framework\Serialize\Serializer\Serialize::class);
+        $this->serialize = (new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this))->getObject(\Magento\Framework\Serialize\Serializer\Json::class);
         $this->deciderHelper = $this->createPartialMock(
             DeciderHelper::class,
             ['ifShouldDisablePrefillAddressForLoggedInCustomer', 'handleVirtualProductsAsPhysical',

--- a/Test/Unit/Helper/SessionTest.php
+++ b/Test/Unit/Helper/SessionTest.php
@@ -106,8 +106,9 @@ class SessionTest extends BoltTestCase
                 'sessionType' => 'frontend',
                 'sessionID' => $this->checkoutSession->getSessionId()
             ],
-            unserialize(
-                TestHelper::getProperty($this->session, 'cache')->load(Session::BOLT_SESSION_PREFIX . self::QUOTE_ID)
+            json_decode(
+                TestHelper::getProperty($this->session, 'cache')->load(Session::BOLT_SESSION_PREFIX . self::QUOTE_ID),
+                true
             )
         );
     }

--- a/Test/Unit/Helper/SessionTest.php
+++ b/Test/Unit/Helper/SessionTest.php
@@ -184,7 +184,7 @@ class SessionTest extends BoltTestCase
             ['save', 'load']
         );
 
-        $cache->expects(self::once())->method('load')->willReturn('a:2:{s:11:"sessionType";s:8:"frontend";s:9:"sessionID";s:4:"1111";}');
+        $cache->expects(self::once())->method('load')->willReturn('{"sessionType":"frontend","sessionID":"1111"}');
         TestHelper::setProperty($this->session, 'appState', $appState);
         TestHelper::setInaccessibleProperty($this->session, 'cache', $cache);
         $result = $this->session->loadSession($quote);

--- a/Test/Unit/TestHelper.php
+++ b/Test/Unit/TestHelper.php
@@ -143,7 +143,7 @@ class TestHelper extends TestCase
     public static function serialize($class, $data)
     {
         return (new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($class))
-            ->getObject(\Magento\Framework\Serialize\Serializer\Serialize::class)->serialize($data);
+            ->getObject(\Magento\Framework\Serialize\Serializer\Json::class)->serialize($data);
     }
     
     /**

--- a/Test/Unit/TestHelper.php
+++ b/Test/Unit/TestHelper.php
@@ -143,7 +143,7 @@ class TestHelper extends TestCase
     public static function serialize($class, $data)
     {
         return (new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($class))
-            ->getObject(\Zend\Serializer\Adapter\PhpSerialize::class)->serialize($data);
+            ->getObject(\Magento\Framework\Serialize\Serializer\Serialize::class)->serialize($data);
     }
     
     /**

--- a/ThirdPartyModules/MageWorld/Affiliate.php
+++ b/ThirdPartyModules/MageWorld/Affiliate.php
@@ -19,7 +19,7 @@ namespace Bolt\Boltpay\ThirdPartyModules\MageWorld;
 
 use Bolt\Boltpay\Helper\Bugsnag;
 use Magento\Framework\App\CacheInterface;
-use Zend\Serializer\Adapter\PhpSerialize as Serialize;
+use Magento\Framework\Serialize\Serializer\Serialize as Serialize;
 use Bolt\Boltpay\Helper\Session as BoltSession;
 use Bolt\Boltpay\Helper\Cart as BoltCart;
 use Magento\Quote\Model\Quote;

--- a/ThirdPartyModules/MageWorld/Affiliate.php
+++ b/ThirdPartyModules/MageWorld/Affiliate.php
@@ -19,7 +19,7 @@ namespace Bolt\Boltpay\ThirdPartyModules\MageWorld;
 
 use Bolt\Boltpay\Helper\Bugsnag;
 use Magento\Framework\App\CacheInterface;
-use Magento\Framework\Serialize\Serializer\Serialize as Serialize;
+use Magento\Framework\Serialize\SerializerInterface as Serialize;
 use Bolt\Boltpay\Helper\Session as BoltSession;
 use Bolt\Boltpay\Helper\Cart as BoltCart;
 use Magento\Quote\Model\Quote;

--- a/ThirdPartyModules/Mageside/CustomShippingPrice.php
+++ b/ThirdPartyModules/Mageside/CustomShippingPrice.php
@@ -22,7 +22,7 @@ use Bolt\Boltpay\Helper\Session as BoltSession;
 use Magento\Backend\Model\Auth\Session as AuthSession;
 use Magento\User\Model\UserFactory;
 use Magento\Framework\App\CacheInterface;
-use Magento\Framework\Serialize\Serializer\Serialize as Serialize;
+use Magento\Framework\Serialize\SerializerInterface as Serialize;
 
 class CustomShippingPrice
 {

--- a/ThirdPartyModules/Mageside/CustomShippingPrice.php
+++ b/ThirdPartyModules/Mageside/CustomShippingPrice.php
@@ -22,7 +22,7 @@ use Bolt\Boltpay\Helper\Session as BoltSession;
 use Magento\Backend\Model\Auth\Session as AuthSession;
 use Magento\User\Model\UserFactory;
 use Magento\Framework\App\CacheInterface;
-use Zend\Serializer\Adapter\PhpSerialize as Serialize;
+use Magento\Framework\Serialize\Serializer\Serialize as Serialize;
 
 class CustomShippingPrice
 {


### PR DESCRIPTION
# Description
Externally reported issue
https://github.com/BoltApp/bolt-magento2/issues/1371

Hi,
We are upgrading our site from Magento 2.4.2-p1 to Magento 2.4.3. We are facing the issue while running the site and we got the below error.

Class Zend\Serializer\Adapter\PhpSerialize does not exist

Fixes: https://boltpay.atlassian.net/browse/M2P-666

#changelog Magento 2.4.3 support - replace Zend PhpSerialize with Magento Serializer Interface

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira ticket link and provided a changelog message.
