### PR TITLE
Discount type refactoring

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -2289,8 +2289,8 @@ class Cart extends AbstractHelper
                     'description'       => 'Store Credit',
                     'amount'            => $roundedAmount,
                     'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_STORE_CREDIT,
-                    'discount_type'     => $this->discountHelper->getBoltDiscountType('by_fixed'), // For v1/discounts.code.apply and v2/cart.update
-                    'type'              => $this->discountHelper->getBoltDiscountType('by_fixed'), // For v1/merchant/order
+                    'discount_type'     => DiscountHelper::BOLT_DISCOUNT_TYPE_FIXED, // For v1/discounts.code.apply and v2/cart.update
+                    'type'              => DiscountHelper::BOLT_DISCOUNT_TYPE_FIXED, // For v1/merchant/order
                 ];
 
                 $diff -= CurrencyUtils::toMinorWithoutRounding($amount, $currencyCode) - $roundedAmount;
@@ -2313,8 +2313,8 @@ class Cart extends AbstractHelper
                         'description'       => 'Store Credit',
                         'amount'            => $roundedAmount,
                         'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_STORE_CREDIT,
-                        'discount_type'     => $this->discountHelper->getBoltDiscountType('by_fixed'), // For v1/discounts.code.apply and v2/cart.update
-                        'type'              => $this->discountHelper->getBoltDiscountType('by_fixed'), // For v1/merchant/order
+                        'discount_type'     => Discount::BOLT_DISCOUNT_TYPE_FIXED, // For v1/discounts.code.apply and v2/cart.update
+                        'type'              => Discount::BOLT_DISCOUNT_TYPE_FIXED, // For v1/merchant/order
                     ];
 
                     $diff -= CurrencyUtils::toMinorWithoutRounding($amount, $currencyCode) - $roundedAmount;
@@ -2336,8 +2336,8 @@ class Cart extends AbstractHelper
                     'description'       => 'Reward Points',
                     'amount'            => $roundedAmount,
                     'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_STORE_CREDIT,
-                    'discount_type'     => $this->discountHelper->getBoltDiscountType('by_fixed'), // For v1/discounts.code.apply and v2/cart.update
-                    'type'              => $this->discountHelper->getBoltDiscountType('by_fixed'), // For v1/merchant/order
+                    'discount_type'     => Discount::BOLT_DISCOUNT_TYPE_FIXED, // For v1/discounts.code.apply and v2/cart.update
+                    'type'              => Discount::BOLT_DISCOUNT_TYPE_FIXED, // For v1/merchant/order
                 ];
 
                 $diff -= CurrencyUtils::toMinorWithoutRounding($amount, $currencyCode) - $roundedAmount;
@@ -2360,8 +2360,8 @@ class Cart extends AbstractHelper
                         'description'       => 'Reward Points',
                         'amount'            => $roundedAmount,
                         'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_STORE_CREDIT,
-                        'discount_type'     => $this->discountHelper->getBoltDiscountType('by_fixed'), // For v1/discounts.code.apply and v2/cart.update
-                        'type'              => $this->discountHelper->getBoltDiscountType('by_fixed'), // For v1/merchant/order
+                        'discount_type'     => DiscountHelper::BOLT_DISCOUNT_TYPE_FIXED, // For v1/discounts.code.apply and v2/cart.update
+                        'type'              => DiscountHelper::BOLT_DISCOUNT_TYPE_FIXED, // For v1/merchant/order
                     ];
 
                     $diff -= CurrencyUtils::toMinorWithoutRounding($amount, $currencyCode) - $roundedAmount;
@@ -2400,8 +2400,8 @@ class Cart extends AbstractHelper
                         'amount'            => $roundedDiscountAmount,
                         'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_GIFTCARD,
                         'reference'         => $gcCode,
-                        'discount_type'     => $this->discountHelper->getBoltDiscountType('by_fixed'), // For v1/discounts.code.apply and v2/cart.update
-                        'type'              => $this->discountHelper->getBoltDiscountType('by_fixed'), // For v1/merchant/order
+                        'discount_type'     => DiscountHelper::BOLT_DISCOUNT_TYPE_FIXED, // For v1/discounts.code.apply and v2/cart.update
+                        'type'              => DiscountHelper::BOLT_DISCOUNT_TYPE_FIXED, // For v1/merchant/order
                     ];
                     $this->logEmptyDiscountCode($gcCode, $gcDescription);
                     $discounts[] = $discountItem;

