### PR TITLE
Implement get order status endpoint

### DIFF
--- a/Api/Data/DefaultOrderStatusInterface.php
+++ b/Api/Data/DefaultOrderStatusInterface.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2022 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+namespace Bolt\Boltpay\Api\Data;
+
+/**
+ * Default Order status interface.
+ *
+ * @api
+ */
+interface DefaultOrderStatusInterface
+{
+
+    /**
+     * Get state.
+     *
+     * @return string
+     * @api
+     */
+    public function getState();
+
+    /**
+     * Set state.
+     *
+     * @param string $name
+     *
+     * @return $this
+     * @api
+     */
+    public function setState($state);
+
+    /**
+     * Get status
+     *
+     * @return string
+     * @api
+     */
+    public function getStatus();
+
+    /**
+     * Set status.
+     *
+     * @param string $version
+     *
+     * @return $this
+     * @api
+     */
+    public function setStatus($status);
+ }

--- a/Api/Data/DefaultOrderStatusInterface.php
+++ b/Api/Data/DefaultOrderStatusInterface.php
@@ -35,7 +35,7 @@ interface DefaultOrderStatusInterface
     /**
      * Set state.
      *
-     * @param string $name
+     * @param string $state
      *
      * @return $this
      * @api
@@ -53,7 +53,7 @@ interface DefaultOrderStatusInterface
     /**
      * Set status.
      *
-     * @param string $version
+     * @param string $status
      *
      * @return $this
      * @api

--- a/Api/GetDefaultOrderStatusesInterface.php
+++ b/Api/GetDefaultOrderStatusesInterface.php
@@ -26,8 +26,6 @@ interface GetDefaultOrderStatusesInterface
      *
      * @api
      *
-     * @param string $cartId
-     *
      * @return \Bolt\Boltpay\Api\Data\DefaultOrderStatusInterface[]
      */
     public function get();

--- a/Api/GetDefaultOrderStatusesInterface.php
+++ b/Api/GetDefaultOrderStatusesInterface.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2022 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Api;
+
+use Magento\Sales\Model\Order;
+
+interface GetDefaultOrderStatusesInterface
+{
+    /**
+     * Get default order statuses
+     *
+     * @api
+     *
+     * @param string $cartId
+     *
+     * @return \Bolt\Boltpay\Api\Data\DefaultOrderStatusInterface[]
+     */
+    public function get();
+}

--- a/Model/Api/Data/DefaultOrderStatus.php
+++ b/Model/Api/Data/DefaultOrderStatus.php
@@ -50,7 +50,7 @@ class DefaultOrderStatus implements DefaultOrderStatusInterface, \JsonSerializab
     /**
      * Set state.
      *
-     * @param string $name
+     * @param string $state
      *
      * @return $this
      * @api
@@ -76,7 +76,7 @@ class DefaultOrderStatus implements DefaultOrderStatusInterface, \JsonSerializab
     /**
      * Set status.
      *
-     * @param string $version
+     * @param string $status
      *
      * @return $this
      * @api

--- a/Model/Api/Data/DefaultOrderStatus.php
+++ b/Model/Api/Data/DefaultOrderStatus.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2022 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Model\Api\Data;
+
+use Bolt\Boltpay\Api\Data\DefaultOrderStatusInterface;
+
+/**
+ * Class DefaultOrderStatus.
+ * 
+ * @package Bolt\Boltpay\Model\Api\Data
+ */
+class DefaultOrderStatus implements DefaultOrderStatusInterface, \JsonSerializable
+{
+    /**
+     * @var string
+     */
+    private $state;
+
+    /**
+     * @var string
+     */
+    private $status;
+
+    /**
+     * Get state.
+     *
+     * @return string
+     * @api
+     */
+    public function getState()
+    {
+        return $this->state;
+    }
+
+    /**
+     * Set state.
+     *
+     * @param string $name
+     *
+     * @return $this
+     * @api
+     */
+    public function setState($state)
+    {
+        $this->state = $state;
+
+        return $this;
+    }
+
+    /**
+     * Get status
+     *
+     * @return string
+     * @api
+     */
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    /**
+     * Set status.
+     *
+     * @param string $version
+     *
+     * @return $this
+     * @api
+     */
+    public function setStatus($status)
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'state' => $this->state,
+            'status' => $this->status,
+        ];
+    }
+}

