### PR TITLE
M2P-683 Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Block\JsProductPageTest

### DIFF
--- a/Test/Unit/TestUtils.php
+++ b/Test/Unit/TestUtils.php
@@ -290,6 +290,88 @@ class TestUtils
         return $product;
     }
 
+
+    /**
+     * @return mixed
+     */
+    public static function createConfigurableProduct()
+    {
+        $product = Bootstrap::getObjectManager()->create(Product::class);
+        $product->setTypeId(\Magento\ConfigurableProduct\Model\Product\Type\Configurable::TYPE_CODE)
+            ->setAttributeSetId(4)
+            ->setWebsiteIds([1])
+            ->setName('Test Configurable Product')
+            ->setSku(md5(uniqid(rand(), true)))
+            ->setPrice(100)
+            ->setDescription('Product Description')
+            ->setMetaTitle('meta title')
+            ->setMetaKeyword('meta keyword')
+            ->setMetaDescription('meta description')
+            ->setVisibility(\Magento\Catalog\Model\Product\Visibility::VISIBILITY_BOTH)
+            ->setStatus(\Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_ENABLED)
+            ->setCategoryIds([2])
+            ->setStockData(['use_config_manage_stock' => 0])
+            ->setCanSaveCustomOptions(true)
+            ->setHasOptions(true)
+            ->setUrlKey('test-virtual-product-'.round(microtime(true) * 1000));
+        $product->save();
+        return $product;
+    }
+
+    /**
+     * @return mixed
+     */
+    public static function createDownloadableProduct()
+    {
+        $product = Bootstrap::getObjectManager()->create(Product::class);
+        $product->setTypeId(\Magento\Downloadable\Model\Product\Type::TYPE_DOWNLOADABLE)
+            ->setAttributeSetId(4)
+            ->setWebsiteIds([1])
+            ->setName('Test Downloadable Product')
+            ->setSku(md5(uniqid(rand(), true)))
+            ->setPrice(100)
+            ->setDescription('Product Description')
+            ->setMetaTitle('meta title')
+            ->setMetaKeyword('meta keyword')
+            ->setMetaDescription('meta description')
+            ->setVisibility(\Magento\Catalog\Model\Product\Visibility::VISIBILITY_BOTH)
+            ->setStatus(\Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_ENABLED)
+            ->setCategoryIds([2])
+            ->setStockData(['use_config_manage_stock' => 0])
+            ->setCanSaveCustomOptions(true)
+            ->setHasOptions(true)
+            ->setUrlKey('test-downloadable-product-'.round(microtime(true) * 1000));
+        $product->save();
+        return $product;
+    }
+
+    /**
+     * @return mixed
+     */
+    public static function createGroupProduct()
+    {
+        $product = Bootstrap::getObjectManager()->create(Product::class);
+        $product->setTypeId(\Magento\GroupedProduct\Model\Product\Type\Grouped::TYPE_CODE)
+            ->setAttributeSetId(4)
+            ->setWebsiteIds([1])
+            ->setName('Test Group Product')
+            ->setSku(md5(uniqid(rand(), true)))
+            ->setPrice(100)
+            ->setDescription('Product Description')
+            ->setMetaTitle('meta title')
+            ->setMetaKeyword('meta keyword')
+            ->setMetaDescription('meta description')
+            ->setVisibility(\Magento\Catalog\Model\Product\Visibility::VISIBILITY_BOTH)
+            ->setStatus(\Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_ENABLED)
+            ->setCategoryIds([2])
+            ->setStockData(['use_config_manage_stock' => 0])
+            ->setCanSaveCustomOptions(true)
+            ->setHasOptions(true)
+            ->setUrlKey('test-group-product-'.round(microtime(true) * 1000));
+        $product->save();
+        return $product;
+    }
+
     public static function setSecureAreaIfNeeded()
     {
         $registry = Bootstrap::getObjectManager()->get("\Magento\Framework\Registry");


### PR DESCRIPTION
# Description
Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Block\JsProductPageTest

Fixes: https://boltpay.atlassian.net/browse/M2P-683

#changelog M2P-683 Use integration test instead of unit test for all methods in class Bolt\Boltpay\Test\Unit\Block\JsProductPageTest

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