--- a/Helper/Discount.php
+++ b/Helper/Discount.php
@@ -40,6 +40,11 @@ use Bolt\Boltpay\Model\EventsForThirdPartyModules;
  */
 class Discount extends AbstractHelper
 {
+    // Bolt discount types
+    const BOLT_DISCOUNT_TYPE_FIXED = "fixed_amount";
+    const BOLT_DISCOUNT_TYPE_PERCENTAGE = "percentage";
+    const BOLT_DISCOUNT_TYPE_FREE_SHIPPING = "free_shipping";
+
     // Discount totals key identifiers
     const AMASTY_GIFTCARD = 'amasty_giftcard';
     const GIFT_VOUCHER_AFTER_TAX = 'giftvoucheraftertax';
@@ -346,14 +351,12 @@ class Discount extends AbstractHelper
         switch ($type) {
             case "by_fixed":
             case "cart_fixed":
-                return "fixed_amount";
+                return self::BOLT_DISCOUNT_TYPE_FIXED;
             case "by_percent":
-                return "percentage";
-            case "by_shipping":
-                return "shipping";
+                return self::BOLT_DISCOUNT_TYPE_PERCENTAGE;
         }
 
-        return "fixed_amount";
+        return self::BOLT_DISCOUNT_TYPE_FIXED;
     }
     
     /**

--- a/Model/Api/DiscountCodeValidation.php
+++ b/Model/Api/DiscountCodeValidation.php
@@ -19,6 +19,7 @@ namespace Bolt\Boltpay\Model\Api;
 
 use Bolt\Boltpay\Api\DiscountCodeValidationInterface;
 use Bolt\Boltpay\Helper\Cart as CartHelper;
+use Bolt\Boltpay\Helper\Discount;
 use Bolt\Boltpay\Helper\Shared\CurrencyUtils;
 use Bolt\Boltpay\Model\ErrorResponse as BoltErrorResponse;
 use Magento\Framework\Exception\LocalizedException;
@@ -262,7 +263,7 @@ class DiscountCodeValidation extends UpdateCartCommon implements DiscountCodeVal
                 'discount_code'   => $code,
                 'discount_amount' => abs(CurrencyUtils::toMinor($giftAmount, $immutableQuote->getQuoteCurrencyCode())),
                 'description'     =>  __('Gift Card'),
-                'discount_type'   => $this->discountHelper->getBoltDiscountType('by_fixed'),
+                'discount_type'   => Discount::BOLT_DISCOUNT_TYPE_FIXED,
             ];
         }
 

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -4142,7 +4142,6 @@ ORDER
         ->willReturn(self::CURRENCY_CODE);
         $this->immutableQuoteMock->expects(static::once())->method('getUseCustomerBalance')->willReturn(true);
         $this->immutableQuoteMock->expects(static::any())->method('getCouponCode')->willReturn(false);
-        $this->discountHelper->expects(static::exactly(2))->method('getBoltDiscountType')->with('by_fixed')->willReturn('fixed_amount');
         $this->immutableQuoteMock->expects(static::once())->method('getUseRewardPoints')->willReturn(false);
 
         ObjectManager::setInstance($this->objectManagerMock);
@@ -4228,7 +4227,6 @@ ORDER
         ->getMock();
         $this->objectManagerMock->expects(static::once())->method('create')
         ->with('Magento\Reward\Model\Reward')->willReturn($rewardModelMock);
-        $this->discountHelper->expects(static::exactly(2))->method('getBoltDiscountType')->with('by_fixed')->willReturn('fixed_amount');
 
         $this->customerSession->expects(static::once())->method('getCustomer')->willReturn($this->customerMock);
         $rewardModelMock->expects(static::once())->method('setCustomer')->with($this->customerMock)
@@ -4337,7 +4335,6 @@ ORDER
         $quote->expects(static::any())->method("getData")->with("giftcert_code")->willReturn($unirgyGiftcertCode);
         $this->discountHelper->expects(static::once())->method('getUnirgyGiftCertBalanceByCode')
         ->with($unirgyGiftcertCode)->willReturn($appliedDiscount);
-        $this->discountHelper->expects(static::exactly(2))->method('getBoltDiscountType')->with('by_fixed')->willReturn('fixed_amount');
         $this->quoteAddressTotal->expects(static::once())->method('getValue')->willReturn(5);
         $quote->expects(static::any())->method('getTotals')
         ->willReturn([DiscountHelper::UNIRGY_GIFT_CERT => $this->quoteAddressTotal]);

--- a/Test/Unit/Helper/DiscountTest.php
+++ b/Test/Unit/Helper/DiscountTest.php
@@ -539,7 +539,6 @@ class DiscountTest extends BoltTestCase
             ['types' => 'by_fixed', 'expectedResult' => 'fixed_amount'],
             ['types' => 'cart_fixed', 'expectedResult' => 'fixed_amount'],
             ['types' => 'by_percent', 'expectedResult' => 'percentage'],
-            ['types' => 'by_shipping', 'expectedResult' => 'shipping'],
             ['types' => 'none_list', 'expectedResult' => 'fixed_amount'],
             ['types' => '', 'expectedResult' => 'fixed_amount'],
         ];

--- a/Test/Unit/ThirdPartyModules/Aheadworks/RewardPointsTest.php
+++ b/Test/Unit/ThirdPartyModules/Aheadworks/RewardPointsTest.php
@@ -42,11 +42,6 @@ class RewardPointsTest extends BoltTestCase
     const ORDER_ID = 123;
 
     /**
-     * @var Discount|\PHPUnit_Framework_MockObject_MockObject
-     */
-    private $discountHelperMock;
-
-    /**
      * @var Bugsnag|\PHPUnit_Framework_MockObject_MockObject
      */
     private $bugsnagHelperMock;
