### PR TITLE
Add feature switch for order status update

### DIFF
--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -398,10 +398,10 @@ class Decider extends AbstractHelper
     }
     
     /**
-     * Disallow the order in processing/complete/closed status won't be updated back to pending_review/new
+     * Checks whether the feature switch for preventing the plugin method from overriding the order status
      */
-    public function isDisallowOrderStatusUpdatedBack()
+    public function isDisallowOrderStatusOverride()
     {
-        return $this->isSwitchEnabled(Definitions::M2_DISALLOW_SPECIFIC_ORDER_STATUS_UPDATE);
+        return $this->isSwitchEnabled(Definitions::M2_DISALLOW_ORDER_STATUS_OVERRIDE);
     }
 }

--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -396,4 +396,12 @@ class Decider extends AbstractHelper
     {
         return $this->isSwitchEnabled(Definitions::M2_ENABLE_PRODUCT_ENDPOINT);
     }
+    
+    /**
+     * Disallow the order in processing/complete/closed status won't be updated back to pending_review/new
+     */
+    public function isDisallowOrderStatusUpdatedBack()
+    {
+        return $this->isSwitchEnabled(Definitions::M2_DISALLOW_SPECIFIC_ORDER_STATUS_UPDATE);
+    }
 }

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -221,6 +221,11 @@ class Definitions
      * Prevent Bolt IPs from being saved as customer IP on quote
      */
     const M2_PREVENT_SETTING_BOLT_IPS_AS_CUSTOMER_IP_ON_QUOTE = 'M2_PREVENT_SETTING_BOLT_IPS_AS_CUSTOMER_IP_ON_QUOTE';
+    
+    /**
+     * Disallow the order in processing/complete/closed status won't be updated back to pending_review/new
+     */
+    const M2_DISALLOW_SPECIFIC_ORDER_STATUS_UPDATE = 'M2_DISALLOW_SPECIFIC_ORDER_STATUS_UPDATE';
 
     /**
      * Enable product endpoint
@@ -454,6 +459,12 @@ class Definitions
             self::NAME_KEY        => self::M2_ENABLE_PRODUCT_ENDPOINT,
             self::VAL_KEY         => true,
             self::DEFAULT_VAL_KEY => false,
+            self::ROLLOUT_KEY     => 100
+        ],
+        self::M2_DISALLOW_SPECIFIC_ORDER_STATUS_UPDATE => [
+            self::NAME_KEY        => self::M2_DISALLOW_SPECIFIC_ORDER_STATUS_UPDATE,
+            self::VAL_KEY         => true,
+            self::DEFAULT_VAL_KEY => true,
             self::ROLLOUT_KEY     => 100
         ],
     ];

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -486,7 +486,7 @@ class Definitions
             self::NAME_KEY        => self::M2_DISALLOW_ORDER_STATUS_OVERRIDE,
             self::VAL_KEY         => true,
             self::DEFAULT_VAL_KEY => false,
-            self::ROLLOUT_KEY     => 100
+            self::ROLLOUT_KEY     => 0
         ],
         self::M2_ENABLE_API_DRIVEN_INTEGRAION => [
             self::NAME_KEY        => self::M2_ENABLE_API_DRIVEN_INTEGRAION,

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -464,7 +464,7 @@ class Definitions
         self::M2_DISALLOW_SPECIFIC_ORDER_STATUS_UPDATE => [
             self::NAME_KEY        => self::M2_DISALLOW_SPECIFIC_ORDER_STATUS_UPDATE,
             self::VAL_KEY         => true,
-            self::DEFAULT_VAL_KEY => true,
+            self::DEFAULT_VAL_KEY => false,
             self::ROLLOUT_KEY     => 100
         ],
     ];

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -225,7 +225,7 @@ class Definitions
     /**
      * Disallow the order in processing/complete/closed status won't be updated back to pending_review/new
      */
