### PR TITLE
Fix js whendefined callback conflicts

### DIFF
--- a/view/frontend/templates/button_product_page.phtml
+++ b/view/frontend/templates/button_product_page.phtml
@@ -316,7 +316,7 @@ foreach ($block->getAdditionalCheckoutButtonAttributes() as $attrName => $attrVa
                 // if connect.js is not loaded postpone until it is
                 whenDefined(window, 'BoltCheckout', function(){
                     BoltCheckout.configureProductCheckout(cart, hints, callbacks);
-                });
+                }, 'configureProductCheckout');
             };
 
             setupProductPage();

--- a/view/frontend/templates/js/boltglobaljs.phtml
+++ b/view/frontend/templates/js/boltglobaljs.phtml
@@ -60,11 +60,19 @@ $onSuccessCode = $block->getJavascriptSuccess() . $trackCallbackCode['success'];
     // Wait for an object to be defined and
     // execute a callback when it becomes available
     ////////////////////////////////////////////////////////////////////////
-    window.whenDefined = function(obj, property, callback) {
+    window.whenDefinedCallbacks = new Map([]);
+    window.whenDefined = function(obj, property, callback, key) {
         if (obj[property]) {
             callback();
         } else {
-            var prop = '_'+property;
+            let prop = '_'+property;
+            if (!window.whenDefinedCallbacks.has(property)) {
+                window.whenDefinedCallbacks.set(property, new Map([]))
+            }
+            let propertyCallbacks = window.whenDefinedCallbacks.get(property);
+            if (key) {
+                propertyCallbacks.set(key, callback);
+            }
             Object.defineProperty(obj, property, {
                 configurable: true,
                 enumerable: true,
@@ -75,7 +83,12 @@ $onSuccessCode = $block->getJavascriptSuccess() . $trackCallbackCode['success'];
                 // calls callback when variable is set
                 set: function(value) {
                     this[prop] = value;
-                    callback();
+                    for (let propertyCallback of propertyCallbacks.values()) {
+                        propertyCallback();
+                    }
+                    if (!key) {
+                        callback();
+                    }
                 }
             });
         }

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -422,7 +422,7 @@ $isLoadTrackJsDynamic = $block->isDisableTrackJsOnNonBoltPages() && $isLoadConne
                 scriptTag.setAttribute('src', settings.connect_url);
             }
         };
-        
+
         var insertConnectScriptWithoutSrc = function() {
             var scriptTag = document.getElementById('bolt-connect');
             var publishableKey = getCheckoutKey();
@@ -438,7 +438,7 @@ $isLoadTrackJsDynamic = $block->isDisableTrackJsOnNonBoltPages() && $isLoadConne
             document.head.appendChild(scriptTag);
             return true;
         };
-        
+
         var insertTrackScript = function() {
             var scriptTag = document.getElementById('bolt-track');
             var publishableKey = getCheckoutKey();
@@ -765,7 +765,7 @@ $isLoadTrackJsDynamic = $block->isDisableTrackJsOnNonBoltPages() && $isLoadConne
                 // Check if BoltCheckout is defined (connect.js executed).
                 // If not, postpone processing until it is
                 if (!window.BoltCheckout) {
-                    whenDefined(window, 'BoltCheckout', callConfigure);
+                    whenDefined(window, 'BoltCheckout', callConfigure, 'callConfigure');
                     return;
                 }
                 // waiting while all JS code is loaded
@@ -1110,7 +1110,7 @@ $isLoadTrackJsDynamic = $block->isDisableTrackJsOnNonBoltPages() && $isLoadConne
             // Check if BoltCheckout is defined (connect.js executed).
             // If not, postpone processing until it is
             if (!window.BoltCheckout) {
-                whenDefined(window, 'BoltCheckout', boltCheckoutSetup);
+                whenDefined(window, 'BoltCheckout', boltCheckoutSetup, 'boltCheckoutSetup');
                 return;
             }
 
@@ -1159,12 +1159,12 @@ $isLoadTrackJsDynamic = $block->isDisableTrackJsOnNonBoltPages() && $isLoadConne
                         // We haven't seen magento cart yet. If Magento cart isn't set it means that bolt cart is wrong
                         return;
                     }
-                    
+
                     if (data.hints === undefined) {
                         // In some contexts, the data only has data_id.
                         return;
                     }
