### PR TITLE
EN-5429 Bugfix: catalog price rule is not calculated for backoffice order

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -45,7 +45,6 @@ use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\DataObjectFactory;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
-use Magento\Framework\Registry;
 use Magento\Framework\Serialize\SerializerInterface as Serialize;
 use Magento\Framework\Session\SessionManagerInterface as CheckoutSession;
 use Magento\Framework\Webapi\Exception as WebapiException;
@@ -249,11 +248,6 @@ class Cart extends AbstractHelper
     private $quoteManagement;
 
     /**
-     * @var Registry
-     */
-    private $coreRegistry;
-
-    /**
      * @var MetricsClient
      */
     private $metricsClient;
@@ -299,7 +293,6 @@ class Cart extends AbstractHelper
      * @param CartManagementInterface    $quoteManagement
      * @param HookHelper                 $hookHelper
      * @param CustomerRepository         $customerRepository
-     * @param Registry                   $coreRegistry
      * @param MetricsClient              $metricsClient
      * @param DeciderHelper              $deciderHelper
      * @param Serialize                  $serialize
@@ -333,7 +326,6 @@ class Cart extends AbstractHelper
         CartManagementInterface $quoteManagement,
         HookHelper $hookHelper,
         CustomerRepository $customerRepository,
-        Registry $coreRegistry,
         MetricsClient $metricsClient,
         DeciderHelper $deciderHelper,
         Serialize $serialize,
@@ -366,7 +358,6 @@ class Cart extends AbstractHelper
         $this->quoteManagement = $quoteManagement;
         $this->hookHelper = $hookHelper;
         $this->customerRepository = $customerRepository;
-        $this->coreRegistry = $coreRegistry;
         $this->metricsClient = $metricsClient;
         $this->deciderHelper = $deciderHelper;
         $this->serialize = $serialize;
@@ -1863,25 +1854,6 @@ class Cart extends AbstractHelper
         }
 
         $this->setLastImmutableQuote($immutableQuote);
-        if ($this->isBackendSession()) {
-            /**
-             * initialize rule data for backend orders, consumed by
-             * @see \Magento\CatalogRule\Observer\ProcessAdminFinalPriceObserver::execute
-             */
-            $this->coreRegistry->unregister('rule_data');
-            $this->coreRegistry->register(
-                'rule_data',
-                new \Magento\Framework\DataObject(
-                    [
-                        'store_id'          => $this->checkoutSession->getStore()->getId(),
-                        'website_id'        => $this->checkoutSession->getStore()->getWebsiteId(),
-                        'customer_group_id' => $immutableQuote->getCustomerGroupId()
-                            ? $immutableQuote->getCustomerGroupId()
-                            : $this->checkoutSession->getCustomerGroupId()
-                    ]
-                )
-            );
-        }
 
         $immutableQuote->collectTotals();
 

--- a/Test/Unit/Controller/Adminhtml/Cart/DataTest.php
+++ b/Test/Unit/Controller/Adminhtml/Cart/DataTest.php
@@ -324,7 +324,7 @@ class DataTest extends BoltTestCase
         static::assertAttributeEquals($this->bugsnagHelperMock, 'bugsnag', $instance);
         static::assertAttributeEquals($this->metricsClientMock, 'metricsClient', $instance);
         static::assertAttributeEquals($this->dataObjectFactoryMock, 'dataObjectFactory', $instance);
