### PR TITLE
M2P-703 Bugfix: Js syntax error when Minify Html is enabled in production mode

### DIFF
--- a/view/frontend/templates/js/boltglobaljs.phtml
+++ b/view/frontend/templates/js/boltglobaljs.phtml
@@ -80,6 +80,5 @@ $onSuccessCode = $block->getJavascriptSuccess() . $trackCallbackCode['success'];
             });
         }
     };
-    ////////////////////////////////////////////////////////////////////////
 </script>
 <?= $block->getAdditionalHtml() ?>


### PR DESCRIPTION
# Description
This happens because HTML parser as defined by W3C is totally separated from the JavaScript parser. After the <script> tag it looks for the closing </script>, regardless that it's inside comments or strings, it treats JS code as normal text, as a result, the JS comment before the closing </script> breaks JS code when minified.

Fixes: https://boltpay.atlassian.net/browse/M2P-703

#changelog Bugfix: Js syntax error when Minify Html is enabled in production mode

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
