### PR TITLE
Fix for Aheadworks Store Plugin to support API invoice creation

### DIFF
--- a/Plugin/Magento/Sales/Model/InvoiceOrderPlugin.php
+++ b/Plugin/Magento/Sales/Model/InvoiceOrderPlugin.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2022 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Plugin\Magento\Sales\Model;
+
+use Magento\Sales\Model\InvoiceOrder;
+use Magento\Sales\Api\InvoiceRepositoryInterface;
+
+class InvoiceOrderPlugin
+{
+    /**
+     * @var InvoiceRepositoryInterface
+     */
+    private $invoiceRepository;
+
+    /**
+     * @param InvoiceRepositoryInterface $invoiceRepository
+     */
+    public function __construct(
+        InvoiceRepositoryInterface $invoiceRepository
+    ) {
+        $this->invoiceRepository = $invoiceRepository;
+    }
+
+    /**
+     * Aheadworks Store Credit extension doesn't apply points if invoice created via API call
+     * It happens because the module expected to see direct save call $invoice->save() but API
+     * saves invoice via resource model
+     * So in this plugin we trigger direct invoice saving after API call
+     * This plugin should be reverted once issue is fixed on Aheadworks Store Credit side.
+     *
+     * @param InvoiceOrder $subject
+     * @param int $result
+     * @return int
+     */
+    public function afterExecute(InvoiceOrder $subject, $result)
+    {
+        $invoice = $this->invoiceRepository->get($result);
+        $invoice->save();
+
+        return $result;
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -374,4 +374,7 @@
             <argument name="filesystem" xsi:type="object">Magento\Framework\Filesystem\Driver\File</argument>
         </arguments>
     </virtualType>
+    <type name="Magento\Sales\Model\InvoiceOrder">
+        <plugin name="BoltBoltpayInvoiceOrderPlugin" type="Bolt\Boltpay\Plugin\Magento\Sales\Model\InvoiceOrderPlugin" sortOrder="1"/>
+    </type>
 </config>


### PR DESCRIPTION
Aheadworks Store Credit extension doesn't apply points if invoice created via API call
It happens because the module expected to see direct save call $invoice->save() but API
saves invoice via resource model
So in this plugin we trigger direct invoice saving after API call
This PR should be reverted once the issue is fixed on Aheadworks Store Credit side.

https://app.asana.com/0/0/1202418007292947/f

#changelog Fix for Aheadworks Store Plugin to support API invoice creation