### PR TITLE
Fix compatibility issues with PHP 8.1

### DIFF
--- a/Api/Data/GetProductDataInterface.php
+++ b/Api/Data/GetProductDataInterface.php
@@ -31,7 +31,7 @@ interface GetProductDataInterface
      * Get product info.
      *
      * @api
-     * @return \Bolt\Boltpay\Api\Data\ProductInventoryInfoInterface;
+     * @return \Bolt\Boltpay\Api\Data\ProductInventoryInfoInterface
      */
     public function getProductInventory();
 

--- a/Controller/Adminhtml/Cart/Data.php
+++ b/Controller/Adminhtml/Cart/Data.php
@@ -45,7 +45,6 @@ class Data extends \Magento\Sales\Controller\Adminhtml\Order\Create
 {
     /**
      * @var JsonFactory
-     * @deprecated
      */
     private $resultJsonFactory;
 

--- a/Controller/Cart/Hints.php
+++ b/Controller/Cart/Hints.php
@@ -64,8 +64,8 @@ class Hints extends Action
      */
     public function execute()
     {
+        $result = $this->resultJsonFactory->create();
         try {
-            $result = $this->resultJsonFactory->create();
             $hints = $this->cartHelper->getHints(null, 'product');
             $result->setData([
                 'hints' => $hints

--- a/Helper/AutomatedTesting.php
+++ b/Helper/AutomatedTesting.php
@@ -64,7 +64,7 @@ class AutomatedTesting extends AbstractHelper
     private $searchCriteriaBuilder;
 
     /**
-     * @var SortOrderBuilder;
+     * @var SortOrderBuilder
      */
     private $sortOrderBuilder;
 
@@ -271,6 +271,7 @@ class AutomatedTesting extends AbstractHelper
             $simpleStoreItem = $this->convertToStoreItem($simpleProduct, 'simple');
             $virtualStoreItem = $this->convertToStoreItem($virtualProduct, 'virtual');
             $saleStoreItem = $this->convertToStoreItem($saleProduct, 'sale');
+            $storeItems = [];
             $storeItems[] = $simpleStoreItem;
             if ($virtualStoreItem !== null) {
                 $storeItems[] = $virtualStoreItem;

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -2691,6 +2691,7 @@ class Cart extends AbstractHelper
                 $this->metricsClient->processMetric("order_token.success", 1, "order_token.latency", $startTime);
             } else {
                 // Empty cart - order_token not fetched because doesn't exist. Not a failure.
+                $responseData = [];
                 $responseData['cart'] = [];
             }
 

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -1526,6 +1526,7 @@ class Config extends AbstractHelper
                 }
             }
         }
+        return '';
     }
 
     /**

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -586,7 +586,7 @@ class Config extends AbstractHelper
         if ($this->isSandboxModeSet($storeId)) {
             return $this->getApiUrlFromAdditionalConfig($storeId) ?: $this->getCustomURLValueOrDefault(self::XML_PATH_CUSTOM_API, self::API_URL_SANDBOX);
         }
-        return self::API_URL_PRODUCTION ?: '';
+        return self::API_URL_PRODUCTION;
     }
 
     /**

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -586,7 +586,7 @@ class Config extends AbstractHelper
         if ($this->isSandboxModeSet($storeId)) {
             return $this->getApiUrlFromAdditionalConfig($storeId) ?: $this->getCustomURLValueOrDefault(self::XML_PATH_CUSTOM_API, self::API_URL_SANDBOX);
         }
-        return self::API_URL_PRODUCTION;
+        return self::API_URL_PRODUCTION ?: '';
     }
 
     /**
@@ -602,7 +602,7 @@ class Config extends AbstractHelper
         if ($this->isSandboxModeSet($storeId)) {
             return $this->getMerchantDashboardUrlFromAdditionalConfig($storeId) ?: $this->getCustomURLValueOrDefault(self::XML_PATH_CUSTOM_MERCHANT_DASH, self::MERCHANT_DASH_SANDBOX);
         }
-        return self::MERCHANT_DASH_PRODUCTION;
+        return self::MERCHANT_DASH_PRODUCTION ?: '';
     }
 
     /**
@@ -618,7 +618,7 @@ class Config extends AbstractHelper
         if ($this->isSandboxModeSet($storeId)) {
             return $this->getCdnUrlFromAdditionalConfig($storeId) ?: $this->getCustomURLValueOrDefault(self::XML_PATH_CUSTOM_CDN, self::CDN_URL_SANDBOX);
         }
-        return self::CDN_URL_PRODUCTION;
+        return self::CDN_URL_PRODUCTION ?: '';
     }
 
     /**
@@ -636,7 +636,7 @@ class Config extends AbstractHelper
         } else if ($isAllowCustomURLForProduction) {
             $url = $this->getCdnUrlFromAdditionalConfig($storeId) ?: $this->getCustomURLValueOrDefault(self::XML_PATH_CUSTOM_CDN, self::CDN_URL_PRODUCTION);
         } else {
-            $url = self::CDN_URL_PRODUCTION;
+            $url = self::CDN_URL_PRODUCTION ?: '';
         }
         return $url . '/checkout';
     }
@@ -654,7 +654,7 @@ class Config extends AbstractHelper
         if ($this->isSandboxModeSet($storeId)) {
             return $this->getAccountUrlFromAdditionalConfig($storeId) ?: $this->getCustomURLValueOrDefault(self::XML_PATH_CUSTOM_ACCOUNT, self::ACCOUNT_URL_SANDBOX);
         }
-        return self::ACCOUNT_URL_PRODUCTION;
+        return self::ACCOUNT_URL_PRODUCTION ?: '';
     }
 
     /**
@@ -681,11 +681,11 @@ class Config extends AbstractHelper
     /**
      * Get module version
      *
-     * @return false|string
+     * @return string
      */
     public function getModuleVersion()
     {
-        return $this->moduleResource->getDataVersion('Bolt_Boltpay');
+        return $this->moduleResource->getDataVersion('Bolt_Boltpay') ?: '';
     }
 
     /**
@@ -701,20 +701,20 @@ class Config extends AbstractHelper
                 ->getLockedRepository()
                 ->findPackage(self::BOLT_COMPOSER_NAME, '*');
 
-            return ($boltPackage) ? $boltPackage->getVersion() : null;
+            return ($boltPackage) ? $boltPackage->getVersion() : '';
         } catch (Exception $exception) {
-            return null;
+            return '';
         }
     }
 
     /**
      * Get store version
      *
-     * @return false|string
+     * @return string
      */
     public function getStoreVersion()
     {
-        return $this->productMetadata->getVersion();
+        return $this->productMetadata->getVersion() ?: '';
     }
 
     /**
@@ -742,7 +742,7 @@ class Config extends AbstractHelper
             self::XML_PATH_TITLE,
             ScopeInterface::SCOPE_STORE,
             $storeId
-        );
+        ) ?: '';
     }
 
     /**
@@ -754,7 +754,7 @@ class Config extends AbstractHelper
      */
     public function getApiKey($storeId = null)
     {
-        return $this->getEncryptedKey(self::XML_PATH_API_KEY, $storeId);
+        return $this->getEncryptedKey(self::XML_PATH_API_KEY, $storeId) ?: '';
     }
 
     /**
@@ -766,7 +766,7 @@ class Config extends AbstractHelper
      */
     public function getSigningSecret($storeId = null)
     {
-        return $this->getEncryptedKey(self::XML_PATH_SIGNING_SECRET, $storeId);
+        return $this->getEncryptedKey(self::XML_PATH_SIGNING_SECRET, $storeId) ?: '';
     }
 
     /**
@@ -790,7 +790,7 @@ class Config extends AbstractHelper
      */
     public function getPublishableKeyPayment($storeId = null)
     {
-        return $this->getEncryptedKey(self::XML_PATH_PUBLISHABLE_KEY_PAYMENT, $storeId);
+        return $this->getEncryptedKey(self::XML_PATH_PUBLISHABLE_KEY_PAYMENT, $storeId) ?: '';
     }
 
     /**
@@ -802,7 +802,7 @@ class Config extends AbstractHelper
      */
     public function getPublishableKeyBackOffice($storeId = null)
     {
-        return $this->getEncryptedKey(self::XML_PATH_PUBLISHABLE_KEY_BACK_OFFICE, $storeId);
+        return $this->getEncryptedKey(self::XML_PATH_PUBLISHABLE_KEY_BACK_OFFICE, $storeId) ?: '';
     }
 
     /**
@@ -818,7 +818,7 @@ class Config extends AbstractHelper
             self::XML_PATH_BUTTON_COLOR,
             ScopeInterface::SCOPE_STORE,
             $storeId
-        );
+        ) ?: '';
     }
 
     /**
@@ -834,7 +834,7 @@ class Config extends AbstractHelper
             self::XML_PATH_REPLACE_SELECTORS,
             ScopeInterface::SCOPE_STORE,
             $storeId
-        );
+        ) ?: '';
     }
 
     /**
@@ -850,7 +850,7 @@ class Config extends AbstractHelper
             self::XML_PATH_TOTALS_CHANGE_SELECTORS,
             ScopeInterface::SCOPE_STORE,
             $storeId
-        );
+        ) ?: '';
     }
 
     /**
@@ -866,7 +866,7 @@ class Config extends AbstractHelper
             self::XML_PATH_GLOBAL_CSS,
             ScopeInterface::SCOPE_STORE,
             $storeId
-        );
+        ) ?: '';
     }
     
     /**
@@ -882,7 +882,7 @@ class Config extends AbstractHelper
             self::XML_PATH_GLOBAL_JS,
             ScopeInterface::SCOPE_STORE,
             $storeId
-        );
+        ) ?: '';
     }
 
     /**
@@ -892,7 +892,7 @@ class Config extends AbstractHelper
      */
     public function getShowCcTypeInOrderGrid()
     {
-        return $this->getScopeConfig()->getValue(self::XML_PATH_SHOW_CC_TYPE_IN_ORDER_GRID);
+        return $this->getScopeConfig()->getValue(self::XML_PATH_SHOW_CC_TYPE_IN_ORDER_GRID) ?: '';
     }
 
     /**
@@ -908,7 +908,7 @@ class Config extends AbstractHelper
             self::XML_PATH_ADDITIONAL_CHECKOUT_BUTTON_CLASS,
             ScopeInterface::SCOPE_STORE,
             $storeId
-        );
+        ) ?: '';
     }
 
     /**
@@ -996,7 +996,7 @@ class Config extends AbstractHelper
             self::XML_PATH_SUCCESS_PAGE_REDIRECT,
             ScopeInterface::SCOPE_STORE,
             $storeId
-        );
+        ) ?: '';
     }
 
     /**
@@ -1012,7 +1012,7 @@ class Config extends AbstractHelper
             self::XML_PATH_JAVASCRIPT_SUCCESS,
             ScopeInterface::SCOPE_STORE,
             $storeId
-        );
+        ) ?: '';
     }
 
     /**
@@ -1077,7 +1077,7 @@ class Config extends AbstractHelper
             self::XML_PATH_PRODUCT_ORDER_MANAGEMENT_SELECTOR,
             ScopeInterface::SCOPE_STORE,
             $store
-        );
+        ) ?: '';
     }
 
     /**
@@ -1190,7 +1190,7 @@ class Config extends AbstractHelper
      */
     public function getGeolocationApiKey($storeId = null)
     {
-        return $this->getEncryptedKey(self::XML_PATH_GEOLOCATION_API_KEY, $storeId);
+        return $this->getEncryptedKey(self::XML_PATH_GEOLOCATION_API_KEY, $storeId) ?: '';
     }
 
     /**
@@ -1206,7 +1206,7 @@ class Config extends AbstractHelper
             self::XML_PATH_ADDITIONAL_JS,
             ScopeInterface::SCOPE_STORE,
             $storeId
-        );
+        ) ?: '';
     }
 
     /**
@@ -1220,7 +1220,7 @@ class Config extends AbstractHelper
             self::XML_PATH_TRACK_CHECKOUT_START,
             ScopeInterface::SCOPE_STORE,
             $storeId
-        );
+        ) ?: '';
     }
 
     /**
@@ -1234,7 +1234,7 @@ class Config extends AbstractHelper
             self::XML_PATH_TRACK_EMAIL_ENTER,
             ScopeInterface::SCOPE_STORE,
             $storeId
-        );
+        ) ?: '';
     }
 
     /**
@@ -1248,7 +1248,7 @@ class Config extends AbstractHelper
             self::XML_PATH_TRACK_SHIPPING_DETAILS_COMPLETE,
             ScopeInterface::SCOPE_STORE,
             $storeId
-        );
+        ) ?: '';
     }
 
     /**
@@ -1262,7 +1262,7 @@ class Config extends AbstractHelper
             self::XML_PATH_TRACK_SHIPPING_OPTIONS_COMPLETE,
             ScopeInterface::SCOPE_STORE,
             $storeId
-        );
+        ) ?: '';
     }
 
     /**
@@ -1276,7 +1276,7 @@ class Config extends AbstractHelper
             self::XML_PATH_TRACK_PAYMENT_SUBMIT,
             ScopeInterface::SCOPE_STORE,
             $storeId
-        );
+        ) ?: '';
     }
 
     /**
@@ -1290,7 +1290,7 @@ class Config extends AbstractHelper
             self::XML_PATH_TRACK_SUCCESS,
             ScopeInterface::SCOPE_STORE,
             $storeId
-        );
+        ) ?: '';
     }
 
     /**
@@ -1304,7 +1304,7 @@ class Config extends AbstractHelper
             self::XML_PATH_TRACK_CLOSE,
             ScopeInterface::SCOPE_STORE,
             $storeId
-        );
+        ) ?: '';
     }
 
     /**
@@ -1477,7 +1477,7 @@ class Config extends AbstractHelper
      *
      * @param null $storeId
      *
-     * @return string
+     * @return int
      */
     public function getPriceFaultTolerance($storeId = null)
     {
@@ -2260,7 +2260,7 @@ class Config extends AbstractHelper
     {
         return $this->getScopeConfig()->getValue(
             self::XML_PATH_CONNECT_INTEGRATION_MODE
-        );
+        ) ?: '';
     }
 
     /**
@@ -2357,7 +2357,7 @@ class Config extends AbstractHelper
             $path,
             ScopeInterface::SCOPE_STORE,
             $storeId
-        );
+        ) ?: '';
 
         //Decrypt management key
         $key = $this->encryptor->decrypt($key);
@@ -2456,7 +2456,7 @@ class Config extends AbstractHelper
      */
     public function getCdnUrlFromAdditionalConfig($storeId = null)
     {
-        return $this->getAdditionalConfigProperty('cdnURL', $storeId);
+        return $this->getAdditionalConfigProperty('cdnURL', $storeId) ?: '';
     }
     
     /**
@@ -2473,7 +2473,7 @@ class Config extends AbstractHelper
      */
     public function getAccountUrlFromAdditionalConfig($storeId = null)
     {
-        return $this->getAdditionalConfigProperty('accountURL', $storeId);
+        return $this->getAdditionalConfigProperty('accountURL', $storeId) ?: '';
     }
     
     /**
@@ -2490,7 +2490,7 @@ class Config extends AbstractHelper
      */
     public function getApiUrlFromAdditionalConfig($storeId = null)
     {
-        return $this->getAdditionalConfigProperty('apiURL', $storeId);
+        return $this->getAdditionalConfigProperty('apiURL', $storeId) ?: '';
     }
     
     /**
@@ -2507,6 +2507,6 @@ class Config extends AbstractHelper
      */
     public function getMerchantDashboardUrlFromAdditionalConfig($storeId = null)
     {
-        return $this->getAdditionalConfigProperty('merchantDashboardURL', $storeId);
+        return $this->getAdditionalConfigProperty('merchantDashboardURL', $storeId) ?: '';
     }
 }