-        static::assertAttributeEquals($this->coreRegistryMock, 'Registry', $instance);
+        static::assertAttributeEquals($this->coreRegistryMock, 'coreRegistry', $instance);
     }
 
     /**
@@ -341,7 +341,7 @@ class DataTest extends BoltTestCase
         $this->coreRegistryMock->expects(static::once())->method('unregister')->with('rule_data');
         $this->coreRegistryMock->expects(static::once())->method('register')->with(
             'rule_data',
-            new DataObject(
+            new \Magento\Framework\DataObject(
                 [
                 'store_id'          => self::STORE_ID,
                 'website_id'        => 1,
@@ -395,7 +395,7 @@ class DataTest extends BoltTestCase
         $this->coreRegistryMock->expects(static::once())->method('unregister')->with('rule_data');
         $this->coreRegistryMock->expects(static::once())->method('register')->with(
             'rule_data',
-            new DataObject(
+            new \Magento\Framework\DataObject(
                 [
                 'store_id'          => self::STORE_ID,
                 'website_id'        => 1,
@@ -441,7 +441,7 @@ class DataTest extends BoltTestCase
         $this->coreRegistryMock->expects(static::once())->method('unregister')->with('rule_data');
         $this->coreRegistryMock->expects(static::once())->method('register')->with(
             'rule_data',
-            new DataObject(
+            new \Magento\Framework\DataObject(
                 [
                 'store_id'          => self::STORE_ID,
                 'website_id'        => 1,
@@ -512,6 +512,7 @@ class DataTest extends BoltTestCase
     {
         $this->sessionMock->expects(static::once())->method('getStoreId')->willReturn(self::STORE_ID);
         $this->currentMock->expects(static::once())->method('_initSession');
+        $this->currentMock->expects(static::once())->method('_getSession')->willReturn($this->sessionMock);
         $this->cartHelperMock->expects(static::never())->method('getBoltpayOrder');
 
         $this->orderCreateModel->expects(static::once())->method('getQuote')->willReturn($this->quoteMock);

--- a/Test/Unit/Controller/Adminhtml/Cart/DataTest.php
+++ b/Test/Unit/Controller/Adminhtml/Cart/DataTest.php
@@ -246,7 +246,7 @@ class DataTest extends BoltTestCase
         $this->dataObjectFactoryMock = $this->createMock(DataObjectFactory::class);
         $this->sessionMock = $this->createPartialMock(
             \Magento\Backend\Model\Session\Quote::class,
-            ['getStoreId']
+            ['getStoreId', 'getStore']
         );
         $this->orderCreateModel = $this->getMockBuilder(
             \Magento\Sales\Model\AdminOrder\Create::class
@@ -472,10 +472,13 @@ class DataTest extends BoltTestCase
             ->getMock();
         $this->cartHelperMock->method('getBoltpayOrder')->willThrowException($exception);
         $currentMock->method('getRequest')->willReturn($this->request);
+        $storeMock = $this->createMock(\Magento\Store\Model\Store::class);
+        $storeMock->method('getWebsiteId')->willReturn(1);
+        $this->sessionMock->method('getStore')->willReturn($storeMock);
+        $this->sessionMock->expects(static::once())->method('getStoreId')->willReturn(self::STORE_ID);
         $currentMock->method('_getSession')->willReturn($this->sessionMock);
         $currentMock->method('_getOrderCreateModel')->willReturn($this->orderCreateModel);
         $this->orderCreateModel->method('getQuote')->willReturn($this->quoteMock);
-        $this->sessionMock->expects(static::once())->method('getStoreId')->willReturn(self::STORE_ID);
         $this->orderCreateModel->expects(static::once())->method('getBillingAddress')
             ->willReturn($this->quoteBillingAddressMock);
         $currentMock->execute();
@@ -518,6 +521,9 @@ class DataTest extends BoltTestCase
     {
         $this->sessionMock->expects(static::once())->method('getStoreId')->willReturn(self::STORE_ID);
         $this->currentMock->expects(static::once())->method('_initSession');
+        $storeMock = $this->createMock(\Magento\Store\Model\Store::class);
+        $storeMock->method('getWebsiteId')->willReturn(1);
+        $this->sessionMock->method('getStore')->willReturn($storeMock);
         $this->currentMock->expects(static::exactly(2))->method('_getSession')->willReturn($this->sessionMock);
         $this->cartHelperMock->expects(static::never())->method('getBoltpayOrder');
 

--- a/Test/Unit/Controller/Adminhtml/Cart/DataTest.php
+++ b/Test/Unit/Controller/Adminhtml/Cart/DataTest.php
@@ -545,7 +545,7 @@ class DataTest extends BoltTestCase
         $this->orderCreateModel->expects(static::once())->method('getQuote')->willReturn($this->quoteMock);
         $this->orderCreateModel->expects(static::never())->method('getBillingAddress')
             ->willReturn($this->quoteBillingAddressMock);
-
+        $this->quoteMock->expects(static::once())->method('getCustomerGroupId')->willReturn(1);
         $this->quoteMock->expects(static::once())->method('getCustomerId')->willReturn(null);
         $this->quoteMock->expects(static::once())->method('getCustomerEmail')->willReturn(self::CUSTOMER_EMAIL);
         $this->cartHelperMock->expects(static::once())->method('getCustomerByEmail')->with(self::CUSTOMER_EMAIL)

--- a/Test/Unit/Controller/Adminhtml/Cart/DataTest.php
+++ b/Test/Unit/Controller/Adminhtml/Cart/DataTest.php
@@ -236,6 +236,7 @@ class DataTest extends BoltTestCase
                 'getCustomerEmail',
                 'getCustomerId',
                 'setCustomerEmail',
+                'getCustomerGroupId',
             ]
         );
 
@@ -348,7 +349,7 @@ class DataTest extends BoltTestCase
                 [
                 'store_id'          => self::STORE_ID,
                 'website_id'        => 1,
-                'customer_group_id' => \Magento\Customer\Api\Data\GroupInterface::CUST_GROUP_ALL
+                'customer_group_id' => 1
                 ]
             )
         );
@@ -371,6 +372,7 @@ class DataTest extends BoltTestCase
         $currentMock->method('getRequest')->willReturn($this->request);
         $currentMock->method('_getSession')->willReturn($this->sessionMock);
         $currentMock->method('_getOrderCreateModel')->willReturn($this->orderCreateModel);
+        $this->quoteMock->expects(static::once())->method('getCustomerGroupId')->willReturn(1);
         $this->orderCreateModel->method('getQuote')->willReturn($this->quoteMock);
         $this->orderCreateModel->expects(static::once())->method('getBillingAddress')
             ->willReturn($this->quoteBillingAddressMock);
@@ -405,7 +407,7 @@ class DataTest extends BoltTestCase
                 [
                 'store_id'          => self::STORE_ID,
                 'website_id'        => 1,
-                'customer_group_id' => \Magento\Customer\Api\Data\GroupInterface::CUST_GROUP_ALL
+                'customer_group_id' => 1
                 ]
             )
         );
@@ -427,6 +429,7 @@ class DataTest extends BoltTestCase
         $currentMock->method('getRequest')->willReturn($this->request);
         $currentMock->method('_getSession')->willReturn($this->sessionMock);
         $currentMock->method('_getOrderCreateModel')->willReturn($this->orderCreateModel);
+        $this->quoteMock->expects(static::once())->method('getCustomerGroupId')->willReturn(1);
         $this->orderCreateModel->method('getQuote')->willReturn($this->quoteMock);
         $this->orderCreateModel->expects(static::once())->method('getBillingAddress')
             ->willReturn($this->quoteBillingAddressMock);
@@ -451,7 +454,7 @@ class DataTest extends BoltTestCase
                 [
                 'store_id'          => self::STORE_ID,
                 'website_id'        => 1,
-                'customer_group_id' => \Magento\Customer\Api\Data\GroupInterface::CUST_GROUP_ALL
+                'customer_group_id' => 1
                 ]
             )
         );
@@ -478,6 +481,7 @@ class DataTest extends BoltTestCase
         $this->sessionMock->expects(static::once())->method('getStoreId')->willReturn(self::STORE_ID);
         $currentMock->method('_getSession')->willReturn($this->sessionMock);
         $currentMock->method('_getOrderCreateModel')->willReturn($this->orderCreateModel);
+        $this->quoteMock->expects(static::once())->method('getCustomerGroupId')->willReturn(1);
         $this->orderCreateModel->method('getQuote')->willReturn($this->quoteMock);
         $this->orderCreateModel->expects(static::once())->method('getBillingAddress')
             ->willReturn($this->quoteBillingAddressMock);
@@ -525,6 +529,17 @@ class DataTest extends BoltTestCase
         $storeMock->method('getWebsiteId')->willReturn(1);
         $this->sessionMock->method('getStore')->willReturn($storeMock);
         $this->currentMock->expects(static::exactly(2))->method('_getSession')->willReturn($this->sessionMock);
+        $this->coreRegistryMock->expects(static::once())->method('unregister')->with('rule_data');
+        $this->coreRegistryMock->expects(static::once())->method('register')->with(
+            'rule_data',
+            new \Magento\Framework\DataObject(
+                [
+                'store_id'          => self::STORE_ID,
+                'website_id'        => 1,
+                'customer_group_id' => 1
+                ]
+            )
+        );
         $this->cartHelperMock->expects(static::never())->method('getBoltpayOrder');
 
         $this->orderCreateModel->expects(static::once())->method('getQuote')->willReturn($this->quoteMock);

--- a/Test/Unit/Controller/Adminhtml/Cart/DataTest.php
+++ b/Test/Unit/Controller/Adminhtml/Cart/DataTest.php
@@ -334,6 +334,9 @@ class DataTest extends BoltTestCase
      */
     public function execute_NoBoltpayOrder()
     {
+        $storeMock = $this->createMock(\Magento\Store\Model\Store::class);
+        $storeMock->method('getWebsiteId')->willReturn(1);
+        $this->sessionMock->method('getStore')->willReturn($storeMock);
         $this->sessionMock->method('getStoreId')->willReturn(self::STORE_ID);
         $this->cartHelperMock->method('getBoltpayOrder')->willReturn(null);
 
@@ -379,6 +382,9 @@ class DataTest extends BoltTestCase
      */
     public function execute_HappyPath()
     {
+        $storeMock = $this->createMock(\Magento\Store\Model\Store::class);
+        $storeMock->method('getWebsiteId')->willReturn(1);
+        $this->sessionMock->method('getStore')->willReturn($storeMock);
         $this->sessionMock->method('getStoreId')->willReturn(self::STORE_ID);
 
         $boltpayOrder = $this->getMockBuilder(Response::class)
@@ -512,7 +518,7 @@ class DataTest extends BoltTestCase
     {
         $this->sessionMock->expects(static::once())->method('getStoreId')->willReturn(self::STORE_ID);
         $this->currentMock->expects(static::once())->method('_initSession');
-        $this->currentMock->expects(static::once())->method('_getSession')->willReturn($this->sessionMock);
+        $this->currentMock->expects(static::exactly(2))->method('_getSession')->willReturn($this->sessionMock);
         $this->cartHelperMock->expects(static::never())->method('getBoltpayOrder');
 
         $this->orderCreateModel->expects(static::once())->method('getQuote')->willReturn($this->quoteMock);

--- a/Test/Unit/Controller/Adminhtml/Cart/DataTest.php
+++ b/Test/Unit/Controller/Adminhtml/Cart/DataTest.php
@@ -33,6 +33,7 @@ use Magento\Framework\DataObjectFactory;
 use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Magento\Framework\Escaper;
+use Magento\Framework\Registry;
 use Magento\Framework\View\Result\PageFactory;
 use Magento\Store\Model\StoreManagerInterface;
 
@@ -155,6 +156,11 @@ class DataTest extends BoltTestCase
      * @var Json|\PHPUnit\Framework\MockObject\MockObject
      */
     private $resultJsonMock;
+    
+    /**
+     * @var Registry|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $coreRegistryMock;
 
     protected function setUpInternal()
     {
@@ -253,7 +259,11 @@ class DataTest extends BoltTestCase
         $this->resultPageFactoryMock = $this->createMock(PageFactory::class);
         $this->resultForwardFactoryMock = $this->createMock(ForwardFactory::class);
         $this->storeManagerMock = $this->createMock(StoreManagerInterface::class);
-
+        $this->coreRegistryMock = $this->createMock(Registry::class);
+        $this->coreRegistryMock = $this->createPartialMock(
+            Registry::class,
+            ['unregister', 'register']
+        );
         $this->currentMock = $this->getMockBuilder(Data::class)
             ->setConstructorArgs(
                 [
@@ -264,6 +274,7 @@ class DataTest extends BoltTestCase
                     $this->bugsnagHelperMock,
                     $this->metricsClientMock,
                     $this->dataObjectFactoryMock,
+                    $this->coreRegistryMock,
                 ]
             )
             ->setMethods(['_getSession', '_initSession', '_getOrderCreateModel'])
@@ -303,7 +314,8 @@ class DataTest extends BoltTestCase
             $this->configHelperMock,
             $this->bugsnagHelperMock,
             $this->metricsClientMock,
-            $this->dataObjectFactoryMock
+            $this->dataObjectFactoryMock,
+            $this->coreRegistryMock
         );
 
         static::assertAttributeEquals($this->resultJsonFactory, 'resultJsonFactory', $instance);
@@ -312,6 +324,7 @@ class DataTest extends BoltTestCase
         static::assertAttributeEquals($this->bugsnagHelperMock, 'bugsnag', $instance);
         static::assertAttributeEquals($this->metricsClientMock, 'metricsClient', $instance);
         static::assertAttributeEquals($this->dataObjectFactoryMock, 'dataObjectFactory', $instance);
+        static::assertAttributeEquals($this->coreRegistryMock, 'Registry', $instance);
     }
 
     /**
@@ -325,7 +338,17 @@ class DataTest extends BoltTestCase
         $this->cartHelperMock->method('getBoltpayOrder')->willReturn(null);
 
         $resultJsonFactory = $this->buildJsonMocks($this->noTokenCartData);
-
+        $this->coreRegistryMock->expects(static::once())->method('unregister')->with('rule_data');
+        $this->coreRegistryMock->expects(static::once())->method('register')->with(
+            'rule_data',
+            new DataObject(
+                [
+                'store_id'          => self::STORE_ID,
+                'website_id'        => 1,
+                'customer_group_id' => \Magento\Customer\Api\Data\GroupInterface::CUST_GROUP_ALL
+                ]
+            )
+        );
         $currentMock = $this->getMockBuilder(Data::class)
             ->setMethods(['getRequest', '_getSession', '_initSession', '_getOrderCreateModel'])
             ->setConstructorArgs(
@@ -336,7 +359,8 @@ class DataTest extends BoltTestCase
                     $this->configHelperMock,
                     $this->bugsnagHelperMock,
                     $this->metricsClientMock,
-                    $this->dataObjectFactoryMock
+                    $this->dataObjectFactoryMock,
+                    $this->coreRegistryMock
                 ]
             )
             ->getMock();
@@ -368,7 +392,17 @@ class DataTest extends BoltTestCase
             ->willReturn($boltpayOrder);
 
         $resultJsonFactory = $this->buildJsonMocks($this->happyCartData);
-
+        $this->coreRegistryMock->expects(static::once())->method('unregister')->with('rule_data');
+        $this->coreRegistryMock->expects(static::once())->method('register')->with(
+            'rule_data',
+            new DataObject(
+                [
+                'store_id'          => self::STORE_ID,
+                'website_id'        => 1,
+                'customer_group_id' => \Magento\Customer\Api\Data\GroupInterface::CUST_GROUP_ALL
+                ]
+            )
+        );
         $currentMock = $this->getMockBuilder(Data::class)
             ->setMethods(['getRequest', '_getSession', '_initSession', '_getOrderCreateModel'])
             ->setConstructorArgs(
@@ -379,7 +413,8 @@ class DataTest extends BoltTestCase
                     $this->configHelperMock,
                     $this->bugsnagHelperMock,
                     $this->metricsClientMock,
-                    $this->dataObjectFactoryMock
+                    $this->dataObjectFactoryMock,
+                    $this->coreRegistryMock
                 ]
             )
             ->getMock();
@@ -403,7 +438,17 @@ class DataTest extends BoltTestCase
 
         $bugsnag = $this->createMock(Bugsnag::class);
         $bugsnag->expects(static::once())->method('notifyException')->with($exception);
-
+        $this->coreRegistryMock->expects(static::once())->method('unregister')->with('rule_data');
+        $this->coreRegistryMock->expects(static::once())->method('register')->with(
+            'rule_data',
+            new DataObject(
+                [
+                'store_id'          => self::STORE_ID,
+                'website_id'        => 1,
+                'customer_group_id' => \Magento\Customer\Api\Data\GroupInterface::CUST_GROUP_ALL
+                ]
+            )
+        );
         $currentMock = $this->getMockBuilder(Data::class)
             ->setMethods(['getRequest', '_getSession', '_initSession', '_getOrderCreateModel'])
             ->setConstructorArgs(
@@ -414,7 +459,8 @@ class DataTest extends BoltTestCase
                     $this->configHelperMock,
                     $bugsnag,
                     $this->metricsClientMock,
-                    $this->dataObjectFactoryMock
+                    $this->dataObjectFactoryMock,
+                    $this->coreRegistryMock
                 ]
             )
             ->getMock();

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -3132,7 +3132,7 @@ ORDER
     {
         $this->checkoutSession = $this->createPartialMock(
             \Magento\Backend\Model\Session\Quote::class,
-            ['getStore', 'getCustomerGroupId', 'getQuote', 'getOrderId']
+            ['getStore', 'getQuote', 'getOrderId']
         );
         $testItem = [
         'reference'    => self::PRODUCT_ID,
@@ -3179,16 +3179,12 @@ ORDER
         ->willReturn(self::IMMUTABLE_QUOTE_ID);
         $this->immutableQuoteMock->expects(static::atLeastOnce())->method('getQuoteCurrencyCode')
         ->willReturn(self::CURRENCY_CODE);
-        $this->immutableQuoteMock->expects(static::atLeastOnce())->method('getCustomerGroupId')
-        ->willReturn(null);
 
         $storeMock = $this->createMock(\Magento\Store\Model\Store::class);
         $storeMock->method('getId')->willReturn(self::STORE_ID);
         $storeMock->method('getWebsiteId')->willReturn(1);
 
         $this->checkoutSession->method('getStore')->willReturn($storeMock);
-        $this->checkoutSession->method('getCustomerGroupId')
-        ->willReturn(\Magento\Customer\Api\Data\GroupInterface::NOT_LOGGED_IN_ID);
         $this->deciderHelper->expects(self::once())->method('isAddSessionIdToCartMetadata')->willReturn(true);
         $currentMock->getCartData(
             true,
@@ -3223,7 +3219,7 @@ ORDER
     {
         $this->checkoutSession = $this->createPartialMock(
             \Magento\Backend\Model\Session\Quote::class,
-            ['getStore', 'getCustomerGroupId', 'getQuote', 'getOrderId']
+            ['getStore', 'getQuote', 'getOrderId']
         );
         $testItem = [
             'reference'    => self::PRODUCT_ID,
@@ -3270,17 +3266,12 @@ ORDER
             ->willReturn(self::IMMUTABLE_QUOTE_ID);
         $this->immutableQuoteMock->expects(static::atLeastOnce())->method('getQuoteCurrencyCode')
             ->willReturn(self::CURRENCY_CODE);
-        $this->immutableQuoteMock->expects(static::atLeastOnce())->method('getCustomerGroupId')
-            ->willReturn(null);
 
         $storeMock = $this->createMock(\Magento\Store\Model\Store::class);
         $storeMock->method('getId')->willReturn(self::STORE_ID);
         $storeMock->method('getWebsiteId')->willReturn(1);
 
         $this->checkoutSession->method('getStore')->willReturn($storeMock);
-        $this->checkoutSession->method('getCustomerGroupId')
-            ->willReturn(\Magento\Customer\Api\Data\GroupInterface::NOT_LOGGED_IN_ID);
-
         $this->checkoutSession->method('getOrderId')->willReturn(self::ORIGINAL_ORDER_ENTITY_ID);
         $this->deciderHelper->expects(self::once())->method('isAddSessionIdToCartMetadata')->willReturn(true);
         $result = $currentMock->getCartData(
@@ -3316,7 +3307,7 @@ ORDER
     {
         $this->checkoutSession = $this->createPartialMock(
             \Magento\Backend\Model\Session\Quote::class,
-            ['getStore', 'getCustomerGroupId', 'getQuote', 'getOrderId']
+            ['getStore', 'getQuote', 'getOrderId']
         );
         $testItem = [
         'reference'    => self::PRODUCT_ID,
@@ -3363,15 +3354,12 @@ ORDER
         ->willReturn(self::IMMUTABLE_QUOTE_ID);
         $this->immutableQuoteMock->expects(static::atLeastOnce())->method('getQuoteCurrencyCode')
         ->willReturn(self::CURRENCY_CODE);
-        $this->immutableQuoteMock->expects(static::exactly(2))->method('getCustomerGroupId')
-        ->willReturn(\Magento\Customer\Api\Data\GroupInterface::CUST_GROUP_ALL);
 
         $storeMock = $this->createMock(\Magento\Store\Model\Store::class);
         $storeMock->method('getId')->willReturn(self::STORE_ID);
         $storeMock->method('getWebsiteId')->willReturn(1);
 
         $this->checkoutSession->method('getStore')->willReturn($storeMock);
-        $this->checkoutSession->expects(static::never())->method('getCustomerGroupId');
         $this->deciderHelper->expects(self::once())->method('isAddSessionIdToCartMetadata')->willReturn(true);
         $currentMock->getCartData(
             true,

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -45,7 +45,6 @@ use Magento\Framework\ObjectManagerInterface;
 use Magento\Framework\Session\Generic as GenericSession;
 use Magento\Framework\Session\SessionManagerInterface;
 use Magento\Customer\Model\Address;
-use Magento\Framework\Registry;
 use Magento\Quote\Model\Quote;
 use Magento\Quote\Model\Quote\Item;
 use Magento\Sales\Model\Order;
@@ -289,11 +288,6 @@ class CartTest extends BoltTestCase
     private $giftwrapping;
 
     /**
-     * @var Registry|\PHPUnit\Framework\MockObject\MockObject
-     */
-    private $coreRegistry;
-
-    /**
      * @var MetricsClient
      */
     private $metricsClient;
@@ -448,7 +442,6 @@ class CartTest extends BoltTestCase
         $this->objectManagerMock = $this->getMockBuilder(ObjectManagerInterface::class)
             ->getMockForAbstractClass();
         $this->customerMock = $this->createPartialMock(Customer::class, ['getEmail']);
-        $this->coreRegistry = $this->createMock(Registry::class);
         $this->metricsClient = $this->createMock(MetricsClient::class);
         $this->serialize = (new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this))->getObject(\Magento\Framework\Serialize\Serializer\Json::class);
         $this->deciderHelper = $this->createPartialMock(
@@ -513,7 +506,6 @@ class CartTest extends BoltTestCase
                     $this->quoteManagement,
                     $this->hookHelper,
                     $this->customerRepository,
-                    $this->coreRegistry,
                     $this->metricsClient,
                     $this->deciderHelper,
                     $this->serialize,
@@ -719,7 +711,6 @@ class CartTest extends BoltTestCase
             $this->quoteManagement,
             $this->hookHelper,
             $this->customerRepository,
-            $this->coreRegistry,
             $this->metricsClient,
             $this->deciderHelper,
             $this->serialize,
@@ -791,7 +782,6 @@ class CartTest extends BoltTestCase
         static::assertAttributeInstanceOf(CartManagementInterface::class, 'quoteManagement', $instance);
         static::assertAttributeInstanceOf(HookHelper::class, 'hookHelper', $instance);
         static::assertAttributeInstanceOf(CustomerRepository::class, 'customerRepository', $instance);
-        static::assertAttributeInstanceOf(Registry::class, 'coreRegistry', $instance);
         static::assertAttributeInstanceOf(StockState::class, 'stockState', $instance);
     }
 
@@ -3199,17 +3189,6 @@ ORDER
         $this->checkoutSession->method('getStore')->willReturn($storeMock);
         $this->checkoutSession->method('getCustomerGroupId')
         ->willReturn(\Magento\Customer\Api\Data\GroupInterface::NOT_LOGGED_IN_ID);
-        $this->coreRegistry->expects(static::once())->method('unregister')->with('rule_data');
-        $this->coreRegistry->expects(static::once())->method('register')->with(
-            'rule_data',
-            new DataObject(
-                [
-                'store_id'          => self::STORE_ID,
-                'website_id'        => 1,
-                'customer_group_id' => \Magento\Customer\Api\Data\GroupInterface::NOT_LOGGED_IN_ID
-                ]
-            )
-        );
         $this->deciderHelper->expects(self::once())->method('isAddSessionIdToCartMetadata')->willReturn(true);
         $currentMock->getCartData(
             true,
@@ -3393,17 +3372,6 @@ ORDER
 
         $this->checkoutSession->method('getStore')->willReturn($storeMock);
         $this->checkoutSession->expects(static::never())->method('getCustomerGroupId');
-        $this->coreRegistry->expects(static::once())->method('unregister')->with('rule_data');
-        $this->coreRegistry->expects(static::once())->method('register')->with(
-            'rule_data',
-            new DataObject(
-                [
-                'store_id'          => self::STORE_ID,
-                'website_id'        => 1,
-                'customer_group_id' => \Magento\Customer\Api\Data\GroupInterface::CUST_GROUP_ALL
-                ]
-            )
-        );
         $this->deciderHelper->expects(self::once())->method('isAddSessionIdToCartMetadata')->willReturn(true);
         $currentMock->getCartData(
             true,


### PR DESCRIPTION
# Description

Actually this is a bug of M2 and it had been fixed from M2 v2.3.5 ([Related commit in M2 core](https://github.com/magento/magento2/commit/edfc05b0634f253c2cf12687d288ae8b1e62190c)).

To fix this bug in Bolt plugin, we need to register rule_data before saving quote or calculating quote totals.

This PR has been tested with M2 v2.2.9 v2.2.11 v2.3.3 v2.3.6 v2.4.2-p1

Fixes: https://boltpay.atlassian.net/browse/EN-5429

#changelog Bugfix: catalog price rule is not calculated for backoffice order

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
