### PR TITLE
Bugfix: Bolt PPC does not work properly with items that have a quantity of 1

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1790,7 +1790,7 @@ class Cart extends AbstractHelper
         // If the immutable quote is passed (i.e. discount code validation, bugsnag report generation)
         // load the parent quote, otherwise load the session quote
         /** @var Quote $quote */
-        $quote = $immutableQuote ?
+        $quote = ($immutableQuote && $immutableQuote->getBoltParentQuoteId() != $immutableQuote->getId()) ?
             $this->getQuoteById($immutableQuote->getBoltParentQuoteId()) :
             $this->checkoutSession->getQuote();
 
@@ -2568,7 +2568,7 @@ class Cart extends AbstractHelper
         //make sure we recollect totals
         $quote->setTotalsCollectedFlag(false);
         $this->eventsForThirdPartyModules->dispatchEvent("beforeGetCartDataForCreateCart", $quote, $this->sessionHelper->getCheckoutSession());
-        $cart_data = $this->getCartData(false);
+        $cart_data = $this->getCartData(false, '', $quote);
         $cart_data['order_reference'] = $quoteId;
         $this->quoteResourceSave($quote);
         $this->saveQuote($quote);

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -2564,10 +2564,11 @@ class Cart extends AbstractHelper
         $quote->setIsActive(false);
         $this->saveQuote($quote);
         $this->sessionHelper->loadSession($quote, $metadata);
+        $this->checkoutSession = $this->sessionHelper->getCheckoutSession();
         //make sure we recollect totals
         $quote->setTotalsCollectedFlag(false);
         $this->eventsForThirdPartyModules->dispatchEvent("beforeGetCartDataForCreateCart", $quote, $this->sessionHelper->getCheckoutSession());
-        $cart_data = $this->getCartData(false, '', $quote);
+        $cart_data = $this->getCartData(false);
         $cart_data['order_reference'] = $quoteId;
         $this->quoteResourceSave($quote);
         $this->saveQuote($quote);


### PR DESCRIPTION
# Description
The M2 class Magento\CatalogInventory\Model\Quote\Item\QuantityValidator\QuoteItemQtyList processes product qty from quote items and is used only in singleton mode. When its function getQty is called for item quantity validation, it would add qty to existing quote item.

For Bolt PPC, the function QuoteItemQtyList->getQty  is called twice and result in this bug if the product only has 1 in stock
1. When adding product to the empty cart created for PPC in the method Bolt\Boltpay\Helper\Cart->createCart, the item qty stored in QuoteItemQtyList  is 1.
2. When getting parent quote by the method getQuoteById in the method Bolt\Boltpay\Helper\Cart->getCartData, the item qty stored in QuoteItemQtyList becomes 2.

Actually the parent quote and immutable quote are identical in Bolt PPC, so there is no need to call getQuoteById to load immutable quote. Instead, we can get it from checkout session.

Fixes: https://app.asana.com/0/1201080688422141/1201123179533620/f

#changelog Bugfix: Bolt PPC does not work properly with items that have a quantity of 1

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
