### PR TITLE
Bugfix: Unexpected order status in the delete order endpoint

### DIFF
--- a/Model/Api/OrderManagement.php
+++ b/Model/Api/OrderManagement.php
@@ -376,9 +376,8 @@ class OrderManagement implements OrderManagementInterface
     public function deleteById($id)
     {
         $order = $this->orderHelper->getOrderById($id);
-        if ($order->getStatus() != OrderModel::STATE_PENDING_PAYMENT) {
-
-            throw new WebapiException(__('Unexpected order status'), 0, 422);
+        if ($order->getState() != OrderModel::STATE_PENDING_PAYMENT) {
+            throw new WebapiException(__('Unexpected order state'), 0, 422);
         }
         $payment = $order->getPayment();
         if ($payment && $payment->getCcTransId() != "") {


### PR DESCRIPTION
# Description
Steps to replicate the issue:
- Create new order status (pending_ogone) and assign it to the pending_payment state and set it as default
- Place an order with invalid card info and get a failed payment
- After that, Bolt calls the delete order endpoint and throws the exception: Unexpected order status

See the Datadog link here:
https://app.datadoghq.com/logs?query=%40merchant_name%3A%22John%20McCombs%20Testing%22%20-service%3Aasyncjobs&event=AQAAAYBxEsjmid-36QAAAABBWUJ4RXVnaEFBQ0xvNjN5NWxfSjZBQUU&index=&from_ts=1648573874478&to_ts=1651165874478&live=true

**Actual result** :
Magento order isn't deleted
**Expected result** :
No exception and Magento order should be deleted

So this PR resolves the issue by correcting the condition logic (**use the order state instead of the order status**) in the delete order endpoint 


Fixes: https://app.asana.com/0/564264490825835/1202198919778485

#changelog Bugfix: Unexpected order status in the delete order endpoint

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
