### PR TITLE
Add Aheadworks Store Credit to layout to be rendered below the cart

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -322,6 +322,11 @@ class Config extends AbstractHelper
     const XML_PATH_AHEADWORKS_REWARD_POINTS_ON_CART = 'payment/boltpay/aheadworks_reward_points_on_cart';
     
     /**
+     * Use Aheadworks Store Credit on Shopping Cart configuration path
+     */
+    const XML_PATH_AHEADWORKS_STORE_CREDIT_ON_CART = 'payment/boltpay/aheadworks_store_credit_on_cart';
+    
+    /**
      * Use MageWorx Reward Points on Shopping Cart configuration path
      */
     const XML_PATH_MAGEWORX_REWARD_POINTS_ON_CART = 'payment/boltpay/mageworx_reward_points_on_cart';
@@ -2201,6 +2206,22 @@ class Config extends AbstractHelper
     {
         return $this->getScopeConfig()->isSetFlag(
             self::XML_PATH_AHEADWORKS_REWARD_POINTS_ON_CART,
+            ScopeInterface::SCOPE_STORE,
+            $store
+        );
+    }
+    
+    /**
+     * Get Use Aheadworks Store Credit on Shopping Cart configuration
+     *
+     * @param int|string|Store $store
+     *
+     * @return bool
+     */
+    public function getUseAheadworksStoreCreditConfig($store = null)
+    {
+        return $this->getScopeConfig()->isSetFlag(
+            self::XML_PATH_AHEADWORKS_STORE_CREDIT_ON_CART,
             ScopeInterface::SCOPE_STORE,
             $store
         );

--- a/Model/EventsForThirdPartyModules.php
+++ b/Model/EventsForThirdPartyModules.php
@@ -962,6 +962,11 @@ class EventsForThirdPartyModules
                     "sendClasses" => ["MageWorx\RewardPoints\Helper\Data"],
                     "boltClass"   => MageWorx_RewardPoints::class,
                 ],
+                "Aheadworks_StoreCredit" => [
+                    "module"      => "Aheadworks_StoreCredit",
+                    "sendClasses" => ["Aheadworks\StoreCredit\Api\CustomerStoreCreditManagementInterface"],
+                    "boltClass"   => Aheadworks_StoreCredit::class,
+                ],
             ]
         ],
         "saveSessionData" => [

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -394,6 +394,12 @@
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <if_module_enabled>Aheadworks_RewardPoints</if_module_enabled>
                     </field>
+                    <field id="aheadworks_store_credit" translate="label" type="select" sortOrder="11" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Use Aheadworks Store Credit on Shopping Cart</label>
+                        <config_path>payment/boltpay/aheadworks_store_credit_on_cart</config_path>
+                        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                        <if_module_enabled>Aheadworks_StoreCredit</if_module_enabled>
+                    </field>
                     <field id="store_credit" translate="label" type="select" sortOrder="240" showInDefault="1" showInWebsite="1" showInStore="1">
                         <label>Use Store Credit on Shopping Cart</label>
                         <config_path>payment/boltpay/store_credit</config_path>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -78,6 +78,7 @@ tr.shipping.totals td.amount span.price,
                 <universal_debug>1</universal_debug>
                 <aheadworks_reward_points_on_cart>1</aheadworks_reward_points_on_cart>
                 <mageworx_reward_points_on_cart>1</mageworx_reward_points_on_cart>
+                <aheadworks_store_credit_on_cart>1</aheadworks_store_credit_on_cart>
             </boltpay>
         </payment>
     </default>


### PR DESCRIPTION
# Description
Add Aheadworks Store Credit to layout to be rendered below the cart

Fixes: (link Jira ticket)

#changelog Add Aheadworks Store Credit to layout to be rendered below the cart

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
