### PR TITLE
M2P-694 Add support for MageWorx_ShippingRules

### DIFF
--- a/Controller/Adminhtml/Cart/Data.php
+++ b/Controller/Adminhtml/Cart/Data.php
@@ -33,6 +33,7 @@ use Magento\Framework\Registry;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\View\Result\PageFactory;
 use Magento\Store\Model\StoreManagerInterface;
+use Bolt\Boltpay\Model\EventsForThirdPartyModules;
 
 /**
  * Class Data.
@@ -81,6 +82,11 @@ class Data extends \Magento\Sales\Controller\Adminhtml\Order\Create
     private $storeManager;
     
     /**
+     * @var EventsForThirdPartyModules
+     */
+    private $eventsForThirdPartyModules;
+    
+    /**
      * Core registry
      *
      * @var Registry
@@ -96,6 +102,7 @@ class Data extends \Magento\Sales\Controller\Adminhtml\Order\Create
      * @param MetricsClient              $metricsClient
      * @param DataObjectFactory          $dataObjectFactory
      * @param Registry                   $coreRegistry
+     * @param EventsForThirdPartyModules $eventsForThirdPartyModules
      * @param Product|null               $productHelper
      * @param Escaper|null               $escaper
      * @param PageFactory|null           $resultPageFactory
@@ -111,6 +118,7 @@ class Data extends \Magento\Sales\Controller\Adminhtml\Order\Create
         MetricsClient $metricsClient,
         DataObjectFactory $dataObjectFactory,
         Registry $coreRegistry,
+        EventsForThirdPartyModules $eventsForThirdPartyModules,
         Product $productHelper = null,
         Escaper $escaper = null,
         PageFactory $resultPageFactory = null,
@@ -132,6 +140,7 @@ class Data extends \Magento\Sales\Controller\Adminhtml\Order\Create
         $this->dataObjectFactory = $dataObjectFactory;
         $this->coreRegistry = $coreRegistry;
         $this->storeManager = $storeManager ?: ObjectManager::getInstance()->get(StoreManagerInterface::class);
+        $this->eventsForThirdPartyModules = $eventsForThirdPartyModules;
     }
 
     /**
@@ -186,6 +195,7 @@ class Data extends \Magento\Sales\Controller\Adminhtml\Order\Create
                 $this->_getOrderCreateModel()->saveQuote();
             }
 
+            $this->eventsForThirdPartyModules->dispatchEvent("beforeGetBoltpayOrderForBackofficeOrder", $this);
             // call the Bolt API
             $boltpayOrder = $this->cartHelper->getBoltpayOrder(true);
             // If empty cart - order_token not fetched because doesn't exist. Not a failure.

--- a/Model/EventsForThirdPartyModules.php
+++ b/Model/EventsForThirdPartyModules.php
@@ -49,6 +49,7 @@ use Bolt\Boltpay\Helper\Bugsnag;
 use Bolt\Boltpay\ThirdPartyModules\ImaginationMedia\TmwGiftCard as ImaginationMedia_TmwGiftCard;
 use Bolt\Boltpay\ThirdPartyModules\Amasty\Preorder as Amasty_Preorder;
 use Bolt\Boltpay\ThirdPartyModules\MageWorx\RewardPoints as MageWorx_RewardPoints;
+use Bolt\Boltpay\ThirdPartyModules\MageWorx\ShippingRules as MageWorx_ShippingRules;
 use Exception;
 
 class EventsForThirdPartyModules
@@ -403,6 +404,15 @@ class EventsForThirdPartyModules
                     'sendClasses' => ['Route\Route\Model\Route\Merchant',
                                       'Route\Route\Helper\Data'],
                     'boltClass'   => Route_Route::class,
+                ],
+            ],
+        ],
+        'beforeGetBoltpayOrderForBackofficeOrder' => [
+            "listeners" => [
+                'MageWorx_ShippingRules' => [
+                    "module" => "MageWorx_ShippingRules",
+                    'checkClasses' => ['MageWorx\ShippingRules\Model\Plugin\Shipping\Rate\Result\Append'],
+                    "boltClass" => MageWorx_ShippingRules::class,
                 ],
             ],
         ],

--- a/Test/Unit/Controller/Adminhtml/Cart/DataTest.php
+++ b/Test/Unit/Controller/Adminhtml/Cart/DataTest.php
@@ -36,6 +36,7 @@ use Magento\Framework\Escaper;
 use Magento\Framework\Registry;
 use Magento\Framework\View\Result\PageFactory;
 use Magento\Store\Model\StoreManagerInterface;
+use Bolt\Boltpay\Model\EventsForThirdPartyModules;
 
 /**
  * Class DataTest
@@ -161,6 +162,11 @@ class DataTest extends BoltTestCase
      * @var Registry|\PHPUnit\Framework\MockObject\MockObject
      */
     private $coreRegistryMock;
