### PR TITLE
Bugfix: Magento dashboard filter does not capture Bolt APM orders

### DIFF
--- a/Plugin/Magento/Framework/View/Element/UiComponent/DataProvider/RegularFilterPlugin.php
+++ b/Plugin/Magento/Framework/View/Element/UiComponent/DataProvider/RegularFilterPlugin.php
@@ -80,9 +80,9 @@ class RegularFilterPlugin
             );
             $paymentMethod = str_replace(Payment::METHOD_CODE . '_', '', $filter->getValue());
             $collectionSelect->where(
-                    'main_table.payment_method = "'. Payment::METHOD_CODE .'"
-                    AND ('. $collectionAdapter->quoteInto('additional_information like ?', '%' . $paymentMethod . '%') .' OR '. $collectionAdapter->quoteInto('cc_type = ?', $paymentMethod) .')'
-                );
+                'main_table.payment_method = "'. Payment::METHOD_CODE .'"
+                AND ('. $collectionAdapter->quoteInto('additional_information like ?', '%' . $paymentMethod . '%') .' OR '. $collectionAdapter->quoteInto('cc_type = ?', $paymentMethod) .')'
+            );
         } else {
             return $proceed($collection, $filter);
         }

--- a/Plugin/Magento/Framework/View/Element/UiComponent/DataProvider/RegularFilterPlugin.php
+++ b/Plugin/Magento/Framework/View/Element/UiComponent/DataProvider/RegularFilterPlugin.php
@@ -67,23 +67,22 @@ class RegularFilterPlugin
         Collection $collection,
         Filter $filter
     ) {
-        if ($this->config->getShowCcTypeInOrderGrid() &&
-            $collection instanceof OrderGridCollection &&
+        if ($collection instanceof OrderGridCollection &&
             $filter->getField() == 'payment_method' &&
             strpos($filter->getValue(), Payment::METHOD_CODE . '_') !== false
         ) {
-            $collection->getSelect()->joinLeft(
+            $collectionSelect = $collection->getSelect();
+            $collectionAdapter = $collectionSelect->getConnection();
+            $collectionSelect->joinLeft(
                 ['payment' => $this->resourceConnection->getTableName('sales_order_payment')],
                 'main_table.entity_id = payment.parent_id',
-                ['cc_type' => 'LOWER(cc_type)']
+                ['additional_information' => 'LOWER(additional_information)', 'cc_type' => 'LOWER(cc_type)']
             );
-
-            $collection->getSelect()
-                ->where(
-                    'main_table.payment_method = "'. Payment::METHOD_CODE .'" AND cc_type = ?',
-                    str_replace(Payment::METHOD_CODE . '_', '', $filter->getValue())
+            $paymentMethod = str_replace(Payment::METHOD_CODE . '_', '', $filter->getValue());
+            $collectionSelect->where(
+                    'main_table.payment_method = "'. Payment::METHOD_CODE .'"
+                    AND ('. $collectionAdapter->quoteInto('additional_information like ?', '%' . $paymentMethod . '%') .' OR '. $collectionAdapter->quoteInto('cc_type = ?', $paymentMethod) .')'
                 );
-
         } else {
             return $proceed($collection, $filter);
         }


### PR DESCRIPTION
# Description
The APM info is saved in the additional_information field of sales_order_payment table, so we need to filter the payment method with that field.

Fixes: https://app.asana.com/0/1124368832381302/1202128894520486/f

#changelog Bugfix: Magento dashboard filter does not capture Bolt APM orders

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
