### PR TITLE
Setup dev mode for integration API

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -221,6 +221,11 @@ class Config extends AbstractHelper
      * Path for custom public key, used only for dev mode.
      */
     const XML_PATH_CUSTOM_PUBLIC_KEY = 'payment/boltpay/custom_public_key';
+    
+    /**
+     * Path for custom integration url, used only for dev mode.
+     */
+    const XML_PATH_CUSTOM_INTEGRATION = 'payment/boltpay/custom_integration';
 
     /**
      * Bolt sandbox url
@@ -2508,5 +2513,38 @@ class Config extends AbstractHelper
     public function getMerchantDashboardUrlFromAdditionalConfig($storeId = null)
     {
         return $this->getAdditionalConfigProperty('merchantDashboardURL', $storeId);
+    }
+    
+    /**
+     * Get Integration base URL
+     *
+     * @param null|string $storeId
+     *
+     * @return string
+     */
+    public function getIntegrationBaseUrl($storeId = null)
+    {
+        //Check for sandbox mode
+        if ($this->isSandboxModeSet($storeId)) {
+            return $this->getMerchantDashboardUrlFromAdditionalConfig($storeId) ?: $this->getCustomURLValueOrDefault(self::XML_PATH_CUSTOM_INTEGRATION, self::API_URL_SANDBOX);
+        }
+        return self::API_URL_PRODUCTION;
+    }
+    
+    /**
+     * Get Bolt additional configuration for integration base URL, stored in the following format:
+     *
+     * {
+     *   "integrationBaseURL": "https://api-sandbox.bolt.com/"
+     * }
+     * defaults to empty string if not set
+     *
+     * @param int|string $storeId
+     *
+     * @return string
+     */
+    public function getIntegrationBaseUrlFromAdditionalConfig($storeId = null)
+    {
+        return $this->getAdditionalConfigProperty('integrationBaseURL', $storeId);
     }
 }

--- a/Helper/IntegrationManagement.php
+++ b/Helper/IntegrationManagement.php
@@ -75,13 +75,9 @@ class IntegrationManagement extends AbstractHelper
     
     const BOLT_INTEGRATION_NAME = 'boltIntegration';
     
