### PR TITLE
Add support for MageWorld Affiliate 1.4.2

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -933,9 +933,7 @@ class Order extends AbstractHelper
             });
         }
         ///////////////////////////////////////////////////////////////
-
-        $this->eventsForThirdPartyModules->dispatchEvent("beforeSaveUpdateOrder", $immutableQuote, $transaction);
-
+        
         // check if the order exists
         $order = $this->getExistingOrder($incrementId, $parentQuoteId);
 

--- a/Model/EventsForThirdPartyModules.php
+++ b/Model/EventsForThirdPartyModules.php
@@ -978,7 +978,7 @@ class EventsForThirdPartyModules
                 ],
                 [
                     "module" => "MW_Affiliate",
-                    "checkClasses" => ["MW\Affiliate\Helper\Data"],
+                    "sendClasses" => ["MW\Affiliate\Helper\Data"],
                     "boltClass" => MW_Affiliate::class,
                 ],
             ],
@@ -1190,6 +1190,12 @@ class EventsForThirdPartyModules
                     "checkClasses" => self::AMASTY_GIFTCARD_V25_CHECK_CLASSES,
                     'sendClasses'  => ['Amasty\GiftCardAccount\Model\GiftCardExtension\Order\Handlers\SaveHandler'],
                     "boltClass"    => Amasty_GiftCardAccount::class,
+                ],
+                'MW_Affiliate' => [
+                    "module" => "MW_Affiliate",
+                    "sendClasses" => ["MW\Affiliate\Helper\Data",
+                                      "MW\Affiliate\Observer\SalesOrderAfter"],
+                    "boltClass" => MW_Affiliate::class,
                 ],
             ],
         ],

--- a/Model/EventsForThirdPartyModules.php
+++ b/Model/EventsForThirdPartyModules.php
@@ -331,15 +331,6 @@ class EventsForThirdPartyModules
                 ],
             ]
         ],
-        'beforeSaveUpdateOrder' => [
-            "listeners" => [
-                [
-                    "module" => "MW_Affiliate",
-                    "checkClasses" => ["MW\Affiliate\Helper\Data"],
-                    "boltClass" => MW_Affiliate::class,
-                ],
-            ]
-        ],
         "setExtraAddressInformation" => [
             "listeners" => [
                 [

--- a/ThirdPartyModules/MageWorld/Affiliate.php
+++ b/ThirdPartyModules/MageWorld/Affiliate.php
@@ -149,7 +149,7 @@ class Affiliate
     }
     
     /**
-     * Restore MW affiliate referral link info to the cookies.
+     * Restore MW affiliate referral link info/referral code to the cookies/session.
      *
      * @param OrderModel $result
      * @param \MW\Affiliate\Helper\Data $mwAffiliateHelperData


### PR DESCRIPTION
# Description
The merchant updates MageWorld Affiliate from 1.4.0 to 1.4.2 and experiences an issue that the commission is not applied to the affiliate's acct. This PR is to fix this compatibility issue.

Tested with both MageWorld Affiliate 1.4.0 and 1.4.2

Fixes: [(link Jira ticket)](https://app.asana.com/0/951157735838091/1201423349470785/f)

#changelog Add support for MageWorld Affiliate 1.4.2

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
