### PR TITLE
Fix empty quote creation

### DIFF
--- a/Test/Unit/TestUtils.php
+++ b/Test/Unit/TestUtils.php
@@ -9,6 +9,7 @@ use Magento\TestFramework\Helper\Bootstrap;
 
 use Magento\Quote\Model\Quote;
 use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Model\Quote\AddressFactory;
 use Magento\Sales\Model\Order\Item as OrderItem;
 use Magento\Sales\Model\Order\Address as OrderAddress;
 use Magento\Sales\Model\Order;
@@ -43,6 +44,11 @@ class TestUtils
     {
         $quote = Bootstrap::getObjectManager()->create(Quote::class);
         $quote->setQuoteCurrencyCode("USD");
+
+        $addressFactory = Bootstrap::getObjectManager()->get(AddressFactory::class);
+        $quote->setBillingAddress($addressFactory->create());
+        $quote->setShippingAddress($addressFactory->create());
+
         if ($data) {
             foreach ($data as $key => $value) {
                 $quote->setData($key, $value);


### PR DESCRIPTION
If we create quotes without addresses it does nothing during total calculation so total, as well as item price, will be empty.
We didn't face this before because we worked with immutable quotes. When we create an immutable quote we add addresses.

#changelog Fx empty quote creation for integration tests