### PR TITLE
Use discount name instead of discount description for automatic coupons

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -261,7 +261,7 @@ class Cart extends AbstractHelper
      * @var Serialize
      */
     private $serialize;
-    
+
     /**
      * @var MsrpHelper
      */
@@ -2207,8 +2207,9 @@ class Cart extends AbstractHelper
                             break;
                         case RuleInterface::COUPON_TYPE_NO_COUPON:
                         default:
+                            $description = trim($rule->getDescription()) ? $rule->getDescription() : $rule->getName();
                             $discounts[] = [
-                                'description'       => trim(__('Discount ') . $rule->getDescription()),
+                                'description'       => trim(__('Discount ') . $description),
                                 'amount'            => $roundedAmount,
                                 'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_AUTO_PROMO,
                                 'discount_type'     => $this->discountHelper->getBoltDiscountType($rule->getSimpleAction()), // For v1/discounts.code.apply and v2/cart.update

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -3878,7 +3878,7 @@ ORDER
         $appliedDiscountNoCoupon = 15; // $
         $shippingAddress->expects(static::once())->method('getDiscountAmount')->willReturn($appliedDiscount);
 
-        $quote->method('getAppliedRuleIds')->willReturn('2,3,4,5');
+        $quote->method('getAppliedRuleIds')->willReturn('2,3,4,5,6');
 
         $rule2 = $this->getMockBuilder(DataObject::class)
         ->setMethods(['getCouponType', 'getDescription'])
@@ -3895,7 +3895,7 @@ ORDER
         ->getMock();
         $rule3->expects(static::once())->method('getCouponType')
         ->willReturn('NO_COUPON');
-        $rule3->expects(static::once())->method('getDescription')
+        $rule3->expects(static::exactly(2))->method('getDescription')
         ->willReturn('Shopping cart price rule for the cart over $10');
         $rule3->expects(static::exactly(2))->method('getSimpleAction')
         ->willReturn('by_fixed');
@@ -3913,17 +3913,28 @@ ORDER
         $rule5->expects(static::once())->method('getDescription')
         ->willReturn('');
 
-        $this->ruleRepository->expects(static::exactly(4))
+        $rule6 = $this->getMockBuilder(DataObject::class)
+            ->setMethods(['getCouponType', 'getDescription','getName','getSimpleAction'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $rule6->expects(static::once())->method('getCouponType')
+            ->willReturn('NO_COUPON');
+        $rule6->expects(static::once())->method('getDescription')->willReturn(null);
+        $rule6->expects(static::once())->method('getName')->willReturn('Shopping cart price rule for the cart over $10');
+        $rule6->method('getSimpleAction')->willReturn('by_fixed');
+
+        $this->ruleRepository->expects(static::exactly(5))
         ->method('getById')
         ->withConsecutive(
             [2],
             [3],
             [4],
-            [5]
+            [5],
+            [6]
         )
-        ->willReturnOnConsecutiveCalls($rule2, $rule3, $rule4, $rule5);
+        ->willReturnOnConsecutiveCalls($rule2, $rule3, $rule4, $rule5, $rule6);
 
-        $this->discountHelper->expects(static::exactly(2))->method('getBoltDiscountType')->with('by_fixed')->willReturn('fixed_amount');
+        $this->discountHelper->method('getBoltDiscountType')->with('by_fixed')->willReturn('fixed_amount');
 
         $checkoutSession = $this->createPartialMock(
             CheckoutSession::class,
@@ -3931,7 +3942,7 @@ ORDER
         );
         $checkoutSession->expects(static::once())
                     ->method('getBoltCollectSaleRuleDiscounts')
-                    ->willReturn([2 => $appliedDiscount, 3 => $appliedDiscountNoCoupon, 4 => 0, 5 => $appliedDiscount]);
+                    ->willReturn([2 => $appliedDiscount, 3 => $appliedDiscountNoCoupon, 4 => 0, 5 => $appliedDiscount, 6 => $appliedDiscountNoCoupon]);
         $this->sessionHelper->expects(static::once())->method('getCheckoutSession')
          ->willReturn($checkoutSession);
 
@@ -3949,7 +3960,7 @@ ORDER
         static::assertEquals($diffResult, $diff);
         $expectedDiscountAmount = 100 * $appliedDiscount;
         $expectedDiscountAmountNoCoupon = 100 * $appliedDiscountNoCoupon;
-        $expectedTotalAmount = $totalAmount - (2 * $expectedDiscountAmount) - $expectedDiscountAmountNoCoupon;
+        $expectedTotalAmount = $totalAmount - (2 * $expectedDiscountAmount) - 2 * $expectedDiscountAmountNoCoupon;
         $expectedDiscount = [
         [
             'description' => self::COUPON_DESCRIPTION,
@@ -3973,6 +3984,13 @@ ORDER
             'discount_category' => 'coupon',
             'discount_type'     => 'fixed_amount',
             'type'              => 'fixed_amount',
+        ],
+        [
+            'description' => trim(__('Discount ') . 'Shopping cart price rule for the cart over $10'),
+            'amount'      => $expectedDiscountAmountNoCoupon,
+            'discount_category' => 'automatic_promotion',
+            'discount_type'   => 'fixed_amount',
+            'type'   => 'fixed_amount',
         ],
         ];
         static::assertEquals($expectedDiscount, $discounts);


### PR DESCRIPTION
# Description
The automatic discount description is shown as part of a discount tag on the Bolt modal. That discount description isn't a required field. When it's empty, the discount tag will be very indescriptive and confuse the customers.

This PR resolves the issue by using the required discount name as part of the discount tag. 

Fixes: https://app.asana.com/0/0/1201256841759895/1201384293294758/f

#changelog Use discount name instead of discount description for automatic coupons

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
