### PR TITLE
M2 Oauth: Set Defaults for Integration Config

### DIFF
--- a/etc/integration/config.xml
+++ b/etc/integration/config.xml
@@ -20,7 +20,7 @@
 <integrations>
     <integration name="boltIntegration">
         <email>integrations@bolt.com</email>
-        <endpoint_url></endpoint_url>
-        <identity_link_url></identity_link_url>
+        <endpoint_url>https://api-sandbox.bolt.com/v1/magento2/bolt-checkout/authorize</endpoint_url>
+        <identity_link_url>https://status.bolt.com</identity_link_url>
     </integration>
 </integrations>


### PR DESCRIPTION
# Description
Setting default for config file used to generate initial integration object. For some installations of Magento there is a minimum character requirement. Encountered while integrating Audio Advice with API flow.

Fixes: (link Jira ticket)

#changelog

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