--- a/Helper/Discount.php
+++ b/Helper/Discount.php
@@ -244,7 +244,7 @@ class Discount extends AbstractHelper
      * Apply Unirgy Gift Cert to quote
      *
      * @param Quote $quote
-     * @param string $giftCard
+     * @param \Unirgy\Giftcert\Model\Cert $giftCard
      *
      */
     public function addUnirgyGiftCertToQuote($quote, $giftCard)

--- a/Helper/JWT/JWK.php
+++ b/Helper/JWT/JWK.php
@@ -97,7 +97,7 @@ class JWK
         if (!isset($jwk['kty'])) {
             throw new UnexpectedValueException('JWK must contain a "kty" parameter');
         }
-
+        $publicKey = '';
         switch ($jwk['kty']) {
             case 'RSA':
                 if (\array_key_exists('d', $jwk)) {
@@ -114,11 +114,12 @@ class JWK
                         'OpenSSL error: ' . \openssl_error_string()
                     );
                 }
-                return $publicKey;
+                break;
             default:
                 // Currently only RSA is supported
                 break;
         }
+        return $publicKey;
     }
 
     /**

--- a/Helper/JWT/JWT.php
+++ b/Helper/JWT/JWT.php
@@ -219,11 +219,12 @@ class JWT
             throw new DomainException('Algorithm not supported');
         }
         list($function, $algorithm) = static::$supported_algs[$alg];
+        $signature = '';
         switch ($function) {
             case 'hash_hmac':
-                return \hash_hmac($algorithm, $msg, $key, true);
+                $signature = \hash_hmac($algorithm, $msg, $key, true);
+                break;
             case 'openssl':
-                $signature = '';
                 $success = \openssl_sign($msg, $signature, $key, $algorithm);
                 if (!$success) {
                     throw new DomainException('OpenSSL unable to sign data');
@@ -231,8 +232,11 @@ class JWT
                 if ($alg === 'ES256') {
                     $signature = self::signatureFromDER($signature, 256);
                 }
-                return $signature;
+                break;
+            default:
+                break;
         }
+        return $signature;
     }
 
     /**

--- a/Helper/Metric.php
+++ b/Helper/Metric.php
@@ -57,7 +57,7 @@ class Metric implements \JsonSerializable
     /**
      * Required function to use the json_encode function
      *
-     * @return array()
+     * @return array
      */
     public function jsonSerialize(): array
     {

--- a/Helper/ModuleRetriever.php
+++ b/Helper/ModuleRetriever.php
@@ -57,18 +57,18 @@ class ModuleRetriever
     public function getInstalledModules()
     {
         $connection = $this->resource->getConnection();
+        $installedModules = [];
         try {
-            $installedModules = [];
             $rows = $connection->fetchAll('SELECT module, schema_version FROM setup_module');
             foreach ($rows as $row) {
                 $installedModules[] = $this->pluginVersionFactory->create()
                                                                  ->setName($row['module'])
                                                                  ->setVersion($row['schema_version']);
             }
-
-            return $installedModules;
         } catch (\Exception $e) {
             $this->bugsnag->notifyException($e);
+        } finally {
+            return $installedModules;
         }
     }
 }

