### PR TITLE
M2P-691 Create setting to show/hide Bolt checkout button on cart page

### DIFF
--- a/Block/Js.php
+++ b/Block/Js.php
@@ -209,6 +209,11 @@ class Js extends Template
      */
     public function getGlobalCSS()
     {
+        if ($this->isBoltOnCartDisabled()) {
+            // If Bolt is disabled on the cart page,
+            // we need to override the global css style to show M2 native checkout button
+            return $this->configHelper->getGlobalCSS() . 'button[data-role=proceed-to-checkout]{display:block!important;}';
+        }
         return $this->configHelper->getGlobalCSS();
     }
     
@@ -640,6 +645,21 @@ function($argName) {
     public function isLoggedIn(): bool
     {
         return $this->httpContext->getValue(\Magento\Customer\Model\Context::CONTEXT_AUTH);
+    }
+    
+    /**
+     * Returns configuration value for Bolt Order Caching
+     *
+     * @see \Bolt\Boltpay\Helper\Config::isBoltOrderCachingEnabled
+     *
+     * @param null $storeId
+     *
+     * @return bool
+     */
+    public function isBoltOnCartDisabled()
+    {
+        $storeId = $this->getStoreId();
+        return $this->isOnCartPage() && !$this->configHelper->getBoltOnCartPage($storeId);
     }
 
     /**

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -1827,6 +1827,10 @@ class Config extends AbstractHelper
         $boltSettings[] = $this->boltConfigSettingFactory->create()
             ->setName('minicart_support')
             ->setValue(var_export($this->getMinicartSupport(), true));
+        // Display Bolt Checkout on the Cart Page configuration path
+        $boltSettings[] = $this->boltConfigSettingFactory->create()
+            ->setName('enable_bolt_on_cart_page')
+            ->setValue(var_export($this->getBoltOnCartPage(), true));    
         // Client IP Restriction
         $boltSettings[] = $this->boltConfigSettingFactory->create()
             ->setName('ip_whitelist')

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -295,6 +295,11 @@ class Config extends AbstractHelper
      * MiniCart Support configuration path
      */
     const XML_PATH_MINICART_SUPPORT = 'payment/boltpay/minicart_support';
+    
+    /**
+     * Display Bolt Checkout on the Cart Page configuration path
+     */
+    const XML_PATH_BOLT_ON_CART_PAGE = 'payment/boltpay/enable_bolt_on_cart_page';
 
     /**
      * Client IP Whitelist configuration path
@@ -442,6 +447,7 @@ class Config extends AbstractHelper
         'track_on_close'                     => self::XML_PATH_TRACK_CLOSE,
         'additional_config'                  => self::XML_PATH_ADDITIONAL_CONFIG,
         'minicart_support'                   => self::XML_PATH_MINICART_SUPPORT,
+        'enable_bolt_on_cart_page'           => self::XML_PATH_BOLT_ON_CART_PAGE,
         'ip_whitelist'                       => self::XML_PATH_IP_WHITELIST,
         'store_credit'                       => self::XML_PATH_STORE_CREDIT,
         'reward_points'                      => self::XML_PATH_REWARD_POINTS,
@@ -1317,6 +1323,22 @@ class Config extends AbstractHelper
     {
         return $this->getScopeConfig()->isSetFlag(
             self::XML_PATH_MINICART_SUPPORT,
+            ScopeInterface::SCOPE_STORE,
+            $store
+        );
+    }
+    
+    /**
+     * Get Display Bolt Checkout on the Cart Page config
+     *
+     * @param int|string|Store $store
+     *
+     * @return boolean
+     */
+    public function getBoltOnCartPage($store = null)
+    {
+        return $this->getScopeConfig()->isSetFlag(
+            self::XML_PATH_BOLT_ON_CART_PAGE,
             ScopeInterface::SCOPE_STORE,
             $store
         );

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -615,7 +615,7 @@ class JsTest extends BoltTestCase
             color: red;
         }button[data-role=proceed-to-checkout]{display:block!important;}';
 
-        static::assertEquals($value, $result, 'getGlobalCSS() method: not working properly');
+        static::assertEquals($expectedResult, $result, 'getGlobalCSS() method: not working properly');
     }
     
     /**

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -2176,7 +2176,7 @@ function(arg) {
             'getAdditionalCheckoutButtonAttributes',
             'isBoltOrderCachingEnabled',
             'isBoltSSOEnabled',
-            'isBoltOnCartDisabled',
+            'getBoltOnCartPage',
         ];
 
         $this->configHelper = $this->getMockBuilder(HelperConfig::class)

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -591,7 +591,7 @@ class JsTest extends BoltTestCase
     {
         $value = '.replaceable-example-selector1 {
             color: red;
-        }button[data-role=proceed-to-checkout]{display:block!important;}';
+        }';
 
         $this->currentMock->expects(static::once())
                           ->method('getRequest')
@@ -610,6 +610,10 @@ class JsTest extends BoltTestCase
             ->willReturn($value);
 
         $result = $this->currentMock->getGlobalCSS();
+        
+        $expectedResult = '.replaceable-example-selector1 {
+            color: red;
+        }button[data-role=proceed-to-checkout]{display:block!important;}';
 
         static::assertEquals($value, $result, 'getGlobalCSS() method: not working properly');
     }
@@ -2596,7 +2600,8 @@ function(arg) {
         $this->currentMock->expects(static::once())
                           ->method('getFullActionName')
                           ->willReturn($fullActionName);
-        $this->configHelper->expects(static::once())
+        $this->configHelper->expects(($fullActionName == 'checkout_cart_index')
+                                    ? static::once() : static::never())
                            ->method('getBoltOnCartPage')
                            ->with(self::STORE_ID)
                            ->willReturn($getBoltOnCartPage);

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -561,10 +561,8 @@ class JsTest extends BoltTestCase
         $value = '.replaceable-example-selector1 {
             color: red;
         }';
-
-        $this->configHelper->expects(static::once())
-            ->method('isBoltOnCartDisabled')
-            ->willReturn(false);
+        
+        $this->requestMock->method('getFullActionName')->willReturn('catalog_product_view');
             
         $this->configHelper->expects(static::once())
             ->method('getGlobalCSS')
@@ -589,9 +587,11 @@ class JsTest extends BoltTestCase
             color: red;
         }button[data-role=proceed-to-checkout]{display:block!important;}';
 
+        $this->requestMock->method('getFullActionName')->willReturn('checkout_cart_index');
+        
         $this->configHelper->expects(static::once())
-            ->method('isBoltOnCartDisabled')
-            ->willReturn(true);
+            ->method('getBoltOnCartPage')
+            ->willReturn(false);
             
         $this->configHelper->expects(static::once())
             ->method('getGlobalCSS')

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -562,7 +562,13 @@ class JsTest extends BoltTestCase
             color: red;
         }';
         
-        $this->requestMock->method('getFullActionName')->willReturn('catalog_product_view');
+        $this->currentMock->expects(static::once())
+                          ->method('getRequest')
+                          ->willReturnSelf();
+                          
+        $this->currentMock->expects(static::once())
+                          ->method('getFullActionName')
+                          ->willReturn('catalog_product_view');
             
         $this->configHelper->expects(static::once())
             ->method('getGlobalCSS')
@@ -587,7 +593,13 @@ class JsTest extends BoltTestCase
             color: red;
         }button[data-role=proceed-to-checkout]{display:block!important;}';
 
-        $this->requestMock->method('getFullActionName')->willReturn('checkout_cart_index');
+        $this->currentMock->expects(static::once())
+                          ->method('getRequest')
+                          ->willReturnSelf();
+                          
+        $this->currentMock->expects(static::once())
+                          ->method('getFullActionName')
+                          ->willReturn('checkout_cart_index');
         
         $this->configHelper->expects(static::once())
             ->method('getBoltOnCartPage')
@@ -2571,14 +2583,24 @@ function(arg) {
      *
      * @covers ::isBoltOnCartDisabled
      *
-     * @param bool $isBoltOnCartEnabled
-     * @param bool $isOnCartPage
+     * @param bool $getBoltOnCartPage
+     * @param bool $fullActionName
      * @param bool $expectedResult
      */
