### PR TITLE
Set dev mode for local development by additional configuration

### DIFF
--- a/Block/Js.php
+++ b/Block/Js.php
@@ -139,8 +139,9 @@ class Js extends Template
      */
     public function getPayByLinkUrl()
     {
+        $storeId = $this->getStoreId();
         return $this->configHelper->getPayByLinkUrl(
-            $this->featureSwitches->isAllowCustomURLForProduction()
+            $this->featureSwitches->isAllowCustomURLForProduction(), $storeId
         );
     }
 

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -584,7 +584,7 @@ class Config extends AbstractHelper
     {
         //Check for sandbox mode
         if ($this->isSandboxModeSet($storeId)) {
-            return $this->getCustomURLValueOrDefault(self::XML_PATH_CUSTOM_API, self::API_URL_SANDBOX);
+            return $this->getApiUrlFromAdditionalConfig($storeId) ?: $this->getCustomURLValueOrDefault(self::XML_PATH_CUSTOM_API, self::API_URL_SANDBOX);
         }
         return self::API_URL_PRODUCTION;
     }
@@ -600,7 +600,7 @@ class Config extends AbstractHelper
     {
         //Check for sandbox mode
         if ($this->isSandboxModeSet($storeId)) {
-            return $this->getCustomURLValueOrDefault(self::XML_PATH_CUSTOM_MERCHANT_DASH, self::MERCHANT_DASH_SANDBOX);
+            return $this->getMerchantDashboardUrlFromAdditionalConfig($storeId) ?: $this->getCustomURLValueOrDefault(self::XML_PATH_CUSTOM_MERCHANT_DASH, self::MERCHANT_DASH_SANDBOX);
         }
         return self::MERCHANT_DASH_PRODUCTION;
     }
@@ -616,7 +616,7 @@ class Config extends AbstractHelper
     {
         //Check for sandbox mode
         if ($this->isSandboxModeSet($storeId)) {
-            return $this->getCustomURLValueOrDefault(self::XML_PATH_CUSTOM_CDN, self::CDN_URL_SANDBOX);
+            return $this->getCdnUrlFromAdditionalConfig($storeId) ?: $this->getCustomURLValueOrDefault(self::XML_PATH_CUSTOM_CDN, self::CDN_URL_SANDBOX);
         }
         return self::CDN_URL_PRODUCTION;
     }
@@ -625,15 +625,16 @@ class Config extends AbstractHelper
      * Get Bolt PaybByLink URL
      *
      * @param bool $isAllowCustomURLForProduction
+     * @param int|string $storeId
      *
      * @return string
      */
-    public function getPayByLinkUrl($isAllowCustomURLForProduction = false)
+    public function getPayByLinkUrl($isAllowCustomURLForProduction = false, $storeId = null)
     {
         if ($this->isSandboxModeSet()) {
-            $url = $this->getCustomURLValueOrDefault(self::XML_PATH_CUSTOM_CDN, self::CDN_URL_SANDBOX);
+            $url = $this->getCdnUrlFromAdditionalConfig($storeId) ?: $this->getCustomURLValueOrDefault(self::XML_PATH_CUSTOM_CDN, self::CDN_URL_SANDBOX);
         } else if ($isAllowCustomURLForProduction) {
-            $url = $this->getCustomURLValueOrDefault(self::XML_PATH_CUSTOM_CDN, self::CDN_URL_PRODUCTION);
+            $url = $this->getCdnUrlFromAdditionalConfig($storeId) ?: $this->getCustomURLValueOrDefault(self::XML_PATH_CUSTOM_CDN, self::CDN_URL_PRODUCTION);
         } else {
             $url = self::CDN_URL_PRODUCTION;
         }
@@ -651,7 +652,7 @@ class Config extends AbstractHelper
     {
         //Check for sandbox mode
         if ($this->isSandboxModeSet($storeId)) {
-            return $this->getCustomURLValueOrDefault(self::XML_PATH_CUSTOM_ACCOUNT, self::ACCOUNT_URL_SANDBOX);
+            return $this->getAccountUrlFromAdditionalConfig($storeId) ?: $this->getCustomURLValueOrDefault(self::XML_PATH_CUSTOM_ACCOUNT, self::ACCOUNT_URL_SANDBOX);
         }
         return self::ACCOUNT_URL_PRODUCTION;
     }
@@ -2439,5 +2440,73 @@ class Config extends AbstractHelper
             ScopeInterface::SCOPE_STORE,
             $storeId
         );
