### PR TITLE
Add support for Amasty gift card 2.5.x

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -1326,8 +1326,7 @@ class Order extends AbstractHelper
         // When the create_order hook (thread 1) takes a lot of time to execute and returns a timeout, the authorize/payment hook (thread 2) is sent to Magento.
         // It updates the order prior to the create_order hook (thread 1) process.
         // This ensures that the returned order in the create_order hook is the latest updated order.
-        $existingOrder = $this->cartHelper->getOrderById($order->getId());
-        $existingOrder = $this->eventsForThirdPartyModules->runFilter('beforeGetOrderByIdProcessNewOrder', $existingOrder, $order);
+        $existingOrder = $this->eventsForThirdPartyModules->runFilter('beforeGetOrderByIdProcessNewOrder', $this->cartHelper->getOrderById($order->getId()), $order);
         $orderPayment = $existingOrder->getPayment();
         if ($orderPayment && $orderPayment->getMethod() !== Payment::METHOD_CODE) {
             throw new LocalizedException(__(

--- a/Model/EventsForThirdPartyModules.php
+++ b/Model/EventsForThirdPartyModules.php
@@ -418,6 +418,17 @@ class EventsForThirdPartyModules
                 ],
             ],
         ],
+        'orderPostprocess' => [
+            "listeners" => [
+                'Amasty Giftcard V2.5' => [
+                    "module"       => "Amasty_GiftCardAccount",
+                    "checkClasses" => self::AMASTY_GIFTCARD_V25_CHECK_CLASSES,
+                    'sendClasses'  => ['Amasty\GiftCardAccount\Model\GiftCardAccount\GiftCardAccountTransactionProcessor',
+                                       'Amasty\GiftCardAccount\Model\GiftCardAccount\Repository'],
+                    "boltClass"    => Amasty_GiftCardAccount::class,
+                ],
+            ],
+        ],
     ];
 
     const filterListeners = [
@@ -1167,6 +1178,16 @@ class EventsForThirdPartyModules
                 ],
             ],
         ],
+        'beforeGetOrderByIdProcessNewOrder' => [
+            "listeners" => [
+                'Amasty Giftcard V2.5' => [
+                    "module"       => "Amasty_GiftCardAccount",
+                    "checkClasses" => self::AMASTY_GIFTCARD_V25_CHECK_CLASSES,
+                    'sendClasses'  => ['Amasty\GiftCardAccount\Model\GiftCardExtension\Order\Handlers\SaveHandler'],
+                    "boltClass"    => Amasty_GiftCardAccount::class,
+                ],
+            ],
+        ],
     ];
 
     /**
@@ -1178,6 +1199,13 @@ class EventsForThirdPartyModules
         'Amasty\GiftCard\Model\ResourceModel\Quote\CollectionFactory',
         'Amasty\GiftCard\Api\CodeRepositoryInterface',
         'Amasty\GiftCard\Api\AccountRepositoryInterface',
+    ];
+    
+    /**
+     * @var array Classes used to verify that Amasty Giftcard module version >= 2.5.0
+     */
+    const AMASTY_GIFTCARD_V25_CHECK_CLASSES = [
+        'Amasty\GiftCardAccount\Model\GiftCardAccount\GiftCardAccountTransactionProcessor',
     ];
 
     /**

--- a/ThirdPartyModules/Amasty/GiftCardAccount.php
+++ b/ThirdPartyModules/Amasty/GiftCardAccount.php
@@ -408,13 +408,11 @@ class GiftCardAccount
     }
     
     /**
-     * Complete the transaction of Amasty Gift Card once the order is created.
+     * Clone the gift card info to the latest updated order.
      *
-     * @param \Amasty\GiftCardAccount\Model\GiftCardAccount\GiftCardAccountTransactionProcessor $giftCardAccountTransactionProcessor
-     * @param \Amasty\GiftCardAccount\Model\GiftCardAccount\Repository $giftCardAccountRepository
-     * @param OrderModel $order
-     * @param Quote $quote
-     * @param \stdClass $transaction
+     * @param \Magento\Sales\Model\Order $result
+     * @param \Amasty\GiftCardAccount\Model\GiftCardExtension\Order\Handlers\SaveHandler $giftCardAccountRepository
+     * @param \Magento\Sales\Model\Order $order
      */
     public function beforeGetOrderByIdProcessNewOrder($result, $giftCardAccountSaveHandler, $order)
     {
@@ -439,7 +437,7 @@ class GiftCardAccount
      *
      * @param \Amasty\GiftCardAccount\Model\GiftCardAccount\GiftCardAccountTransactionProcessor $giftCardAccountTransactionProcessor
      * @param \Amasty\GiftCardAccount\Model\GiftCardAccount\Repository $giftCardAccountRepository
-     * @param OrderModel $order
+     * @param \Magento\Sales\Model\Order $order
      * @param Quote $quote
      * @param \stdClass $transaction
      */

--- a/ThirdPartyModules/Amasty/GiftCardAccount.php
+++ b/ThirdPartyModules/Amasty/GiftCardAccount.php
@@ -406,4 +406,57 @@ class GiftCardAccount
             $this->bugsnagHelper->notifyException($e);
         }
     }
