### PR TITLE
Minor modifications to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 # Description
 Please include a summary of the change and which issue is fixed. Include the motivation for the changes, and comment on your PR if necessary for clarity.
 
-Fixes: (link Jira ticket)
+Fixes: (link ticket)
 
 #changelog
 
@@ -12,8 +12,8 @@ Fixes: (link Jira ticket)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] This change requires a documentation update
 
-
 # How Has This Been Tested?
+
 Please validate that you have tested your change in at least one of the following areas:
 
 - [ ] Successfully tested locally (or docker image)
@@ -21,6 +21,7 @@ Please validate that you have tested your change in at least one of the followin
 - [ ] Successfully tested on a merchant's staging server
 
 # For PR Reviewer 
+
 - [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
 - [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?
 
@@ -31,4 +32,4 @@ Please validate that you have tested your change in at least one of the followin
 - [ ] I have commented my code, particularly in hard-to-understand areas.
 - [ ] New and existing unit tests pass locally with my changes.
 - [ ] I have created or modified unit tests to sufficiently cover my changes.
-- [ ] I have added my Jira ticket link and provided a changelog message.
+- [ ] I have added my ticket link and provided a changelog message.


### PR DESCRIPTION
# Description
1. Replace JIRA with neutral "ticket". We don't use JIRA anymore and we may move away from Asana down the road, so better to use neutral "ticket". 
2. Even out the spacing.

#changelog Minor modifications to PR template