+    }
+    
+    /**
+     * Get Bolt additional configuration for CDN URL, stored in the following format:
+     *
+     * {
+     *   "cdnURL": "https://api-sandbox.bolt.com/"
+     * }
+     * defaults to empty string if not set
+     *
+     * @param int|string $storeId
+     *
+     * @return string
+     */
+    public function getCdnUrlFromAdditionalConfig($storeId = null)
+    {
+        return $this->getAdditionalConfigProperty('cdnURL', $storeId);
+    }
+    
+    /**
+     * Get Bolt additional configuration for account URL, stored in the following format:
+     *
+     * {
+     *   "accountURL": "https://api-sandbox.bolt.com/"
+     * }
+     * defaults to empty string if not set
+     *
+     * @param int|string $storeId
+     *
+     * @return string
+     */
+    public function getAccountUrlFromAdditionalConfig($storeId = null)
+    {
+        return $this->getAdditionalConfigProperty('accountURL', $storeId);
+    }
+    
+    /**
+     * Get Bolt additional configuration for api URL, stored in the following format:
+     *
+     * {
+     *   "apiURL": "https://api-sandbox.bolt.com/"
+     * }
+     * defaults to empty string if not set
+     *
+     * @param int|string $storeId
+     *
+     * @return string
+     */
+    public function getApiUrlFromAdditionalConfig($storeId = null)
+    {
+        return $this->getAdditionalConfigProperty('apiURL', $storeId);
+    }
+    
+    /**
+     * Get Bolt additional configuration for merchant dashboard URL, stored in the following format:
+     *
+     * {
+     *   "merchantDashboardURL": "https://api-sandbox.bolt.com/"
+     * }
+     * defaults to empty string if not set
+     *
+     * @param int|string $storeId
+     *
+     * @return string
+     */
+    public function getMerchantDashboardUrlFromAdditionalConfig($storeId = null)
+    {
+        return $this->getAdditionalConfigProperty('merchantDashboardURL', $storeId);
     }
 }

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -81,7 +81,11 @@ class ConfigTest extends BoltTestCase
     "ignoredShippingAddressCoupons": [
         "IGNORED_SHIPPING_ADDRESS_COUPON"
     ],
-     "priceFaultTolerance": "10"
+     "priceFaultTolerance": "10",
+     "merchantDashboardURL": "https://test-sandbox.bolt.com/",
+     "apiURL": "https://test-sandbox.bolt.com/",
+     "accountURL": "https://test-sandbox.bolt.com/",
+     "cdnURL": "https://test-sandbox.bolt.com/"
 }
 JSON;
 
@@ -110,6 +114,20 @@ JSON;
         $store = $this->objectManager->get(\Magento\Store\Model\StoreManagerInterface::class);
         $this->storeId = $store->getStore()->getId();
     }
