### PR TITLE
Bugfix: Discount amount getting doubled

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -2916,7 +2916,7 @@ class Cart extends AbstractHelper
                     /* @var \Magento\SalesRule\Api\Data\DiscountDataInterface $discountData */
                     $discountData = $value->getDiscountData();
                     $salesRuleId = $value->getRuleID();
-                    if (!empty($cartFixedRules) && array_key_exists($salesRuleId, $cartFixedRules)) {
+                    if (!empty($cartFixedRules) && array_key_exists($salesRuleId, $cartFixedRules) && $cartFixedRules[$salesRuleId] > DiscountHelper::MIN_NONZERO_VALUE) {
                         $rule = $this->ruleRepository->getById($salesRuleId);
                         $saleRuleDiscountsDetails[$salesRuleId] = $discountData->getAmount() + $rule->getDiscountAmount() - $cartFixedRules[$salesRuleId];
                     } else {


### PR DESCRIPTION
# Description
Magento 2 has a bug with cart rule "Fixed amount discount for whole cart" and fixed in v2.3.6 ([PR 26419](https://github.com/magento/magento2/pull/26419)) . So in M2 v2.3.4-p2, the code $address->getCartFixedRules() returns an array 
```
[
     "ruleid" => 0.00
]
```
even there is no discount applied to shipping. And it causes double discount error in Bolt plugin.

Solution: validate the discount amount before calculation.

Fixes:  https://app.asana.com/0/1200879031426307/1202082673763428/f

#changelog Bugfix: Discount amount getting doubled

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