--- a/Model/Api/GetDefaultOrderStatuses.php
+++ b/Model/Api/GetDefaultOrderStatuses.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2022 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Model\Api;
+
+use Bolt\Boltpay\Model\Api\Data\DefaultOrderStatusFactory;
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Config as OrderConfig;
+
+/**
+ * Get Default Order Statuses
+ *
+ * @api
+ */
+class GetDefaultOrderStatuses implements \Bolt\Boltpay\Api\GetDefaultOrderStatusesInterface
+{
+    /**
+     * @var OrderConfig
+     */
+    private $_orderConfig;
+
+    /**
+     * @var DefaultOrderStatusFactory
+     */
+    private $defaultOrderStatusFactory;
+
+    /**
+     * @param OrderConfig               $orderConfig
+     * @param DefaultOrderStatusFactory $DefaultOrderStatusFactory
+     */
+    public function __construct(
+        OrderConfig               $orderConfig,
+        DefaultOrderStatusFactory $defaultOrderStatusFactory
+    ) {
+        $this->_orderConfig = $orderConfig;
+        $this->defaultOrderStatusFactory = $defaultOrderStatusFactory;
+    }
+
+
+    /**
+     * Get default order statuses
+     *
+     * @api
+     *
+     * @param string $cartId
+     *
+     * @return \Bolt\Boltpay\Api\Data\DefaultOrderStatusInterface[]
+     */
+    public function get() {
+        $result = [];
+        $states = [
+            Order::STATE_NEW,
+            Order::STATE_PENDING_PAYMENT,
+            Order::STATE_PROCESSING,
+            Order::STATE_COMPLETE,
+            Order::STATE_CLOSED,
+            Order::STATE_CANCELED,
+            Order::STATE_HOLDED,
+            Order::STATE_PAYMENT_REVIEW,
+        ];
+        foreach ($states as $state) {
+            $status = $this->_orderConfig->getStateDefaultStatus($state);
+            $result[] = $this->defaultOrderStatusFactory->create()
+                ->setState($state)->setStatus($status);
+        }
+        return $result;
+    }
+}

--- a/Model/Api/GetDefaultOrderStatuses.php
+++ b/Model/Api/GetDefaultOrderStatuses.php
@@ -50,13 +50,10 @@ class GetDefaultOrderStatuses implements \Bolt\Boltpay\Api\GetDefaultOrderStatus
         $this->defaultOrderStatusFactory = $defaultOrderStatusFactory;
     }
 
-
     /**
      * Get default order statuses
      *
      * @api
-     *
-     * @param string $cartId
      *
      * @return \Bolt\Boltpay\Api\Data\DefaultOrderStatusInterface[]
      */

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -101,6 +101,10 @@
     <preference for="Bolt\Boltpay\Api\CartManagementInterface" type="Bolt\Boltpay\Model\Api\CartManagement" />
     <preference for="Bolt\Boltpay\Api\Data\GetMaskedQuoteIDDataInterface"   type="Bolt\Boltpay\Model\Api\Data\GetMaskedQuoteIDData" />
 
+    <!-- For get default order statuses endpoint -->
+    <preference for="Bolt\Boltpay\Api\GetDefaultOrderStatusesInterface" type="Bolt\Boltpay\Model\Api\GetDefaultOrderStatuses" />
+    <preference for="Bolt\Boltpay\Api\Data\DefaultOrderStatusInterface"   type="Bolt\Boltpay\Model\Api\Data\DefaultOrderStatus" />
+
     <virtualType name="boltUnirgyGiftCert" type="Bolt\Boltpay\Model\ThirdPartyModuleFactory">
         <arguments>
             <argument name="moduleName" xsi:type="string">Unirgy_Giftcert</argument>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -156,4 +156,11 @@
             <parameter name="cartId" force="true">%cart_id%</parameter>
         </data>
     </route>
+    <!--Get default order statuses-->
+    <route url="/V1/bolt/boltpay/defaultOrderStatuses" method="GET">
+        <service class="Bolt\Boltpay\Api\GetDefaultOrderStatusesInterface" method="get"/>
+        <resources>
+            <resource ref="Magento_Sales::create" />
+        </resources>
+    </route>
 </routes>


### PR DESCRIPTION
Magento doesn't have API for get default order status per order state but we need to set status during webhook handling.
So need to have this simple GET endpoint.

#changelog Implement get order status endpoint


