### PR TITLE
Clear outdated cart cache for API driven approach

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -912,6 +912,9 @@ class Cart extends AbstractHelper
 
         // cache Bolt order
         if ($isBoltOrderCachingEnabled) {
+            if ($this->deciderHelper->isAPIDrivenIntegrationEnabled()) {
+                $this->cache->clean([self::BOLT_ORDER_TAG . '_' . $cart['order_reference']]);
+            }
             $this->saveToCache(
                 $boltOrder,
                 $cacheIdentifier,


### PR DESCRIPTION
We cache many bolt orders per the same [parent] quote id, so if user, for example, adds discount and then removed it we can find a bolt order without a discount in the cache.

This approach work with API driven as well, there is no known issue, but it looks error-prone to me.
Let's take bolt order from cache only if quote was not changed from the last call.

Down the road, we will change cache key: it makes sense to have quote_id as cache rather than hash of cart content.


#changelog Clear outdated cart cache for API driven approach