@@ -97,7 +92,6 @@ class RewardPointsTest extends BoltTestCase
      */
     protected function setUpInternal()
     {
-        $this->discountHelperMock = $this->createPartialMock(Discount::class, []);
         $this->bugsnagHelperMock = $this->createMock(Bugsnag::class);
         $this->quoteRepositoryMock = $this->createMock(CartRepositoryInterface::class);
         $this->orderServiceMock = $this->createMock(OrderService::class);
@@ -106,7 +100,6 @@ class RewardPointsTest extends BoltTestCase
         $this->currentMock = $this->getMockBuilder(\Bolt\Boltpay\ThirdPartyModules\Aheadworks\RewardPoints::class)
             ->setConstructorArgs(
                 [
-                    $this->discountHelperMock,
                     $this->bugsnagHelperMock,
                     $this->configHelperMock,
                     $this->customerSessionMock,
@@ -143,14 +136,12 @@ class RewardPointsTest extends BoltTestCase
     public function __construct_always_setsInternalProperties()
     {
         $instance = new \Bolt\Boltpay\ThirdPartyModules\Aheadworks\RewardPoints(
-            $this->discountHelperMock,
             $this->bugsnagHelperMock,
             $this->configHelperMock,
             $this->customerSessionMock,
             $this->quoteRepositoryMock,
             $this->orderServiceMock
         );
-        static::assertAttributeEquals($this->discountHelperMock, 'discountHelper', $instance);
         static::assertAttributeEquals($this->bugsnagHelperMock, 'bugsnagHelper', $instance);
         static::assertAttributeEquals($this->configHelperMock, 'configHelper', $instance);
         static::assertAttributeEquals($this->customerSessionMock, 'customerSession', $instance);

--- a/Test/Unit/ThirdPartyModules/Amasty/GiftCardAccountTest.php
+++ b/Test/Unit/ThirdPartyModules/Amasty/GiftCardAccountTest.php
@@ -312,10 +312,6 @@ class GiftCardAccountTest extends BoltTestCase
         $immutableQuote = $this->getQuoteMock($this->getAddressMock(), $shippingAddress);
         $shippingAddress->expects(static::any())->method('getDiscountAmount')->willReturn(false);
         $this->discountHelper->expects(static::never())->method('getUnirgyGiftCertBalanceByCode');
-        $this->discountHelper->expects(static::exactly(1))
-            ->method('getBoltDiscountType')->with('by_fixed')->willReturn(
-                'fixed_amount'
-            );
         $this->discountHelper->expects(static::once())->method('getAmastyPayForEverything')->willReturn(true);
         $this->quoteAddressTotal->expects(static::once())->method('getValue')->willReturn(5);
         $immutableQuote->expects(static::any())->method('getTotals')

--- a/Test/Unit/ThirdPartyModules/Amasty/StoreCreditTest.php
+++ b/Test/Unit/ThirdPartyModules/Amasty/StoreCreditTest.php
@@ -38,11 +38,6 @@ class StoreCreditTest extends BoltTestCase
     private $storeCredit;
 
     /**
-     * @var Discount
-     */
-    private $discountHelper;
-
-    /**
      * @var Bugsnag
      */
     private $bugsnagHelper;
@@ -62,7 +57,6 @@ class StoreCreditTest extends BoltTestCase
         }
         $this->objectManager = Bootstrap::getObjectManager();
         $this->storeCredit = $this->objectManager->create(StoreCredit::class);
-        $this->discountHelper = $this->objectManager->create(Discount::class);
         $this->bugsnagHelper = $this->objectManager->create(Bugsnag::class);
         $this->configHelper = $this->objectManager->create(Config::class);
     }
@@ -75,8 +69,7 @@ class StoreCreditTest extends BoltTestCase
      */
     public function __construct_always_setsInternalProperties()
     {
-        $instance = new StoreCredit($this->discountHelper, $this->bugsnagHelper, $this->configHelper);
-        static::assertAttributeEquals($this->discountHelper, 'discountHelper', $instance);
+        $instance = new StoreCredit($this->bugsnagHelper, $this->configHelper);
         static::assertAttributeEquals($this->bugsnagHelper, 'bugsnagHelper', $instance);
         static::assertAttributeEquals($this->configHelper, 'configHelper', $instance);
     }

--- a/ThirdPartyModules/Aheadworks/Giftcard.php
+++ b/ThirdPartyModules/Aheadworks/Giftcard.php
@@ -37,11 +37,6 @@ class Giftcard
     private $bugsnagHelper;
 
     /**
-     * @var Discount
-     */
-    protected $discountHelper;
-
-    /**
      * @var Bolt\Boltpay\Helper\FeatureSwitch\Decider
      */
     private $featureSwitches;
@@ -49,18 +44,15 @@ class Giftcard
     /**
      * @param OrderService $orderService Magento order service instance
      * @param Bugsnag $bugsnagHelper Bugsnag helper instance
-     * @param Discount $discountHelper
      * @param Decider  $featureSwitches
      */
     public function __construct(
         OrderService  $orderService,
         Bugsnag       $bugsnagHelper,
-        Discount      $discountHelper,
         Decider       $featureSwitches
     ) {
         $this->orderService   = $orderService;
         $this->bugsnagHelper  = $bugsnagHelper;
-        $this->discountHelper = $discountHelper;
         $this->featureSwitches = $featureSwitches;
     }
 
@@ -96,9 +88,9 @@ class Giftcard
                     'amount'            => CurrencyUtils::toMinor($giftcardQuote->getGiftcardBalance(), $currencyCode),
                     'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_GIFTCARD,
                     // For v1/discounts.code.apply and v2/cart.update
-                    'discount_type'     => $this->discountHelper->getBoltDiscountType('by_fixed'),
+                    'discount_type'     => Discount::BOLT_DISCOUNT_TYPE_FIXED,
                     // For v1/merchant/order
-                    'type'              => $this->discountHelper->getBoltDiscountType('by_fixed'),
+                    'type'              => Discount::BOLT_DISCOUNT_TYPE_FIXED,
                 ];
                 $totalAmount -= CurrencyUtils::toMinor($giftcardQuote->getGiftcardAmount(), $currencyCode);
             }

--- a/ThirdPartyModules/Aheadworks/RewardPoints.php
+++ b/ThirdPartyModules/Aheadworks/RewardPoints.php
@@ -37,11 +37,6 @@ class RewardPoints
     private $bugsnagHelper;
 
     /**
-     * @var Discount
-     */
-    protected $discountHelper;
-
-    /**
      * @var CartRepositoryInterface
      */
     private $quoteRepository;
