### PR TITLE
Redirect to success page: search for orders by incrementID

### DIFF
--- a/Controller/ReceivedUrlTrait.php
+++ b/Controller/ReceivedUrlTrait.php
@@ -210,11 +210,7 @@ trait ReceivedUrlTrait
      */
     private function getOrderByIncrementId($incrementId)
     {
-        if ($this->cartHelper->getFeatureSwitchDeciderHelper()->isAPIDrivenIntegrationEnabled()) {
-            $order = $this->cartHelper->getOrderById($incrementId);
-        } else {
-            $order = $this->orderHelper->getExistingOrder($incrementId);
-        }
+        $order = $this->orderHelper->getExistingOrder($incrementId);
 
         if (!$order) {
             throw new NoSuchEntityException(


### PR DESCRIPTION
Partially revert PR https://github.com/BoltApp/bolt-magento2/pull/1468 because we update the server part to return Incremental ID instead of order ID.

asana:
https://app.asana.com/0/1124368832381302/1202229182315897/f

#changelog Redirect to success page: search for orders by incrementID 