### PR TITLE
Amasty_Promo: Support coupon with items discount

### DIFF
--- a/ThirdPartyModules/Amasty/Promo.php
+++ b/ThirdPartyModules/Amasty/Promo.php
@@ -91,8 +91,11 @@ class Promo
                 foreach ($salesruleIds as $salesruleId) {
                     $rule = $this->ruleRepository->getById($salesruleId);
 
-                    if (in_array($rule->getSimpleAction(), self::PROMO_RULES)) {
-                        $amount = $rule->getDiscountAmount();
+                    if (
+                        in_array($rule->getSimpleAction(), self::PROMO_RULES)
+                        && !$rule->getExtensionAttributes()->getAmpromoRule()->getItemsDiscount()
+                    ) {
+                        $amount = 0;
                         $roundedAmount = CurrencyUtils::toMinor($amount, $currencyCode);
                         $discountItem = [
                             'description' => $rule->getDescription(),
@@ -125,10 +128,12 @@ class Promo
      */
     public function filterGetBoltCollectSaleRuleDiscounts($result, $rule)
     {
-        if (in_array($rule->getSimpleAction(), self::PROMO_RULES)) {
+        if (
+            in_array($rule->getSimpleAction(), self::PROMO_RULES)
+            && !$rule->getExtensionAttributes()->getAmpromoRule()->getItemsDiscount()
+        ) {
             $ruleId = $rule->getRuleId();
-            $discountAmount = $rule->getDiscountAmount();
-            $result[$ruleId] = $discountAmount;
+            $result[$ruleId] = 0;
         }
         return $result;
     }


### PR DESCRIPTION
# Description

Currently,  a mismatch discount issue happens if a customer applies an Amasty coupon with the rule type of **auto-add promo item**. The reason is that that the discount amount value of the Amasty rule (**$rule->getDiscountAmount**) is the number of promo items. In reality, it is always set to 0 when processing an order 

![image](https://user-images.githubusercontent.com/2002287/137786545-ae0bc513-af4e-4b6d-9097-3c39a4d5c66a.png)

=> So this PR is to set the discount amount to 0 if the customer applies Amasty coupon  
**Change** $amount = $rule->getDiscountAmount();  **to** $amount = 0;



Fixes: https://boltpay.atlassian.net/browse/M2P-721

#changelog Amasty_Promo: Support coupon with items discount

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
