### PR TITLE
Bugfix: SQL error if joining same table to collection select multiple times

### DIFF
--- a/Plugin/Magento/Framework/View/Element/UiComponent/DataProvider/RegularFilterPlugin.php
+++ b/Plugin/Magento/Framework/View/Element/UiComponent/DataProvider/RegularFilterPlugin.php
@@ -76,12 +76,12 @@ class RegularFilterPlugin
             $collectionSelect->joinLeft(
                 ['payment' => $this->resourceConnection->getTableName('sales_order_payment')],
                 'main_table.entity_id = payment.parent_id',
-                ['additional_information' => 'LOWER(additional_information)', 'cc_type' => 'LOWER(cc_type)']
+                []
             );
             $paymentMethod = str_replace(Payment::METHOD_CODE . '_', '', $filter->getValue());
             $collectionSelect->where(
                 'main_table.payment_method = "'. Payment::METHOD_CODE .'"
-                AND ('. $collectionAdapter->quoteInto('additional_information like ?', '%' . $paymentMethod . '%') .' OR '. $collectionAdapter->quoteInto('cc_type = ?', $paymentMethod) .')'
+                AND ('. $collectionAdapter->quoteInto('LOWER(payment.additional_information) like ?', '%' . $paymentMethod . '%') .' OR '. $collectionAdapter->quoteInto('LOWER(payment.cc_type) = ?', $paymentMethod) .')'
             );
         } else {
             return $proceed($collection, $filter);


### PR DESCRIPTION
# Description
Any 3p plugin could join table sales_order_payment to collection select for specific purpose, usually it also selects some columns from table sales_order_payment. As a result, there could be conflict with the columns we select in Bolt plugin
```
['additional_information' => 'LOWER(additional_information)', 'cc_type' => 'LOWER(cc_type)']
```

To solve this issue, just use an empty array for the list of columns, cause we do not need any columns from this joined table as query result.

Fixes: https://app.asana.com/0/1124368832381302/1202182258989837/f

#changelog Bugfix: SQL error if joining same table to collection select multiple times

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
