### PR TITLE
Inject Openreplay into M2 + feature switch

### DIFF
--- a/Block/Js.php
+++ b/Block/Js.php
@@ -32,7 +32,7 @@ use Magento\Framework\View\Element\Template\Context;
 use Magento\Quote\Model\Quote;
 
 /**
- * Js Block. The block class used in track.phtml block.
+ * Js Block. The block class used in boltjs.phtml block.
  *
  * @SuppressWarnings(PHPMD.DepthOfInheritance)
  */
@@ -110,6 +110,16 @@ class Js extends Template
     public function getTrackJsUrl()
     {
         return $this->configHelper->getCdnUrl() . '/track.js';
+    }
+
+    /**
+     * Get open replay js url
+     *
+     * @return string
+     */
+    public function getOpenReplayJsUrl()
+    {
+        return $this->configHelper->getCdnUrl() . '/openreplay.js';
     }
 
     /**
@@ -293,6 +303,7 @@ class Js extends Template
         return json_encode([
             'connect_url'                           => $this->getConnectJsUrl(),
             'track_url'                             => $this->getTrackJsUrl(),
+            'openreplay_url'                        => $this->getOpenReplayJsUrl(),
             'publishable_key_payment'               => $this->configHelper->getPublishableKeyPayment(),
             'publishable_key_checkout'              => $this->configHelper->getPublishableKeyCheckout(),
             'publishable_key_back_office'           => $this->configHelper->getPublishableKeyBackOffice(),
@@ -512,6 +523,19 @@ class Js extends Template
     public function isDisableTrackJsOnNonBoltPages()
     {
         if ($this->featureSwitches->isDisableTrackJsOnNonBoltPages()) {
+            return true;
+        }
+        
+        return false;
+    }
+
+    /**
+     * If feature switch M2_DISABLE_OPENREPLAY is enabled,
+     * then the Bolt openreplay.js would be disabled everywhere (catalog, product, cart and checkout).
+     */
+    public function isDisableOpenReplayJs()
+    {
+        if ($this->featureSwitches->isDisableOpenReplayJs()) {
             return true;
         }
         

--- a/Block/JsProductPage.php
+++ b/Block/JsProductPage.php
@@ -31,7 +31,7 @@ use Magento\Framework\App\Http\Context as HttpContext;
 use Magento\Framework\View\Element\Template\Context;
 
 /**
- * Js Block. The block class used in replace.phtml and track.phtml blocks.
+ * Js Block. The block class used in replace.phtml and boltjs.phtml blocks.
  *
  * @SuppressWarnings(PHPMD.DepthOfInheritance)
  */

--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -328,6 +328,11 @@ class Decider extends AbstractHelper
         return $this->isSwitchEnabled(Definitions::M2_DISABLE_TRACK_ON_NON_BOLT_PAGES);
     }
 