-    const BOLT_INTEGRATION_AUTHENTICATION_ENDPOINT_URL_SANDBOX = 'https://api-sandbox.bolt.com/v1/magento2/bolt-checkout/authorize';
-    const BOLT_INTEGRATION_IDENTITY_LINKING_URL_SANDBOX = 'https://status.bolt.com/';
-    const BOLT_INTEGRATION_TOKEN_EXCHANGE_URL_SANDBOX = 'https://api-sandbox.bolt.com/v1/magento2/bolt-checkout/exchange';
-    
-    const BOLT_INTEGRATION_AUTHENTICATION_ENDPOINT_URL_PRODUCTION = 'https://api.bolt.com/v1/magento2/bolt-checkout/authorize';
-    const BOLT_INTEGRATION_IDENTITY_LINKING_URL_PRODUCTION = 'https://status.bolt.com/';
-    const BOLT_INTEGRATION_TOKEN_EXCHANGE_URL_PRODUCTION = 'https://api.bolt.com/v1/magento2/bolt-checkout/exchange';
+    const BOLT_INTEGRATION_AUTHENTICATION_ENDPOINT_URL = '/v1/magento2/bolt-checkout/authorize';
+    const BOLT_INTEGRATION_IDENTITY_LINKING_URL = 'https://status.bolt.com/';
+    const BOLT_INTEGRATION_TOKEN_EXCHANGE_URL = '/v1/magento2/bolt-checkout/exchange';
     
     /**
      * @var \Magento\Integration\Model\ConfigBasedIntegrationManager
@@ -410,11 +406,7 @@ class IntegrationManagement extends AbstractHelper
      */
     public function getEndpointUrl($storeId = null)
     {
-        //Check for sandbox mode
-        if ($this->configHelper->isSandboxModeSet($storeId)) {
-            return self::BOLT_INTEGRATION_AUTHENTICATION_ENDPOINT_URL_SANDBOX;
-        }
-        return self::BOLT_INTEGRATION_AUTHENTICATION_ENDPOINT_URL_PRODUCTION;
+        return rtrim($this->configHelper->getIntegrationBaseUrl($storeId), '/') . self::BOLT_INTEGRATION_AUTHENTICATION_ENDPOINT_URL;
     }
     
     /**
@@ -426,11 +418,7 @@ class IntegrationManagement extends AbstractHelper
      */
     public function getIdentityLinkUrl($storeId = null)
     {
-        //Check for sandbox mode
-        if ($this->configHelper->isSandboxModeSet($storeId)) {
-            return self::BOLT_INTEGRATION_IDENTITY_LINKING_URL_SANDBOX;
-        }
-        return self::BOLT_INTEGRATION_IDENTITY_LINKING_URL_PRODUCTION;
+        return self::BOLT_INTEGRATION_IDENTITY_LINKING_URL;
     }
     
     /**
@@ -442,11 +430,7 @@ class IntegrationManagement extends AbstractHelper
      */
     public function getTokensExchangeUrl($storeId = null)
     {
-        //Check for sandbox mode
-        if ($this->configHelper->isSandboxModeSet($storeId)) {
-            return self::BOLT_INTEGRATION_TOKEN_EXCHANGE_URL_SANDBOX;
-        }
-        return self::BOLT_INTEGRATION_TOKEN_EXCHANGE_URL_PRODUCTION;
+        return rtrim($this->configHelper->getIntegrationBaseUrl($storeId), '/') . self::BOLT_INTEGRATION_TOKEN_EXCHANGE_URL;
     }
 
     /**

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -85,7 +85,8 @@ class ConfigTest extends BoltTestCase
      "merchantDashboardURL": "https://test-sandbox.bolt.com/",
      "apiURL": "https://test-sandbox.bolt.com/",
      "accountURL": "https://test-sandbox.bolt.com/",
-     "cdnURL": "https://test-sandbox.bolt.com/"
+     "cdnURL": "https://test-sandbox.bolt.com/",
+     "integrationBaseURL": "https://test-sandbox.bolt.com/"
 }
 JSON;
 
@@ -1357,5 +1358,68 @@ Room 4000',
         ];
         TestUtils::setupBoltConfig($configData);
         $this->assertEquals('customer_note', $this->configHelper->getOrderCommentField());
+    }
+    
+    /**
+     * @test
+     * @covers ::getIntegrationBaseUrl
+     */
+    public function getIntegrationBaseUrl_returnIntegrationBaseUrlSandbox()
+    {
+        $configData = [
+            [
+                'path' => Config::XML_PATH_SANDBOX_MODE,
+                'value' => true,
+                'scope' => \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                'scopeId' => $this->storeId,
+            ]
+        ];
+        TestUtils::setupBoltConfig($configData);
+        $result = $this->configHelper->getIntegrationBaseUrl();
+        self::assertEquals(BoltConfig::API_URL_SANDBOX, $result);
+    }
+    
+    /**
+     * @test
+     * @covers ::getIntegrationBaseUrl
+     */
+    public function getIntegrationBaseUrl_returnAdditionalConfigIntegrationBaseUrl()
+    {
+        $configData = [
+            [
+                'path' => Config::XML_PATH_SANDBOX_MODE,
+                'value' => true,
+                'scope' => \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                'scopeId' => $this->storeId,
+            ],
+            [
+                'path' => Config::XML_PATH_ADDITIONAL_CONFIG,
+                'value' => self::ADDITIONAL_CONFIG,
+                'scope' => \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                'scopeId' => $this->storeId,
+            ],
+        ];
+        TestUtils::setupBoltConfig($configData);
+        $result = $this->configHelper->getIntegrationBaseUrl();
+        self::assertEquals("https://test-sandbox.bolt.com/", $result);
+    }
+
+    /**
+     * @test
+     * @covers ::getIntegrationBaseUrl
+     */
+    public function getIntegrationBaseUrl_returnIntegrationBaseUrlProduction()
+    {
+        $configData = [
+            [
+                'path' => Config::XML_PATH_SANDBOX_MODE,
+                'value' => false,
+                'scope' => \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                'scopeId' => $this->storeId,
+            ]
+        ];
+        TestUtils::setupBoltConfig($configData);
+        $result = $this->configHelper->getIntegrationBaseUrl();
+        self::assertEquals(BoltConfig::API_URL_PRODUCTION, $result);
     }
 }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -312,6 +312,10 @@
                         <label>Custom Public Key</label>
                         <config_path>payment/boltpay/custom_public_key</config_path>
                     </field>
+                    <field id="custom_integration" translate="label" type="text" sortOrder="296" showInDefault="0" showInWebsite="0" showInStore="0">
+                        <label>Custom Integration URL</label>
+                        <config_path>payment/boltpay/custom_integration</config_path>
+                    </field>
                     <field id="enable_store_pickup_feature" translate="label" sortOrder="300" type="select" showInDefault="1" showInWebsite="1" showInStore="1">
                         <label>Enable In-Store Pickup Feature</label>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -30,6 +30,7 @@
                 <custom_merchant_dash></custom_merchant_dash>
                 <custom_cdn></custom_cdn>
                 <custom_public_key></custom_public_key>
+                <custom_integration></custom_integration>
                 <debug>0</debug>
                 <product_page_checkout>0</product_page_checkout>
                 <order_management>0</order_management>


### PR DESCRIPTION
# Description
Currently we hardcoded sandbox and production urls but we need staging for our QA env. If someone pushed the key exchange button which sent the key exchange request to api-sandbox so old oauth that lived in staging was killed

Solution: we follow the same approach as dev mode for local development (refer to [PR 487](https://github.com/BoltApp/bolt-magento2/pull/487/)), so the plugin gets the integration API urls from DB instead of hardcoding.

Fixes: https://app.asana.com/0/1200879031426307/1202291518627542/f

#changelog Setup dev mode for integration API

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
