### PR TITLE
EN-6094 Fix bug: Can not refund if an order is adjusted price mismatch

### DIFF
--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -396,4 +396,9 @@ class Decider extends AbstractHelper
     {
         return $this->isSwitchEnabled(Definitions::M2_ENABLE_PRODUCT_ENDPOINT);
     }
+
+    public function isIncludeMismatchAmountIntoTaxWhenAdjustingPriceMismatch()
+    {
+        return $this->isSwitchEnabled(Definitions::M2_INCLUDE_MISMATCH_AMOUNT_INTO_TAX_WHEN_ADJUSTING_PRICE_MISMATCH);
+    }
 }

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -46,6 +46,11 @@ class Definitions
     const M2_BOLT_ENABLED = 'M2_BOLT_ENABLED';
 
     /**
+     * Enable including mismatch amount into tax when adjusting price mismatch
+     */
+    const M2_INCLUDE_MISMATCH_AMOUNT_INTO_TAX_WHEN_ADJUSTING_PRICE_MISMATCH = 'M2_INCLUDE_MISMATCH_AMOUNT_INTO_TAX_WHEN_ADJUSTING_PRICE_MISMATCH';
+
+    /**
      * Enable logging of missing quote failed hooks
      *
      */
@@ -236,6 +241,12 @@ class Definitions
         ],
         self::M2_BOLT_ENABLED => [
             self::NAME_KEY        => self::M2_BOLT_ENABLED,
+            self::VAL_KEY         => true,
+            self::DEFAULT_VAL_KEY => false,
+            self::ROLLOUT_KEY     => 100
+        ],
+        self::M2_INCLUDE_MISMATCH_AMOUNT_INTO_TAX_WHEN_ADJUSTING_PRICE_MISMATCH => [
+            self::NAME_KEY        => self::M2_INCLUDE_MISMATCH_AMOUNT_INTO_TAX_WHEN_ADJUSTING_PRICE_MISMATCH,
             self::VAL_KEY         => true,
             self::DEFAULT_VAL_KEY => false,
             self::ROLLOUT_KEY     => 100

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -749,6 +749,11 @@ class Order extends AbstractHelper
 
         if (abs($totalMismatch) > 0 && abs($totalMismatch) <= $priceFaultTolerance) {
             $boltGrandTotal = CurrencyUtils::toMajor($boltTotalAmount, $currencyCode);
+            if ($this->featureSwitches->isIncludeMismatchAmountIntoTaxWhenAdjustingPriceMismatch()){
+                $order->setTaxAmount($order->getTaxAmount() + CurrencyUtils::toMajor($totalMismatch, $currencyCode))
+                    ->setBaseTaxAmount($order->getBaseTaxAmount() + CurrencyUtils::toMajor($totalMismatch, $currencyCode));
+            }
+
             $order->setBaseGrandTotal($boltGrandTotal)->setGrandTotal($boltGrandTotal);
 
             $this->bugsnag->registerCallback(function ($report) use ($quote, $boltTotalAmount, $magentoTotalAmount) {

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -4641,6 +4641,8 @@ class OrderTest extends BoltTestCase
         $magentoTotalAmount = CurrencyUtils::toMinor($grandTotal, 'USD');
         $totalMismatch = $cartTotalAmount - $magentoTotalAmount;
         $recordMismatch = abs($totalMismatch) > 0 && abs($totalMismatch) <= $priceFaultTolerance;
+        $taxAmountBeforeAdjustingPriceMismatch = $order->getTaxAmount();
+        $baseTaxAmountBeforeAdjustingPriceMismatch = $order->getBaseTaxAmount();
 
         TestHelper::invokeMethod(
             $orderHelper,
@@ -4651,6 +4653,8 @@ class OrderTest extends BoltTestCase
         if ($recordMismatch) {
             self::assertEquals(CurrencyUtils::toMajor($cartTotalAmount, 'USD'), $order->getGrandTotal());
             self::assertEquals(CurrencyUtils::toMajor($cartTotalAmount, 'USD'), $order->getBaseGrandTotal());
+            self::assertEquals($taxAmountBeforeAdjustingPriceMismatch + CurrencyUtils::toMajor($totalMismatch, 'USD'), $order->getTaxAmount());
+            self::assertEquals($baseTaxAmountBeforeAdjustingPriceMismatch + CurrencyUtils::toMajor($totalMismatch, 'USD'), $order->getBaseTaxAmount());
         } else {
             self::assertEquals($grandTotal, $order->getGrandTotal());
             self::assertEquals($grandTotal, $order->getBaseGrandTotal());


### PR DESCRIPTION
# Description

Currently, we can't refund if an order is adjusted price mismatch. 
See the detail in this task: https://app.asana.com/0/564264490825835/1201256841759895

=> The root cause is that the grand total isn't correct in the admin new credit memo creation page. This PR is to correct the credit memo grand total by including the mismatch amount into the tax amount when adjusting price mismatch.

FYI, this logic is the same as M1 logic. See here: https://github.com/BoltApp/bolt-magento1/blob/master/app/code/community/Bolt/Boltpay/Model/Order.php#L518

Fixes: https://boltpay.atlassian.net/browse/EN-6094

#changelog EN-6094 Fix bug: Can not refund if an order is adjusted price mismatch

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