@@ -64,7 +59,6 @@ class RewardPoints
     /**
      * StoreCredit constructor.
      *
-     * @param Discount                $discountHelper
      * @param Bugsnag                 $bugsnagHelper
      * @param Config                  $configHelper
      * @param CustomerSession         $customerSession
@@ -72,14 +66,12 @@ class RewardPoints
      * @param OrderService            $orderService
      */
     public function __construct(
-        Discount $discountHelper,
         Bugsnag $bugsnagHelper,
         Config $configHelper,
         CustomerSession $customerSession,
         CartRepositoryInterface $quoteRepository,
         OrderService $orderService
     ) {
-        $this->discountHelper = $discountHelper;
         $this->bugsnagHelper = $bugsnagHelper;
         $this->quoteRepository = $quoteRepository;
         $this->orderService = $orderService;
@@ -119,15 +111,14 @@ class RewardPoints
                     : abs(
                         $quote->getData('base_aw_reward_points_amount')
                     );
-                $discountType = $this->discountHelper->getBoltDiscountType('by_fixed');
                 $roundedAmount = CurrencyUtils::toMinor($amount, $currencyCode);
                 $discounts[] = [
                     'description'       => __('Reward Points'),
                     'amount'            => $roundedAmount,
                     'reference'         => self::AHEADWORKS_REWARD_POINTS,
                     'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_STORE_CREDIT,
-                    'discount_type'     => $discountType, // For v1/discounts.code.apply and v2/cart.update
-                    'type'              => $discountType, // For v1/merchant/order
+                    'discount_type'     => Discount::BOLT_DISCOUNT_TYPE_FIXED, // For v1/discounts.code.apply and v2/cart.update
+                    'type'              => Discount::BOLT_DISCOUNT_TYPE_FIXED, // For v1/merchant/order
                 ];
 
                 $diff -= CurrencyUtils::toMinorWithoutRounding($amount, $currencyCode) - $roundedAmount;

--- a/ThirdPartyModules/Aheadworks/StoreCredit.php
+++ b/ThirdPartyModules/Aheadworks/StoreCredit.php
@@ -44,11 +44,6 @@ class StoreCredit
     private $configHelper;
 
     /**
-     * @var Discount
-     */
-    protected $discountHelper;
-    
-    /**
      * @var CartRepositoryInterface
      */
     private $quoteRepository;
@@ -60,20 +55,17 @@ class StoreCredit
 
     /**
      * StoreCredit constructor.
-     * @param Discount                $discountHelper
      * @param Bugsnag                 $bugsnagHelper
      * @param Config                  $configHelper
      * @param CartRepositoryInterface $quoteRepository
      * @param CustomerSession         $customerSession
      */
     public function __construct(
-        Discount $discountHelper,
         Bugsnag $bugsnagHelper,
         Config $configHelper,
         CartRepositoryInterface $quoteRepository,
         CustomerSession $customerSession
     ) {
-        $this->discountHelper = $discountHelper;
         $this->bugsnagHelper = $bugsnagHelper;
         $this->configHelper = $configHelper;
         $this->quoteRepository = $quoteRepository;
@@ -104,15 +96,14 @@ class StoreCredit
                 $amount = abs($this->aheadworksCustomerStoreCreditManagement
                     ->getCustomerStoreCreditBalance($quote->getCustomerId()));
                 $currencyCode = $quote->getQuoteCurrencyCode();
-                $discountType = $this->discountHelper->getBoltDiscountType('by_fixed');
                 $roundedAmount = CurrencyUtils::toMinor($amount, $currencyCode);
                 $discounts[] = [
                     'description' => 'Store Credit',
                     'amount' => $roundedAmount,
                     'reference' => self::AHEADWORKS_STORE_CREDIT,
                     'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_STORE_CREDIT,
-                    'discount_type' => $discountType, // For v1/discounts.code.apply and v2/cart.update
-                    'type' => $discountType, // For v1/merchant/order
+                    'discount_type' => Discount::BOLT_DISCOUNT_TYPE_FIXED, // For v1/discounts.code.apply and v2/cart.update
+                    'type' => Discount::BOLT_DISCOUNT_TYPE_FIXED, // For v1/merchant/order
                 ];
 
                 $diff -= CurrencyUtils::toMinorWithoutRounding($amount, $currencyCode) - $roundedAmount;

--- a/ThirdPartyModules/Amasty/GiftCard.php
+++ b/ThirdPartyModules/Amasty/GiftCard.php
@@ -139,7 +139,6 @@ class GiftCard
                 $giftcardQuotes = $giftcardQuoteCollectionFactory->create()->joinAccount()
                     ->getGiftCardsByQuoteId($quote->getId());
                 /** @var \Amasty\GiftCard\Model\Quote|\Amasty\GiftCard\Model\Account $giftcard */
-                $discountType = $this->discountHelper->getBoltDiscountType('by_fixed');
                 foreach ($giftcardQuotes->getItems() as $giftcard) {
                     $amount = abs($giftcard->getCurrentValue());
                     $roundedAmount = CurrencyUtils::toMinor($amount, $currencyCode);
@@ -149,9 +148,9 @@ class GiftCard
                         'amount'            => $roundedAmount,
                         'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_GIFTCARD,
                         'reference'         => $giftCardCode,
-                        'discount_type'     => $discountType,
+                        'discount_type'     => Discount::BOLT_DISCOUNT_TYPE_FIXED,
                         // For v1/discounts.code.apply and v2/cart.update
-                        'type'              => $discountType,
+                        'type'              => Discount::BOLT_DISCOUNT_TYPE_FIXED,
                         // For v1/merchant/order
                     ];
                     $discountAmount += $amount;

--- a/ThirdPartyModules/Amasty/GiftCardAccount.php
+++ b/ThirdPartyModules/Amasty/GiftCardAccount.php
@@ -133,7 +133,6 @@ class GiftCardAccount
             // the "fixed_amount" type is added below.
             ///////////////////////////////////////////////////////////////////////////
             if ($totalDiscount && $totalDiscount->getValue()) {
-                $discountType = $this->discountHelper->getBoltDiscountType('by_fixed');
                 $appliedGiftCardItems = [];
                 if ($this->discountHelper->getAmastyPayForEverything()) {
                     $giftcardQuote = $giftcardQuoteRepository->getByQuoteId($quote->getId());
@@ -165,8 +164,8 @@ class GiftCardAccount
                         'amount'            => $roundedAmount,
                         'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_GIFTCARD,
                         'reference'         => $appliedGiftCardItem['code'],
-                        'discount_type'     => $discountType, // For v1/discounts.code.apply and v2/cart.update
-                        'type'              => $discountType, // For v1/merchant/order
+                        'discount_type'     => Discount::BOLT_DISCOUNT_TYPE_FIXED, // For v1/discounts.code.apply and v2/cart.update
+                        'type'              => Discount::BOLT_DISCOUNT_TYPE_FIXED, // For v1/merchant/order
                     ];
                     $discountAmount += $appliedGiftCardItem['amount'];
                     $roundedDiscountAmount += $roundedAmount;

--- a/ThirdPartyModules/Amasty/Rewards.php
+++ b/ThirdPartyModules/Amasty/Rewards.php
@@ -35,11 +35,6 @@ class Rewards
     private $bugsnagHelper;
 
     /**
-     * @var Discount
-     */
-    protected $discountHelper;
-
-    /**
      * @var Quote
      */
     protected $amastyRewardsResourceQuote;
@@ -56,16 +51,13 @@ class Rewards
 
     /**
      * @param Bugsnag $bugsnagHelper Bugsnag helper instance
-     * @param Discount $discountHelper
      * @param ResourceConnection $resourceConnection
      */
     public function __construct(
         Bugsnag   $bugsnagHelper,
-        Discount  $discountHelper,
         ResourceConnection $resourceConnection
     ) {
         $this->bugsnagHelper   = $bugsnagHelper;
-        $this->discountHelper  = $discountHelper;
         $this->resourceConnection = $resourceConnection;
     }
 
@@ -107,9 +99,9 @@ class Rewards
                     'reference'         => self::AMASTY_REWARD,
                     'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_STORE_CREDIT,
                     // For v1/discounts.code.apply and v2/cart.update
-                    'discount_type'     => $this->discountHelper->getBoltDiscountType('by_fixed'),
+                    'discount_type'     => Discount::BOLT_DISCOUNT_TYPE_FIXED,
                     // For v1/merchant/order
-                    'type'              => $this->discountHelper->getBoltDiscountType('by_fixed'),
+                    'type'              => Discount::BOLT_DISCOUNT_TYPE_FIXED,
                 ];
                 $diff -= CurrencyUtils::toMinorWithoutRounding($amount, $currencyCode) - $roundedAmount;
                 $totalAmount -= $roundedAmount;

--- a/ThirdPartyModules/Amasty/StoreCredit.php
+++ b/ThirdPartyModules/Amasty/StoreCredit.php
@@ -32,27 +32,19 @@ class StoreCredit
     private $bugsnagHelper;
 
     /**
-     * @var Discount
-     */
-    protected $discountHelper;
-
-    /**
      * @var Config
      */
     protected $configHelper;
 
     /**
      * StoreCredit constructor.
-     * @param Discount $discountHelper
      * @param Bugsnag $bugsnagHelper
      * @param Config $configHelper
      */
     public function __construct(
-        Discount $discountHelper,
         Bugsnag $bugsnagHelper,
         Config $configHelper
     ) {
-        $this->discountHelper = $discountHelper;
         $this->bugsnagHelper = $bugsnagHelper;
         $this->configHelper = $configHelper;
     }
@@ -78,13 +70,12 @@ class StoreCredit
                 $amount = abs($totals[self::AMASTY_STORECREDIT]->getValue());
                 $currencyCode = $quote->getQuoteCurrencyCode();
                 $roundedDiscountAmount = CurrencyUtils::toMinor($amount, $currencyCode);
-                $discountType = $this->discountHelper->getBoltDiscountType('by_fixed');
                 $discounts[] = [
                     'description' => $totals[self::AMASTY_STORECREDIT]->getTitle(),
                     'amount' => $roundedDiscountAmount,
                     'reference' => self::AMASTY_STORECREDIT,
-                    'discount_type' => $discountType, // For v1/discounts.code.apply and v2/cart.update
-                    'type' => $discountType, // For v1/discounts.code.apply and v2/cart.update
+                    'discount_type' => Discount::BOLT_DISCOUNT_TYPE_FIXED, // For v1/discounts.code.apply and v2/cart.update
+                    'type' => Discount::BOLT_DISCOUNT_TYPE_FIXED, // For v1/discounts.code.apply and v2/cart.update
                     'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_STORE_CREDIT
                 ];
 

--- a/ThirdPartyModules/BagRiders/StoreCredit.php
+++ b/ThirdPartyModules/BagRiders/StoreCredit.php
@@ -24,11 +24,6 @@ class StoreCredit
     private $bugsnagHelper;
 
     /**
-     * @var Discount
-     */
-    private $discountHelper;
-
-    /**
      * @var Config
      */
     private $configHelper;
@@ -40,19 +35,16 @@ class StoreCredit
 
     /**
      * StoreCredit constructor.
-     * @param Discount $discountHelper
      * @param Bugsnag $bugsnagHelper
      * @param Config $configHelper
      * @param PriceCurrencyInterface $priceCurrency
      */
     public function __construct(
-        Discount $discountHelper,
         Bugsnag $bugsnagHelper,
         Config $configHelper,
         PriceCurrencyInterface $priceCurrency
     )
     {
-        $this->discountHelper = $discountHelper;
         $this->bugsnagHelper = $bugsnagHelper;
         $this->configHelper = $configHelper;
         $this->priceCurrency = $priceCurrency;
@@ -92,13 +84,12 @@ class StoreCredit
                         2
                     );                   
                     $roundedDiscountAmount = CurrencyUtils::toMinor($amount, $currencyCode);
-                    $discountType = $this->discountHelper->getBoltDiscountType('by_fixed');
                     $discounts[] = [
                         'description' => 'Bag Riders Store Credit',
                         'amount' => $roundedDiscountAmount,
                         'reference' => self::BAGRIDERS_STORECREDIT_REFERENCE,
-                        'discount_type' => $discountType, // For v1/discounts.code.apply and v2/cart.update
-                        'type' => $discountType, // For v1/discounts.code.apply and v2/cart.update
+                        'discount_type' => Discount::BOLT_DISCOUNT_TYPE_FIXED, // For v1/discounts.code.apply and v2/cart.update
+                        'type' => Discount::BOLT_DISCOUNT_TYPE_FIXED, // For v1/discounts.code.apply and v2/cart.update
                         'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_STORE_CREDIT
                     ];
     

--- a/ThirdPartyModules/Bss/StoreCredit.php
+++ b/ThirdPartyModules/Bss/StoreCredit.php
@@ -41,20 +41,12 @@ class StoreCredit
     private $bugsnagHelper;
 
     /**
-     * @var Discount
-     */
-    protected $discountHelper;
-
-    /**
      * StoreCredit constructor.
-     * @param Discount $discountHelper
      * @param Bugsnag $bugsnagHelper
      */
     public function __construct(
-        Discount $discountHelper,
         Bugsnag $bugsnagHelper
     ) {
-        $this->discountHelper = $discountHelper;
         $this->bugsnagHelper = $bugsnagHelper;
     }
 
@@ -89,8 +81,8 @@ class StoreCredit
                     'amount' => $roundedAmount,
                     'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_STORE_CREDIT,
                     // For v1/discounts.code.apply and v2/cart.update
-                    'discount_type' => $this->discountHelper->getBoltDiscountType('by_fixed'),
-                    'type' => $this->discountHelper->getBoltDiscountType('by_fixed'), // For v1/merchant/order
+                    'discount_type' => Discount::BOLT_DISCOUNT_TYPE_FIXED,
+                    'type' => Discount::BOLT_DISCOUNT_TYPE_FIXED, // For v1/merchant/order
                 ];
 
                 $diff -= CurrencyUtils::toMinorWithoutRounding($amount, $currencyCode) - $roundedAmount;

--- a/ThirdPartyModules/ImaginationMedia/TmwGiftCard.php
+++ b/ThirdPartyModules/ImaginationMedia/TmwGiftCard.php
@@ -26,11 +26,6 @@ class TmwGiftCard
     const IMAGINATIONMEDIA_GIFTCARD = 'imaginationmediagifcard';
 
     /**
-     * @var Discount
-     */
-    protected $discountHelper;
-
-    /**
      * @var Bugsnag
      */
     private $bugsnagHelper;
@@ -42,15 +37,12 @@ class TmwGiftCard
 
     /**
      * GiftCardDiscount constructor.
-     * @param Discount $discountHelper
      * @param Bugsnag $bugsnagHelper
      */
     public function __construct(
-        Discount $discountHelper,
         Bugsnag $bugsnagHelper
     )
     {
-        $this->discountHelper = $discountHelper;
         $this->bugsnagHelper = $bugsnagHelper;
     }
 
@@ -84,8 +76,8 @@ class TmwGiftCard
                     'reference' => self::IMAGINATIONMEDIA_GIFTCARD,
                     'amount' => $roundedAmount,
                     'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_GIFTCARD,
-                    'discount_type' => $this->discountHelper->getBoltDiscountType('by_fixed'), // For v1/discounts.code.apply and v2/cart.update
-                    'type' => $this->discountHelper->getBoltDiscountType('by_fixed'), // For v1/merchant/order
+                    'discount_type' => Discount::BOLT_DISCOUNT_TYPE_FIXED, // For v1/discounts.code.apply and v2/cart.update
+                    'type' => Discount::BOLT_DISCOUNT_TYPE_FIXED, // For v1/merchant/order
                 ];
 
                 $diff -= CurrencyUtils::toMinorWithoutRounding($giftCard, $currencyCode) - $roundedAmount;

