### PR TITLE
Bugfix: Sporadic issues with shoppers not being redirected to the confirmation page

### DIFF
--- a/Controller/Adminhtml/Order/ReceivedUrl.php
+++ b/Controller/Adminhtml/Order/ReceivedUrl.php
@@ -27,8 +27,12 @@ use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\Sales\Model\Order;
 use Bolt\Boltpay\Helper\Order as OrderHelper;
 use Bolt\Boltpay\Controller\ReceivedUrlTrait;
+use Bolt\Boltpay\Helper\Session as BoltSession;
+use Magento\Framework\App\CacheInterface;
+use Magento\Framework\Serialize\SerializerInterface as Serialize;
+use Bolt\Boltpay\Controller\ReceivedUrlInterface;
 
-class ReceivedUrl extends Action
+class ReceivedUrl extends Action implements ReceivedUrlInterface
 {
     use ReceivedUrlTrait;
 
@@ -42,6 +46,8 @@ class ReceivedUrl extends Action
      * @param LogHelper       $logHelper
      * @param CheckoutSession $checkoutSession
      * @param OrderHelper     $orderHelper
+     * @param CacheInterface  $cache
+     * @param Serialize       $serialize
      */
     public function __construct(
         Context $context,
@@ -50,7 +56,9 @@ class ReceivedUrl extends Action
         Bugsnag $bugsnag,
         LogHelper $logHelper,
         CheckoutSession $checkoutSession,
-        OrderHelper $orderHelper
+        OrderHelper $orderHelper,
+        CacheInterface $cache,
+        Serialize $serialize
     ) {
         parent::__construct($context);
         $this->configHelper = $configHelper;
@@ -59,6 +67,8 @@ class ReceivedUrl extends Action
         $this->logHelper = $logHelper;
         $this->checkoutSession = $checkoutSession;
         $this->orderHelper = $orderHelper;
+        $this->cache = $cache;
+        $this->serialize = $serialize;
     }
 
     /**

--- a/Controller/Adminhtml/Order/ReceivedUrl.php
+++ b/Controller/Adminhtml/Order/ReceivedUrl.php
@@ -27,7 +27,6 @@ use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\Sales\Model\Order;
 use Bolt\Boltpay\Helper\Order as OrderHelper;
 use Bolt\Boltpay\Controller\ReceivedUrlTrait;
-use Bolt\Boltpay\Helper\Session as BoltSession;
 use Magento\Framework\App\CacheInterface;
 use Magento\Framework\Serialize\SerializerInterface as Serialize;
 use Bolt\Boltpay\Controller\ReceivedUrlInterface;

--- a/Controller/Order/ReceivedUrl.php
+++ b/Controller/Order/ReceivedUrl.php
@@ -28,8 +28,12 @@ use Magento\Sales\Model\Order;
 use Bolt\Boltpay\Helper\Order as OrderHelper;
 use Bolt\Boltpay\Controller\ReceivedUrlTrait;
 use Magento\Backend\Model\UrlInterface as BackendUrl;
+use Bolt\Boltpay\Helper\Session as BoltSession;
+use Magento\Framework\App\CacheInterface;
+use Magento\Framework\Serialize\SerializerInterface as Serialize;
+use Bolt\Boltpay\Controller\ReceivedUrlInterface;
 
-class ReceivedUrl extends Action
+class ReceivedUrl extends Action implements ReceivedUrlInterface
 {
     use ReceivedUrlTrait;
 
@@ -49,6 +53,8 @@ class ReceivedUrl extends Action
      * @param CheckoutSession $checkoutSession
      * @param OrderHelper     $orderHelper
      * @param BackendUrl      $backendUrl
+     * @param CacheInterface  $cache
+     * @param Serialize       $serialize
      */
     public function __construct(
         Context $context,
@@ -58,7 +64,9 @@ class ReceivedUrl extends Action
         LogHelper $logHelper,
         CheckoutSession $checkoutSession,
         OrderHelper $orderHelper,
-        BackendUrl $backendUrl
+        BackendUrl $backendUrl,
+        CacheInterface $cache,
+        Serialize $serialize
     ) {
         parent::__construct($context);
         $this->configHelper = $configHelper;
@@ -68,6 +76,8 @@ class ReceivedUrl extends Action
         $this->checkoutSession = $checkoutSession;
         $this->orderHelper = $orderHelper;
         $this->backendUrl = $backendUrl;
+        $this->cache = $cache;
+        $this->serialize = $serialize;
     }
 
     /**

--- a/Controller/Order/ReceivedUrl.php
+++ b/Controller/Order/ReceivedUrl.php
@@ -28,7 +28,6 @@ use Magento\Sales\Model\Order;
 use Bolt\Boltpay\Helper\Order as OrderHelper;
 use Bolt\Boltpay\Controller\ReceivedUrlTrait;
 use Magento\Backend\Model\UrlInterface as BackendUrl;
-use Bolt\Boltpay\Helper\Session as BoltSession;
 use Magento\Framework\App\CacheInterface;
 use Magento\Framework\Serialize\SerializerInterface as Serialize;
 use Bolt\Boltpay\Controller\ReceivedUrlInterface;

--- a/Controller/ReceivedUrlInterface.php
+++ b/Controller/ReceivedUrlInterface.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2022 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Controller;
+
+interface ReceivedUrlInterface
+{
+    const BOLT_ORDER_SUCCESS_PREFIX  = 'BOLT_ORDER_SUCCESS_';
+}

--- a/Controller/ReceivedUrlTrait.php
+++ b/Controller/ReceivedUrlTrait.php
@@ -30,6 +30,7 @@ use Magento\Sales\Model\Order;
 use Bolt\Boltpay\Helper\Order as OrderHelper;
 use Magento\Framework\App\CacheInterface;
 use Magento\Framework\Serialize\SerializerInterface as Serialize;
+use Bolt\Boltpay\Controller\ReceivedUrlInterface;
 
 trait ReceivedUrlTrait
 {
@@ -137,7 +138,7 @@ trait ReceivedUrlTrait
                 // add order information to the session
                 $this->clearOrderSession($order, $redirectUrl);
                 
-                $cacheIdentifier = self::BOLT_ORDER_SUCCESS_PREFIX . $this->checkoutSession->getSessionId();
+                $cacheIdentifier = ReceivedUrlInterface::BOLT_ORDER_SUCCESS_PREFIX . $this->checkoutSession->getSessionId();
                 
                 $sessionData = [
                     "LastQuoteId"   => $quote->getId(),

--- a/Controller/ReceivedUrlTrait.php
+++ b/Controller/ReceivedUrlTrait.php
@@ -30,7 +30,6 @@ use Magento\Sales\Model\Order;
 use Bolt\Boltpay\Helper\Order as OrderHelper;
 use Magento\Framework\App\CacheInterface;
 use Magento\Framework\Serialize\SerializerInterface as Serialize;
-use Bolt\Boltpay\Helper\Session as BoltSession;
 
 trait ReceivedUrlTrait
 {

--- a/Controller/ReceivedUrlTrait.php
+++ b/Controller/ReceivedUrlTrait.php
@@ -28,6 +28,9 @@ use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\Quote\Model\Quote;
 use Magento\Sales\Model\Order;
 use Bolt\Boltpay\Helper\Order as OrderHelper;
+use Magento\Framework\App\CacheInterface;
+use Magento\Framework\Serialize\SerializerInterface as Serialize;
+use Bolt\Boltpay\Helper\Session as BoltSession;
 
 trait ReceivedUrlTrait
 {
@@ -55,6 +58,12 @@ trait ReceivedUrlTrait
      * @var OrderHelper
      */
     private $orderHelper;
+    
+    /** @var CacheInterface */
+    private $cache;
+    
+    /** @var Serialize */
+    private $serialize;
 
     /**
      * @return \Magento\Framework\App\ResponseInterface
@@ -128,6 +137,19 @@ trait ReceivedUrlTrait
 
                 // add order information to the session
                 $this->clearOrderSession($order, $redirectUrl);
+                
+                $cacheIdentifier = self::BOLT_ORDER_SUCCESS_PREFIX . $this->checkoutSession->getSessionId();
+                
+                $sessionData = [
+                    "LastQuoteId"   => $quote->getId(),
+                    "LastSuccessQuoteId"   => $quote->getId(),
+                    "LastOrderId"   => $order->getId(),
+                    "RedirectUrl"   => $redirectUrl,
+                    "LastRealOrderId"   => $order->getIncrementId(),
+                    "LastOrderStatus"   => $order->getStatus(),
+                ];
+                
+                $this->cache->save($this->serialize->serialize($sessionData), $cacheIdentifier, [], 600);
 
                 $this->_redirect($redirectUrl);
             } catch (NoSuchEntityException $noSuchEntityException) {

--- a/Plugin/Magento/Checkout/Model/Session/SuccessValidatorPlugin.php
+++ b/Plugin/Magento/Checkout/Model/Session/SuccessValidatorPlugin.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2022 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+namespace Bolt\Boltpay\Plugin\Magento\Checkout\Model\Session;
+
+use Bolt\Boltpay\Helper\Session as BoltSession;
+use Bolt\Boltpay\Controller\ReceivedUrlInterface;
+use Magento\Framework\App\CacheInterface;
+use Magento\Framework\Serialize\SerializerInterface as Serialize;
+use Magento\Checkout\Model\Session as CheckoutSession;
+
+/**
+ * Plugin for {@see \Magento\Checkout\Model\Session\SuccessValidator}
+ */
+class SuccessValidatorPlugin
+{
+    /** @var CacheInterface */
+    private $cache;
+    
+    /** @var Serialize */
+    private $serialize;
+    
+    /** @var CheckoutSession */
+    private $checkoutSession;
+
+    /**
+     * @param \Magento\Framework\App\CacheInterface $cache
+     * @param \Magento\Framework\Serialize\SerializerInterface $serialize
+     * @param \Magento\Checkout\Model\Session $checkoutSession
+     * @codeCoverageIgnore
+     */
+    public function __construct(
+        CacheInterface $cache,
+        Serialize $serialize,
+        CheckoutSession $checkoutSession
+    ) {
+        $this->cache = $cache;
+        $this->serialize = $serialize;
+        $this->checkoutSession = $checkoutSession;
+    }
+
+    /**
+     * Restore checkout session data from cache
+     */
+    public function beforeIsValid(\Magento\Checkout\Model\Session\SuccessValidator $subject)
+    {
+        $cacheIdentifier = ReceivedUrlInterface::BOLT_ORDER_SUCCESS_PREFIX . $this->checkoutSession->getSessionId();
+        if ($serialized = $this->cache->load($cacheIdentifier)) {
+            $sessionData = $this->serialize->unserialize($serialized);
+            
+            $this->checkoutSession
+                ->setLastQuoteId($sessionData['LastQuoteId'])
+                ->setLastSuccessQuoteId($sessionData['LastSuccessQuoteId'])
+                ->clearHelperData();
+            
+            $this->checkoutSession
+                ->setLastOrderId($sessionData['LastOrderId'])
+                ->setRedirectUrl($sessionData['RedirectUrl'])
+                ->setLastRealOrderId($sessionData['LastRealOrderId'])
+                ->setLastOrderStatus($sessionData['LastOrderStatus']);
+                
+            $this->cache->remove($cacheIdentifier);
+        }
+        
+        return null;
+    }
+}

--- a/Test/Unit/Controller/Adminhtml/Order/ReceivedUrlTest.php
+++ b/Test/Unit/Controller/Adminhtml/Order/ReceivedUrlTest.php
@@ -30,6 +30,9 @@ use Magento\Sales\Model\Order;
 use Bolt\Boltpay\Helper\Order as OrderHelper;
 use Magento\Backend\Model\UrlInterface;
 use Bolt\Boltpay\Test\Unit\TestHelper;
+use Magento\Framework\App\CacheInterface;
+use Magento\Framework\Serialize\SerializerInterface as Serialize;
+use Bolt\Boltpay\Controller\ReceivedUrlInterface;
 use PHPUnit_Framework_MockObject_MockObject;
 
 /**
@@ -79,6 +82,16 @@ class ReceivedUrlTest extends BoltTestCase
      * @var UrlInterface
      */
     private $backendUrl;
+    
+    /**
+     * @var CacheInterface
+     */
+    private $cache;
+
+    /**
+     * @var Serialize
+     */
+    private $serialize;
 
     /**
      * @var ReceivedUrl
@@ -99,6 +112,8 @@ class ReceivedUrlTest extends BoltTestCase
         $this->checkoutSession = $this->createMock(CheckoutSession::class);
         $this->orderHelper = $this->createMock(OrderHelper::class);
         $this->order = $this->createPartialMock(Order::class, ['getStoreId','getId','getStore']);
+        $this->cache = $this->createMock(CacheInterface::class);
+        $this->serialize = $this->createMock(Serialize::class);
         $this->currentMock = $this->getMockBuilder(ReceivedUrl::class)
             ->setConstructorArgs([
                 $this->context,
@@ -107,7 +122,9 @@ class ReceivedUrlTest extends BoltTestCase
                 $this->bugsnag,
                 $this->logHelper,
                 $this->checkoutSession,
-                $this->orderHelper
+                $this->orderHelper,
+                $this->cache,
+                $this->serialize
             ])
             ->disableProxyingToOriginalMethods()
             ->getMock();

--- a/Test/Unit/Controller/Order/ReceivedUrlTest.php
+++ b/Test/Unit/Controller/Order/ReceivedUrlTest.php
@@ -37,6 +37,9 @@ use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Magento\Backend\Model\UrlInterface as BackendUrl;
 use Magento\Framework\App\Response\RedirectInterface;
+use Magento\Framework\App\CacheInterface;
+use Magento\Framework\Serialize\SerializerInterface as Serialize;
+use Bolt\Boltpay\Controller\ReceivedUrlInterface;
 
 /**
  * @coversDefaultClass \Bolt\Boltpay\Controller\Order\ReceivedUrl
@@ -121,6 +124,16 @@ class ReceivedUrlTest extends BoltTestCase
      * @var RedirectInterface | MockObject
      */
     private $redirect;
+    
+    /**
+     * @var CacheInterface
+     */
+    private $cache;
+
+    /**
+     * @var Serialize
+     */
+    private $serialize;
 
     /**
      * @test
@@ -700,6 +713,8 @@ class ReceivedUrlTest extends BoltTestCase
         $this->orderHelper = $this->createMock(OrderHelper::class);
         $this->backendUrl = $this->createMock(BackendUrl::class);
         $this->redirect = $this->createMock(RedirectInterface::class);
+        $this->cache = $this->createMock(CacheInterface::class);
+        $this->serialize = $this->createMock(Serialize::class);
     }
 
     private function createOrderMock($state)
@@ -737,6 +752,8 @@ class ReceivedUrlTest extends BoltTestCase
                 $orderHelper,
                 $this->backendUrl,
                 $this->redirect,
+                $this->cache,
+                $this->serialize
             ])
             ->getMock();
         return $receivedUrl;

--- a/Test/Unit/Controller/Order/ReceivedUrlTest.php
+++ b/Test/Unit/Controller/Order/ReceivedUrlTest.php
@@ -751,7 +751,6 @@ class ReceivedUrlTest extends BoltTestCase
                 $checkoutSession,
                 $orderHelper,
                 $this->backendUrl,
-                $this->redirect,
                 $this->cache,
                 $this->serialize
             ])

--- a/Test/Unit/Controller/ReceivedUrlTraitTest.php
+++ b/Test/Unit/Controller/ReceivedUrlTraitTest.php
@@ -27,6 +27,7 @@ use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Quote\Model\Quote;
 use Magento\Sales\Model\Order;
+use Bolt\Boltpay\Controller\ReceivedUrlInterface;
 
 /**
  * Class ReceivedUrlTraitTest

--- a/Test/Unit/Controller/ReceivedUrlTraitTest.php
+++ b/Test/Unit/Controller/ReceivedUrlTraitTest.php
@@ -28,6 +28,8 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Quote\Model\Quote;
 use Magento\Sales\Model\Order;
 use Bolt\Boltpay\Controller\ReceivedUrlInterface;
+use Magento\Framework\App\CacheInterface;
+use Magento\Framework\Serialize\SerializerInterface as Serialize;
 
 /**
  * Class ReceivedUrlTraitTest
@@ -96,6 +98,16 @@ class ReceivedUrlTraitTest extends BoltTestCase
      * @var \Magento\Sales\Model\Order\Payment|\PHPUnit\Framework\MockObject\MockObject|\PHPUnit_Framework_MockObject_MockObject
      */
     private $paymentMock;
+    
+    /**
+     * @var CacheInterface
+     */
+    private $cache;
+
+    /**
+     * @var Serialize
+     */
+    private $serialize;
 
     public function setUpInternal()
     {
@@ -117,10 +129,14 @@ class ReceivedUrlTraitTest extends BoltTestCase
         $this->quote = $this->createPartialMock(Quote::class, ['getId']);
         $this->order = $this->createPartialMock(Order::class, ['getId', 'getIncrementId', 'getStatus', 'getState', 'getPayment', 'addStatusHistoryComment', 'save']);
         $this->paymentMock = $this->createMock(\Magento\Sales\Model\Order\Payment::class);
+        $this->cache = $this->createMock(CacheInterface::class);
+        $this->serialize = $this->createMock(Serialize::class);
         TestHelper::setProperty($this->currentMock, 'cartHelper', $this->cartHelper);
         TestHelper::setProperty($this->currentMock, 'checkoutSession', $this->checkoutSession);
         TestHelper::setProperty($this->currentMock, 'orderHelper', $this->orderHelper);
         TestHelper::setProperty($this->currentMock, 'configHelper', $this->configHelper);
+        TestHelper::setProperty($this->currentMock, 'cache', $this->cache);
+        TestHelper::setProperty($this->currentMock, 'serialize', $this->serialize);
     }
 
     /**

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -85,4 +85,8 @@
         <plugin sortOrder="1" name="boltBoltpayRemove"
                 type="Bolt\Boltpay\Plugin\Magento\Rewards\Controller\Cart\RemoveActionPlugin"/>
     </type>
+    <type name="Magento\Checkout\Model\Session\SuccessValidator">
+        <plugin sortOrder="1" name="boltBoltpaySuccessValidatorPlugin"
+                type="Bolt\Boltpay\Plugin\Magento\Checkout\Model\Session\SuccessValidatorPlugin"/>
+    </type>
 </config>


### PR DESCRIPTION
# Description
Root cause: the variables (such as LastQuoteId, LastSuccessQuoteId and etc.) saved in the checkout session lost for some reasons, therefore, the redirection can not pass validation (https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Checkout/Model/Session/SuccessValidator.php#L34) and stay on the empty cart page.

Solution: use Magento cache to store these variables instead.

Fixes: https://app.asana.com/0/474713171217346/1201502391293711/f

#changelog Bugfix: Sporadic issues with shoppers not being redirected to the confirmation page

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
