### PR TITLE
Bugfix: Unable to checkout with fixed amount shipping discount - BO

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -65,6 +65,7 @@ use Magento\SalesRule\Model\Rule;
 use Magento\SalesRule\Model\RuleRepository;
 use Magento\Store\Model\App\Emulation;
 use Magento\Store\Model\ScopeInterface;
+use Magento\Framework\Pricing\Helper\Data as PriceHelper;
 use Zend_Http_Client_Exception;
 
 /**
@@ -267,6 +268,11 @@ class Cart extends AbstractHelper
      * @var MsrpHelper
      */
     private $msrpHelper;
+    
+    /**
+     * @var PriceHelper
+     */
+    private $priceHelper;
 
     /**
      * @param Context                    $context
@@ -300,6 +306,7 @@ class Cart extends AbstractHelper
      * @param EventsForThirdPartyModules $eventsForThirdPartyModules
      * @param RuleRepository             $ruleRepository
      * @param MsrpHelper                 $msrpHelper
+     * @param PriceHelper                $priceHelper
      */
     public function __construct(
         Context $context,
@@ -332,7 +339,8 @@ class Cart extends AbstractHelper
         Serialize $serialize,
         EventsForThirdPartyModules $eventsForThirdPartyModules,
         RuleRepository $ruleRepository,
-        MsrpHelper $msrpHelper
+        MsrpHelper $msrpHelper,
+        PriceHelper $priceHelper
     ) {
         parent::__construct($context);
         $this->checkoutSession = $checkoutSession;
@@ -365,6 +373,7 @@ class Cart extends AbstractHelper
         $this->eventsForThirdPartyModules = $eventsForThirdPartyModules;
         $this->ruleRepository = $ruleRepository;
         $this->msrpHelper = $msrpHelper;
+        $this->priceHelper = $priceHelper;
     }
 
     /**
@@ -886,7 +895,7 @@ class Cart extends AbstractHelper
                     ]
                 );
 
-                if ($this->deciderHelper->isAPIDrivenIntegrationEnabled()) {
+                if ($this->isBackendSession() || $this->deciderHelper->isAPIDrivenIntegrationEnabled()) {
                     return $boltOrder;
                 }
 
@@ -1878,6 +1887,10 @@ class Cart extends AbstractHelper
 
         if ($immutableQuote) {
             $this->setLastImmutableQuote($immutableQuote);
+            if ($this->isBackendSession()) {
+                $address = $this->getCalculationAddress($immutableQuote);
+                $address->setCollectShippingRates(true);
+            }
             $immutableQuote->collectTotals();
         } else {
             if ($this->deciderHelper->isRecalculateTotalForAPIDrivenIntegration()) {
@@ -2037,8 +2050,6 @@ class Cart extends AbstractHelper
                     return [];
                 }
             } else {
-                $address->setCollectShippingRates(true);
-
                 // assign parent shipping method to clone
                 if (!$address->getShippingMethod() && $parentQuote) {
                     $address->setShippingMethod($parentQuote->getShippingAddress()->getShippingMethod());
@@ -2051,10 +2062,13 @@ class Cart extends AbstractHelper
                     );
                     return [];
                 }
-
-                $this->collectAddressTotals($quote, $address);
-                $address->save();
-
+                
+                if (!$this->isBackendSession()) {
+                    $address->setCollectShippingRates(true);
+                    $this->collectAddressTotals($quote, $address);
+                    $address->save();
+                }
+                
                 // Shipping address
                 $shipAddress = [
                     'first_name' => $address->getFirstname(),
@@ -2072,8 +2086,20 @@ class Cart extends AbstractHelper
 
                 if ($this->isAddressComplete($shipAddress)) {
                     $cost = $address->getShippingAmount();
-                    $rounded_cost = CurrencyUtils::toMinor($cost, $currencyCode);
-
+                    $shippingService = $address->getShippingDescription();                    
+                    $shippingDiscountAmount = $this->eventsForThirdPartyModules->runFilter("collectShippingDiscounts", $address->getShippingDiscountAmount(), $quote, $address);
+                    if ($shippingDiscountAmount >= DiscountHelper::MIN_NONZERO_VALUE && !$this->ignoreAdjustingShippingAmount($quote)) {
+                        $cost = $cost - $shippingDiscountAmount;
+                        $rounded_cost = CurrencyUtils::toMinor($cost, $currencyCode);
+                        if ($rounded_cost == 0) {
+                            $shippingService .= ' [free&nbsp;shipping&nbsp;discount]';
+                        } else {
+                            $shippingDiscountAmount = $this->priceHelper->currency($shippingDiscountAmount, true, false);
+                            $shippingService .= " [$shippingDiscountAmount" . "&nbsp;discount]";
+                        }
+                    } else {
+                        $rounded_cost = CurrencyUtils::toMinor($cost, $currencyCode);
+                    }
                     $diff += CurrencyUtils::toMinorWithoutRounding($cost, $currencyCode) - $rounded_cost;
                     $totalAmount += $rounded_cost;
 
@@ -2081,7 +2107,7 @@ class Cart extends AbstractHelper
                         'cost' => $rounded_cost,
                         'tax_amount' => CurrencyUtils::toMinor($address->getShippingTaxAmount(), $currencyCode),
                         'shipping_address' => $shipAddress,
-                        'service' => $shippingAddress->getShippingDescription(),
+                        'service' => $shippingService,
                         'reference' => $shippingAddress->getShippingMethod(),
                     ]];
                 } else {

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1887,7 +1887,7 @@ class Cart extends AbstractHelper
 
         if ($immutableQuote) {
             $this->setLastImmutableQuote($immutableQuote);
-            if ($this->isBackendSession()) {
+            if ($this->isBackendSession() && !$immutableQuote->isVirtual()) {
                 $address = $this->getCalculationAddress($immutableQuote);
                 $address->setCollectShippingRates(true);
             }

--- a/Model/Api/CreateOrder.php
+++ b/Model/Api/CreateOrder.php
@@ -680,7 +680,7 @@ class CreateOrder implements CreateOrderInterface
         }
         if ($quote->getShippingAddress() && !$quote->isVirtual()) {
             $amount = $quote->getShippingAddress()->getShippingAmount();
-            if (! $this->isBackOfficeOrder($quote) && !$this->cartHelper->ignoreAdjustingShippingAmount($quote)) {
+            if (!$this->cartHelper->ignoreAdjustingShippingAmount($quote)) {
                 $amount -= $quote->getShippingAddress()->getShippingDiscountAmount();
             }
             $storeCost = CurrencyUtils::toMinor($amount, $quote->getQuoteCurrencyCode());

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -3228,7 +3228,7 @@ ORDER
         $this->immutableQuoteMock->expects(static::once())->method('getAllVisibleItems')->willReturn(true);
         $this->quoteMock->expects(static::any())->method('getShippingAddress')
         ->willReturn($this->quoteShippingAddress);
-        $this->immutableQuoteMock->expects(static::once())->method('isVirtual')->willReturn(true);
+        $this->immutableQuoteMock->expects(static::exactly(2))->method('isVirtual')->willReturn(true);
         $this->immutableQuoteMock->expects(static::once())->method('getBillingAddress')
         ->willReturn($this->quoteBillingAddress);
         $this->immutableQuoteMock->expects(static::any())->method('getShippingAddress')
@@ -3315,7 +3315,7 @@ ORDER
         $this->immutableQuoteMock->expects(static::once())->method('getAllVisibleItems')->willReturn(true);
         $this->quoteMock->expects(static::any())->method('getShippingAddress')
             ->willReturn($this->quoteShippingAddress);
-        $this->immutableQuoteMock->expects(static::once())->method('isVirtual')->willReturn(true);
+        $this->immutableQuoteMock->expects(static::exactly(2))->method('isVirtual')->willReturn(true);
         $this->immutableQuoteMock->expects(static::once())->method('getBillingAddress')
             ->willReturn($this->quoteBillingAddress);
         $this->immutableQuoteMock->expects(static::any())->method('getShippingAddress')
@@ -3403,7 +3403,7 @@ ORDER
         $this->immutableQuoteMock->expects(static::once())->method('getAllVisibleItems')->willReturn(true);
         $this->quoteMock->expects(static::any())->method('getShippingAddress')
         ->willReturn($this->quoteShippingAddress);
-        $this->immutableQuoteMock->expects(static::once())->method('isVirtual')->willReturn(true);
+        $this->immutableQuoteMock->expects(static::exactly(2))->method('isVirtual')->willReturn(true);
         $this->immutableQuoteMock->expects(static::once())->method('getBillingAddress')
         ->willReturn($this->quoteBillingAddress);
         $this->immutableQuoteMock->expects(static::any())->method('getShippingAddress')

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -91,6 +91,7 @@ use Bolt\Boltpay\Model\EventsForThirdPartyModules;
 use Magento\SalesRule\Model\RuleRepository;
 use Bolt\Boltpay\Helper\FeatureSwitch\Definitions;
 use Magento\Msrp\Helper\Data as MsrpHelper;
+use Magento\Framework\Pricing\Helper\Data as PriceHelper;
 
 /**
  * @coversDefaultClass \Bolt\Boltpay\Helper\Cart
@@ -312,6 +313,9 @@ class CartTest extends BoltTestCase
     
     /** @var MockObject|MsrpHelper */
     private $msrpHelper;
