### PR TITLE
Do not create immutable quote for API driven integration

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -2656,7 +2656,7 @@ class Cart extends AbstractHelper
             }
 
             // get immutable quote id stored with cart data
-            if ($response) {
+            if (!$this->deciderHelper->isAPIDrivenIntegrationEnabled() && $response) {
                 $cartReference = $this->getImmutableQuoteIdFromBoltCartArray($responseData['cart']);
             } else {
                 $cartReference = '';

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1840,23 +1840,36 @@ class Cart extends AbstractHelper
         // cart data is being created for sending to Bolt create
         // order API, otherwise skip this step
         ////////////////////////////////////////////////////////
-        if (!$immutableQuote) {
+        if (!$immutableQuote && !$this->deciderHelper->isAPIDrivenIntegrationEnabled()) {
             $immutableQuote = $this->createImmutableQuote($quote);
         }
 
         ////////////////////////////////////////////////////////
 
         // Get array of all items that can be display directly
-        $items = $immutableQuote->getAllVisibleItems();
+        if ($immutableQuote) {
+            $items = $immutableQuote->getAllVisibleItems();
+        } else {
+            // hereinafter null immutable quote means we are in new API driven flow
+            $items = $quote->getAllVisibleItems();
+        }
 
         if (!$items) {
             // This is the case when customer empties the cart.
             return [];
         }
 
-        $this->setLastImmutableQuote($immutableQuote);
-
-        $immutableQuote->collectTotals();
+        if ($immutableQuote) {
+            $this->setLastImmutableQuote($immutableQuote);
+            $immutableQuote->collectTotals();
+        } else {
+            if ($this->deciderHelper->isRecalculateTotalForAPIDrivenIntegration()) {
+                // we did not change the quote there is no reason to spend time
+                // recalculating total
+                // but we have this settings just in case
+                $quote->collectTotals();
+            }
+        }
 
         $cart = $this->buildCartFromQuote($quote, $immutableQuote, $items, $placeOrderPayload, $paymentOnly);
         if ($cart == []) {
@@ -1864,18 +1877,16 @@ class Cart extends AbstractHelper
             return $cart;
         }
 
-        // Set order_reference to parent quote id.
-        // This is the constraint field on Bolt side and this way
-        // duplicate payments / orders are prevented
-        $cart['order_reference'] = $immutableQuote->getBoltParentQuoteId();
+        if ($immutableQuote) {
+            $cart['order_reference'] = $immutableQuote->getBoltParentQuoteId();
+            $this->sessionHelper->cacheFormKey($immutableQuote);
+        } else {
+            $cart['order_reference'] = $quote->getId();
+        }
 
         if ($this->deciderHelper->isIncludeUserGroupIntoCart()) {
             $cart['metadata']['user_group_id'] = $this->getUserGroupId();
         }
-
-        $this->sessionHelper->cacheFormKey($immutableQuote);
-
-        // $this->logHelper->addInfoLog(json_encode($cart, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES));
 
         return $cart;
     }
@@ -1883,7 +1894,7 @@ class Cart extends AbstractHelper
     /**
      * Build cart data from quote.
      *
-     * @param Quote  $quote
+     * @param Quote  $parentQuote
      * @param Quote  $immutableQuote
      * @param array  $items
      * @param bool   $paymentOnly           flag that represents the type of checkout
@@ -1893,18 +1904,22 @@ class Cart extends AbstractHelper
      * @return array
      * @throws \Exception
      */
-    public function buildCartFromQuote($quote, $immutableQuote, $items, $placeOrderPayload, $paymentOnly, $requireBillingAddress = true)
+    public function buildCartFromQuote($parentQuote, $immutableQuote, $items, $placeOrderPayload, $paymentOnly, $requireBillingAddress = true)
     {
+        // work with parent (native) quote for API driven flow
+        // and with immutable quote for legacy flow
+        $quote = $immutableQuote ?: $parentQuote;
         $cart = [];
 
-        $billingAddress  = $immutableQuote->getBillingAddress();
-        $shippingAddress = $immutableQuote->getShippingAddress();
+        $billingAddress  = $quote->getBillingAddress();
+        $shippingAddress = $quote->getShippingAddress();
 
         //Use display_id to hold and transmit, all the way back and forth, reserved order id
         $cart['display_id'] = '';
 
-        //Store immutable quote id in metadata of cart
-        $cart['metadata']['immutable_quote_id'] = $immutableQuote->getId();
+        if ($immutableQuote) {
+            $cart['metadata']['immutable_quote_id'] = $immutableQuote->getId();
+        }
 
         // Transmit session ID via cart metadata, making it available for session emulation in API calls
         if ($this->deciderHelper->isAddSessionIdToCartMetadata()) {
@@ -1913,7 +1928,7 @@ class Cart extends AbstractHelper
             );
         }
 
-        $sessionData = $this->eventsForThirdPartyModules->runFilter('collectSessionData', [], $quote, $immutableQuote);
+        $sessionData = $this->eventsForThirdPartyModules->runFilter('collectSessionData', [], $parentQuote, $immutableQuote);
         if (!empty($sessionData)) {
             $cart['metadata'][Session::ENCRYPTED_SESSION_DATA_KEY] = $this->encryptMetadataValue(
                 json_encode($sessionData)
@@ -1926,10 +1941,10 @@ class Cart extends AbstractHelper
         }
 
         //Currency
-        $currencyCode = $immutableQuote->getQuoteCurrencyCode();
+        $currencyCode = $quote->getQuoteCurrencyCode();
         $cart['currency'] = $currencyCode;
 
-        list ($cart['items'], $totalAmount, $diff) = $this->getCartItems($immutableQuote, $immutableQuote->getStoreId());
+        list ($cart['items'], $totalAmount, $diff) = $this->getCartItems($quote, $quote->getStoreId());
 
         // Email field is mandatory for saving the address.
         // For back-office orders (payment only) we need to get it from the store.
@@ -1937,7 +1952,7 @@ class Cart extends AbstractHelper
         $email = $billingAddress->getEmail()
             ?: $shippingAddress->getEmail()
             ?: $this->customerSession->getCustomer()->getEmail()
-            ?: $immutableQuote->getCustomerEmail();
+            ?: $quote->getCustomerEmail();
 
         // Billing address
         $cartBillingAddress = [
@@ -1988,13 +2003,13 @@ class Cart extends AbstractHelper
             $cart['billing_address'] = $cartBillingAddress;
         }
 
-        $address = $this->getCalculationAddress($immutableQuote);
+        $address = $this->getCalculationAddress($quote);
 
         // payment only checkout, include shipments, tax and grand total
         if ($paymentOnly) {
-            if ($immutableQuote->isVirtual()) {
+            if ($quote->isVirtual()) {
                 if (!empty($cart['billing_address'])) {
-                    $this->collectAddressTotals($immutableQuote, $address);
+                    $this->collectAddressTotals($quote, $address);
                     $address->save();
                 } elseif ($requireBillingAddress) {
                     $this->logAddressData($cartBillingAddress);
@@ -2008,8 +2023,8 @@ class Cart extends AbstractHelper
                 $address->setCollectShippingRates(true);
 
                 // assign parent shipping method to clone
-                if (!$address->getShippingMethod() && $quote) {
-                    $address->setShippingMethod($quote->getShippingAddress()->getShippingMethod());
+                if (!$address->getShippingMethod() && $parentQuote) {
+                    $address->setShippingMethod($parentQuote->getShippingAddress()->getShippingMethod());
                 }
 
                 if (!$address->getShippingMethod()) {
@@ -2020,7 +2035,7 @@ class Cart extends AbstractHelper
                     return [];
                 }
 
-                $this->collectAddressTotals($immutableQuote, $address);
+                $this->collectAddressTotals($quote, $address);
                 $address->save();
 
                 // Shipping address
@@ -2079,7 +2094,7 @@ class Cart extends AbstractHelper
             $totalAmount,
             $diff,
             $paymentOnly,
-            $immutableQuote
+            $quote
         );
         $cart['discounts'] = $discounts;
         /////////////////////////////////////////////////////////////////////////////////

--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -401,4 +401,14 @@ class Decider extends AbstractHelper
     {
         return $this->isSwitchEnabled(Definitions::M2_INCLUDE_MISMATCH_AMOUNT_INTO_TAX_WHEN_ADJUSTING_PRICE_MISMATCH);
     }
+    
+    public function isAPIDrivenIntegrationEnabled()
+    {
+        return $this->isSwitchEnabled(Definitions::M2_ENABLE_API_DRIVEN_INTEGRAION);
+    }
+
+    public function isRecalculateTotalForAPIDrivenIntegration()
+    {
+        return $this->isSwitchEnabled(Definitions::M2_RECALCULATE_TOTAL_FOR_API_DRIVEN_INTEGRAION);
+    }
 }

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -232,6 +232,16 @@ class Definitions
      */
     const M2_ENABLE_PRODUCT_ENDPOINT = 'M2_ENABLE_PRODUCT_ENDPOINT';
 
+    /**
+     * Enable API driven integration
+     */
+    const M2_ENABLE_API_DRIVEN_INTEGRAION = 'M2_ENABLE_API_DRIVEN_INTEGRAION';
+
+    /**
+     * Recalculate quote total for API driven integration
+     */
+    const M2_RECALCULATE_TOTAL_FOR_API_DRIVEN_INTEGRAION = 'M2_RECALCULATE_TOTAL_FOR_API_DRIVEN_INTEGRAION';
+
     const DEFAULT_SWITCH_VALUES = [
         self::M2_SAMPLE_SWITCH_NAME => [
             self::NAME_KEY        => self::M2_SAMPLE_SWITCH_NAME,
@@ -466,6 +476,18 @@ class Definitions
             self::VAL_KEY         => true,
             self::DEFAULT_VAL_KEY => false,
             self::ROLLOUT_KEY     => 100
+        ],
+        self::M2_ENABLE_API_DRIVEN_INTEGRAION => [
+            self::NAME_KEY        => self::M2_ENABLE_API_DRIVEN_INTEGRAION,
+            self::VAL_KEY         => true,
+            self::DEFAULT_VAL_KEY => false,
+            self::ROLLOUT_KEY     => 0
+        ],
+        self::M2_RECALCULATE_TOTAL_FOR_API_DRIVEN_INTEGRAION => [
+            self::NAME_KEY        => self::M2_RECALCULATE_TOTAL_FOR_API_DRIVEN_INTEGRAION,
+            self::VAL_KEY         => true,
+            self::DEFAULT_VAL_KEY => false,
+            self::ROLLOUT_KEY     => 0
         ],
     ];
 }

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -448,7 +448,7 @@ class CartTest extends BoltTestCase
             DeciderHelper::class,
             ['ifShouldDisablePrefillAddressForLoggedInCustomer', 'handleVirtualProductsAsPhysical',
              'isIncludeUserGroupIntoCart', 'isAddSessionIdToCartMetadata', 'isCustomizableOptionsSupport',
-             'isPreventBoltCartForQuotesWithError']
+             'isPreventBoltCartForQuotesWithError','isAPIDrivenIntegrationEnabled']
         );
         $this->eventsForThirdPartyModules = $this->createPartialMock(EventsForThirdPartyModules::class, ['runFilter','dispatchEvent']);
         $this->eventsForThirdPartyModules->method('runFilter')->will($this->returnArgument(1));

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -2801,6 +2801,58 @@ ORDER
         static::assertEquals($expected, $result);
     }
 
+    /**
+     * @test
+     * @covers ::getCartData
+     */
+    public function getCartData_inAPIDrivenFlowAndMultistepWithNoDiscount_returnsCartData() {
+        $boltHelperCart = Bootstrap::getObjectManager()->create(BoltHelperCart::class);
+        $quote = TestUtils::createQuote();
+        $quote = TestUtils::getQuoteById($quote->getId());
+        $product = TestUtils::createSimpleProduct();
+        $product =  Bootstrap::getObjectManager()->create("Magento\Catalog\Model\ProductRepository")->getByID($product->getID());
+
+        $quote->addProduct($product, 1);
+
+        $quote->setTotalsCollectedFlag(false)->collectTotals();
+
+        TestUtils::setQuoteToSession($quote);
+
+        $apiDrivenFeatureSwitch = TestUtils::saveFeatureSwitch(Definitions::M2_ENABLE_API_DRIVEN_INTEGRAION, true);
+        $result = $boltHelperCart->getCartData(false, "");
+        TestUtils::cleanupFeatureSwitch($apiDrivenFeatureSwitch);
+
+        // check image url
+        static::assertMatchesRegularExpression(
+            "|https?://localhost/(pub\/)?static/version\d+/frontend/Magento/luma/en_US/Magento_Catalog/images/product/placeholder/small_image.jpg|",
+            $result['items'][0]['image_url']
+        );
+        unset($result['items'][0]['image_url']);
+
+        $expected = [
+            'order_reference' => $quote->getId(),
+            'display_id'      => '',
+            'currency'        => self::CURRENCY_CODE,
+            'items'           => [
+                [
+                    'reference'    => $product->getId(),
+                    'name'         => 'Test Product',
+                    'total_amount' => 10000,
+                    'unit_price'   => 10000,
+                    'quantity'     => 1,
+                    'sku'          => $product->getSku(),
+                    'type'         => 'physical',
+                    'description'  => 'Product Description',
+                ]
+            ],
+            'discounts'       => [],
+            'total_amount'    => 10000,
+            'tax_amount'      => 0,
+        ];
+
+        static::assertEquals($expected, $result);
+    }
+
     public function dataProvider_sessionIdToCartMetadataSwitch()
     {
         return [


### PR DESCRIPTION
- introduce feature switch M2_ENABLE_API_DRIVEN_INTEGRAION
- Under feature switch update **getCartData** function to create bolt order without immutable quote creation.

Eventually we will delete code for immutable quote so I prefer to have few <IF> statement for now rather than separate function.

Fixes: (link Jira ticket)

#changelog Do not create immutable quote for API driven integration

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