--- a/Model/Api/CartManagement.php
+++ b/Model/Api/CartManagement.php
@@ -91,7 +91,7 @@ class CartManagement implements CartManagementInterface
      *
      * @param string $cartId
      *
-     * @return \Bolt\Boltpay\Api\Data\GetMaskedQuoteInterface
+     * @return \Bolt\Boltpay\Api\Data\GetMaskedQuoteIDDataInterface
      *
      * @throws WebapiException
      */

--- a/Model/Api/CreateOrder.php
+++ b/Model/Api/CreateOrder.php
@@ -190,8 +190,8 @@ class CreateOrder implements CreateOrderInterface
         $order = null,
         $currency = null
     ) {
+        $startTime = $this->metricsClient->getCurrentTime();
         try {
-            $startTime = $this->metricsClient->getCurrentTime();
             $payload = $this->request->getContent();
             $this->logHelper->addInfoLog('[-= Pre-Auth CreateOrder =-]');
             $this->logHelper->addInfoLog($payload);

--- a/Model/Api/Data/GetProductData.php
+++ b/Model/Api/Data/GetProductData.php
@@ -203,7 +203,7 @@ class GetProductData implements GetProductDataInterface, \JsonSerializable
      * Set children info.
      *
      * @api
-     * @param \Magento\ConfigurableProduct\Api\Data\OptionInterface $options
+     * @param \Magento\ConfigurableProduct\Api\Data\OptionInterface[] $options
      *
      * @return $this
      */

--- a/Model/Api/OAuthRedirect.php
+++ b/Model/Api/OAuthRedirect.php
@@ -199,7 +199,6 @@ class OAuthRedirect implements OAuthRedirectInterface
     /**
      * Retrieve cookie manager
      *
-     * @deprecated 100.1.0
      * @return \Magento\Framework\Stdlib\Cookie\PhpCookieManager
      */
     private function getCookieManager()

--- a/Model/Api/OrderManagement.php
+++ b/Model/Api/OrderManagement.php
@@ -368,7 +368,6 @@ class OrderManagement implements OrderManagementInterface
      * Deletes a specified order by ID.
      *
      * @param int $id The order ID.
-     * @return bool
      * @throws \Magento\Framework\Exception\CouldNotDeleteException
      * @throws NoSuchEntityException
      * @throws WebapiException

--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -882,7 +882,7 @@ class ShippingMethods implements ShippingMethodsInterface
                 ]);
             });
 
