### PR TITLE
Bugfix: Mismatch shipping issue if the quote has a cart rule of 'Fixed amount discount for whole cart' and 'Apply to shipping amount'

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -2761,4 +2761,32 @@ class Cart extends AbstractHelper
     {
         return $this->deciderHelper;
     }
+
+    /**
+     * Ignore adjusting shipping amount if quote has a cart rule of "Fixed amount discount for whole cart" and "Apply to shipping amount"
+     *
+     * @param $quote
+     * @return bool
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
+    public function ignoreAdjustingShippingAmount($quote)
+    {
+        if ($quote->getAppliedRuleIds()){
+            $salesruleIds = explode(',', $quote->getAppliedRuleIds());
+
+            foreach ($salesruleIds as $salesruleId) {
+                $rule = $this->ruleRepository->getById($salesruleId);
+                if (
+                    $rule &&
+                    $rule->getSimpleAction() == \Magento\SalesRule\Api\Data\RuleInterface::DISCOUNT_ACTION_FIXED_AMOUNT_FOR_CART
+                    && $rule->getApplyToShipping()
+                ) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
 }

--- a/Model/Api/CreateOrder.php
+++ b/Model/Api/CreateOrder.php
@@ -680,7 +680,7 @@ class CreateOrder implements CreateOrderInterface
         }
         if ($quote->getShippingAddress() && !$quote->isVirtual()) {
             $amount = $quote->getShippingAddress()->getShippingAmount();
-            if (! $this->isBackOfficeOrder($quote)) {
+            if (! $this->isBackOfficeOrder($quote) && !$this->cartHelper->ignoreAdjustingShippingAmount($quote)) {
                 $amount -= $quote->getShippingAddress()->getShippingDiscountAmount();
             }
             $storeCost = CurrencyUtils::toMinor($amount, $quote->getQuoteCurrencyCode());


### PR DESCRIPTION
# Description
Currently, customers can't place an order if they apply a coupon of 'Fixed amount discount for whole cart' and 'Apply to shipping amount'. This is because that the mismatch shipping issue. This PR fixes the issue by correcting the shipping amount calculation in the Bolt modal. 

Fixes: https://app.asana.com/0/564264490825835/1201367629380173

#changelog Bugfix: Mismatch shipping issue if the quote has a cart rule of 'Fixed amount discount for whole cart' and 'Apply to shipping amount'

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
