### PR TITLE
Bugfix: tax calculation error if ship-to-store option selected

### DIFF
--- a/Model/Api/Tax.php
+++ b/Model/Api/Tax.php
@@ -261,7 +261,7 @@ class Tax extends ShippingTax implements TaxInterface
     {
         $this->setAddressInformation($addressData, $shipping_option, $ship_to_store_option);
 
-        if ($this->cartHelper->checkIfQuoteHasCartFixedAmountAndApplyToShippingRuleAndTableRateShippingMethod($this->quote, $shipping_option['reference']))  {
+        if ($shipping_option && $this->cartHelper->checkIfQuoteHasCartFixedAmountAndApplyToShippingRuleAndTableRateShippingMethod($this->quote, $shipping_option['reference']))  {
             // If a customer applies a cart rule (fixed amount for whole cart and apply to shipping) and the table rate shipping method,
             // we must re-set FreeMethodWeight of the parent quote from the immutable quote to get the correct shipping amount
             $this->immutableQuote->collectTotals();


### PR DESCRIPTION
# Description
When the ship-to-store option is selected, the shipping_option in payload of tax api request is null and it causes an error `Trying to access array offset on value of type null` in this line https://github.com/BoltApp/bolt-magento2/blob/396cbb3662fc0a4652bd3d85e9b40e9e3829ee2c/Model/Api/Tax.php#L264

So we need to check $shipping_option before processing.

Fixes: (link Jira ticket)

#changelog Bugfix: tax calculation error if ship-to-store option selected

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
