### PR TITLE
Bugfix: Discount error with specific condition of Table Rates shipping method

### DIFF
--- a/Model/Api/UpdateCartCommon.php
+++ b/Model/Api/UpdateCartCommon.php
@@ -271,8 +271,6 @@ abstract class UpdateCartCommon
 
         $shippingAddress
             ->setShippingMethod($shipment['reference'])
-            ->setCollectShippingRates(true)
-            ->collectShippingRates()
             ->save();
     }
 

--- a/Test/Unit/Model/Api/UpdateCartCommonTest.php
+++ b/Test/Unit/Model/Api/UpdateCartCommonTest.php
@@ -323,8 +323,6 @@ class UpdateCartCommonTest extends BoltTestCase
             [
                 'setShouldIgnoreValidation',
                 'setShippingMethod',
-                'setCollectShippingRates',
-                'collectShippingRates',
                 'addData',
                 'save'
             ]
@@ -653,8 +651,6 @@ class UpdateCartCommonTest extends BoltTestCase
             )
             ->willReturnSelf();
         $quoteAddress->expects(static::once())->method('setShippingMethod')->with('flatrate_flatrate')->willReturnSelf();
-        $quoteAddress->expects(static::once())->method('setCollectShippingRates')->with(true)->willReturnSelf();
-        $quoteAddress->expects(static::once())->method('collectShippingRates')->willReturnSelf();
         $quoteAddress->expects(static::once())->method('save');
         
         $immutableQuoteMock->expects(self::once())->method('getShippingAddress')->willReturn($quoteAddress);


### PR DESCRIPTION
# Description
For the cart.update and discounts.code.apply api request, if there is shipment info in the payload, we save the address data into shipping address of quote and calculate shipping rate then. After investigation, the shipping rate calculation is unnecessary and causes this bug. So the solution is to remove the related code.

Fixes: https://app.asana.com/0/1201104538767801/1201308276077754/f

#changelog Bugfix: Discount error with specific condition of Table Rates shipping method

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
