### PR TITLE
Get Dynamic SKU of the bundle product when building Bolt cart

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1476,9 +1476,10 @@ class Cart extends AbstractHelper
                 // Load item product object
                 ////////////////////////////////////
                 $customizableOptions = null;
-                $itemSku = trim($item->getSku());
+                $itemSku = $this->getSkuFromQuoteItem($item);
                 $itemReference = $item->getProductId();
                 $itemName = $item->getName();
+                
                 //By default this feature switch is enabled.
                 if ($this->deciderHelper->isCustomizableOptionsSupport()) {
                     try {
@@ -1522,7 +1523,8 @@ class Cart extends AbstractHelper
                 $product['total_amount'] = $roundedTotalAmount;
                 $product['unit_price']   = CurrencyUtils::toMinor($unitPrice, $currencyCode);
                 $product['quantity']     = $quantity;
-                $product['sku']          = trim($item->getSku());
+                $product['sku']          = $this->getSkuFromQuoteItem($item);
+                
                 if ($this->msrpHelper->canApplyMsrp($_product) && $_product->getMsrp() !== null) {
                     $product['msrp']     = CurrencyUtils::toMinor($_product->getMsrp(), $currencyCode);
                 }
@@ -2951,5 +2953,28 @@ class Cart extends AbstractHelper
         return $this->deciderHelper->isCollectDiscountsByPlugin()
             || ($this->configHelper->isActive($quote->getStore()->getId())
             && version_compare($this->configHelper->getStoreVersion(), '2.3.4', '<'));
+    }
+    
+    /**
+     * Get SKU of quote item
+     *
+     * @param \Magento\Quote\Model\Quote\Item $item
+     *
+     * @return string
+     */
+    public function getSkuFromQuoteItem($item)
+    {
+        // Get "Dynamic SKU" of the bundle product, so the quote item can be recognized.
+        if (($product = $item->getProduct())
+            && $item->getProductType() == \Magento\Catalog\Model\Product\Type::TYPE_BUNDLE
+            && ($oldSkuType = $product->getData('sku_type'))) {
+            // If "Dynamic SKU" is disabled, we need to enable it temporarily.
+            $product->setData('sku_type', 0);
+            $itemSku = $product->getTypeInstance()->getSku($product);
+            $product->setData('sku_type', $oldSkuType);
+            return $itemSku;
+        }
+        
+        return trim($item->getSku());
     }
 }

--- a/Model/Api/CreateOrder.php
+++ b/Model/Api/CreateOrder.php
@@ -519,7 +519,7 @@ class CreateOrder implements CreateOrderInterface
 
         $quoteSkus = array_map(
             function ($item) {
-                return trim($item->getSku());
+                return $this->cartHelper->getSkuFromQuoteItem($item);
             },
             $quoteItems
         );
@@ -543,7 +543,7 @@ class CreateOrder implements CreateOrderInterface
 
         foreach ($quoteItems as $item) {
             /** @var QuoteItem $item */
-            $sku = trim($item->getSku());
+            $sku = $this->cartHelper->getSkuFromQuoteItem($item);
             $itemPrice = CurrencyUtils::toMinor($item->getCalculationPrice(), $quote->getQuoteCurrencyCode());
 
             $this->hasItemErrors($item);

--- a/Model/Api/CreateOrder.php
+++ b/Model/Api/CreateOrder.php
@@ -547,6 +547,13 @@ class CreateOrder implements CreateOrderInterface
             $itemPrice = CurrencyUtils::toMinor($item->getCalculationPrice(), $quote->getQuoteCurrencyCode());
 
             $this->hasItemErrors($item);
+            if (empty($transactionItems)) {
+                throw new BoltException(
+                    __('Quote item does not exist in Bolt cart. Item id: ' . $item->getItemId() .', SKU: ' . $this->cartHelper->getSkuFromQuoteItem($item)),
+                    null,
+                    self::E_BOLT_ITEM_PRICE_HAS_BEEN_UPDATED
+                );
+            }
             $this->validateItemPrice($sku, $itemPrice, $transactionItems);
         }
     }

--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -272,7 +272,7 @@ class ShippingMethods implements ShippingMethodsInterface
 
         $quoteItems = ['quantity' => [], 'total' => []];
         foreach ($this->quote->getAllVisibleItems() as $item) {
-            $sku = trim($item->getSku());
+            $sku = $this->cartHelper->getSkuFromQuoteItem($item);
             $quantity = round($item->getQty());
             $unitPrice = round($item->getCalculationPrice(), 2);
             if (!isset($quoteItems['quantity'][$sku])) {
@@ -577,7 +577,7 @@ class ShippingMethods implements ShippingMethodsInterface
 
             // include products in cache key
             foreach ($quote->getAllVisibleItems() as $item) {
-                $cacheIdentifier .= '_'.trim($item->getSku()).'_'.$item->getQty();
+                $cacheIdentifier .= '_'.$this->cartHelper->getSkuFromQuoteItem($item).'_'.$item->getQty();
             }
 
             // include applied rule ids (discounts) in cache key


### PR DESCRIPTION
# Description
If the "Dynamic SKU" is disabled for bundle product, the cart items may have same SKU and unit price, as a result, the Bolt Hail can not distinguish them from each another and just treat them as identical cart item. Then the items in Bolt cart does not match the quote items in M2 cart and causes the error "Undefined variable: transactionUnitPrice in boltpay/bolt-magento2/Model/Api/CreateOrder.php"

Solution: When building Bolt cart, we always get Dynamic SKU of the bundle product.

Fixes: https://app.asana.com/0/951157735838091/1202162571831912/f

#changelog Get Dynamic SKU of the bundle product when building Bolt cart

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