--- a/ThirdPartyModules/J2t/Rewardpoints.php
+++ b/ThirdPartyModules/J2t/Rewardpoints.php
@@ -34,11 +34,6 @@ class Rewardpoints
     private $bugsnagHelper;
 
     /**
-     * @var Discount
-     */
-    private $discountHelper;
-    
-    /**
      * @var PriceCurrencyInterface
      */
     private $priceCurrency;
@@ -55,18 +50,15 @@ class Rewardpoints
 
     /**
      * @param Bugsnag                $bugsnagHelper
-     * @param Discount               $discountHelper
      * @param PriceCurrencyInterface $priceCurrency
      * @param QuoteRepository        $quoteRepository
      */
     public function __construct(
         Bugsnag $bugsnagHelper,
-        Discount $discountHelper,
         PriceCurrencyInterface $priceCurrency,
         QuoteRepository $quoteRepository
     ) {
         $this->bugsnagHelper = $bugsnagHelper;
-        $this->discountHelper = $discountHelper;
         $this->priceCurrency = $priceCurrency;
         $this->quoteRepository = $quoteRepository;
     }
@@ -107,16 +99,15 @@ class Rewardpoints
                 $discountAmount = abs($this->priceCurrency->convert($pointsValue));        
                 $currencyCode = $quote->getQuoteCurrencyCode();                
                 $roundedDiscountAmount = CurrencyUtils::toMinor($discountAmount, $currencyCode);