-    public function isBoltOnCartDisabled_withVariousConfigs_returnsCorrectResult($isBoltOnCartEnabled, $isOnCartPage, $expectedResult)
+    public function isBoltOnCartDisabled_withVariousConfigs_returnsCorrectResult($getBoltOnCartPage, $fullActionName, $expectedResult)
     {
-        $this->configHelper->expects(static::once())->method('getBoltOnCartPage')->with(self::STORE_ID)->willReturn(true);
-        static::assertTrue($this->currentMock->isBoltOrderCachingEnabled(self::STORE_ID));
+        $this->currentMock->expects(static::once())->method('getStoreId')->willReturn(self::STORE_ID);
+        $this->currentMock->expects(static::once())
+                          ->method('getRequest')
+                          ->willReturnSelf();
+        $this->currentMock->expects(static::once())
+                          ->method('getFullActionName')
+                          ->willReturn($fullActionName);
+        $this->configHelper->expects(static::once())
+                           ->method('getBoltOnCartPage')
+                           ->with(self::STORE_ID)
+                           ->willReturn($getBoltOnCartPage);
+        static::assertEquals($expectedResult, $this->currentMock->isBoltOnCartDisabled());
     }
     
     /**
@@ -2592,24 +2614,24 @@ function(arg) {
     {
         return [
             [
-                'isBoltOnCartEnabled' => true,
-                'isOnCartPage'        => true,
-                'expectedResult'      => false
+                'getBoltOnCartPage' => true,
+                'fullActionName'    => 'checkout_cart_index',
+                'expectedResult'    => false
             ],
             [
-                'isBoltOnCartEnabled' => true,
-                'isOnCartPage'        => false,
-                'expectedResult'      => false
+                'getBoltOnCartPage' => true,
+                'fullActionName'    => 'catalog_product_view',
+                'expectedResult'    => false
             ],
             [
-                'isBoltOnCartEnabled' => false,
-                'isOnCartPage'        => true,
-                'expectedResult'      => true
+                'getBoltOnCartPage' => false,
+                'fullActionName'    => 'checkout_cart_index',
+                'expectedResult'    => true
             ],
             [
-                'isBoltOnCartEnabled' => false,
-                'isOnCartPage'        => false,
-                'expectedResult'      => false
+                'getBoltOnCartPage' => false,
+                'fullActionName'    => 'catalog_product_view',
+                'expectedResult'    => false
             ],
         ];
     }

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -332,6 +332,7 @@ JSON;
             ['shouldTrackCheckoutFunnel', BoltConfig::XML_PATH_TRACK_CHECKOUT_FUNNEL, false],
             ['getIsPreAuth', BoltConfig::XML_PATH_IS_PRE_AUTH],
             ['getMinicartSupport', BoltConfig::XML_PATH_MINICART_SUPPORT, false],
+            ['getBoltOnCartPage', BoltConfig::XML_PATH_BOLT_ON_CART_PAGE, false],
             ['useStoreCreditConfig', BoltConfig::XML_PATH_STORE_CREDIT],
             ['useAmastyStoreCreditConfig', BoltConfig::XML_PATH_AMASTY_STORE_CREDIT],
             ['useRewardPointsConfig', BoltConfig::XML_PATH_REWARD_POINTS, false],

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -80,6 +80,12 @@
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <comment>Display Bolt Checkout in the Native Checkout Page</comment>
                     </field>
+                    <field id="enable_bolt_on_cart_page" translate="label" type="select" sortOrder="260" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Cart Page</label>
+                        <config_path>payment/boltpay/enable_bolt_on_cart_page</config_path>
+                        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                        <comment>Display Bolt Checkout on the Cart Page</comment>
+                    </field>
                 </group>
                 <group id="additional" translate="label" type="text" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Additional options</label>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -60,6 +60,7 @@ tr.shipping.totals td.amount span.price,
                 <prefetch_shipping>0</prefetch_shipping>
                 <reset_shipping_calculation>0</reset_shipping_calculation>
                 <minicart_support>1</minicart_support>
+                <enable_bolt_on_cart_page>1</enable_bolt_on_cart_page>
                 <store_credit>0</store_credit>
                 <amasty_store_credit>0</amasty_store_credit>
                 <reward_points>0</reward_points>

--- a/view/frontend/templates/button.phtml
+++ b/view/frontend/templates/button.phtml
@@ -20,7 +20,7 @@
  *
  * @var $block \Bolt\Boltpay\Block\Js
  */
