### PR TITLE
Add callback parameter in the onClose callback

### DIFF
--- a/view/frontend/templates/js/boltglobaljs.phtml
+++ b/view/frontend/templates/js/boltglobaljs.phtml
@@ -49,7 +49,7 @@ $onSuccessCode = $block->getJavascriptSuccess() . $trackCallbackCode['success'];
         ?>,
         onPaymentSubmit: <?= /* @noEscape */ $block->wrapWithCatch($trackCallbackCode['payment_submit']); ?>,
         onSuccess: <?= /* @noEscape */ $block->wrapWithCatch($onSuccessCode, 'data') ?>,
-        onClose: <?= /* @noEscape */ $block->wrapWithCatch($trackCallbackCode['close']); ?>,
+        onClose: <?= /* @noEscape */ $block->wrapWithCatch($trackCallbackCode['close'], 'callbacks'); ?>,
     };
 
     ////////////////////////////////////////////////////////////////////////

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -540,7 +540,7 @@ $isLoadConnectJsDynamic = $block->isLoadConnectJsDynamic();
 
             close: function () {
                 popUpOpen = false;
-                trackCallbacks.onClose();
+                trackCallbacks.onClose(callbacks);
 
                 if (callbacks.success_url) {
                     // redirect on success order save


### PR DESCRIPTION
# Description
In some cases, merchants need to use the callbacks info in the onClose callback to handle their custom logic. So this PR is to add callbacks parameter in the onClose callback

Fixes: https://app.asana.com/0/1137788479595677/1201410252410780

#changelog Add callback parameter in the onClose callback

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
