### PR TITLE
Bugfix: subtotal calculation issue with reorder functionality

### DIFF
--- a/Plugin/ClearQuote.php
+++ b/Plugin/ClearQuote.php
@@ -19,6 +19,7 @@ namespace Bolt\Boltpay\Plugin;
 
 use Magento\Checkout\Model\Session as CheckoutSession;
 use Bolt\Boltpay\Helper\Cart as CartHelper;
+use Bolt\Boltpay\Helper\Config as ConfigHelper;
 
 class ClearQuote
 {
@@ -26,6 +27,11 @@ class ClearQuote
      * @var CartHelper
      */
     private $cartHelper;
+    
+    /**
+     * @var ConfigHelper
+     */
+    private $configHelper;
 
     /**
      * @var \Magento\Quote\Model\Quote|null
@@ -34,11 +40,14 @@ class ClearQuote
 
     /**
      * @param CartHelper $cartHelper
+     * @param ConfigHelper $configHelper
      */
     public function __construct(
-        CartHelper $cartHelper
+        CartHelper $cartHelper,
+        ConfigHelper $configHelper
     ) {
         $this->cartHelper = $cartHelper;
+        $this->configHelper = $configHelper;
     }
 
     /**
@@ -83,9 +92,11 @@ class ClearQuote
             return $subject;
         }
 
-        // Workaround for known magento issue - https://github.com/magento/magento2/issues/12504
-        $subject->setLoadInactive(false);
-        $subject->replaceQuote($subject->getQuote()->save());
+        if (version_compare($this->configHelper->getStoreVersion(), '2.2.0', '<')) {
+            // Workaround for known magento issue - https://github.com/magento/magento2/issues/12504
+            $subject->setLoadInactive(false);
+            $subject->replaceQuote($subject->getQuote()->save());
+        }
 
         return $subject;
     }


### PR DESCRIPTION
# Description
The code

`$subject->setLoadInactive(false);
$subject->replaceQuote($subject->getQuote()->save());`

in the plugin method afterClearQuote is to fix issue for specific Magento versions and causes bug with reorder functionality in M2 v2.4.0+. 

So we add conditional statement to fix this bug.

Fixes: [(link Jira ticket)](https://app.asana.com/0/951157735838091/1201324830035954/f)

#changelog Bugfix: subtotal calculation issue with reorder functionality

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