+    
+    /**
+     * @var EventsForThirdPartyModules|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $eventsForThirdPartyModulesMock;
 
     protected function setUpInternal()
     {
@@ -265,6 +271,8 @@ class DataTest extends BoltTestCase
             Registry::class,
             ['unregister', 'register']
         );
+        $this->eventsForThirdPartyModulesMock = $this->createPartialMock(EventsForThirdPartyModules::class, ['dispatchEvent']);
+        $this->eventsForThirdPartyModulesMock->method('dispatchEvent')->willReturnSelf();
         $this->currentMock = $this->getMockBuilder(Data::class)
             ->setConstructorArgs(
                 [
@@ -276,6 +284,7 @@ class DataTest extends BoltTestCase
                     $this->metricsClientMock,
                     $this->dataObjectFactoryMock,
                     $this->coreRegistryMock,
+                    $this->eventsForThirdPartyModulesMock
                 ]
             )
             ->setMethods(['_getSession', '_initSession', '_getOrderCreateModel'])
@@ -316,7 +325,8 @@ class DataTest extends BoltTestCase
             $this->bugsnagHelperMock,
             $this->metricsClientMock,
             $this->dataObjectFactoryMock,
-            $this->coreRegistryMock
+            $this->coreRegistryMock,
+            $this->eventsForThirdPartyModulesMock
         );
 
         static::assertAttributeEquals($this->resultJsonFactory, 'resultJsonFactory', $instance);
@@ -326,6 +336,7 @@ class DataTest extends BoltTestCase
         static::assertAttributeEquals($this->metricsClientMock, 'metricsClient', $instance);
         static::assertAttributeEquals($this->dataObjectFactoryMock, 'dataObjectFactory', $instance);
         static::assertAttributeEquals($this->coreRegistryMock, 'coreRegistry', $instance);
+        static::assertAttributeEquals($this->eventsForThirdPartyModulesMock, 'eventsForThirdPartyModules', $instance);
     }
 
     /**
@@ -364,7 +375,8 @@ class DataTest extends BoltTestCase
                     $this->bugsnagHelperMock,
                     $this->metricsClientMock,
                     $this->dataObjectFactoryMock,
-                    $this->coreRegistryMock
+                    $this->coreRegistryMock,
+                    $this->eventsForThirdPartyModulesMock
                 ]
             )
             ->getMock();
@@ -422,7 +434,8 @@ class DataTest extends BoltTestCase
                     $this->bugsnagHelperMock,
                     $this->metricsClientMock,
                     $this->dataObjectFactoryMock,
-                    $this->coreRegistryMock
+                    $this->coreRegistryMock,
+                    $this->eventsForThirdPartyModulesMock
                 ]
             )
             ->getMock();
@@ -469,7 +482,8 @@ class DataTest extends BoltTestCase
                     $bugsnag,
                     $this->metricsClientMock,
                     $this->dataObjectFactoryMock,
-                    $this->coreRegistryMock
+                    $this->coreRegistryMock,
+                    $this->eventsForThirdPartyModulesMock
                 ]
             )
             ->getMock();

--- a/ThirdPartyModules/MageWorx/ShippingRules.php
+++ b/ThirdPartyModules/MageWorx/ShippingRules.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\ThirdPartyModules\MageWorx;
+
+use Bolt\Boltpay\Helper\Bugsnag;
+use Bolt\Boltpay\Helper\Config;
+use Bolt\Boltpay\Helper\Discount;
+use Bolt\Boltpay\Helper\Shared\CurrencyUtils;
+use Magento\Customer\Model\Session as CustomerSession;
+use Magento\Quote\Model\Quote;
+
+class ShippingRules
+{    
+    /**
+     * To setup customer group id for applying MageWorx shipping rules.
+     *
+     * @return void
+     */
+    public function beforeGetBoltpayOrderForBackofficeOrder($createAction)
+    {
+        // Before applying the valid rules, MageWorx_ShippingRules would fetch customer group id,
+        // if param collect_shipping_rates exists in the request, it gets customer group id from quote,
+        // if not, it gets customer group id from customer session.
+        // For Bolt backoffice order, only the quote has proper customer group id.
+        $createAction->getRequest()->setParam('collect_shipping_rates', '1');
+    }
+}


### PR DESCRIPTION
# Description
When creating backoffice order, the MageWorx Shipping Rules is not applied to shipping rate and result in a shipping total mismatch error.

Root cause : Before applying the valid rules, MageWorx_ShippingRules would fetch customer group id, if param collect_shipping_rates exists in the request, it gets customer group id from quote, if not, it gets customer group id from customer session instead. For Bolt backoffice order, only the quote has proper customer group id, so we need to set param collect_shipping_rates exists.

Fixes: https://boltpay.atlassian.net/browse/M2P-694

#changelog Add support for MageWorx_ShippingRules

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