-            $this->bugsnag->notifyError('Shipping Method Error', $error);
+            $this->bugsnag->notifyError('Shipping Method Error', var_export($errors, true));
         }
 
         if (!$shippingMethods) {

--- a/Model/Api/Tax.php
+++ b/Model/Api/Tax.php
@@ -120,7 +120,6 @@ class Tax extends ShippingTax implements TaxInterface
      * @param array $addressData
      * @param array|null $shipping_option
      * @param array|null $ship_to_store_option
-     * @return TotalsInformationInterface
      */
     public function setAddressInformation($addressData, $shipping_option, $ship_to_store_option)
     {
@@ -128,7 +127,7 @@ class Tax extends ShippingTax implements TaxInterface
         $this->addressInformation->setAddress($address);
 
         if ($this->quote->isVirtual() || (!$shipping_option && !$ship_to_store_option)) {
-            return ;
+            return;
         }
 
         if ($shipping_option) {

--- a/Model/Api/UpdateCart.php
+++ b/Model/Api/UpdateCart.php
@@ -422,7 +422,6 @@ class UpdateCart extends UpdateCartCommon implements UpdateCartInterface
     /**
      * @param array $result
      * @param Quote $quote
-     * @return array
      * @throws \Exception
      */
     protected function sendSuccessResponse($result, $quote = null)

--- a/Model/Api/UpdateCartCommon.php
+++ b/Model/Api/UpdateCartCommon.php
@@ -328,6 +328,7 @@ abstract class UpdateCartCommon
     {
         $items = $quote->getAllVisibleItems();
         $currencyCode = $quote->getQuoteCurrencyCode();
+        $products = [];
 
         foreach ($items as $item) {
             $product = [];

--- a/Model/Api/UpdateCartContext.php
+++ b/Model/Api/UpdateCartContext.php
@@ -240,12 +240,12 @@ class UpdateCartContext
         DiscountHelper              $discountHelper,
         TotalsCollector             $totalsCollector,
         SessionHelper               $sessionHelper,
-        CacheInterface              $cache = null,
         EventsForThirdPartyModules  $eventsForThirdPartyModules,
         ProductRepositoryInterface  $productRepositoryInterface,
         StockStateInterface         $stockStateInterface,
         CartRepositoryInterface     $cartRepositoryInterface,
         Decider                     $featureSwitches,
+        CacheInterface              $cache = null,
         CartExtensionFactory        $cartExtensionFactory = null,
         ShippingAssignmentProcessor $shippingAssignmentProcessor = null
     ) {
@@ -268,13 +268,13 @@ class UpdateCartContext
         $this->discountHelper = $discountHelper;
         $this->totalsCollector = $totalsCollector;
         $this->sessionHelper = $sessionHelper;
-        $this->cache = $cache ?: \Magento\Framework\App\ObjectManager::getInstance()
-                ->get(\Magento\Framework\App\CacheInterface::class);
         $this->eventsForThirdPartyModules = $eventsForThirdPartyModules;
         $this->productRepositoryInterface = $productRepositoryInterface;
         $this->stockStateInterface = $stockStateInterface;
         $this->cartRepositoryInterface = $cartRepositoryInterface;
         $this->featureSwitches = $featureSwitches;
+        $this->cache = $cache ?: \Magento\Framework\App\ObjectManager::getInstance()
+                ->get(\Magento\Framework\App\CacheInterface::class);
         $this->cartExtensionFactory = $cartExtensionFactory
             ?? \Magento\Framework\App\ObjectManager::getInstance()->get(CartExtensionFactory::class);
         $this->shippingAssignmentProcessor = $shippingAssignmentProcessor

--- a/Model/Api/UpdateDiscountTrait.php
+++ b/Model/Api/UpdateDiscountTrait.php
@@ -555,8 +555,6 @@ trait UpdateDiscountTrait
 
             return false;
         }
-
-        return true;
     }
 
     /**

--- a/Model/Payment.php
+++ b/Model/Payment.php
@@ -388,8 +388,8 @@ class Payment extends AbstractMethod
      */
     public function capture(InfoInterface $payment, $amount)
     {
+        $startTime = $this->metricsClient->getCurrentTime();
         try {
-            $startTime = $this->metricsClient->getCurrentTime();
             if ($payment->getCcTransId()) {
                 // api flow
                 if ($payment->getCcStatusDescription() == "completed") {

--- a/Model/ThirdPartyModuleFactory.php
+++ b/Model/ThirdPartyModuleFactory.php
@@ -57,8 +57,8 @@ class ThirdPartyModuleFactory
     ) {
         $this->_moduleManager = $moduleManager;
         $this->_objectManager = $objectManager;
-        $this->moduleName = $moduleName;
-        $this->className = $className;
+        $this->moduleName = $moduleName ?: '';
+        $this->className = $className ?: '';
         $this->logHelper = $logHelper;
     }
 

--- a/Observer/TrackingSaveObserver.php
+++ b/Observer/TrackingSaveObserver.php
@@ -99,9 +99,8 @@ class TrackingSaveObserver implements ObserverInterface
         if (!$this->decider->isTrackShipmentEnabled()) {
             return;
         }
-
+        $startTime = $this->metricsClient->getCurrentTime();
         try {
-            $startTime = $this->metricsClient->getCurrentTime();
             /** @var \Magento\Sales\Model\Order\Shipment\Track $tracking */
             $tracking = $observer->getEvent()->getTrack();
 

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -1223,7 +1223,7 @@ Room 4000',
         $e = new \Exception(__('Test'));
         $composerFactory->expects(self::once())->method('getVersion')->willThrowException($e);
         TestHelper::setInaccessibleProperty($this->configHelper, 'composerFactory', $composerFactory);
-        $this->assertNull($this->configHelper->getComposerVersion());
+        $this->assertEquals('', $this->configHelper->getComposerVersion());
     }
 
     /**
@@ -1315,7 +1315,7 @@ Room 4000',
         $composerFactory->expects(self::once())->method('findPackage')->with(Config::BOLT_COMPOSER_NAME, '*')->willReturn(null);
         $composerFactory->expects(self::never())->method('getVersion');
         TestHelper::setInaccessibleProperty($this->configHelper, 'composerFactory', $composerFactory);
-        $this->assertNull($this->configHelper->getComposerVersion());
+        $this->assertEquals('', $this->configHelper->getComposerVersion());
     }
 
     /**

--- a/Test/Unit/Model/Api/UpdateCartCommonTest.php
+++ b/Test/Unit/Model/Api/UpdateCartCommonTest.php
@@ -252,12 +252,12 @@ class UpdateCartCommonTest extends BoltTestCase
                     $this->discountHelper,
                     $this->totalsCollector,
                     $this->sessionHelper,
-                    $this->cache,
                     $this->eventsForThirdPartyModules,
                     $this->productRepositoryInterface,
                     $this->stockStateInterface,
                     $this->cartRepository,
-                    $this->featureSwitches
+                    $this->featureSwitches,
+                    $this->cache
                 ]
             )
             ->enableProxyingToOriginalMethods()

--- a/Test/Unit/Model/Api/UpdateCartContextTest.php
+++ b/Test/Unit/Model/Api/UpdateCartContextTest.php
@@ -274,12 +274,12 @@ class UpdateCartContextTest extends BoltTestCase
             $this->discountHelper,
             $this->totalsCollector,
             $this->sessionHelper,
-            $this->cache,
             $this->eventsForThirdPartyModules,
             $this->productRepositoryInterface,
             $this->stockStateInterface,
             $this->cartRepositoryInterface,
-            $this->featureSwitches
+            $this->featureSwitches,            
+            $this->cache
         );
         
         static::assertAttributeInstanceOf(Request::class, 'request', $instance);

--- a/Test/Unit/Model/Api/UpdateCartContextTest.php
+++ b/Test/Unit/Model/Api/UpdateCartContextTest.php
@@ -233,12 +233,12 @@ class UpdateCartContextTest extends BoltTestCase
                     $this->discountHelper,
                     $this->totalsCollector,
                     $this->sessionHelper,
-                    $this->cache,
                     $this->eventsForThirdPartyModules,
                     $this->productRepositoryInterface,
                     $this->stockStateInterface,
                     $this->cartRepositoryInterface,
-                    $this->featureSwitches
+                    $this->featureSwitches,
+                    $this->cache
                 ]
             )
             ->enableProxyingToOriginalMethods()

--- a/ThirdPartyModules/Aheadworks/Sarp2.php
+++ b/ThirdPartyModules/Aheadworks/Sarp2.php
@@ -61,7 +61,7 @@ class Sarp2
         $class = SpecificationFactory::class;
         $globalConfig = $this->configLoader->load(\Magento\Framework\App\Area::AREA_GLOBAL);
         $adminConfig = $this->configLoader->load(\Magento\Framework\App\Area::AREA_ADMINHTML);
-
+        $merged = [];
         if ($this->configLoader instanceof \Magento\Framework\App\ObjectManager\ConfigLoader\Compiled) {
             //PRODUCTION MODE
             $merged['arguments'][$class] = array_merge(

--- a/ThirdPartyModules/Amasty/GiftCard.php
+++ b/ThirdPartyModules/Amasty/GiftCard.php
@@ -319,8 +319,8 @@ class GiftCard
         if ($source->getId() == $destination->getId()) {
             return;
         }
+        $connection = $this->resourceConnection->getConnection();
         try {
-            $connection = $this->resourceConnection->getConnection();
             $connection->beginTransaction();
             $giftCardTable = $this->resourceConnection->getTableName('amasty_amgiftcard_quote');
 

--- a/ThirdPartyModules/Amasty/GiftCardAccount.php
+++ b/ThirdPartyModules/Amasty/GiftCardAccount.php
@@ -402,10 +402,10 @@ class GiftCardAccount
     public function removeAmastyGiftCard($amastyGiftCardAccountManagement, $codeId, $quote)
     {
         try {
-            if ($quote->getExtensionAttributes() && $quote->getExtensionAttributes()->getAmGiftcardQuote()) {
-                $cards = $quote->getExtensionAttributes()->getAmGiftcardQuote()->getGiftCards();
+            if (!$quote->getExtensionAttributes() || !$quote->getExtensionAttributes()->getAmGiftcardQuote()) {
+                return;
             }
-
+            $cards = $quote->getExtensionAttributes()->getAmGiftcardQuote()->getGiftCards();
             $giftCodeExists = false;
             $giftCode = '';
             foreach ($cards as $k => $card) {

--- a/ThirdPartyModules/MageWorx/RewardPoints.php
+++ b/ThirdPartyModules/MageWorx/RewardPoints.php
@@ -192,8 +192,6 @@ class RewardPoints
     
     /**
      * Check whether the customer choose to use maximum
-     *
-     * @return string
      */
     private function getAppliedRewardsMode()
     {

--- a/ThirdPartyModules/Mirasvit/Rewards.php
+++ b/ThirdPartyModules/Mirasvit/Rewards.php
@@ -539,8 +539,6 @@ class Rewards
     
     /**
      * Check whether the customer choose to use maximum
-     *
-     * @return string
      */
     private function getAppliedRewardsMode()
     {


### PR DESCRIPTION
# Description
There are still some deprecated functionality errors in Bolt plugin once upgrading PHP to 8.1

`Deprecated Functionality: trim(): Passing null to parameter #1 ($string) of type string is deprecated`

Actually most of such errors are related to the functions in Bolt\Boltpay\Helper\Config, that the function is expected to return string but eventually null is returned. So in this PR we force to return empty string if any null value is detected.

Updates: using PHP 8 compatibility checker, we found some more compatibility issues and fix them in this PR as well

Fixes: https://app.asana.com/0/951157735838091/1202225151737588/f

#changelog Fix compatibility issues with PHP 8.1

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