-    const M2_DISALLOW_SPECIFIC_ORDER_STATUS_UPDATE = 'M2_DISALLOW_SPECIFIC_ORDER_STATUS_UPDATE';
+    const M2_DISALLOW_ORDER_STATUS_OVERRIDE = 'M2_DISALLOW_ORDER_STATUS_OVERRIDE';
 
     /**
      * Enable product endpoint
@@ -461,8 +461,8 @@ class Definitions
             self::DEFAULT_VAL_KEY => false,
             self::ROLLOUT_KEY     => 100
         ],
-        self::M2_DISALLOW_SPECIFIC_ORDER_STATUS_UPDATE => [
-            self::NAME_KEY        => self::M2_DISALLOW_SPECIFIC_ORDER_STATUS_UPDATE,
+        self::M2_DISALLOW_ORDER_STATUS_OVERRIDE => [
+            self::NAME_KEY        => self::M2_DISALLOW_ORDER_STATUS_OVERRIDE,
             self::VAL_KEY         => true,
             self::DEFAULT_VAL_KEY => false,
             self::ROLLOUT_KEY     => 100

--- a/Plugin/OrderPlugin.php
+++ b/Plugin/OrderPlugin.php
@@ -121,7 +121,7 @@ class OrderPlugin
             return [Order::STATE_PROCESSING];
         }
         
-        if (!$this->featureSwitches->isDisallowOrderStatusUpdatedBack()) {
+        if ($this->featureSwitches->isDisallowOrderStatusOverride()) {
             return [$status];
         }
         

--- a/Plugin/OrderPlugin.php
+++ b/Plugin/OrderPlugin.php
@@ -125,7 +125,7 @@ class OrderPlugin
         
         // The order state is for Magento to understand and process the order in a defined workflow.
         // Whereas, the order status is for store owners to understand and process the order in a workflow.
-        // The merchant may create any number of custom order statuses to manege the exact order flow.
+        // The merchant may create any number of custom order statuses to manage the exact order flow.
         // The feature switch M2_DISALLOW_ORDER_STATUS_OVERRIDE is for preventing the plugin method from overriding the order status.
         if ($this->featureSwitches->isDisallowOrderStatusOverride()) {
             return [$status];

--- a/Plugin/OrderPlugin.php
+++ b/Plugin/OrderPlugin.php
@@ -116,11 +116,17 @@ class OrderPlugin
             return [$status];
         }
 
+        // Recharge customer with an existing Bolt credit card is a custom behavior of Bolt plugin,
+        // so feature switch M2_DISALLOW_ORDER_STATUS_OVERRIDE does not affect it. 
         if ($subject->getIsRechargedOrder()) {
             // Check and set the recharged order state to processing
             return [Order::STATE_PROCESSING];
         }
         
+        // The order state is for Magento to understand and process the order in a defined workflow.
+        // Whereas, the order status is for store owners to understand and process the order in a workflow.
+        // The merchant may create any number of custom order statuses to manege the exact order flow.
+        // The feature switch M2_DISALLOW_ORDER_STATUS_OVERRIDE is for preventing the plugin method from overriding the order status.
         if ($this->featureSwitches->isDisallowOrderStatusOverride()) {
             return [$status];
         }


### PR DESCRIPTION
# Description
The order state is for Magento to understand and process the order in a defined workflow. Whereas, the order status is for store owners to understand and process the order in a workflow. The merchant may create any number of custom order statuses to manege the exact order flow, but currently the plugin method Bolt\Boltpay\Plugin\OrderPlugin::beforeSetStatus() has logic to ensure that the order in processing/complete/closed status won't be updated back to pending_review and override the default "pending" order status with the "pending_payment", that causes conflict issue. 

To fix this issue, we add a new feature switch M2_DISALLOW_ORDER_STATUS_OVERRIDE to enable/disable the logic.

Fixes: [(link Jira ticket)](https://app.asana.com/0/951157735838091/1201290052673025/f)

#changelog Add feature switch for order status update

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
