### PR TITLE
Use rule name as coupon description only under feature switch

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -2231,7 +2231,10 @@ class Cart extends AbstractHelper
                         break;
                     case RuleInterface::COUPON_TYPE_NO_COUPON:
                     default:
-                        $description = trim($rule->getDescription()) ? $rule->getDescription() : $rule->getName();
+                        $description = $rule->getDescription();
+                        if (!$description && $this->deciderHelper->isUseRuleNameIfDescriptionEmpty()) {
+                            $description = $rule->getName();
+                        }
                         $discounts[] = [
                             'description'       => trim(__('Discount ') . $description),
                             'amount'            => $roundedAmount,

--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -441,4 +441,9 @@ class Decider extends AbstractHelper
     {
         return $this->isSwitchEnabled(Definitions::M2_ALLOW_CUSTOM_CDN_URL_FOR_PRODUCTION);
     }
+
+    public function isUseRuleNameIfDescriptionEmpty()
+    {
+        return $this->isSwitchEnabled(Definitions::M2_USE_RULE_NAME_IF_DESCRIPTION_EMPTY);
+    }
 }

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -262,6 +262,11 @@ class Definitions
      */
     const M2_ALLOW_CUSTOM_CDN_URL_FOR_PRODUCTION = 'M2_ALLOW_CUSTOM_CDN_URL_FOR_PRODUCTION';
 
+    /**
+     * Use rule name as coupon description if rule description is empty
+     */
+    const M2_USE_RULE_NAME_IF_DESCRIPTION_EMPTY = 'M2_USE_RULE_NAME_IF_DESCRIPTION_EMPTY';
+
     const DEFAULT_SWITCH_VALUES = [
         self::M2_SAMPLE_SWITCH_NAME => [
             self::NAME_KEY        => self::M2_SAMPLE_SWITCH_NAME,
@@ -529,6 +534,12 @@ class Definitions
         ],
         self::M2_ALLOW_CUSTOM_CDN_URL_FOR_PRODUCTION => [
             self::NAME_KEY        => self::M2_ALLOW_CUSTOM_CDN_URL_FOR_PRODUCTION,
+            self::VAL_KEY         => true,
+            self::DEFAULT_VAL_KEY => false,
+            self::ROLLOUT_KEY     => 0
+        ],
+        self::M2_USE_RULE_NAME_IF_DESCRIPTION_EMPTY => [
+            self::NAME_KEY        => self::M2_USE_RULE_NAME_IF_DESCRIPTION_EMPTY,
             self::VAL_KEY         => true,
             self::DEFAULT_VAL_KEY => false,
             self::ROLLOUT_KEY     => 0

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -448,7 +448,7 @@ class CartTest extends BoltTestCase
             DeciderHelper::class,
             ['ifShouldDisablePrefillAddressForLoggedInCustomer', 'handleVirtualProductsAsPhysical',
              'isIncludeUserGroupIntoCart', 'isAddSessionIdToCartMetadata', 'isCustomizableOptionsSupport',
-             'isPreventBoltCartForQuotesWithError','isAPIDrivenIntegrationEnabled']
+             'isPreventBoltCartForQuotesWithError','isAPIDrivenIntegrationEnabled','isUseRuleNameIfDescriptionEmpty']
         );
         $this->eventsForThirdPartyModules = $this->createPartialMock(EventsForThirdPartyModules::class, ['runFilter','dispatchEvent']);
         $this->eventsForThirdPartyModules->method('runFilter')->will($this->returnArgument(1));

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -3955,7 +3955,7 @@ ORDER
         ->getMock();
         $rule3->expects(static::once())->method('getCouponType')
         ->willReturn('NO_COUPON');
-        $rule3->expects(static::exactly(2))->method('getDescription')
+        $rule3->expects(static::any())->method('getDescription')
         ->willReturn('Shopping cart price rule for the cart over $10');
         $rule3->method('getSimpleAction')->willReturn('by_fixed');
 

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -4051,7 +4051,7 @@ ORDER
             'type'              => 'fixed_amount',
         ],
         [
-            'description' => trim(__('Discount ') . 'Shopping cart price rule for the cart over $10'),
+            'description' => trim(__('Discount ')),
             'amount'      => $expectedDiscountAmountNoCoupon,
             'discount_category' => 'automatic_promotion',
             'discount_type'   => 'fixed_amount',

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -3986,7 +3986,7 @@ ORDER
         $rule6->expects(static::once())->method('getCouponType')
             ->willReturn('NO_COUPON');
         $rule6->expects(static::once())->method('getDescription')->willReturn(null);
-        $rule6->expects(static::once())->method('getName')->willReturn('Shopping cart price rule for the cart over $10');
+        $rule6->expects(static::never())->method('getName');
         $rule6->method('getSimpleAction')->willReturn('by_fixed');
 
         $this->ruleRepository->expects(static::exactly(5))


### PR DESCRIPTION
Reverting https://github.com/BoltApp/bolt-magento2/pull/1461/ and use rule name as coupon description only under feature switch.
This fix affects merchants who use automated discounts with empty discount descriptions.
Before this fix we showed to shoppers **rule name** and after fix - word "`Discount`"

The reason under the fix: some merchants save internal information in the discount name field.

#changelog Use rule name as coupon description only under feature switch