### PR TITLE
Add support for caching Fedex API response

### DIFF
--- a/Model/Api/UpdateCartCommon.php
+++ b/Model/Api/UpdateCartCommon.php
@@ -281,6 +281,7 @@ abstract class UpdateCartCommon
      */
     public function preProcessWebhook($storeId = null)
     {
+        HookHelper::$fromBolt = true;
         $this->hookHelper->preProcessWebhook($storeId);
     }
 

--- a/Plugin/Magento/Fedex/Model/CacheFedexResultPlugin.php
+++ b/Plugin/Magento/Fedex/Model/CacheFedexResultPlugin.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+namespace Bolt\Boltpay\Plugin\Magento\Fedex\Model;
+
+use Bolt\Boltpay\Helper\Bugsnag;
+use Bolt\Boltpay\Helper\Hook as HookHelper;
+use Bolt\Boltpay\Helper\Session as SessionHelper;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\App\CacheInterface;
+use Magento\Framework\Serialize\Serializer\Json;
+
+class CacheFedexResultPlugin
+{
+    const BOLT_CACHE_FEDEX_PREFIX  = 'BOLT_CACHE_FEDEX_';
+    const CACHE_LIFE_TIME = 1800;
+    
+    /**
+     * @var Bugsnag
+     */
+    private $bugsnag;
+    
+    /**
+     * @var CacheInterface
+     */
+    private $cache;
+    
+    /**
+     * @var Json
+     */
+    private $json;
+    
+    /**
+     * @var SessionHelper
+     */
+    private $sessionHelper;
+    
+    /**
+     * @var Closure proxy
+     */
+    private $methodCaller;
+    
+    /**
+     * @param Bugsnag         $bugsnag
+     * @param SessionHelper   $sessionHelper
+     * @param CacheInterface  $cache
+     * @param Serialize|null  $serializer
+     */
+    public function __construct(
+        Bugsnag $bugsnag,
+        CacheInterface $cache,
+        SessionHelper $sessionHelper,
+        Json $json = null
+    ) {
+        $this->bugsnag = $bugsnag;
+        $this->sessionHelper = $sessionHelper;
+        $this->cache = $cache;
+        $this->json = $json ?: ObjectManager::getInstance()->get(Json::class);
+        // Call protected method with a Closure proxy
+        $this->methodCaller = function ($methodName, ...$params) {
+            return $this->$methodName(...$params);
+        }; 
+    }
+    
+    /**
+     * Restore cache of Fedex API response.
+     * 
+     * @param \Magento\Fedex\Model\Carrier $subject
+     * @param \Magento\Fedex\Model\Carrier $result
+     * @param \Magento\Quote\Model\Quote\Address\RateRequest $request
+     * @return \Magento\Fedex\Model\Carrier
+     */
+    public function afterSetRequest(\Magento\Fedex\Model\Carrier $subject, $result, $request)
+    {
+        if (!HookHelper::$fromBolt || !$subject->canCollectRates()) {
+            return $result;
+        }
+        $this->restoreFedexResponseFromCacheIfExist($subject, \Magento\Fedex\Model\Carrier::RATE_REQUEST_GENERAL);
+        $this->restoreFedexResponseFromCacheIfExist($subject, \Magento\Fedex\Model\Carrier::RATE_REQUEST_SMARTPOST); 
+        
+        return $result;
+    }
+    
+    /**
+     * Save Fedex API response into cache.
+     * 
+     * @param \Magento\Fedex\Model\Carrier $subject
+     * @param \Magento\Shipping\Model\Rate\Result|bool|null $result
+     * @param \Magento\Quote\Model\Quote\Address\RateRequest $request
+     * @return \Magento\Shipping\Model\Rate\Result|bool|null
+     */
+    public function afterCollectRates(\Magento\Fedex\Model\Carrier $subject, $result, $request)
+    {
+        if (!HookHelper::$fromBolt || !$subject->canCollectRates()) {
+            return $result;
+        }        
+        $this->saveFedexResponseToCacheIfExist($subject, \Magento\Fedex\Model\Carrier::RATE_REQUEST_GENERAL);
+        $this->saveFedexResponseToCacheIfExist($subject, \Magento\Fedex\Model\Carrier::RATE_REQUEST_SMARTPOST);
+        
+        return $result;
+    }
+    
+    /**
+     * Forming request for rate estimation depending to the purpose
+     *
+     * @param \Magento\Fedex\Model\Carrier $subject
+     * @param string $purpose
+     * @return string
+     */
+    private function getFedexRequestString($subject, $purpose)
+    {
+        $ratesRequest = $this->methodCaller->call($subject, '_formRateRequest', $purpose);
+        unset($ratesRequest['RequestedShipment']['ShipTimestamp']);
+        
+        return $this->json->serialize($ratesRequest);
+    }
+    
+    /**
+     * Save Fedex API results into cache.
+     *
+     * @param \Magento\Fedex\Model\Carrier $subject
+     * @param string $purpose
+     */
+    private function saveFedexResponseToCacheIfExist($subject, $purpose)
+    {
+        $requestString = $this->getFedexRequestString($subject, $purpose);
+        $response = $this->methodCaller->call($subject, '_getCachedQuotes', $requestString);
+        if ($response !== null) {
+            $quoteId = $this->sessionHelper->getCheckoutSession()->getQuote()->getId();
+            $cacheId = crc32(self::BOLT_CACHE_FEDEX_PREFIX . $quoteId . $requestString);
+            $this->cache->save(serialize($response), $cacheId, [], self::CACHE_LIFE_TIME);
+        }
+    }
+    
+    /**
+     * Restore cache of Fedex API results.
+     *
+     * @param \Magento\Fedex\Model\Carrier $subject
+     * @param string $purpose
+     */
+    private function restoreFedexResponseFromCacheIfExist($subject, $purpose)
+    {
+        $requestString = $this->getFedexRequestString($subject, $purpose);
+        $quoteId = $this->sessionHelper->getCheckoutSession()->getQuote()->getId();
+        $cacheId = crc32(self::BOLT_CACHE_FEDEX_PREFIX . $quoteId . $requestString);
+        $fedexCache = $this->cache->load($cacheId);
+        if (!empty($fedexCache)) {
+            $fedexCache = unserialize($fedexCache);
+            $this->methodCaller->call($subject, '_setCachedQuotes', $requestString, $fedexCache);
+        }
+    }
+}
+

