### PR TITLE
Allow using carts/mine/payment-information for admin users

### DIFF
--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -145,4 +145,15 @@
             <resource ref="Magento_Sales::create" />
         </resources>
     </route>
+    <!-- Place order for logged in user with payment information saving -->
+    <route url="/V1/bolt/boltpay/carts/mine/payment-information" method="POST">
+        <service class="Magento\Checkout\Api\PaymentInformationManagementInterface" method="savePaymentInformationAndPlaceOrder"/>
+        <resources>
+            <resource ref="Magento_Cart::manage" />
+            <resource ref="Magento_Sales::create" />
+        </resources>
+        <data>
+            <parameter name="cartId" force="true">%cart_id%</parameter>
+        </data>
+    </route>
 </routes>


### PR DESCRIPTION
carts/mine/payment-information is magento endpoint which works for applying payment method to quote and create order.
This is a way how to create order for logged-in magento user.
This PR allows to use payment-information endpoint by admin integration users

#changelog Allow using carts/mine/payment-information for admin users