### PR TITLE
Bugfix: unappropriated error message when cart item is out of stock

### DIFF
--- a/Test/Unit/Model/Api/CreateOrderTest.php
+++ b/Test/Unit/Model/Api/CreateOrderTest.php
@@ -37,6 +37,8 @@ use Bolt\Boltpay\Model\ResponseFactory as BoltResponseFactory;
 use Bolt\Boltpay\Model\RequestFactory as BoltRequestFactory;
 use Magento\Store\Api\WebsiteRepositoryInterface;
 use Magento\Store\Model\StoreManagerInterface;
+use Magento\Quote\Model\Quote\Item as QuoteItem;
+use Magento\CatalogInventory\Helper\Data as CatalogInventoryData;
 
 /**
  * Class CreateOrderTest
@@ -625,6 +627,24 @@ class CreateOrderTest extends BoltTestCase
         $this->expectExceptionCode(CreateOrder::E_BOLT_ITEM_PRICE_HAS_BEEN_UPDATED);
         $this->expectExceptionMessage('Cart data has changed. SKU: ["'.$productSku.'"]');
         $this->createOrder->validateCartItems($quote, json_decode('{"order":{"cart":{"items":{}}}}'));
+    }
+    
+    /**
+     * @test
+     * @covers ::hasItemErrors
+     */
+    public function hasItemErrors_exception()
+    {
+        $quoteItem = $this->objectManager->create(QuoteItem::class);
+        $quoteItem->addErrorInfo(
+            'cataloginventory',
+            CatalogInventoryData::ERROR_QTY,
+            __('This product is out of stock.')
+        );
+        $this->expectException(BoltException::class);
+        $this->expectExceptionCode(CreateOrder::E_BOLT_ITEM_OUT_OF_INVENTORY);
+        $this->expectExceptionMessage('This product is out of stock.');
+        $this->createOrder->hasItemErrors($quoteItem);
     }
 
     /**


### PR DESCRIPTION
# Description
Currently we always get error code from the field "code" of the first element in the ErrorInfos of quote item, but in this case, all the fields of first ErrorInfo element have null value (it seems that it is added by other 3p plugin) when the related cart item is out of stock, and actually the second ErrorInfo element has proper info, therefore, $boltErrorCode does not have appropriated code for out-of-stock, and the Bolt modal just displays a general error message.

To solve such an issue, we need to find the valid error info (code, message and origin) as far as possible. Also from M2 v2.4.3, the ErrorInfo of quote item for inventory error does not have any message value (https://github.com/magento/magento2/commit/7f127923ba83be5dba9caef78ce6f584e0ec16e9), so we have to get the message from StockStateResult of quote item instead.

Fixes: https://app.asana.com/0/1124368832381302/1201965561661002/f

#changelog Bugfix: unappropriated error message when cart item is out of stock

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 
- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Jira ticket link and provided a changelog message.
