### PR TITLE
Code refactoring for collecting discounts

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -2178,7 +2178,6 @@ class Cart extends AbstractHelper
     ) {
         $currencyCode = $quote->getQuoteCurrencyCode();
         $parentQuote = $this->getQuoteById($quote->getBoltParentQuoteId());
-        $address = $this->getCalculationAddress($quote);
         /** @var AddressTotal[] */
         $totals = $quote->getTotals();
         $this->logHelper->addInfoLog('### CartTotals: ' . json_encode(array_keys($totals)));
@@ -2189,52 +2188,42 @@ class Cart extends AbstractHelper
         // selecting specific shipping option, so the conditional statement should also
         // check if getCouponCode is not null
         /////////////////////////////////////////////////////////////////////////////////
-        if (($amount = abs($address->getDiscountAmount())) || $quote->getCouponCode()) {
-            // The discount amount of each sale rule is stored in the checkout session, using rule id as key,
-            // Bolt\Boltpay\Plugin\SalesRuleActionDiscountPlugin
-            $boltCollectSaleRuleDiscounts = $this->sessionHelper->getCheckoutSession()->getBoltCollectSaleRuleDiscounts([]);
-
-            $salesruleIds = explode(',', $quote->getAppliedRuleIds());
-            foreach ($salesruleIds as $salesruleId) {
-                if (!isset($boltCollectSaleRuleDiscounts[$salesruleId])) {
-                    continue;
-                }
+        if ($ruleDiscountDetails = $this->getSaleRuleDiscounts($quote)) {
+            foreach ($ruleDiscountDetails as $salesruleId => $ruleDiscountAmount) {
                 $rule = $this->ruleRepository->getById($salesruleId);
-                $ruleDiscountAmount = $boltCollectSaleRuleDiscounts[$salesruleId];
-                if ($rule && ($ruleDiscountAmount || $rule->getSimpleFreeShipping())) {
-                    $roundedAmount = CurrencyUtils::toMinor($ruleDiscountAmount, $currencyCode);
-                    switch ($rule->getCouponType()) {
-                        case RuleInterface::COUPON_TYPE_SPECIFIC_COUPON:
-                        case RuleInterface::COUPON_TYPE_AUTO:
-                            $couponCode = $quote->getCouponCode();
-                            $ruleDescription = $rule->getDescription();
-                            $description = $ruleDescription !== '' ? $ruleDescription : 'Discount (' . $couponCode . ')';
-                            $discounts[] = [
-                                'description'       => $description,
-                                'amount'            => $roundedAmount,
-                                'reference'         => $couponCode,
-                                'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_COUPON,
-                                'discount_type'     => $this->discountHelper->convertToBoltDiscountType($couponCode), // For v1/discounts.code.apply and v2/cart.update
-                                'type'              => $this->discountHelper->convertToBoltDiscountType($couponCode), // For v1/merchant/order
-                            ];
-                            $this->logEmptyDiscountCode($couponCode, $description);
+                $roundedAmount = CurrencyUtils::toMinor($ruleDiscountAmount, $currencyCode);
+                switch ($rule->getCouponType()) {
+                    case RuleInterface::COUPON_TYPE_SPECIFIC_COUPON:
+                    case RuleInterface::COUPON_TYPE_AUTO:
+                        $couponCode = $quote->getCouponCode();
+                        $ruleDescription = $rule->getDescription();
+                        $description = $ruleDescription !== '' ? $ruleDescription : 'Discount (' . $couponCode . ')';
+                        $discountType = $this->discountHelper->convertToBoltDiscountType($couponCode);
+                        $discounts[] = [
+                            'description'       => $description,
+                            'amount'            => $roundedAmount,
+                            'reference'         => $couponCode,
+                            'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_COUPON,
+                            'discount_type'     => $discountType, // For v1/discounts.code.apply and v2/cart.update
+                            'type'              => $discountType, // For v1/merchant/order
+                        ];
+                        $this->logEmptyDiscountCode($couponCode, $description);
 
-                            break;
-                        case RuleInterface::COUPON_TYPE_NO_COUPON:
-                        default:
-                            $description = trim($rule->getDescription()) ? $rule->getDescription() : $rule->getName();
-                            $discounts[] = [
-                                'description'       => trim(__('Discount ') . $description),
-                                'amount'            => $roundedAmount,
-                                'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_AUTO_PROMO,
-                                'discount_type'     => $this->discountHelper->getBoltDiscountType($rule->getSimpleAction()), // For v1/discounts.code.apply and v2/cart.update
-                                'type'              => $this->discountHelper->getBoltDiscountType($rule->getSimpleAction()), // For v1/merchant/order
-                            ];
+                        break;
+                    case RuleInterface::COUPON_TYPE_NO_COUPON:
+                    default:
+                        $discountType = $this->discountHelper->convertToBoltDiscountType('');
+                        $discounts[] = [
+                            'description'       => trim(__('Discount ') . $rule->getDescription()),
+                            'amount'            => $roundedAmount,
+                            'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_AUTO_PROMO,
+                            'discount_type'     => $discountType, // For v1/discounts.code.apply and v2/cart.update
+                            'type'              => $discountType, // For v1/merchant/order
+                        ];
 
-                            break;
-                    }
-                    $totalAmount -= $roundedAmount;
+                        break;
                 }
+                $totalAmount -= $roundedAmount;
             }
         }
         /////////////////////////////////////////////////////////////////////////////////
@@ -2804,6 +2793,65 @@ class Cart extends AbstractHelper
             }
         }
 
+        return false;
+    }
+    
+    /**
+     * Collect discount amount from each applied sale rules.
+     *
+     * @param \Magento\Quote\Model\Quote $quote
+     *
+     * @return array
+     */
+    public function getSaleRuleDiscounts($quote)
+    {
+        $address = $this->getCalculationAddress($quote);
+        if (!($appliedSaleRuleIds = $address->getAppliedRuleIds())) {
+            return [];
+        }
+        $salesRuleIds = explode(',', $appliedSaleRuleIds);
+        $saleRuleDiscountsDetails = [];
+        // If the Magento version < 2.3.4, we still collect discounts details via plugin methods.
+        if ($this->isCollectDiscountsByPlugin($quote)) {
+            $saleRuleDiscountsDetails = $this->sessionHelper->getCheckoutSession()->getBoltCollectSaleRuleDiscounts([]);
+        } else {
+            /* @var \Magento\SalesRule\Api\Data\RuleDiscountInterface $ruleDiscounts */
+            $extensionSaleRuleDiscounts = $address->getExtensionAttributes()->getDiscounts();
+            if ($extensionSaleRuleDiscounts && is_array($extensionSaleRuleDiscounts)) {
+                foreach ($extensionSaleRuleDiscounts as $value) {
+                    /* @var \Magento\SalesRule\Api\Data\DiscountDataInterface $discountData */
+                    $discountData = $value->getDiscountData();
+                    $saleRuleDiscountsDetails[$value->getRuleID()] = $discountData->getAmount();
+                }
+            }
+        }
+        
+        $ruleDiscountDetails = [];
+        foreach ($salesRuleIds as $salesRuleId) {
+            $rule = $this->ruleRepository->getById($salesRuleId);
+            // Only collect non-zero discount / free shipping promotion
+            if (!$rule || (!array_key_exists($salesRuleId, $saleRuleDiscountsDetails) && !$rule->getSimpleFreeShipping())) {
+                continue;
+            }
+            $ruleDiscountDetails[$salesRuleId] = array_key_exists($salesRuleId, $saleRuleDiscountsDetails) ? $saleRuleDiscountsDetails[$salesRuleId] : 0;
+        }
+        return $ruleDiscountDetails;
+    }
+    
+    /**
+     * If the Magento version < 2.3.4, we still collect discounts details via plugin methods.
+     *
+     * @param \Magento\Quote\Model\Quote $quote
+     *
+     * @return bool
+     */
+    public function isCollectDiscountsByPlugin($quote)
+    {
+        if ($this->configHelper->isActive($quote->getStore()->getId())
+            && version_compare($this->configHelper->getStoreVersion(), '2.3.4', '<')) {
+            return true;
+        }
+        
         return false;
     }
 }

