### PR TITLE
Bugfix: JS error on cart page if quote is empty (M2E)

### DIFF
--- a/Block/Js.php
+++ b/Block/Js.php
@@ -662,17 +662,6 @@ function($argName) {
         $storeId = $this->getStoreId();
         return $this->isOnCartPage() && !$this->configHelper->getBoltOnCartPage($storeId);
     }
-    
-    /**
-     * Return true if cart is empty, otherwise, false.
-     *
-     * @return bool
-     */
-    public function isCartEmpty()
-    {
-        $quote = $this->getQuoteFromCheckoutSession();
-        return $quote ? !($quote->getItemsCount()) : true;
-    }
 
     /**
      * @return string

--- a/Block/Js.php
+++ b/Block/Js.php
@@ -662,6 +662,17 @@ function($argName) {
         $storeId = $this->getStoreId();
         return $this->isOnCartPage() && !$this->configHelper->getBoltOnCartPage($storeId);
     }
+    
+    /**
+     * Return true if cart is empty, otherwise, false.
+     *
+     * @return bool
+     */
+    public function isCartEmpty()
+    {
+        $quote = $this->getQuoteFromCheckoutSession();
+        return $quote ? !($quote->getItemsCount()) : true;
+    }
 
     /**
      * @return string

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -1581,9 +1581,6 @@ $isLoadTrackJsDynamic = $block->isDisableTrackJsOnNonBoltPages() && $isLoadConne
         ?>
     });
 
-    <?php
-    if (!$block->isCartEmpty()) {
-    ?>
     if ((trim(location.pathname, '/') === 'checkout/cart') || (trim(location.pathname, '/') === 'checkout')) {
         require(['domReady!'], function() {
             require([
@@ -1625,7 +1622,4 @@ $isLoadTrackJsDynamic = $block->isDisableTrackJsOnNonBoltPages() && $isLoadConne
             })
        })
     }
-    <?php
-    }
-    ?>
 </script>

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -1581,6 +1581,9 @@ $isLoadTrackJsDynamic = $block->isDisableTrackJsOnNonBoltPages() && $isLoadConne
         ?>
     });
 
+    <?php
+    if (!$block->isCartEmpty()) {
+    ?>
     if ((trim(location.pathname, '/') === 'checkout/cart') || (trim(location.pathname, '/') === 'checkout')) {
         require(['domReady!'], function() {
             require([
@@ -1622,4 +1625,7 @@ $isLoadTrackJsDynamic = $block->isDisableTrackJsOnNonBoltPages() && $isLoadConne
             })
        })
     }
+    <?php
+    }
+    ?>
 </script>

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -1582,30 +1582,58 @@ $isLoadTrackJsDynamic = $block->isDisableTrackJsOnNonBoltPages() && $isLoadConne
     });
 
     if ((trim(location.pathname, '/') === 'checkout/cart') || (trim(location.pathname, '/') === 'checkout')) {
+        define("boltRequireOptional", [], {
+            load : function (moduleName, parentRequire, onload, config){
+                var onLoadSuccess = function(moduleInstance){
+                    // Module successfully loaded, call the onload callback so that
+                    // RequireJS can work its internal magic.
+                    onload(moduleInstance);
+                }
+                var onLoadFailure = function(err){
+                    // Module failed to load.
+                    if (err.requireModules) {
+                        var failedId = err.requireModules[0];
+                        console.warn("Could not load module: " + failedId);
+                        // Undefine the module to cleanup internal stuff in RequireJS
+                        requirejs.undef(failedId);
+                        // Now define the module instance as a simple empty object
+                        define(failedId, [], function(){return {};});
+                        // Now require the module make sure that RequireJS thinks 
+                        // that is it loaded. Since we've just defined it, RequireJS 
+                        // will not attempt to download any more script files and
+                        // will just call the onLoadSuccess handler immediately
+                        parentRequire([failedId], onLoadSuccess);
+                    }
+                }
+                parentRequire([moduleName], onLoadSuccess, onLoadFailure);
+            }
+        });
         require(['domReady!'], function() {
             require([
             'jquery',
-            'Magento_Checkout/js/model/quote',
+            'boltRequireOptional!Magento_Checkout/js/model/quote',
             ], function ($, quote) {
-                // If quote total was changed through a method we didn't create,
+                // If quote is not empty and quote total was changed through a method we didn't create,
                 // we should reload the bolt cart since totals are probably now out of sync.
-                quote.totals.subscribe(function (totals) {
-                    if (waitingForResolvingPromises) {
-                        return;
-                    }
-                    if (expectCartRendering) {
+                if (!jQuery.isEmptyObject(quote)) {
+                    quote.totals.subscribe(function (totals) {
+                        if (waitingForResolvingPromises) {
+                            return;
+                        }
+                        if (expectCartRendering) {
+                            expectCartRendering = false;
+                            try {
+                                if ((totals.base_subtotal+totals.base_discount_amount) * 100 == BoltState.boltCart.total_amount.amount
+                                    <?= /* @noEscape */ $block->getAdditionalQuoteTotalsConditions(); ?>) {
+                                    return;
+                                }
+                            } catch(err) {}
+                        }
+    
                         expectCartRendering = false;
-                        try {
-                            if ((totals.base_subtotal+totals.base_discount_amount) * 100 == BoltState.boltCart.total_amount.amount
-                                <?= /* @noEscape */ $block->getAdditionalQuoteTotalsConditions(); ?>) {
-                                return;
-                            }
-                        } catch(err) {}
-                    }
-
-                    expectCartRendering = false;
-                    $(document).trigger('bolt:createOrder');
-                });
+                        $(document).trigger('bolt:createOrder');
+                    });
+                }
             }, function (err) {
                 //The errback, error callback
                 var errLog = 'Error details: ' + err.message;


### PR DESCRIPTION
# Description
The PR [1413](https://github.com/BoltApp/bolt-magento2/pull/1413) only fix issue for M2 community edition, and there is still similar js error in M2 enterprise edition (It is because the in M2 enterprise edition, the Magento_Checkout/js/model/quote is extended, and the require-specific errbacks of RequireJS can not catch the error)

To fix this error, we use loader plugin of RequireJS to handle such case, log the error in the console and eliminate the exception.

Fixes: (link Jira ticket)

#changelog Bugfix: JS error on cart page if quote is empty (M2E)

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
