### PR TITLE
Reload cart if integration mode changed

### DIFF
--- a/Block/Js.php
+++ b/Block/Js.php
@@ -315,6 +315,7 @@ class Js extends Template
             'always_present_checkout'               => $this->enableAlwaysPresentCheckoutButton(),
             'account_url'                           => $this->getAccountJsUrl(),
             'order_management_selector'             => $this->getOrderManagementSelector(),
+            'api_integration'                       => $this->featureSwitches->isAPIDrivenIntegrationEnabled(),
         ]);
     }
 

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -643,6 +643,7 @@ class Cart extends AbstractHelper
             $identifier .= $this->convertCustomAddressFieldsToCacheIdentifier($immutableQuote);
             $identifier .= $this->convertExternalFieldsToCacheIdentifier($immutableQuote);
         }
+        $identifier .= $this->deciderHelper->isAPIDrivenIntegrationEnabled();
         $identifier = $this->eventsForThirdPartyModules->runFilter('getCartCacheIdentifier', $identifier, $immutableQuote, $cart);
 
         return hash('md5', $identifier);
@@ -883,6 +884,11 @@ class Cart extends AbstractHelper
                         'response' => ArrayHelper::arrayToObject($boltOrderData['response'])
                     ]
                 );
+
+                if ($this->deciderHelper->isAPIDrivenIntegrationEnabled()) {
+                    return $boltOrder;
+                }
+
                 $immutableQuoteId = $this->getImmutableQuoteIdFromBoltOrder($boltOrder->getResponse());
 
                 // found in cache, check if the old immutable quote is still there

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -67,7 +67,7 @@ class JsTest extends BoltTestCase
     /**
      * @var int expected number of settings returned by {@see \Bolt\Boltpay\Block\Js::getSettings}
      */
-    const SETTINGS_NUMBER = 27;
+    const SETTINGS_NUMBER = 28;
 
     /**
      * @var int expeced number of tracking callback returned by {@see \Bolt\Boltpay\Block\Js::getTrackCallbacks}
@@ -815,6 +815,7 @@ class JsTest extends BoltTestCase
         static::assertArrayHasKey('always_present_checkout', $array, $message . 'always_present_checkout');
         $this->assertArrayHasKey('account_url', $array, $message . 'account_url');
         $this->assertArrayHasKey('order_management_selector', $array, $message . 'order_management_selector');
+        $this->assertArrayHasKey('api_integration', $array, $message . 'api_integration');
     }
 
     /**

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -847,7 +847,13 @@ $isLoadTrackJsDynamic = $block->isDisableTrackJsOnNonBoltPages() && $isLoadConne
                     invalidateBoltCart();
                 }
             }
-            
+
+            apiFlow = BoltState.boltCart.cartReference == "";
+            if (apiFlow != settings.api_integration && ( Date.now()/1000 - boltCartDataID > 60) ) {
+                invalidateBoltCart();
+                return;
+            }
+
             <?= /* @noEscape */ $block->getAdditionalInvalidateBoltCartJavascript(); ?>
         }
 

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -817,6 +817,8 @@ $isLoadTrackJsDynamic = $block->isDisableTrackJsOnNonBoltPages() && $isLoadConne
 
         var boltCartDataID;
 
+        var boltCartInvalidated = false;
+
         var invalidateBoltCartIfOutdated = function() {
             if (BoltState.magentoCart === undefined || BoltState.magentoCart.data_id === undefined) {
                 return;
@@ -849,7 +851,8 @@ $isLoadTrackJsDynamic = $block->isDisableTrackJsOnNonBoltPages() && $isLoadConne
             }
 
             apiFlow = BoltState.boltCart.cartReference == "";
-            if (apiFlow != settings.api_integration && ( Date.now()/1000 - boltCartDataID > 60) ) {
+            if (apiFlow != settings.api_integration && !boltCartInvalidated) {
+                boltCartInvalidated = true;
                 invalidateBoltCart();
                 return;
             }


### PR DESCRIPTION
When we disable or enable new api driven flow we should try not to affect the users in the middle of checkout process.

Before this PR users on cart page are blocked until they update cart.

With this PR users on the cart page just need to reload the page to be unblocked.

Just in case we do cart invalidation only once per cart page reloading.

#changelog invalidate cart if plugin mode changed