### PR TITLE
M2P-690 Bypass stock validation for custom cart item

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -2762,7 +2762,13 @@ class Cart extends AbstractHelper
     {
         list ($cartItems,,) = $this->getCartItems($quote, $quote->getStoreId(), 0, 0, false);
         foreach ($cartItems as $item) {
-            $product = $this->productRepository->getById($item['reference']);
+            try {
+                // To support some 3p plugins, we may add fee/gift wrapping as cart item,
+                // but those items are not actual products in store.
+                $product = $this->productRepository->getById($item['reference']);
+            } catch (NoSuchEntityException $e) {
+                continue;
+            }
             if ($product->getTypeId() == \Magento\Bundle\Model\Product\Type::TYPE_CODE) {
                 if (!$product->isAvailable()) {
                     $this->bugsnag->registerCallback(function ($report) use ($item) {   


### PR DESCRIPTION
# Description
To support various types of fee/gift wrapping, we add them as cart item, but those items are not actual products in store. There is no need to validate stock state for them.

Fixes: https://boltpay.atlassian.net/browse/M2P-690

#changelog Bypass stock validation for custom cart item

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