--- a/Plugin/Magento/Fedex/Model/CacheFedexResultPlugin.php
+++ b/Plugin/Magento/Fedex/Model/CacheFedexResultPlugin.php
@@ -11,7 +11,7 @@
  *
  * @category   Bolt
  * @package    Bolt_Boltpay
- * @copyright  Copyright (c) 2020 Bolt Financial, Inc (https://www.bolt.com)
+ * @copyright  Copyright (c) 2022 Bolt Financial, Inc (https://www.bolt.com)
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 namespace Bolt\Boltpay\Plugin\Magento\Fedex\Model;
@@ -23,6 +23,10 @@ use Magento\Framework\App\ObjectManager;
 use Magento\Framework\App\CacheInterface;
 use Magento\Framework\Serialize\Serializer\Json;
 
+/**
+ * Plugin for {@see \Magento\Fedex\Model\Carrier}
+ * Tested up to: Magento 2.4.3-p1
+ */
 class CacheFedexResultPlugin
 {
     const BOLT_CACHE_FEDEX_PREFIX  = 'BOLT_CACHE_FEDEX_';

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -267,11 +267,6 @@
     <type name="Amasty\Promo\Plugin\Quote\Model\Quote\TotalsCollectorPlugin">
         <plugin name="TotalsCollectorPlugin" type="Bolt\Boltpay\Plugin\Amasty\Promo\Quote\Model\Quote\TotalsCollectorPlugin"/>
     </type>
-    <type name="Magento\SalesRule\Model\Utility">
-        <plugin name="Bolt_Boltpay_SalesRule_Model_Utility_Plugin"
-                type="Bolt\Boltpay\Plugin\SalesRuleModelUtilityPlugin"
-                sortOrder="20"/>
-    </type>
     <type name="Magento\Fedex\Model\Carrier">
         <plugin name="Bolt_Boltpay_Cache_Fedex_Api_Result"
                 type="Bolt\Boltpay\Plugin\Magento\Fedex\Model\CacheFedexResultPlugin" sortOrder="10"/>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -267,4 +267,13 @@
     <type name="Amasty\Promo\Plugin\Quote\Model\Quote\TotalsCollectorPlugin">
         <plugin name="TotalsCollectorPlugin" type="Bolt\Boltpay\Plugin\Amasty\Promo\Quote\Model\Quote\TotalsCollectorPlugin"/>
     </type>
+    <type name="Magento\SalesRule\Model\Utility">
+        <plugin name="Bolt_Boltpay_SalesRule_Model_Utility_Plugin"
+                type="Bolt\Boltpay\Plugin\SalesRuleModelUtilityPlugin"
+                sortOrder="20"/>
+    </type>
+    <type name="Magento\Fedex\Model\Carrier">
+        <plugin name="Bolt_Boltpay_Cache_Fedex_Api_Result"
+                type="Bolt\Boltpay\Plugin\Magento\Fedex\Model\CacheFedexResultPlugin" sortOrder="10"/>
+    </type>
 </config>


### PR DESCRIPTION
# Description
For some merchants, they use Fedex as shipping carrier. But when making remote request to Fedex from merchant server, the response takes too long and causes timeout error with Bolt api request.

Solution: The response cache is a feature of M2 core (https://github.com/magento/magento2/blob/f34651e7794d0186dce2f242ebed14f2a6cae11d/app/code/Magento/Fedex/Model/Carrier.php#L515), we make use of it and use plugin method to cache Fedex API response when needed, if the content of request does not change, it can directly use the response from cache. 

Fixes: https://app.asana.com/0/951157735838091/1201488099526448/f

#changelog Add support for caching Fedex API response

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
