### PR TITLE
M2P-688 Not using the cart cache if order reference is associated with an existing order

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -2517,7 +2517,9 @@ class Cart extends AbstractHelper
             // Therefore, we can rely on it in generating the cache identifier.
             $cacheIdentifier = $this->getCartCacheIdentifier($request);
             if ($cart = $this->loadFromCache($cacheIdentifier)) {
-                return $cart;
+                if (!$this->getOrderByQuoteId($cart['order_reference'])) {
+                    return $cart;
+                }
             }
         }
 

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -5592,10 +5592,12 @@ ORDER
             ],
         ];
         $currentMock = $this->getCurrentMock(
-            ['createCart', 'isBoltOrderCachingEnabled', 'getCartCacheIdentifier', 'loadFromCache']
+            ['createCart', 'isBoltOrderCachingEnabled', 'getCartCacheIdentifier', 'loadFromCache','getOrderByQuoteId']
         );
         $currentMock->expects(static::once())->method('isBoltOrderCachingEnabled')->with(self::STORE_ID)
             ->willReturn(true);
+        $currentMock->expects(static::once())->method('getOrderByQuoteId')
+            ->willReturn(false);
         $currentMock->expects(static::once())->method('getCartCacheIdentifier')->with($request)
             ->willReturn(self::CACHE_IDENTIFIER);
         $currentMock->expects(static::once())->method('loadFromCache')->with(self::CACHE_IDENTIFIER)


### PR DESCRIPTION
# Description

Currently, there is an error when placing the same single cart order twice in a row in the product page checkout. 
So this PR resolves the issue by not using cart cache if the cart’s order reference is associated with an existing order
See here: https://prnt.sc/1rpwy8b

Fixes: https://boltpay.atlassian.net/browse/M2P-688

#changelog

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