-if ($block->shouldDisableBoltCheckout()) { return;
+if ($block->shouldDisableBoltCheckout() || $block->isBoltOnCartDisabled()) { return;
 }
 $checkoutButtonUrl = $block->getCheckoutCdnUrl(). '/v1/checkout_button?publishable_key='. $block->getCheckoutKey();
 $additionalCheckoutButtonClass = $block->getAdditionalCheckoutButtonClass();

--- a/view/frontend/templates/button.phtml
+++ b/view/frontend/templates/button.phtml
@@ -20,8 +20,13 @@
  *
  * @var $block \Bolt\Boltpay\Block\Js
  */
-if ($block->shouldDisableBoltCheckout() || $block->isBoltOnCartDisabled()) { return;
+if ($block->shouldDisableBoltCheckout()) { return;
 }
+
+// If Bolt checkout is disabled on the cart page
+if ($block->isBoltOnCartDisabled()) { return;
+}
+
 $checkoutButtonUrl = $block->getCheckoutCdnUrl(). '/v1/checkout_button?publishable_key='. $block->getCheckoutKey();
 $additionalCheckoutButtonClass = $block->getAdditionalCheckoutButtonClass();
 $additionalCheckoutButtonAttributes = '';

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -25,6 +25,10 @@
 if ($block->shouldDisableBoltCheckout()) { return;
 }
 
+// If Bolt checkout is disabled on the cart page
+if ($block->isBoltOnCartDisabled()) { return;
+}
+
 //we need this script only for cart page, checkout page and other pages from white list
 //and for minicart is enabled
 //product page checkout has its own JS script


### PR DESCRIPTION
# Description
To create setting to show/hide Bolt checkout button on cart page.

The Bolt connect.js and track.js would be still loaded on the cart page with/without Bolt checkout button.

Fixes: https://boltpay.atlassian.net/browse/M2P-691

#changelog Create setting to show/hide Bolt checkout button on cart page

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
