### PR TITLE
M2P-687 Bugfix: the success page of backoffice order redirects to a 404 page

### DIFF
--- a/Controller/Adminhtml/Order/ReceivedUrl.php
+++ b/Controller/Adminhtml/Order/ReceivedUrl.php
@@ -89,8 +89,12 @@ class ReceivedUrl extends Action
             'order_id' => $order->getId(),
             'store_id' => $storeId
         ];
-        // Set admin scope
-        $this->_backendUrl->setScope(0);
+        // If "Add Store Code to Urls" is disabled in configuration,
+        // force to set scope entity for retrieving redirect Url.
+        if (!$order->getStore()->isUseStoreInUrl()) {
+            // Set admin scope
+            $this->_backendUrl->setScope(0);
+        }
 
         return $this->_backendUrl->getUrl('sales/order/view', $params);
     }


### PR DESCRIPTION
# Description
If the M2 configuration field "Add Store Code to Urls" is set to Yes, a store code of default website would be added to the Url of success page which leads to a 404 page.  So if "Add Store Code to Urls" is enabled in configuration, we do not need to set scope entity for retrieving redirect Url.

Fixes: https://boltpay.atlassian.net/browse/M2P-687

#changelog Bugfix: the success page of backoffice order redirects to a 404 page

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
