### PR TITLE
Bugfix: JS error if building regular expression with undefined object property

### DIFF
--- a/view/frontend/templates/button_product_page.phtml
+++ b/view/frontend/templates/button_product_page.phtml
@@ -241,11 +241,10 @@ foreach ($block->getAdditionalCheckoutButtonAttributes() as $attrName => $attrVa
                     var name = input.name, value = input.value;
                     var matchResult;
                     for (var index in compositeAttributes) {
-                        var compositeAttribute = compositeAttributes[index];
-                        // Only build regular expression with string
-                        if (typeof compositeAttribute !== 'string' && !(compositeAttribute instanceof String)) {
+                        if (!compositeAttributes.hasOwnProperty(index)) {
                             continue;
                         }
+                        var compositeAttribute = compositeAttributes[index];
                         if (matchResult = name.match(compositeAttribute+'\\[(\\d+)\\]')) {
                             if (!(compositeAttribute in options)) {
                                 options[compositeAttribute] = {};
@@ -255,6 +254,9 @@ foreach ($block->getAdditionalCheckoutButtonAttributes() as $attrName => $attrVa
                         }
                     }
                     for (var index in checkboxAttributes) {
+                        if (!checkboxAttributes.hasOwnProperty(index)) {
+                            continue;
+                        }
                         var checkboxAttribute = checkboxAttributes[index];
                         if (name === checkboxAttribute+'[]') {
                             if (!(checkboxAttribute in options)) {


### PR DESCRIPTION
# Description
In some env, the object contains inherited property, or any property has not been declared at all, and eventually cause error when building regular expression. So we need to check the specified property is a direct property of the object.

Fixes: https://boltpay.atlassian.net/browse/ON-1348

#changelog Bugfix: JS error if building regular expression with undefined object property

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
