### PR TITLE
Magento API: fix redirect for backoiffice orders

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1851,7 +1851,13 @@ class Cart extends AbstractHelper
         // cart data is being created for sending to Bolt create
         // order API, otherwise skip this step
         ////////////////////////////////////////////////////////
-        if (!$immutableQuote && !$this->deciderHelper->isAPIDrivenIntegrationEnabled()) {
+        if ($this->deciderHelper->isAPIDrivenIntegrationEnabled()) {
+            if ($this->isBackendSession() && $quote->getBoltCheckoutType() != self::BOLT_CHECKOUT_TYPE_BACKOFFICE) {
+                $quote->setBoltCheckoutType(self::BOLT_CHECKOUT_TYPE_BACKOFFICE);
+                $quote->save();
+            }
+        }
+        elseif (!$immutableQuote) {
             $immutableQuote = $this->createImmutableQuote($quote);
         }
 


### PR DESCRIPTION
For API-driven approach we need to set bolt checkout type in quote to backoffice.
It allows us to do proper redirect from admin page.

In the legacy approach we set this field for immutable quote in createImmutableQuote() method.

#changelog Magento API: fix redirect for backoiffice orders

