### PR TITLE
Improvement: Move shipping validation prior to tax validation

### DIFF
--- a/Model/Api/CreateOrder.php
+++ b/Model/Api/CreateOrder.php
@@ -454,8 +454,8 @@ class CreateOrder implements CreateOrderInterface
         );
         $this->validateMinimumAmount($quote);
         $this->validateCartItems($quote, $transaction);
-        $this->validateTax($quote, $transaction);
         $this->validateShippingCost($quote, $transaction);
+        $this->validateTax($quote, $transaction);
         $this->validateTotalAmount($quote, $transaction);
     }
 


### PR DESCRIPTION
# Description
**Issue**: 
Currently, Bolt validates tax before shipping. When the mismatched shipping issue causes the mismatched tax issue (shipping is taxable), Bugsnag just logs the mismatched tax issue. This would cause the developers to have a hard time figuring out the root cause.

**Improvement**:
Moving the shipping validation prior to the tax validation. This is the same as Magento flow because Magento calculates shipping before tax. 
See here: 
https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Tax/Model/Sales/Total/Quote/Tax.php#L126

Fixes: (link Jira ticket)

#changelog Improvement: Move shipping validation prior to tax validation

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