+    
+    protected function tearDownInternal()
+    {
+        // Reset additional configuration
+        $configData = [
+            [
+                'path' => Config::XML_PATH_ADDITIONAL_CONFIG,
+                'value' => '',
+                'scope' => \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                'scopeId' => $this->storeId,
+            ],
+        ];
+        TestUtils::setupBoltConfig($configData);
+    }
 
     /**
      * @test
@@ -128,6 +146,31 @@ JSON;
         TestUtils::setupBoltConfig($configData);
         $result = $this->configHelper->getMerchantDashboardUrl();
         self::assertEquals(BoltConfig::MERCHANT_DASH_SANDBOX, $result);
+    }
+    
+    /**
+     * @test
+     * @covers ::getMerchantDashboardUrl
+     */
+    public function getMerchantDashboardUrl_returnAdditionalConfigMerchantDashUrl()
+    {
+        $configData = [
+            [
+                'path' => Config::XML_PATH_SANDBOX_MODE,
+                'value' => true,
+                'scope' => \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                'scopeId' => $this->storeId,
+            ],
+            [
+                'path' => Config::XML_PATH_ADDITIONAL_CONFIG,
+                'value' => self::ADDITIONAL_CONFIG,
+                'scope' => \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                'scopeId' => $this->storeId,
+            ],
+        ];
+        TestUtils::setupBoltConfig($configData);
+        $result = $this->configHelper->getMerchantDashboardUrl();
+        self::assertEquals("https://test-sandbox.bolt.com/", $result);
     }
 
     /**
@@ -218,6 +261,31 @@ JSON;
         $result = $this->configHelper->getCdnUrl();
         self::assertEquals(Config::CDN_URL_SANDBOX, $result);
     }
+    
+    /**
+     * @test
+     * @covers ::getCdnUrl
+     */
+    public function getCdnUrl_setupAdditionalConfig_willReturnCdnUrlSandbox()
+    {
+        $configData = [
+            [
+                'path' => Config::XML_PATH_SANDBOX_MODE,
+                'value' => true,
+                'scope' => \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                'scopeId' => $this->storeId,
+            ],
+            [
+                'path' => Config::XML_PATH_ADDITIONAL_CONFIG,
+                'value' => self::ADDITIONAL_CONFIG,
+                'scope' => \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                'scopeId' => $this->storeId,
+            ],
+        ];
+        TestUtils::setupBoltConfig($configData);
+        $result = $this->configHelper->getCdnUrl();
+        self::assertEquals("https://test-sandbox.bolt.com/", $result);
+    }
 
     /**
      * @test
@@ -256,6 +324,31 @@ JSON;
         $result = $this->configHelper->getAccountUrl();
         self::assertEquals(Config::ACCOUNT_URL_SANDBOX, $result);
     }
+    
+    /**
+     * @test
+     * @covers ::getAccountUrl
+     */
+    public function getAccountUrl_setupAdditionalConfig_willReturnAccountUrlSandbox()
+    {
+        $configData = [
+            [
+                'path' => Config::XML_PATH_SANDBOX_MODE,
+                'value' => true,
+                'scope' => \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                'scopeId' => $this->storeId,
+            ],
+            [
+                'path' => Config::XML_PATH_ADDITIONAL_CONFIG,
+                'value' => self::ADDITIONAL_CONFIG,
+                'scope' => \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                'scopeId' => $this->storeId,
+            ],
+        ];
+        TestUtils::setupBoltConfig($configData);
+        $result = $this->configHelper->getAccountUrl();
+        self::assertEquals("https://test-sandbox.bolt.com/", $result);
+    }
 
     /**
      * @covers ::getApiUrl
@@ -292,6 +385,30 @@ JSON;
         TestUtils::setupBoltConfig($configData);
         $result = $this->configHelper->getApiUrl();
         self::assertEquals(Config::API_URL_SANDBOX, $result);
+    }
+    
+    /**
+     * @test
+     */
+    public function getApiUrl_setupAdditionalConfig_willReturnApiUrlSandbox()
+    {
+        $configData = [
+            [
+                'path' => Config::XML_PATH_SANDBOX_MODE,
+                'value' => true,
+                'scope' => \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                'scopeId' => $this->storeId,
+            ],
+            [
+                'path' => Config::XML_PATH_ADDITIONAL_CONFIG,
+                'value' => self::ADDITIONAL_CONFIG,
+                'scope' => \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                'scopeId' => $this->storeId,
+            ],
+        ];
+        TestUtils::setupBoltConfig($configData);
+        $result = $this->configHelper->getApiUrl();
+        self::assertEquals("https://test-sandbox.bolt.com/", $result);
     }
 
     /**


### PR DESCRIPTION
# Description
Currently the custom api, cdn and merchant dash urls for local development are saved in the core_config_data data table, if we do not have SSH access, there is no way to update these values. 
To make it easier for developer to change the settings, this PR uses additional configuration to setup values instead.

Fixes: https://app.asana.com/0/1124368832381302/1202155503854984/f

#changelog Set dev mode for local development by additional configuration

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
