### PR TITLE
Bugfix: [API-driven] Payment methods field is empty

### DIFF
--- a/Plugin/Magento/Framework/View/Element/UiComponent/DataProvider/DataProviderPlugin.php
+++ b/Plugin/Magento/Framework/View/Element/UiComponent/DataProvider/DataProviderPlugin.php
@@ -107,8 +107,8 @@ class DataProviderPlugin
             if ($payment->getCcTransId()) {
                 // api flow, title rendered on server side
                 $title = $payment->getAdditionalData();
-                if (!$title) {
-                    $item['payment_method'] = $title;
+                if ($title && ($intersection = array_intersect([strtolower (str_replace('Bolt-', '', $title))], array_keys(Order::TP_METHOD_DISPLAY)))) {
+                    $item['payment_method'] = \Bolt\Boltpay\Model\Payment::METHOD_CODE . '_' . reset($intersection);//str_replace('-', '_', $title);
                 }
                 continue;
             }

--- a/Plugin/Magento/Framework/View/Element/UiComponent/DataProvider/DataProviderPlugin.php
+++ b/Plugin/Magento/Framework/View/Element/UiComponent/DataProvider/DataProviderPlugin.php
@@ -108,7 +108,7 @@ class DataProviderPlugin
                 // api flow, title rendered on server side
                 $title = $payment->getAdditionalData();
                 if ($title && ($intersection = array_intersect([strtolower (str_replace('Bolt-', '', $title))], array_keys(Order::TP_METHOD_DISPLAY)))) {
-                    $item['payment_method'] = \Bolt\Boltpay\Model\Payment::METHOD_CODE . '_' . reset($intersection);//str_replace('-', '_', $title);
+                    $item['payment_method'] = \Bolt\Boltpay\Model\Payment::METHOD_CODE . '_' . reset($intersection);
                 }
                 continue;
             }

--- a/Plugin/Magento/Framework/View/Element/UiComponent/DataProvider/RegularFilterPlugin.php
+++ b/Plugin/Magento/Framework/View/Element/UiComponent/DataProvider/RegularFilterPlugin.php
@@ -81,7 +81,7 @@ class RegularFilterPlugin
             $paymentMethod = str_replace(Payment::METHOD_CODE . '_', '', $filter->getValue());
             $collectionSelect->where(
                 'main_table.payment_method = "'. Payment::METHOD_CODE .'"
-                AND ('. $collectionAdapter->quoteInto('LOWER(payment.additional_information) like ?', '%' . $paymentMethod . '%') .' OR '. $collectionAdapter->quoteInto('LOWER(payment.cc_type) = ?', $paymentMethod) .')'
+                AND ('. $collectionAdapter->quoteInto('LOWER(payment.additional_data) like ?', '%' . $paymentMethod . '%') .' OR '. $collectionAdapter->quoteInto('LOWER(payment.additional_information) like ?', '%' . $paymentMethod . '%') .' OR '. $collectionAdapter->quoteInto('LOWER(payment.cc_type) = ?', $paymentMethod) .')'
             );
         } else {
             return $proceed($collection, $filter);


### PR DESCRIPTION
# Description
When checkout with Magento 2 APIs, the payment data saved in sales_order_payment table is different from Bolt APIs. So we need to update related plugin methods for displaying alternative payment type in order grid, as well as the payment method filter of order grid.

Fixes: https://app.asana.com/0/1124368832381302/1202229182315905/f

#changelog Bugfix: [API-driven] Payment methods field is empty

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