+    
+    /** @var MockObject|PriceHelper */
+    private $priceHelper;
 
     /**
      * Setup test dependencies, called before each test
@@ -458,6 +462,7 @@ class CartTest extends BoltTestCase
             ['getById']
         );
         $this->msrpHelper = $this->createPartialMock(MsrpHelper::class, ['canApplyMsrp']);
+        $this->priceHelper = $this->createPartialMock(PriceHelper::class, ['currency']);
         $this->currentMock = $this->getCurrentMock(null);
         $this->objectsToClean = [];
     }
@@ -511,7 +516,8 @@ class CartTest extends BoltTestCase
                     $this->serialize,
                     $this->eventsForThirdPartyModules,
                     $this->ruleRepository,
-                    $this->msrpHelper
+                    $this->msrpHelper,
+                    $this->priceHelper
                 ]
             )
             ->getMock();
@@ -717,7 +723,8 @@ class CartTest extends BoltTestCase
             $this->serialize,
             $this->eventsForThirdPartyModules,
             $this->ruleRepository,
-            $this->msrpHelper
+            $this->msrpHelper,
+            $this->priceHelper
         );
         static::assertAttributeEquals($this->checkoutSession, 'checkoutSession', $instance);
         static::assertAttributeEquals($this->productRepository, 'productRepository', $instance);
@@ -747,6 +754,7 @@ class CartTest extends BoltTestCase
         static::assertAttributeEquals($this->serialize, 'serialize', $instance);
         static::assertAttributeEquals($this->ruleRepository, 'ruleRepository', $instance);
         static::assertAttributeEquals($this->msrpHelper, 'msrpHelper', $instance);
+        static::assertAttributeEquals($this->priceHelper, 'priceHelper', $instance);
     }
 
     /**

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -3219,7 +3219,7 @@ ORDER
         $this->setUpAddressMock($this->quoteBillingAddress);
         $currentMock->expects(static::once())->method('createImmutableQuote')->with($this->quoteMock)
         ->willReturn($this->immutableQuoteMock);
-        $currentMock->expects(static::once())->method('getCalculationAddress')->with($this->immutableQuoteMock)
+        $currentMock->expects(exactly(2))->method('getCalculationAddress')->with($this->immutableQuoteMock)
         ->willReturn($this->quoteBillingAddress);
         $currentMock->expects(static::once())->method('getCartItems')->willReturn($getCartItemsResult);
         $currentMock->expects(static::once())->method('collectDiscounts')->willReturn($collectDiscountsResult);
@@ -3306,7 +3306,7 @@ ORDER
         $this->setUpAddressMock($this->quoteBillingAddress);
         $currentMock->expects(static::once())->method('createImmutableQuote')->with($this->quoteMock)
             ->willReturn($this->immutableQuoteMock);
-        $currentMock->expects(static::once())->method('getCalculationAddress')->with($this->immutableQuoteMock)
+        $currentMock->expects(exactly(2))->method('getCalculationAddress')->with($this->immutableQuoteMock)
             ->willReturn($this->quoteBillingAddress);
         $currentMock->expects(static::once())->method('getCartItems')->willReturn($getCartItemsResult);
         $currentMock->expects(static::once())->method('collectDiscounts')->willReturn($collectDiscountsResult);
@@ -3394,7 +3394,7 @@ ORDER
         $this->setUpAddressMock($this->quoteBillingAddress);
         $currentMock->expects(static::once())->method('createImmutableQuote')->with($this->quoteMock)
         ->willReturn($this->immutableQuoteMock);
-        $currentMock->expects(static::once())->method('getCalculationAddress')->with($this->immutableQuoteMock)
+        $currentMock->expects(exactly(2))->method('getCalculationAddress')->with($this->immutableQuoteMock)
         ->willReturn($this->quoteBillingAddress);
         $currentMock->expects(static::once())->method('getCartItems')->willReturn($getCartItemsResult);
         $currentMock->expects(static::once())->method('collectDiscounts')->willReturn($collectDiscountsResult);

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -3219,7 +3219,7 @@ ORDER
         $this->setUpAddressMock($this->quoteBillingAddress);
         $currentMock->expects(static::once())->method('createImmutableQuote')->with($this->quoteMock)
         ->willReturn($this->immutableQuoteMock);
-        $currentMock->expects(exactly(2))->method('getCalculationAddress')->with($this->immutableQuoteMock)
+        $currentMock->expects(static::exactly(2))->method('getCalculationAddress')->with($this->immutableQuoteMock)
         ->willReturn($this->quoteBillingAddress);
         $currentMock->expects(static::once())->method('getCartItems')->willReturn($getCartItemsResult);
         $currentMock->expects(static::once())->method('collectDiscounts')->willReturn($collectDiscountsResult);
@@ -3306,7 +3306,7 @@ ORDER
         $this->setUpAddressMock($this->quoteBillingAddress);
         $currentMock->expects(static::once())->method('createImmutableQuote')->with($this->quoteMock)
             ->willReturn($this->immutableQuoteMock);
-        $currentMock->expects(exactly(2))->method('getCalculationAddress')->with($this->immutableQuoteMock)
+        $currentMock->expects(static::exactly(2))->method('getCalculationAddress')->with($this->immutableQuoteMock)
             ->willReturn($this->quoteBillingAddress);
         $currentMock->expects(static::once())->method('getCartItems')->willReturn($getCartItemsResult);
         $currentMock->expects(static::once())->method('collectDiscounts')->willReturn($collectDiscountsResult);
@@ -3394,7 +3394,7 @@ ORDER
         $this->setUpAddressMock($this->quoteBillingAddress);
         $currentMock->expects(static::once())->method('createImmutableQuote')->with($this->quoteMock)
         ->willReturn($this->immutableQuoteMock);
-        $currentMock->expects(exactly(2))->method('getCalculationAddress')->with($this->immutableQuoteMock)
+        $currentMock->expects(static::exactly(2))->method('getCalculationAddress')->with($this->immutableQuoteMock)
         ->willReturn($this->quoteBillingAddress);
         $currentMock->expects(static::once())->method('getCartItems')->willReturn($getCartItemsResult);
         $currentMock->expects(static::once())->method('collectDiscounts')->willReturn($collectDiscountsResult);

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -3219,7 +3219,7 @@ ORDER
         $this->setUpAddressMock($this->quoteBillingAddress);
         $currentMock->expects(static::once())->method('createImmutableQuote')->with($this->quoteMock)
         ->willReturn($this->immutableQuoteMock);
-        $currentMock->expects(static::exactly(2))->method('getCalculationAddress')->with($this->immutableQuoteMock)
+        $currentMock->expects(static::once())->method('getCalculationAddress')->with($this->immutableQuoteMock)
         ->willReturn($this->quoteBillingAddress);
         $currentMock->expects(static::once())->method('getCartItems')->willReturn($getCartItemsResult);
         $currentMock->expects(static::once())->method('collectDiscounts')->willReturn($collectDiscountsResult);
@@ -3228,7 +3228,7 @@ ORDER
         $this->immutableQuoteMock->expects(static::once())->method('getAllVisibleItems')->willReturn(true);
         $this->quoteMock->expects(static::any())->method('getShippingAddress')
         ->willReturn($this->quoteShippingAddress);
-        $this->immutableQuoteMock->expects(static::exactly(2))->method('isVirtual')->willReturn(false);
+        $this->immutableQuoteMock->expects(static::exactly(2))->method('isVirtual')->willReturn(true);
         $this->immutableQuoteMock->expects(static::once())->method('getBillingAddress')
         ->willReturn($this->quoteBillingAddress);
         $this->immutableQuoteMock->expects(static::any())->method('getShippingAddress')
@@ -3306,7 +3306,7 @@ ORDER
         $this->setUpAddressMock($this->quoteBillingAddress);
         $currentMock->expects(static::once())->method('createImmutableQuote')->with($this->quoteMock)
             ->willReturn($this->immutableQuoteMock);
-        $currentMock->expects(static::exactly(2))->method('getCalculationAddress')->with($this->immutableQuoteMock)
+        $currentMock->expects(static::once())->method('getCalculationAddress')->with($this->immutableQuoteMock)
             ->willReturn($this->quoteBillingAddress);
         $currentMock->expects(static::once())->method('getCartItems')->willReturn($getCartItemsResult);
         $currentMock->expects(static::once())->method('collectDiscounts')->willReturn($collectDiscountsResult);
@@ -3315,7 +3315,7 @@ ORDER
         $this->immutableQuoteMock->expects(static::once())->method('getAllVisibleItems')->willReturn(true);
         $this->quoteMock->expects(static::any())->method('getShippingAddress')
             ->willReturn($this->quoteShippingAddress);
-        $this->immutableQuoteMock->expects(static::exactly(2))->method('isVirtual')->willReturn(false);
+        $this->immutableQuoteMock->expects(static::exactly(2))->method('isVirtual')->willReturn(true);
         $this->immutableQuoteMock->expects(static::once())->method('getBillingAddress')
             ->willReturn($this->quoteBillingAddress);
         $this->immutableQuoteMock->expects(static::any())->method('getShippingAddress')
@@ -3394,7 +3394,7 @@ ORDER
         $this->setUpAddressMock($this->quoteBillingAddress);
         $currentMock->expects(static::once())->method('createImmutableQuote')->with($this->quoteMock)
         ->willReturn($this->immutableQuoteMock);
-        $currentMock->expects(static::exactly(2))->method('getCalculationAddress')->with($this->immutableQuoteMock)
+        $currentMock->expects(static::once())->method('getCalculationAddress')->with($this->immutableQuoteMock)
         ->willReturn($this->quoteBillingAddress);
         $currentMock->expects(static::once())->method('getCartItems')->willReturn($getCartItemsResult);
         $currentMock->expects(static::once())->method('collectDiscounts')->willReturn($collectDiscountsResult);
@@ -3403,7 +3403,7 @@ ORDER
         $this->immutableQuoteMock->expects(static::once())->method('getAllVisibleItems')->willReturn(true);
         $this->quoteMock->expects(static::any())->method('getShippingAddress')
         ->willReturn($this->quoteShippingAddress);
-        $this->immutableQuoteMock->expects(static::exactly(2))->method('isVirtual')->willReturn(false);
+        $this->immutableQuoteMock->expects(static::exactly(2))->method('isVirtual')->willReturn(true);
         $this->immutableQuoteMock->expects(static::once())->method('getBillingAddress')
         ->willReturn($this->quoteBillingAddress);
         $this->immutableQuoteMock->expects(static::any())->method('getShippingAddress')

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -3228,7 +3228,7 @@ ORDER
         $this->immutableQuoteMock->expects(static::once())->method('getAllVisibleItems')->willReturn(true);
         $this->quoteMock->expects(static::any())->method('getShippingAddress')
         ->willReturn($this->quoteShippingAddress);
-        $this->immutableQuoteMock->expects(static::exactly(2))->method('isVirtual')->willReturn(true);
+        $this->immutableQuoteMock->expects(static::exactly(2))->method('isVirtual')->willReturn(false);
         $this->immutableQuoteMock->expects(static::once())->method('getBillingAddress')
         ->willReturn($this->quoteBillingAddress);
         $this->immutableQuoteMock->expects(static::any())->method('getShippingAddress')
@@ -3315,7 +3315,7 @@ ORDER
         $this->immutableQuoteMock->expects(static::once())->method('getAllVisibleItems')->willReturn(true);
         $this->quoteMock->expects(static::any())->method('getShippingAddress')
             ->willReturn($this->quoteShippingAddress);
-        $this->immutableQuoteMock->expects(static::exactly(2))->method('isVirtual')->willReturn(true);
+        $this->immutableQuoteMock->expects(static::exactly(2))->method('isVirtual')->willReturn(false);
         $this->immutableQuoteMock->expects(static::once())->method('getBillingAddress')
             ->willReturn($this->quoteBillingAddress);
         $this->immutableQuoteMock->expects(static::any())->method('getShippingAddress')
@@ -3403,7 +3403,7 @@ ORDER
         $this->immutableQuoteMock->expects(static::once())->method('getAllVisibleItems')->willReturn(true);
         $this->quoteMock->expects(static::any())->method('getShippingAddress')
         ->willReturn($this->quoteShippingAddress);
-        $this->immutableQuoteMock->expects(static::exactly(2))->method('isVirtual')->willReturn(true);
+        $this->immutableQuoteMock->expects(static::exactly(2))->method('isVirtual')->willReturn(false);
         $this->immutableQuoteMock->expects(static::once())->method('getBillingAddress')
         ->willReturn($this->quoteBillingAddress);
         $this->immutableQuoteMock->expects(static::any())->method('getShippingAddress')


### PR DESCRIPTION
# Description
To fix this bug
1 . Call setCollectShippingRates before collecting quote totals.
2.  Collect shipping discounts when creating Bolt order.

Fixes: https://app.asana.com/0/inbox/632578947811319/1201978015327776/1202036018623393/f

#changelog Bugfix: Unable to checkout with fixed amount shipping discount - BO

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