+    
+    /**
+     * Complete the transaction of Amasty Gift Card once the order is created.
+     *
+     * @param \Amasty\GiftCardAccount\Model\GiftCardAccount\GiftCardAccountTransactionProcessor $giftCardAccountTransactionProcessor
+     * @param \Amasty\GiftCardAccount\Model\GiftCardAccount\Repository $giftCardAccountRepository
+     * @param OrderModel $order
+     * @param Quote $quote
+     * @param \stdClass $transaction
+     */
+    public function beforeGetOrderByIdProcessNewOrder($result, $giftCardAccountSaveHandler, $order)
+    {
+        try {
+            if ($order->getExtensionAttributes() && $order->getExtensionAttributes()->getAmGiftcardOrder()) {
+                $gCardOrder = $order->getExtensionAttributes()->getAmGiftcardOrder();
+                $existingOrderExtension = $result->getExtensionAttributes();
+                $gCardOrder->setOrderId((int)$result->getId());
+                $existingOrderExtension->setAmGiftcardOrder($gCardOrder);
+                $result->setExtensionAttributes($existingOrderExtension);
+                $giftCardAccountSaveHandler->saveAttributes($result);
+            }
+        } catch (\Exception $e) {
+            $this->bugsnagHelper->notifyException($e);
+        } finally {
+            return $result;
+        }
+    }
+    
+    /**
+     * Complete the transaction of Amasty Gift Card once the order is created.
+     *
+     * @param \Amasty\GiftCardAccount\Model\GiftCardAccount\GiftCardAccountTransactionProcessor $giftCardAccountTransactionProcessor
+     * @param \Amasty\GiftCardAccount\Model\GiftCardAccount\Repository $giftCardAccountRepository
+     * @param OrderModel $order
+     * @param Quote $quote
+     * @param \stdClass $transaction
+     */
+    public function orderPostprocess($giftCardAccountTransactionProcessor, $giftCardAccountRepository, $order, $quote, $transaction)
+    {
+        if (!$order->getExtensionAttributes() || !$order->getExtensionAttributes()->getAmGiftcardOrder()) {
+            return;
+        }
+        /** @var GiftCardOrderInterface $gCardOrder */
+        $gCardOrder = $order->getExtensionAttributes()->getAmGiftcardOrder();
+        try {
+            foreach ($gCardOrder->getAppliedAccounts() as $appliedAccount) {
+                $giftCardAccountRepository->save($appliedAccount);
+                $giftCardAccountTransactionProcessor->completeTransaction($appliedAccount);
+            }
+        } catch (\Exception $e) {
+            $this->bugsnagHelper->notifyException($e);
+        }
+    }
 }


### PR DESCRIPTION
# Description
From Amasty gift card 2.5.0 , their team introduces a new feature to restrict the usage of gift card by transaction and the plugin completes the transaction in the observer of event checkout_submit_all_after when the order is created successfully. But in our plugin, we do not trigger this event right after order creation, instead, we trigger it when save&update order by api hooks. At that time, the ExtensionAttributes of order does not contain any gift card info, as a result, the transaction of gift card can not be completed.

Fixes: https://app.asana.com/0/1201104538767801/1201218874560405/f

#changelog Add support for Amasty gift card 2.5.x

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
