### PR TITLE
Fix mismatch discount (rounding) issue by re-setting rounding delta

### DIFF
--- a/Plugin/SalesRuleModelUtilityPlugin.php
+++ b/Plugin/SalesRuleModelUtilityPlugin.php
@@ -62,7 +62,7 @@ class SalesRuleModelUtilityPlugin
                                    $result, $discountData, $item, $qty)
     {
         $checkoutSession = $this->sessionHelper->getCheckoutSession();
-        $savedRuleId = $checkoutSession->getBoltNeedCollectSaleRuleDiscounts('');      
+        $savedRuleId = $checkoutSession->getBoltNeedCollectSaleRuleDiscounts('');
         if (!empty($savedRuleId)) {
             // If the sale rule has no coupon, its discount amount can not be retrieved directly,
             // so we store the discount amount in the checkout session with the rule id as key.
@@ -70,9 +70,11 @@ class SalesRuleModelUtilityPlugin
             if (!empty($boltDiscountBreakdown) && $boltDiscountBreakdown['rule_id'] == $savedRuleId) {
                 $discountAmount = $discountData->getAmount() - $boltDiscountBreakdown['item_discount'];
                 if ($discountAmount >= DiscountHelper::MIN_NONZERO_VALUE || $this->ruleRepository->getById($savedRuleId)->getSimpleFreeShipping()) {
+                    // To avoid the mismatch discount (rounding) issue, we must re-set the rounding delta to correct the Bolt discount
+                    $subject->resetRoundingDeltas();
                     $boltCollectSaleRuleDiscounts = $checkoutSession->getBoltCollectSaleRuleDiscounts([]);
                     if (!isset($boltCollectSaleRuleDiscounts[$savedRuleId])) {
-                        $boltCollectSaleRuleDiscounts[$savedRuleId] = $discountAmount;            
+                        $boltCollectSaleRuleDiscounts[$savedRuleId] = $discountAmount;
                     } else {
                         $boltCollectSaleRuleDiscounts[$savedRuleId] += $discountAmount;
                     }


### PR DESCRIPTION
# Description

Currently, if the cart has multiple products and discounts, there is a mismatch discount (rounding) issue occurring which causes the customers not to be able to place an order.

To correct the Bolt discounts, we need to reset the rounding delta before saving them to the checkout session. Otherwise, $this->_roundingDeltas 
(https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/SalesRule/Model/Utility.php#L200) would return the old values and cause invalid discounts

Fixes: https://app.asana.com/0/564264490825835/1201256841759895

#changelog Fix mismatch discount (rounding) issue by re-setting rounding delta

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