--- a/Plugin/SalesRuleActionDiscountPlugin.php
+++ b/Plugin/SalesRuleActionDiscountPlugin.php
@@ -16,18 +16,23 @@
  */
 namespace Bolt\Boltpay\Plugin;
 
+use Bolt\Boltpay\Helper\Cart as CartHelper;
 use Bolt\Boltpay\Helper\Session as SessionHelper;
 
 class SalesRuleActionDiscountPlugin
 {
+    /** @var CartHelper */
+    private $cartHelper;
 
     /** @var SessionHelper */
     private $sessionHelper;
     
     public function __construct(
-        SessionHelper $sessionHelper
+        SessionHelper $sessionHelper,
+        CartHelper $cartHelper
     ) {
         $this->sessionHelper = $sessionHelper;
+        $this->cartHelper = $cartHelper;
     }
     
     public function afterCalculate(
@@ -37,6 +42,10 @@ class SalesRuleActionDiscountPlugin
         $item,
         $qty
     ) {
+        if (!$this->cartHelper->isCollectDiscountsByPlugin($item->getQuote())) {
+            return $result;
+        }
+        
         $checkoutSession = $this->sessionHelper->getCheckoutSession();
 
         // Save the sale rule id into session,

--- a/Plugin/SalesRuleQuoteDiscountPlugin.php
+++ b/Plugin/SalesRuleQuoteDiscountPlugin.php
@@ -17,20 +17,30 @@
 namespace Bolt\Boltpay\Plugin;
 
 use Bolt\Boltpay\Helper\Session as SessionHelper;
+use Bolt\Boltpay\Helper\Cart as CartHelper;
 
 class SalesRuleQuoteDiscountPlugin
 {
     /** @var SessionHelper */
     private $sessionHelper;
+
+    /** @var CartHelper */
+    private $cartHelper;
     
     public function __construct(
-        SessionHelper $sessionHelper
+        SessionHelper $sessionHelper,
+        CartHelper $cartHelper
     ) {
         $this->sessionHelper = $sessionHelper;
+        $this->cartHelper = $cartHelper;
     }
     
     public function beforeCollect(\Magento\SalesRule\Model\Quote\Discount $subject, $quote, $shippingAssignment, $total)
     {
+        if (!$this->cartHelper->isCollectDiscountsByPlugin($quote)) {
+            return [$quote, $shippingAssignment, $total];
+        }
+        
         $items = $shippingAssignment->getItems();
         
         if (!count($items)) {

--- a/Test/Unit/Model/Api/UpdateDiscountTraitTest.php
+++ b/Test/Unit/Model/Api/UpdateDiscountTraitTest.php
@@ -35,6 +35,7 @@ use Bolt\Boltpay\Exception\BoltException;
 use Bolt\Boltpay\Model\ErrorResponse as BoltErrorResponse;
 use Bolt\Boltpay\Helper\Log as LogHelper;
 use Bolt\Boltpay\Helper\Bugsnag;
+use Bolt\Boltpay\Helper\Cart as CartHelper;
 use Bolt\Boltpay\Helper\Discount as DiscountHelper;
 use Bolt\Boltpay\Test\Unit\TestHelper;
 use Bolt\Boltpay\Model\EventsForThirdPartyModules;
@@ -133,6 +134,11 @@ class UpdateDiscountTraitTest extends BoltTestCase
      * @var MockObject|EventsForThirdPartyModules
      */
     private $eventsForThirdPartyModules;
+    
+    /**
+     * @var MockObject|CartHelper
+     */
+    private $cartHelper;
 
     /**
      * @var UpdateDiscountTrait
@@ -185,6 +191,10 @@ class UpdateDiscountTraitTest extends BoltTestCase
         $this->discountHelper = $this->getMockBuilder(DiscountHelper::class)
             ->disableOriginalConstructor()
             ->getMock();
+            
+        $this->cartHelper = $this->getMockBuilder(CartHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $this->sessionHelper = $this->getMockBuilder(SessionHelper::class)
             ->setMethods(['getCheckoutSession'])
@@ -214,6 +224,7 @@ class UpdateDiscountTraitTest extends BoltTestCase
         TestHelper::setProperty($this->currentMock, 'totalsCollector', $this->totalsCollector);
         TestHelper::setProperty($this->currentMock, 'sessionHelper', $this->sessionHelper);
         TestHelper::setProperty($this->currentMock, 'eventsForThirdPartyModules', $this->eventsForThirdPartyModules);
+        TestHelper::setProperty($this->currentMock, 'cartHelper', $this->cartHelper);
 
         $this->initRequiredMocks();
     }
@@ -601,16 +612,9 @@ class UpdateDiscountTraitTest extends BoltTestCase
 
         $this->discountHelper->expects(self::once())->method('setCouponCode')
             ->with($quote, self::COUPON_CODE);
-
-        $checkoutSession = $this->createPartialMock(
-            CheckoutSession::class,
-            ['getBoltCollectSaleRuleDiscounts']
-        );
-        $checkoutSession->expects(static::once())
-                        ->method('getBoltCollectSaleRuleDiscounts')
-                        ->willReturn([self::RULE_ID => 10]);
-        $this->sessionHelper->expects(static::once())->method('getCheckoutSession')
-             ->willReturn($checkoutSession);
+            
+        $this->cartHelper->expects(self::once())->method('getSaleRuleDiscounts')
+            ->with($quote)->willReturn([self::RULE_ID => 10]);
 
         $result = TestHelper::invokeMethod($this->currentMock, 'applyDiscount', [self::COUPON_CODE, $coupon, null, $quote]);
 
@@ -672,15 +676,8 @@ class UpdateDiscountTraitTest extends BoltTestCase
 
         $shippingDiscountAmount = 1000;
 
-        $checkoutSession = $this->createPartialMock(
-            CheckoutSession::class,
-            ['getBoltCollectSaleRuleDiscounts']
-        );
-        $checkoutSession->expects(static::once())
-                        ->method('getBoltCollectSaleRuleDiscounts')
-                        ->willReturn([self::RULE_ID => 10]);
-        $this->sessionHelper->expects(static::once())->method('getCheckoutSession')
-             ->willReturn($checkoutSession);
+        $this->cartHelper->expects(self::once())->method('getSaleRuleDiscounts')
+            ->with($quote)->willReturn([self::RULE_ID => 10]);
 
         $result = [
             'status'          => 'success',
@@ -809,15 +806,8 @@ class UpdateDiscountTraitTest extends BoltTestCase
         $this->discountHelper->expects(self::once())->method('convertToBoltDiscountType')
             ->with(self::COUPON_CODE)->willReturn('fixed_amount');
 
-        $checkoutSession = $this->createPartialMock(
-            CheckoutSession::class,
-            ['getBoltCollectSaleRuleDiscounts']
-        );
-        $checkoutSession->expects(static::once())
-            ->method('getBoltCollectSaleRuleDiscounts')
-            ->willReturn([self::RULE_ID => 10]);
-        $this->sessionHelper->expects(static::once())->method('getCheckoutSession')
-            ->willReturn($checkoutSession);
+        $this->cartHelper->expects(self::once())->method('getSaleRuleDiscounts')
+            ->with($quote)->willReturn([self::RULE_ID => 10]);
 
         $eventsForThirdPartyModules = $this->createMock(EventsForThirdPartyModules::class);
         $eventsForThirdPartyModules->method('runFilter')
@@ -1066,15 +1056,8 @@ class UpdateDiscountTraitTest extends BoltTestCase
         $this->discountHelper->expects(self::once())->method('setCouponCode')
             ->with($quote, self::COUPON_CODE);
 
-        $checkoutSession = $this->createPartialMock(
-            CheckoutSession::class,
-            ['getBoltCollectSaleRuleDiscounts']
-        );
-        $checkoutSession->expects(static::once())
-                        ->method('getBoltCollectSaleRuleDiscounts')
-                        ->willReturn([self::RULE_ID => 10]);
-        $this->sessionHelper->expects(static::once())->method('getCheckoutSession')
-             ->willReturn($checkoutSession);
+        $this->cartHelper->expects(self::once())->method('getSaleRuleDiscounts')
+            ->with($quote)->willReturn([self::RULE_ID => 10]);
 
         $result = TestHelper::invokeMethod($this->currentMock, 'applyingCouponCode', [self::COUPON_CODE, $coupon, $quote]);
 


### PR DESCRIPTION
# Description
From Magento 2 v2.3.4, we can get details of applied sale rules from $address->getExtensionAttributes()->getDiscounts() and there is no need to calculate discount amount of each sale rule via plugin methods separately (That may cause potential bug and we need to maintain the calculation as long as M2 updates).

Then we still keep the approach to collect discounts via plugin methods for the merchant which still use old versions of Magento 2. 

Tested with Magento 2 v2.3.0, v2.3.4, v2.4.0, v2.4.3-p1

Fixes: (link Jira ticket)

#changelog Code refactoring for collecting discounts

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