-                $discount_type = $this->discountHelper->getBoltDiscountType('by_fixed');
                 $discounts[] = [
                     'description'       => 'Reward Points',
                     'amount'            => $roundedDiscountAmount,
                     'reference'         => self::J2T_REWARD_POINTS,
                     'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_STORE_CREDIT,
                     // For v1/discounts.code.apply and v2/cart.update
-                    'discount_type'     => $discount_type,
+                    'discount_type'     => Discount::BOLT_DISCOUNT_TYPE_FIXED,
                     // For v1/merchant/order
-                    'type'              => $discount_type,
+                    'type'              => Discount::BOLT_DISCOUNT_TYPE_FIXED,
                 ];                
                 $diff -= CurrencyUtils::toMinorWithoutRounding($discountAmount, $currencyCode) - $roundedDiscountAmount;
                 $totalAmount -= $roundedDiscountAmount;

--- a/ThirdPartyModules/MageWorld/RewardPoints.php
+++ b/ThirdPartyModules/MageWorld/RewardPoints.php
@@ -27,11 +27,6 @@ class RewardPoints
     const MW_REWARDPOINTS = 'mw_reward_points';
     
     /**
-     * @var Discount
-     */
-    protected $discountHelper;
-    
-    /**
      * @var Bugsnag
      */
     protected $bugsnagHelper;
@@ -52,15 +47,12 @@ class RewardPoints
     protected $mwRewardPointsModelCustomer;
 
     /**
-     * @param Discount       $discountHelper
      * @param Bugsnag        $bugsnagHelper
      */
     public function __construct(
-        Discount        $discountHelper,
         Bugsnag         $bugsnagHelper,
         SessionManager  $sessionManager
     ) {
-        $this->discountHelper = $discountHelper;
         $this->bugsnagHelper  = $bugsnagHelper;
         $this->sessionManager  = $sessionManager;
     }
@@ -107,9 +99,9 @@ class RewardPoints
                     'reference'         => self::MW_REWARDPOINTS,
                     'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_STORE_CREDIT,
                     // For v1/discounts.code.apply and v2/cart.update
-                    'discount_type'     => $this->discountHelper->getBoltDiscountType('by_fixed'),
+                    'discount_type'     => Discount::BOLT_DISCOUNT_TYPE_FIXED,
                     // For v1/merchant/order
-                    'type'              => $this->discountHelper->getBoltDiscountType('by_fixed'),
+                    'type'              => Discount::BOLT_DISCOUNT_TYPE_FIXED,
                 ];
 
                 $diff -= CurrencyUtils::toMinorWithoutRounding($amount, $currencyCode) - $roundedAmount;

--- a/ThirdPartyModules/MageWorx/RewardPoints.php
+++ b/ThirdPartyModules/MageWorx/RewardPoints.php
@@ -47,11 +47,6 @@ class RewardPoints
     private $customerSession;
     
     /**
-     * @var Discount
-     */
-    private $discountHelper;
-    
-    /**
      * @var \MageWorx\RewardPoints\Helper\Data
      */
     private $mageWorxRewardPointsHelper;
@@ -69,18 +64,15 @@ class RewardPoints
      * @param Bugsnag          $bugsnagHelper
      * @param CustomerSession  $customerSession
      * @param Config           $configHelper
-     * @param Discount         $discountHelper
      */
     public function __construct(
         Bugsnag $bugsnagHelper,
         CustomerSession $customerSession,
-        Config $configHelper,
-        Discount $discountHelper
+        Config $configHelper
     ) {
         $this->bugsnagHelper = $bugsnagHelper;
         $this->customerSession = $customerSession;
         $this->configHelper = $configHelper;
-        $this->discountHelper = $discountHelper;
     }
     
     /**
@@ -124,16 +116,15 @@ class RewardPoints
                 }
                 $currencyCode = $quote->getQuoteCurrencyCode();
                 $roundedAmount = CurrencyUtils::toMinor($currencyAmount, $currencyCode);
-                $discountType = $this->discountHelper->getBoltDiscountType('by_fixed');
                 $discounts[] = [
                     'description'       => 'Reward Points',
                     'amount'            => $roundedAmount,
                     'reference'         => self::MAGEWORX_REWARD,
                     'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_STORE_CREDIT,
                     // For v1/discounts.code.apply and v2/cart.update
-                    'discount_type'     => $discountType,
+                    'discount_type'     => Discount::BOLT_DISCOUNT_TYPE_FIXED,
                     // For v1/merchant/order
-                    'type'              => $discountType,
+                    'type'              => Discount::BOLT_DISCOUNT_TYPE_FIXED,
                 ];
                 $diff -= CurrencyUtils::toMinorWithoutRounding($currencyAmount, $currencyCode) - $roundedAmount;
                 $totalAmount -= $roundedAmount;

--- a/ThirdPartyModules/Magento/GiftCardAccount.php
+++ b/ThirdPartyModules/Magento/GiftCardAccount.php
@@ -33,11 +33,6 @@ class GiftCardAccount
     private $bugsnagHelper;
 
     /**
-     * @var Discount
-     */
-    private $discountHelper;
-    
-    /**
      * @var Cart
      */
     private $cartHelper;
