### PR TITLE
Exclude deleted product from Bolt cart

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1431,8 +1431,11 @@ class Cart extends AbstractHelper
 
         $products = array_map(
             function ($item) use ($imageHelper, &$totalAmount, &$diff, $isOrder, $storeId, $currencyCode, $additionalAttributes) {
+                $_product = $item->getProduct();
+                if (!$_product) {
+                    return [];
+                }
                 $product = [];
-
                 if ($isOrder) {
                     $unitPrice = $item->getPrice();
                     $quantity = round($item->getQtyOrdered());
@@ -1453,13 +1456,11 @@ class Cart extends AbstractHelper
                 ////////////////////////////////////
                 // Load item product object
                 ////////////////////////////////////
-                //By default this feature switch is enabled.
-                $_product = $item->getProduct();
                 $customizableOptions = null;
                 $itemSku = trim($item->getSku());
                 $itemReference = $item->getProductId();
                 $itemName = $item->getName();
-
+                //By default this feature switch is enabled.
                 if ($this->deciderHelper->isCustomizableOptionsSupport()) {
                     try {
                         $customizableOptions = $this->getProductCustomizableOptions($item);

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -4914,6 +4914,28 @@ ORDER
 
         TestUtils::cleanupSharedFixtures([$order]);
     }
+    
+    /**
+     * @test
+     * that getCartItemsForOrder returns expected data and attributes
+     *
+     * @covers ::getCartItemsForOrder
+     */
+    public function getCartItemsForOrder_WithDeletedProduct()
+    {
+        $product = TestUtils::getSimpleProduct();
+        $quantity = 2;
+
+        $order = TestUtils::createDumpyOrder([], [], [TestUtils::createOrderItemByProduct($product, $quantity)]);
+
+        TestUtils::cleanupSharedFixtures([$product]);
+
+        list($products, $totalAmount, $diff) = $this->currentMock->getCartItemsForOrder($order, self::STORE_ID);
+
+        static::assertCount(0, $products);
+
+        TestUtils::cleanupSharedFixtures([$order]);
+    }
 
         /**
          * @test

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -4923,7 +4923,7 @@ ORDER
      */
     public function getCartItemsForOrder_WithDeletedProduct()
     {
-        $product = TestUtils::getSimpleProduct();
+        $product = TestUtils::createSimpleProduct();
         $quantity = 2;
         $order = TestUtils::createDumpyOrder([], [], [TestUtils::createOrderItemByProduct($product, $quantity)]);
         $product->delete();

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -4925,15 +4925,10 @@ ORDER
     {
         $product = TestUtils::getSimpleProduct();
         $quantity = 2;
-
         $order = TestUtils::createDumpyOrder([], [], [TestUtils::createOrderItemByProduct($product, $quantity)]);
-
-        TestUtils::cleanupSharedFixtures([$product]);
-
+        $product->delete();
         list($products, $totalAmount, $diff) = $this->currentMock->getCartItemsForOrder($order, self::STORE_ID);
-
         static::assertCount(0, $products);
-
         TestUtils::cleanupSharedFixtures([$order]);
     }
 

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -4928,7 +4928,7 @@ ORDER
         $order = TestUtils::createDumpyOrder([], [], [TestUtils::createOrderItemByProduct($product, $quantity)]);
         $product->delete();
         list($products, $totalAmount, $diff) = $this->currentMock->getCartItemsForOrder($order, self::STORE_ID);
-        static::assertCount(0, $products);
+        static::assertCount(0, $products[0]);
         TestUtils::cleanupSharedFixtures([$order]);
     }
 

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -4782,8 +4782,8 @@ class OrderTest extends BoltTestCase
         $this->expectException(BoltException::class);
         $this->expectExceptionMessage(
             sprintf(
-                "Order Delete Error. Order is in invalid state. Order #: %d State: %s Immutable Quote ID: %d",
-                $order->getIncrementId(),
+                "Order Delete Error. Order is in invalid state. Order #: %s State: %s Immutable Quote ID: %d",
+                $incrementId,
                 OrderModel::STATE_PROCESSING,
                 self::QUOTE_ID
             )

--- a/Test/Unit/TestUtils.php
+++ b/Test/Unit/TestUtils.php
@@ -173,8 +173,7 @@ class TestUtils
 
         /** @var Order $order */
         $order = $objectManager->create(Order::class);
-        $order->setIncrementId('100000001')
-            ->setState($state)
+        $order->setState($state)
             ->setStatus($order->getConfig()->getStateDefaultStatus($status))
             ->setSubtotal(100)
             ->setGrandTotal(100)


### PR DESCRIPTION
# Description
When getting order items for Bolt cart, we do not check if the related product is already deleted, as a result, there is fatal error with collecting item info.

Solution: check if the product exists before processing.

Fixes: [(link Jira ticket)](https://app.asana.com/0/951157735838091/1201391676862045/f)

#changelog Exclude deleted product from Bolt cart

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