-                    
+
                     boltCartDataID = data.data_id;
                     if (BoltState.magentoCart.data_id > boltCartDataID) {
                         // bolt cart is unactual
@@ -1350,7 +1350,7 @@ $isLoadTrackJsDynamic = $block->isDisableTrackJsOnNonBoltPages() && $isLoadConne
             // Check if cart exists (orderToken received).
             // Othervise, do not update hints until it becomes available.
             if (!BoltState.boltCart.orderToken) {
-                whenDefined(BoltState.boltCart, 'orderToken', configureHints);
+                whenDefined(BoltState.boltCart, 'orderToken', configureHints, 'configureHints');
                 return;
             }
             var new_hints = JSON.stringify(hints);
@@ -1422,9 +1422,9 @@ $isLoadTrackJsDynamic = $block->isDisableTrackJsOnNonBoltPages() && $isLoadConne
             var state_selectors = ['div[name="billingAddressboltpay.region_id"] select[name=region_id]','div[name="shippingAddress.region_id"] select[name=region_id]','.payment-method-boltpay select[name=region_id]'];
         } else {
             var country_selectors = ['select[name=country_id]'];
-            var state_selectors = ['select[name=region_id]'];                
+            var state_selectors = ['select[name=region_id]'];
         }
-        
+
         ///////////////////////////////////////////////////////////
         // Monitor Country DOM element change and update hints
         ///////////////////////////////////////////////////////////
@@ -1440,7 +1440,7 @@ $isLoadTrackJsDynamic = $block->isDisableTrackJsOnNonBoltPages() && $isLoadConne
             configureHints();
         }, true);
         ///////////////////////////////////////////////////////////
-            
+
         ///////////////////////////////////////////////////////////
         // Monitor State DOM element change and update hints
         ///////////////////////////////////////////////////////////
@@ -1479,7 +1479,7 @@ $isLoadTrackJsDynamic = $block->isDisableTrackJsOnNonBoltPages() && $isLoadConne
             if ($isLoadConnectJsDynamic) {
                 if ($isLoadTrackJsDynamic) {
                 ?>
-            insertTrackScript();    
+            insertTrackScript();
                 <?php
                 }
                 ?>
@@ -1559,7 +1559,7 @@ $isLoadTrackJsDynamic = $block->isDisableTrackJsOnNonBoltPages() && $isLoadConne
         ////////////////////////////////////////////////////
         boltCheckoutSetup();
         ////////////////////////////////////////////////////
-        
+
         <?php
         if ($isLoadConnectJsDynamic) {
             ?>
@@ -1571,9 +1571,9 @@ $isLoadTrackJsDynamic = $block->isDisableTrackJsOnNonBoltPages() && $isLoadConne
                 insertTrackScript();
                 <?php
                 }
-                ?>                
+                ?>
                 insertConnectScript();
-            }            
+            }
         }
         customerData.get('cart').subscribe(magentoCartDataListenerLoadConnectJs);
             <?php
@@ -1598,8 +1598,8 @@ $isLoadTrackJsDynamic = $block->isDisableTrackJsOnNonBoltPages() && $isLoadConne
                         requirejs.undef(failedId);
                         // Now define the module instance as a simple empty object
                         define(failedId, [], function(){return {};});
-                        // Now require the module make sure that RequireJS thinks 
-                        // that is it loaded. Since we've just defined it, RequireJS 
+                        // Now require the module make sure that RequireJS thinks
+                        // that is it loaded. Since we've just defined it, RequireJS
                         // will not attempt to download any more script files and
                         // will just call the onLoadSuccess handler immediately
                         parentRequire([failedId], onLoadSuccess);
@@ -1629,7 +1629,7 @@ $isLoadTrackJsDynamic = $block->isDisableTrackJsOnNonBoltPages() && $isLoadConne
                                 }
                             } catch(err) {}
                         }
-    
+
                         expectCartRendering = false;
                         $(document).trigger('bolt:createOrder');
                     });


### PR DESCRIPTION
# Description
Added multiple callbacks ability to window.whenDefined js method for fixing conflicts between replacejs.phtml and button_product_page.phtml. Both files are using the same property for whenDefined method and override each other.

Fixes: https://app.asana.com/0/1200879031426307/1201869413677057/f

#changelog Fix js whendefined callback conflicts

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