@@ -59,18 +54,15 @@ class GiftCardAccount
 
     /**
      * @param Bugsnag     $bugsnagHelper Bugsnag helper instance
-     * @param Discount    $discountHelper
      * @param Cart        $cartHelper
      * @param Decider     $featureSwitches
      */
     public function __construct(
         Bugsnag  $bugsnagHelper,
-        Discount $discountHelper,
         Cart     $cartHelper,
         Decider  $featureSwitches
     ) {
         $this->bugsnagHelper = $bugsnagHelper;
-        $this->discountHelper = $discountHelper;
         $this->cartHelper = $cartHelper;
         $this->featureSwitches = $featureSwitches;
     }
@@ -103,14 +95,13 @@ class GiftCardAccount
             foreach ($giftCardCodes as $giftCardCode => $giftCardAmount) {
                 $amount = abs($giftCardAmount);
                 $roundedAmount = CurrencyUtils::toMinor($amount, $currencyCode);
-                $boltDiscountType = $this->discountHelper->getBoltDiscountType('by_fixed');
                 $discountItem = [
                     'description'       => 'Gift Card: ' . $giftCardCode,
                     'amount'            => $roundedAmount,
                     'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_GIFTCARD,
                     'reference'         => (string)$giftCardCode,
-                    'discount_type'     => $boltDiscountType, // For v1/discounts.code.apply and v2/cart.update
-                    'type'              => $boltDiscountType, // For v1/merchant/order
+                    'discount_type'     => Discount::BOLT_DISCOUNT_TYPE_FIXED, // For v1/discounts.code.apply and v2/cart.update
+                    'type'              => Discount::BOLT_DISCOUNT_TYPE_FIXED, // For v1/merchant/order
                 ];
                 $this->cartHelper->logEmptyDiscountCode($giftCardCode, 'Gift Card: ' . $giftCardCode);
                 $discountAmount += $amount;

--- a/ThirdPartyModules/Mageplaza/GiftCard.php
+++ b/ThirdPartyModules/Mageplaza/GiftCard.php
@@ -36,11 +36,6 @@ class GiftCard
     private $bugsnagHelper;
 
     /**
-     * @var Discount
-     */
-    protected $discountHelper;
-
-    /**
      * @var Session
      */
     private $sessionHelper;
@@ -57,12 +52,10 @@ class GiftCard
     private $featureSwitches;
 
     public function __construct(
-        Discount $discountHelper,
         Bugsnag $bugsnagHelper,
         Session $sessionHelper,
         Decider  $featureSwitches
     ) {
-        $this->discountHelper = $discountHelper;
         $this->bugsnagHelper = $bugsnagHelper;
         $this->sessionHelper = $sessionHelper;
         $this->featureSwitches = $featureSwitches;
@@ -107,9 +100,9 @@ class GiftCard
                         'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_GIFTCARD,
                         'reference' => $giftCardCode,
                         // For v1/discounts.code.apply and v2/cart.update
-                        'discount_type' => $this->discountHelper->getBoltDiscountType('by_fixed'),
+                        'discount_type' => Discount::BOLT_DISCOUNT_TYPE_FIXED,
                         // For v1/merchant/order
-                        'type' => $this->discountHelper->getBoltDiscountType('by_fixed'),
+                        'type' => Discount::BOLT_DISCOUNT_TYPE_FIXED,
                     ];
                     $discountAmount += $amount;
                     $roundedDiscountAmount += $roundedAmount;
@@ -199,7 +192,7 @@ class GiftCard
                 'discount_code' => $code,
                 'discount_amount' => abs(CurrencyUtils::toMinor($giftAmount, $immutableQuote->getQuoteCurrencyCode())),
                 'description' => __('Gift Card'),
-                'discount_type' => $this->discountHelper->getBoltDiscountType('by_fixed'),
+                'discount_type' => Discount::BOLT_DISCOUNT_TYPE_FIXED,
             ];
             return $result;
         } catch (\Exception $e) {

--- a/ThirdPartyModules/Mirasvit/Credit.php
+++ b/ThirdPartyModules/Mirasvit/Credit.php
@@ -38,11 +38,6 @@ class Credit
     protected $appState;
     
     /**
-     * @var DiscountHelper
-     */
-    protected $discountHelper;
-    
-    /**
      * @var SessionHelper
      */
     protected $sessionHelper;
@@ -69,18 +64,15 @@ class Credit
 
     /**
      * Credit constructor.
-     * @param Discount                     $discountHelper
      * @param State                        $appState
      * @param SessionHelper                $sessionHelper
      * @param Bugsnag                      $bugsnagHelper
      */
     public function __construct(
-        Discount      $discountHelper,
         State         $appState,
         SessionHelper $sessionHelper,
         Bugsnag       $bugsnagHelper
     ) {
-        $this->discountHelper  = $discountHelper;
         $this->appState        = $appState;
         $this->sessionHelper   = $sessionHelper;
         $this->bugsnagHelper   = $bugsnagHelper;
@@ -123,9 +115,9 @@ class Credit
                     'amount'            => $roundedAmount,
                     'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_STORE_CREDIT,
                     // For v1/discounts.code.apply and v2/cart.update
-                    'discount_type'     => $this->discountHelper->getBoltDiscountType('by_fixed'),
+                    'discount_type'     => Discount::BOLT_DISCOUNT_TYPE_FIXED,
                     // For v1/merchant/order
-                    'type'              => $this->discountHelper->getBoltDiscountType('by_fixed'),
+                    'type'              => Discount::BOLT_DISCOUNT_TYPE_FIXED,
                 ];
     
                 $diff -= CurrencyUtils::toMinorWithoutRounding($amount, $currencyCode) - $roundedAmount;

--- a/ThirdPartyModules/Mirasvit/Rewards.php
+++ b/ThirdPartyModules/Mirasvit/Rewards.php
@@ -74,11 +74,6 @@ class Rewards
     private $bugsnagHelper;
 
     /**
-     * @var Discount
-     */
-    private $discountHelper;
-
-    /**
      * @var ScopeConfigInterface
      */
     private $scopeConfigInterface;
@@ -108,7 +103,6 @@ class Rewards
     /**
      * Rewards constructor.
      * @param Bugsnag $bugsnagHelper
-     * @param Discount $discountHelper
      * @param ScopeInterface $scopeConfigInterface
      * @param CustomerFactory $customerFactory
      * @param SessionHelper $sessionHelper
@@ -117,7 +111,6 @@ class Rewards
      */
     public function __construct(
         Bugsnag $bugsnagHelper,
-        Discount $discountHelper,
         ScopeConfigInterface $scopeConfigInterface,
         CustomerFactory $customerFactory,
         SessionHelper $sessionHelper,
@@ -125,7 +118,6 @@ class Rewards
         CustomerSession $customerSession
     ) {
         $this->bugsnagHelper = $bugsnagHelper;
-        $this->discountHelper = $discountHelper;
         $this->scopeConfigInterface = $scopeConfigInterface;
         $this->customerFactory = $customerFactory;
         $this->sessionHelper   = $sessionHelper;
@@ -189,7 +181,6 @@ class Rewards
         $this->mirasvitRewardsRuleQuoteSubtotalCalc = $mirasvitRewardsRuleQuoteSubtotalCalc;
         
         list ($discounts, $totalAmount, $diff) = $result;
-        $discountType = $this->discountHelper->getBoltDiscountType('by_fixed');
         try {
             if ($amount = abs($this->getMirasvitRewardsAmount($parentQuote))) {
                 $currencyCode = $parentQuote->getQuoteCurrencyCode();
@@ -203,8 +194,8 @@ class Rewards
                     'amount' => $roundedAmount,
                     'reference' => self::MIRASVIT_REWARDS,
                     'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_STORE_CREDIT,
-                    'discount_type' => $discountType, // For v1/discounts.code.apply and v2/cart.update
-                    'type' => $discountType, // For v1/merchant/order
+                    'discount_type' => Discount::BOLT_DISCOUNT_TYPE_FIXED, // For v1/discounts.code.apply and v2/cart.update
+                    'type' => Discount::BOLT_DISCOUNT_TYPE_FIXED, // For v1/merchant/order
                 ];
 
                 $diff -= CurrencyUtils::toMinorWithoutRounding($amount, $currencyCode) - $roundedAmount;

--- a/ThirdPartyModules/Teamwork/StoreCredit.php
+++ b/ThirdPartyModules/Teamwork/StoreCredit.php
@@ -27,11 +27,6 @@ class StoreCredit
     const TEAMWORK_STORECREDIT = 'teamworkstorecredit';
 
     /**
-     * @var Discount
-     */
-    protected $discountHelper;
-
-    /**
      * @var Bugsnag
      */
     private $bugsnagHelper;
@@ -45,17 +40,14 @@ class StoreCredit
 
     /**
      * StoreCredit constructor.
-     * @param Discount $discountHelper
      * @param Bugsnag $bugsnagHelper
      * @param CurrentCustomer $currentCustomer
      */
     public function __construct(
-        Discount $discountHelper,
         Bugsnag $bugsnagHelper,
         CurrentCustomer $currentCustomer
     )
     {
-        $this->discountHelper = $discountHelper;
         $this->bugsnagHelper = $bugsnagHelper;
         $this->currentCustomer = $currentCustomer;
     }
@@ -92,8 +84,8 @@ class StoreCredit
                     'reference' => self::TEAMWORK_STORECREDIT,
                     'amount' => $roundedAmount,
                     'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_STORE_CREDIT,
-                    'discount_type' => $this->discountHelper->getBoltDiscountType('by_fixed'), // For v1/discounts.code.apply and v2/cart.update
-                    'type' => $this->discountHelper->getBoltDiscountType('by_fixed'), // For v1/merchant/order
+                    'discount_type' => Discount::BOLT_DISCOUNT_TYPE_FIXED, // For v1/discounts.code.apply and v2/cart.update
+                    'type' => Discount::BOLT_DISCOUNT_TYPE_FIXED, // For v1/merchant/order
                 ];
 
                 $diff -= CurrencyUtils::toMinorWithoutRounding($amount, $currencyCode) - $roundedAmount;

--- a/ThirdPartyModules/Teamwork/Token.php
+++ b/ThirdPartyModules/Teamwork/Token.php
@@ -27,26 +27,18 @@ class Token
     const TEAMWORK_TOKEN = 'teamworkstoken';
 
     /**
-     * @var Discount
-     */
-    protected $discountHelper;
-
-    /**
      * @var Bugsnag
      */
     private $bugsnagHelper;
 
     /**
      * Token constructor.
-     * @param Discount $discountHelper
      * @param Bugsnag $bugsnagHelper
      */
     public function __construct(
-        Discount $discountHelper,
         Bugsnag $bugsnagHelper
     )
     {
-        $this->discountHelper = $discountHelper;
         $this->bugsnagHelper = $bugsnagHelper;
     }
 
@@ -75,8 +67,8 @@ class Token
                     'reference' => self::TEAMWORK_TOKEN,
                     'amount' => $roundedAmount,
                     'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_STORE_CREDIT,
-                    'discount_type' => $this->discountHelper->getBoltDiscountType('by_fixed'), // For v1/discounts.code.apply and v2/cart.update
-                    'type' => $this->discountHelper->getBoltDiscountType('by_fixed'), // For v1/merchant/order
+                    'discount_type' => Discount::BOLT_DISCOUNT_TYPE_FIXED, // For v1/discounts.code.apply and v2/cart.update
+                    'type' => Discount::BOLT_DISCOUNT_TYPE_FIXED, // For v1/merchant/order
                 ];
 
                 $diff -= CurrencyUtils::toMinorWithoutRounding($amount, $currencyCode) - $roundedAmount;


### PR DESCRIPTION
Discount type refactoring:
- introduce constants for discount type
- use the constant rather than $this->discountHelper->getBoltDiscountType('by_fixed') call

The purpose of the refactoring: change getBoltDiscountType in the next PR to support free shipping type in magento

https://app.asana.com/0/1201931884901947/1201594901813539/f

#changelog Discount type refactoring