### PR TITLE
Fix Controller/ReceivedUrlTrait.php for M2 API driven

### DIFF
--- a/Controller/ReceivedUrlTrait.php
+++ b/Controller/ReceivedUrlTrait.php
@@ -117,7 +117,9 @@ trait ReceivedUrlTrait
                     );
                 }
 
-                $this->orderHelper->dispatchPostCheckoutEvents($order, $quote);
+                if (!$this->cartHelper->getFeatureSwitchDeciderHelper()->isAPIDrivenIntegrationEnabled()) {
+                    $this->orderHelper->dispatchPostCheckoutEvents($order, $quote);
+                }
 
                 $redirectUrl = $this->getRedirectUrl($order);
 
@@ -208,7 +210,11 @@ trait ReceivedUrlTrait
      */
     private function getOrderByIncrementId($incrementId)
     {
-        $order = $this->orderHelper->getExistingOrder($incrementId);
+        if ($this->cartHelper->getFeatureSwitchDeciderHelper()->isAPIDrivenIntegrationEnabled()) {
+            $order = $this->cartHelper->getOrderById($incrementId);
+        } else {
+            $order = $this->orderHelper->getExistingOrder($incrementId);
+        }
 
         if (!$order) {
             throw new NoSuchEntityException(

--- a/Test/Unit/Controller/Order/ReceivedUrlTest.php
+++ b/Test/Unit/Controller/Order/ReceivedUrlTest.php
@@ -202,14 +202,14 @@ class ReceivedUrlTest extends BoltTestCase
 
         $url = $this->createUrlMock();
 
-        $featureSwitchDeciderMock = $this->createMocK(\Bolt\Boltpay\Helper\FeatureSwitch\Decider::class);
-
         $cartHelper = $this->createMock(CartHelper::class);
         $cartHelper->expects($this->once())
             ->method('getQuoteById')
             ->with(self::QUOTE_ID)
             ->willReturn($quote);
-        $cartHelper->expects($this->once())
+
+        $featureSwitchDeciderMock = $this->createMock(\Bolt\Boltpay\Helper\FeatureSwitch\Decider::class);
+        $cartHelper->expects($this->any())
             ->method('getFeatureSwitchDeciderHelper')
             ->willReturn($featureSwitchDeciderMock);
 
@@ -327,6 +327,11 @@ class ReceivedUrlTest extends BoltTestCase
                    ->with(self::QUOTE_ID)
                    ->willReturn($quote);
 
+        $featureSwitchDeciderMock = $this->createMock(\Bolt\Boltpay\Helper\FeatureSwitch\Decider::class);
+        $cartHelper->expects($this->any())
+            ->method('getFeatureSwitchDeciderHelper')
+            ->willReturn($featureSwitchDeciderMock);
+
         $checkoutSession = $this->createMock(CheckoutSession::class);
 
         $configHelper = $this->createMock(ConfigHelper::class);
@@ -386,6 +391,11 @@ class ReceivedUrlTest extends BoltTestCase
         $cartHelper = $this->createMock(CartHelper::class);
         $cartHelper->method('getQuoteById')
             ->willReturn($quote);
+
+        $featureSwitchDeciderMock = $this->createMock(\Bolt\Boltpay\Helper\FeatureSwitch\Decider::class);
+        $cartHelper->expects($this->any())
+            ->method('getFeatureSwitchDeciderHelper')
+            ->willReturn($featureSwitchDeciderMock);
 
         $checkoutSession = $this->getMockBuilder(CheckoutSession::class)
             ->disableOriginalConstructor()
@@ -668,6 +678,11 @@ class ReceivedUrlTest extends BoltTestCase
         $this->context = $this->createMock(Context::class);
         $this->configHelper = $this->createMock(ConfigHelper::class);
         $this->cartHelper = $this->createMock(CartHelper::class);
+        $featureSwitchDeciderMock = $this->createMock(\Bolt\Boltpay\Helper\FeatureSwitch\Decider::class);
+        $this->cartHelper->expects($this->any())
+            ->method('getFeatureSwitchDeciderHelper')
+            ->willReturn($featureSwitchDeciderMock);
+
         $this->bugsnag = $this->createMock(Bugsnag::class);
         $this->logHelper = $this->createMock(LogHelper::class);
         $this->checkoutSession = $this->getMockBuilder(CheckoutSession::class)


### PR DESCRIPTION
In M2 API driven flow we still need the intermediate redirect page to assign new order to user session on it.
Two differences with the previous flow:
- we send order id, not incremental order id
- we do not need dispatch PostCheckoutEvents because they were already dispatched

#changelog Fix Controller/ReceivedUrlTrait.php for M2 API driven