### PR TITLE
Bugfix: Unable to add/remove Tieredcoupon through Bolt modal

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -2235,7 +2235,8 @@ class Cart extends AbstractHelper
         // check if getCouponCode is not null
         /////////////////////////////////////////////////////////////////////////////////
         if (($amount = abs($address->getDiscountAmount())) || $quote->getCouponCode()) {
-            $ruleDiscountDetails = $this->getSaleRuleDiscounts($quote);
+            $ruleDiscountDetails = $this->getSaleRuleDiscounts($quote);     
+            list($ruleDiscountDetails, $discounts, $totalAmount) = $this->eventsForThirdPartyModules->runFilter('filterQuoteDiscountDetails', [$ruleDiscountDetails, $discounts, $totalAmount], $quote);
             foreach ($ruleDiscountDetails as $salesruleId => $ruleDiscountAmount) {
                 $rule = $this->ruleRepository->getById($salesruleId);
                 $roundedAmount = CurrencyUtils::toMinor($ruleDiscountAmount, $currencyCode);

--- a/Helper/Discount.php
+++ b/Helper/Discount.php
@@ -40,6 +40,9 @@ use Bolt\Boltpay\Model\EventsForThirdPartyModules;
  */
 class Discount extends AbstractHelper
 {
+    // Bolt discount types
+    const BOLT_DISCOUNT_TYPE_FIXED = "fixed_amount";
+    
     // Discount totals key identifiers
     const AMASTY_GIFTCARD = 'amasty_giftcard';
     const GIFT_VOUCHER_AFTER_TAX = 'giftvoucheraftertax';
@@ -320,7 +323,7 @@ class Discount extends AbstractHelper
     public function convertToBoltDiscountType($couponCode)
     {
         if ($couponCode == "") {
-            return "fixed_amount";
+            return self::BOLT_DISCOUNT_TYPE_FIXED;
         }
         
         try {
@@ -346,14 +349,14 @@ class Discount extends AbstractHelper
         switch ($type) {
             case "by_fixed":
             case "cart_fixed":
-                return "fixed_amount";
+                return self::BOLT_DISCOUNT_TYPE_FIXED;
             case "by_percent":
                 return "percentage";
             case "by_shipping":
                 return "shipping";
         }
 
-        return "fixed_amount";
+        return self::BOLT_DISCOUNT_TYPE_FIXED;
     }
     
     /**

--- a/Model/EventsForThirdPartyModules.php
+++ b/Model/EventsForThirdPartyModules.php
@@ -1230,6 +1230,15 @@ class EventsForThirdPartyModules
                 ],
             ],
         ],
+        'filterQuoteDiscountDetails' => [
+            "listeners" => [
+                'Mexbs_Tieredcoupon' => [
+                    'module'      => 'Mexbs_Tieredcoupon',
+                    'sendClasses' => ['Mexbs\Tieredcoupon\Model\TieredcouponFactory'],
+                    'boltClass'   => Mexbs_Tieredcoupon::class,
+                ],
+            ],
+        ],
     ];
 
     /**

--- a/Model/EventsForThirdPartyModules.php
+++ b/Model/EventsForThirdPartyModules.php
@@ -1191,7 +1191,7 @@ class EventsForThirdPartyModules
             "listeners" => [
                 'Mexbs_Tieredcoupon' => [
                     'module'      => 'Mexbs_Tieredcoupon',
-                    'sendClasses' => ['Mexbs\Tieredcoupon\Model\TieredcouponFactory'],
+                    'sendClasses' => ['Mexbs\Tieredcoupon\Helper\Data'],
                     'boltClass'   => Mexbs_Tieredcoupon::class,
                 ],
             ],
@@ -1200,7 +1200,7 @@ class EventsForThirdPartyModules
             "listeners" => [
                 'Mexbs_Tieredcoupon' => [
                     'module'      => 'Mexbs_Tieredcoupon',
-                    'sendClasses' => ['Mexbs\Tieredcoupon\Model\TieredcouponFactory'],
+                    'sendClasses' => ['Mexbs\Tieredcoupon\Helper\Data'],
                     'boltClass'   => Mexbs_Tieredcoupon::class,
                 ],
             ],
@@ -1209,7 +1209,7 @@ class EventsForThirdPartyModules
             "listeners" => [
                 'Mexbs_Tieredcoupon' => [
                     'module'      => 'Mexbs_Tieredcoupon',
-                    'sendClasses' => ['Mexbs\Tieredcoupon\Model\TieredcouponFactory'],
+                    'sendClasses' => ['Mexbs\Tieredcoupon\Helper\Data'],
                     'boltClass'   => Mexbs_Tieredcoupon::class,
                 ],
             ],
@@ -1234,7 +1234,7 @@ class EventsForThirdPartyModules
             "listeners" => [
                 'Mexbs_Tieredcoupon' => [
                     'module'      => 'Mexbs_Tieredcoupon',
-                    'sendClasses' => ['Mexbs\Tieredcoupon\Model\TieredcouponFactory'],
+                    'sendClasses' => ['Mexbs\Tieredcoupon\Helper\Data'],
                     'boltClass'   => Mexbs_Tieredcoupon::class,
                 ],
             ],

--- a/ThirdPartyModules/Mexbs/Tieredcoupon.php
+++ b/ThirdPartyModules/Mexbs/Tieredcoupon.php
@@ -119,17 +119,17 @@ class Tieredcoupon
     /**
      * Check if the coupon is a valid tiered coupon
      *
-     * @param bool                                            $result
-     * @param \Mexbs\Tieredcoupon\Model\TieredcouponFactory   $mexbsTieredcouponCouponFactory
-     * @param mixed                                           $coupon
-     * @param string                                          $couponCode
+     * @param bool                              $result
+     * @param \Mexbs\Tieredcoupon\Helper\Data   $mexbsTieredcouponHelperData
+     * @param mixed                             $coupon
+     * @param string                            $couponCode
      * @return bool
      */
-    public function isValidCouponObj($result, $mexbsTieredcouponCouponFactory, $coupon, $couponCode)
+    public function isValidCouponObj($result, $mexbsTieredcouponHelperData, $coupon, $couponCode)
     {
         try {
             if (!$result) {
-                $tieredCoupon = $mexbsTieredcouponCouponFactory->create()->load($couponCode, 'code');
+                $tieredCoupon = $mexbsTieredcouponHelperData->getTieredCouponByCouponCode($couponCode);
                 if ($tieredCoupon && $tieredCoupon->getId() && $tieredCoupon->getId() === $coupon->getId()) {
                     return true;
                 }
@@ -144,16 +144,16 @@ class Tieredcoupon
     /**
      * Return the sale rule of applied subcoupon
      *
-     * @param mixed|null                                      $result
-     * @param \Mexbs\Tieredcoupon\Model\TieredcouponFactory   $mexbsTieredcouponCouponFactory
-     * @param mixed                                           $coupon
+     * @param mixed|null                        $result
+     * @param \Mexbs\Tieredcoupon\Helper\Data   $mexbsTieredcouponHelperData
+     * @param mixed                             $coupon
      * @return mixed|null
      */
-    public function getCouponRelatedRule($result, $mexbsTieredcouponCouponFactory, $coupon)
+    public function getCouponRelatedRule($result, $mexbsTieredcouponHelperData, $coupon)
     {
         try {
             if (!$result && $coupon) {
-                $tieredCoupon = $mexbsTieredcouponCouponFactory->create()->load($coupon->getCode(), 'code');
+                $tieredCoupon = $mexbsTieredcouponHelperData->getTieredCouponByCouponCode($coupon->getCode());
                 if ($tieredCoupon && $tieredCoupon->getId() && $tieredCoupon->getId() === $coupon->getId()) {
                     $subCouponCodes = $tieredCoupon->getSubCouponCodes();
                     $quote = $this->sessionHelper->getCheckoutSession()->getQuote();
@@ -182,24 +182,24 @@ class Tieredcoupon
     /**
      * Apply tiered coupon to quote
      *
-     * @param bool                                            $result
-     * @param \Mexbs\Tieredcoupon\Model\TieredcouponFactory   $mexbsTieredcouponCouponFactory
-     * @param string                                          $couponCode
-     * @param mixed                                           $coupon
-     * @param \Magento\Quote\Model\Quote                      $quote
-     * @param \Magento\Quote\Model\Quote                      $addQuote
+     * @param bool                              $result
+     * @param \Mexbs\Tieredcoupon\Helper\Data   $mexbsTieredcouponHelperData
+     * @param string                            $couponCode
+     * @param mixed                             $coupon
+     * @param \Magento\Quote\Model\Quote        $quote
+     * @param \Magento\Quote\Model\Quote        $addQuote
      * @return bool
      */
     public function filterApplyingCouponCode(
         $result,
-        $mexbsTieredcouponCouponFactory,
+        $mexbsTieredcouponHelperData,
         $couponCode,
         $coupon,
         $quote,
         $addQuote
     ) {
         if (!$result) {
-            $tieredCoupon = $mexbsTieredcouponCouponFactory->create()->load($couponCode, 'code');
+            $tieredCoupon = $mexbsTieredcouponHelperData->getTieredCouponByCouponCode($couponCode);
             if ($tieredCoupon->getId() === $coupon->getId()) {
                 if (!is_null($addQuote)) {
                     $addQuote->getShippingAddress()->setCollectShippingRates(true);
@@ -260,18 +260,18 @@ class Tieredcoupon
     /**
      * Apply tiered coupon to discounts for Bolt cart
      *
-     * @param bool                                            $result
-     * @param \Mexbs\Tieredcoupon\Model\TieredcouponFactory   $mexbsTieredcouponCouponFactory
-     * @param \Magento\Quote\Model\Quote                      $quote
+     * @param bool                              $result
+     * @param \Mexbs\Tieredcoupon\Helper\Data   $mexbsTieredcouponHelperData
+     * @param \Magento\Quote\Model\Quote        $quote
      * @return array
      */
     public function filterQuoteDiscountDetails(
         $result,
-        $mexbsTieredcouponCouponFactory,
+        $mexbsTieredcouponHelperData,
         $quote
     ) {
         if ($couponCode = $quote->getCouponCode()) {
-            $tieredCoupon = $mexbsTieredcouponCouponFactory->create()->load($couponCode, 'code');
+            $tieredCoupon = $mexbsTieredcouponHelperData->getTieredCouponByCouponCode($couponCode);
             if ($tieredCoupon && $tieredCoupon->getId()) {
                 list($ruleDiscountDetails, $discounts, $totalAmount) = $result;
                 $subCouponCodes = $tieredCoupon->getSubCouponCodes();

--- a/ThirdPartyModules/Mexbs/Tieredcoupon.php
+++ b/ThirdPartyModules/Mexbs/Tieredcoupon.php
@@ -257,6 +257,14 @@ class Tieredcoupon
         return $result;
     }
     
+    /**
+     * Apply tiered coupon to discounts for Bolt cart
+     *
+     * @param bool                                            $result
+     * @param \Mexbs\Tieredcoupon\Model\TieredcouponFactory   $mexbsTieredcouponCouponFactory
+     * @param \Magento\Quote\Model\Quote                      $quote
+     * @return array
+     */
     public function filterQuoteDiscountDetails(
         $result,
         $mexbsTieredcouponCouponFactory,


### PR DESCRIPTION
# Description
To fix the bug that the customer is unable to add/remove Tieredcoupon through Bolt modal

Fixes: https://app.asana.com/0/951157735838091/1201513791312930/f

#changelog Bugfix: Unable to add/remove Tieredcoupon through Bolt modal

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
