### PR TITLE
Fix bug: Bolt button displays even if the bolt_ppc flag is disabled

### DIFF
--- a/Block/JsProductPage.php
+++ b/Block/JsProductPage.php
@@ -179,12 +179,10 @@ class JsProductPage extends Js
 
         // By this point we know that the Select flag is true, the parent check is true, so
         // all that remains is to check if this product has the ppc attribute or not.
-        $attributes = $this->getProduct()->getAttributes();
-        foreach ($attributes as $attribute) {
-            if ($attribute->getName() == 'bolt_ppc') {
+        if ($this->getProduct()->getBoltPpc()) {
                 return true;
-            }
         }
+
         return false;
     }
 }

--- a/Test/Unit/Block/JsProductPageTest.php
+++ b/Test/Unit/Block/JsProductPageTest.php
@@ -266,7 +266,7 @@ class JsProductPageTest extends BoltTestCase
 
         $product = $this->getMockBuilder(Product::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getExtensionAttributes', 'getStockItem', 'getTypeId', 'getId', 'getTypeInstance', 'getChildrenIds', 'getAttributes'])
+            ->setMethods(['getExtensionAttributes', 'getStockItem', 'getTypeId', 'getId', 'getTypeInstance', 'getChildrenIds', 'getAttributes','getBoltPpc'])
             ->getMock();
 
         $productViewMock = $this->getMockBuilder(ProductView::class)
@@ -297,11 +297,7 @@ class JsProductPageTest extends BoltTestCase
         $configHelper->expects(static::once())->method('getSelectProductPageCheckoutFlag')->willReturn(true);
         $configHelper->expects(static::once())->method('getProductPageCheckoutFlag')->willReturn(true);
         $requestMock->expects(static::once())->method('getFullActionName')->willReturn('catalog_product_view');
-        $attr1 = $this->createMock(AbstractAttribute::class);
-        $attr1->expects(static::once())->method('getName')->willReturn('attr1');
-        $attr2 = $this->createMock(AbstractAttribute::class);
-        $attr2->expects(static::once())->method('getName')->willReturn('bolt_ppc');
-        $product->expects(static::once())->method('getAttributes')->willReturn([$attr1, $attr2]);
+        $product->expects(static::once())->method('getBoltPpc')->willReturn(true);
         $this->assertEquals(true, $block->isBoltProductPage());
     }
 }


### PR DESCRIPTION
# Description
Currently, the Bolt button displays even if the bolt_ppc flag is disabled.
![image](https://user-images.githubusercontent.com/2002287/164519696-766ff39e-2965-4257-8084-7e77f74ac7cb.png)

 So this PR fixes the issue by correcting the condition in the isBoltProductPage method in the JSProductPage block

Fixes: https://app.asana.com/0/564264490825835/1202163249205445
#changelog Fix bug: Bolt button displays even if the bolt_ppc flag is disabled

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