+    public function isDisableOpenReplayJs()
+    {
+        return $this->isSwitchEnabled(Definitions::M2_DISABLE_OPENREPLAY);
+    }
+
     public function isReturnErrWhenRunFilter()
     {
         return $this->isSwitchEnabled(Definitions::M2_RETURN_ERR_WHEN_RUN_FILTER);

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -188,6 +188,11 @@ class Definitions
     const M2_DISABLE_TRACK_ON_NON_BOLT_PAGES = 'M2_DISABLE_TRACK_ON_NON_BOLT_PAGES';
 
     /**
+     * Remove openreplay.js everywhere (catalog, product, cart and checkout pages)
+     */
+    const M2_DISABLE_OPENREPLAY = 'M2_DISABLE_OPENREPLAY';
+
+    /**
      * Enable always return error if there is any exception when running filter.
      */
     const M2_RETURN_ERR_WHEN_RUN_FILTER = 'M2_RETURN_ERR_WHEN_RUN_FILTER';
@@ -461,6 +466,12 @@ class Definitions
         ],
         self::M2_DISABLE_TRACK_ON_NON_BOLT_PAGES => [
             self::NAME_KEY        => self::M2_DISABLE_TRACK_ON_NON_BOLT_PAGES,
+            self::VAL_KEY         => true,
+            self::DEFAULT_VAL_KEY => false,
+            self::ROLLOUT_KEY     => 0
+        ],
+        self::M2_DISABLE_OPENREPLAY => [
+            self::NAME_KEY        => self::M2_DISABLE_OPENREPLAY,
             self::VAL_KEY         => true,
             self::DEFAULT_VAL_KEY => false,
             self::ROLLOUT_KEY     => 0

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -67,7 +67,7 @@ class JsTest extends BoltTestCase
     /**
      * @var int expected number of settings returned by {@see \Bolt\Boltpay\Block\Js::getSettings}
      */
-    const SETTINGS_NUMBER = 28;
+    const SETTINGS_NUMBER = 29;
 
     /**
      * @var int expeced number of tracking callback returned by {@see \Bolt\Boltpay\Block\Js::getTrackCallbacks}
@@ -832,6 +832,7 @@ class JsTest extends BoltTestCase
         $message = 'Cannot find following key in the Settings: ';
         static::assertArrayHasKey('connect_url', $array, $message . 'connect_url');
         static::assertArrayHasKey('track_url', $array, $message . 'track_url');
+        static::assertArrayHasKey('openreplay_url', $array, $message . 'openreplay_url');
         static::assertArrayHasKey('publishable_key_payment', $array, $message . 'publishable_key_payment');
         static::assertArrayHasKey('publishable_key_checkout', $array, $message . 'publishable_key_checkout');
         static::assertArrayHasKey('publishable_key_back_office', $array, $message . 'publishable_key_back_office');
@@ -2765,6 +2766,38 @@ function(arg) {
             [
                 'isDisableTrackJsOnNonBoltPages' => false,
                 'expectedResult'                  => false
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider isDisableOpenReplayJs_withVariousConfigsProvider
+     *
+     * @param bool $isDisableOpenReplayJs
+     * @param bool $expectedResult
+     */
+    public function isDisableOpenReplayJs_withVariousConfigs_returnsCorrectResult($isDisableOpenReplayJs, $expectedResult)
+    {
+        $featureSwitch = TestUtils::saveFeatureSwitch(\Bolt\Boltpay\Helper\FeatureSwitch\Definitions::M2_DISABLE_OPENREPLAY, $isDisableOpenReplayJs);
+        static::assertEquals($expectedResult, $this->block->isDisableOpenReplayJs());
+        TestUtils::cleanupFeatureSwitch($featureSwitch);
+    }
+    
+    /**
+     * Data provider for
+     *
+     * @see isDisableOpenReplayJs_withVariousConfigs_returnsCorrectResult
+     *
+     * @return array
+     */
+    public function isDisableOpenReplayJs_withVariousConfigsProvider()
+    {
+        return [
+            [
+                'isDisableOpenReplayJs' => true,
+                'expectedResult'        => true
             ],
         ];
     }

--- a/view/frontend/templates/js/boltjs.phtml
+++ b/view/frontend/templates/js/boltjs.phtml
@@ -16,7 +16,7 @@
  */
 
 /**
- * Track and Connect js template
+ * Track, OpenReplay and Connect js template
  *
  * @var $block \Bolt\Boltpay\Block\Js
  */
@@ -32,6 +32,7 @@ $isLoadBoltJs = $block->isOnPageFromWhiteList() || $block->isMinicartEnabled() |
 $isDisableTrackJs = ($block->isDisableTrackJsOnHomePage() && $block->isOnHomePage())
                     || ($block->isDisableTrackJsOnNonBoltPages() && (!$isLoadBoltJs || !$isLoadConnectJs));
 $isLoadAccountJs = ($block->isBoltSSOEnabled() || $block->isOrderManagementEnabled());
+$isDisableOpenReplayJs = $block->isDisableOpenReplayJs();
 
 if (!$isDisableTrackJs) {
     $trackJsUrl = $block->getTrackJsUrl();
@@ -41,6 +42,22 @@ if (!$isDisableTrackJs) {
         type="text/javascript"
         src="<?= /* @noEscape */
         $trackJsUrl; ?>"
+        data-shopping-cart-id="magento2"
+        async
+        data-publishable-key="<?= /* @noEscape */
+        $checkoutKey; ?>">
+</script>
+
+<?php
+}
+if (!$isDisableOpenReplayJs) {
+    $openReplayJsUrl = $block->getOpenReplayJsUrl();
+?>
+<script
+        id="bolt-openreplay"
+        type="text/javascript"
+        src="<?= /* @noEscape */
+        $openReplayJsUrl; ?>"
         data-shopping-cart-id="magento2"
         async
         data-publishable-key="<?= /* @noEscape */

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -38,6 +38,7 @@ if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled()) { return;
 $connectJsUrl = $block->getConnectJsUrl();
 $isLoadConnectJsDynamic = $block->isLoadConnectJsDynamic();
 $isLoadTrackJsDynamic = $block->isDisableTrackJsOnNonBoltPages() && $isLoadConnectJsDynamic;
+$isLoadOpenReplayJsDynamic = $block->isDisableOpenReplayJs();
 ?>
 
 <script type="text/javascript">
@@ -452,6 +453,23 @@ $isLoadTrackJsDynamic = $block->isDisableTrackJsOnNonBoltPages() && $isLoadConne
             scriptTag.setAttribute('id', 'bolt-track');
             scriptTag.setAttribute('data-publishable-key', publishableKey);
             scriptTag.setAttribute('src', settings.track_url);
+            document.head.appendChild(scriptTag);
+            return true;
+        };
+
+        var insertOpenReplayScript = function() {
+            var scriptTag = document.getElementById('bolt-openreplay');
+            var publishableKey = getCheckoutKey();
+            if (scriptTag) {
+                scriptTag.setAttribute('data-publishable-key', publishableKey);
+                return false;
+            }
+            scriptTag = document.createElement('script');
+            scriptTag.setAttribute('type', 'text/javascript');
+            scriptTag.setAttribute('async', '');
+            scriptTag.setAttribute('id', 'bolt-openreplay');
+            scriptTag.setAttribute('data-publishable-key', publishableKey);
+            scriptTag.setAttribute('src', settings.openreplay_url);
             document.head.appendChild(scriptTag);
             return true;
         };
@@ -1480,6 +1498,13 @@ $isLoadTrackJsDynamic = $block->isDisableTrackJsOnNonBoltPages() && $isLoadConne
                 if ($isLoadTrackJsDynamic) {
                 ?>
             insertTrackScript();
+                <?php
+                }
+                ?>
+            <?php
+            if ($isLoadOpenReplayJsDynamic) {
+                ?>
+            insertOpenReplayScript();
                 <?php
                 }
                 ?>


### PR DESCRIPTION
# Description
Inject Openreplay into M2 behind a feature switch! This is for merchants who do not want the script in their HTML at all due to bloat. 

[COMING SOON: division feature to stop openreplay.js from sending info to us if the merchant wants to opt out but is okay with leaving the script in the html]

#changelog Inject Openreplay into M2 + feature switch

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [X] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
