### PR TITLE
Resolve reported issue with javascript dependencies - load whenDefined via requireJs

### DIFF
--- a/view/frontend/templates/button_product_page.phtml
+++ b/view/frontend/templates/button_product_page.phtml
@@ -53,10 +53,11 @@ foreach ($block->getAdditionalCheckoutButtonAttributes() as $attrName => $attrVa
             'jquery',
             'Magento_Customer/js/model/authentication-popup',
             'Magento_Customer/js/customer-data',
+            'Bolt_Boltpay/js/utils/when-defined',
             'mage/validation/validation',
             'mage/cookies',
             'domReady!'
-        ], function ($, authenticationPopup, customerData) {
+        ], function ($, authenticationPopup, customerData, whenDefined) {
 
             var customer = customerData.get('customer');
             var isGuestCheckoutAllowed = <?= /* @noEscape */ $block->isGuestCheckoutAllowed(); ?>;

--- a/view/frontend/templates/js/boltglobaljs.phtml
+++ b/view/frontend/templates/js/boltglobaljs.phtml
@@ -26,6 +26,15 @@ if ($block->shouldDisableBoltCheckout()) { return;
 }
 ?>
 <script type="text/javascript">
+
+    ////////////////////////////////////////////////////////////////////////
+    // Wait for an object to be defined and
+    // execute a callback when it becomes available
+    ////////////////////////////////////////////////////////////////////////
+    require(['Bolt_Boltpay/js/utils/when-defined'], function (whenDefined) {
+        window['whenDefined'] = whenDefined;
+    });
+
     <?= /* @noEscape */ $block->getGlobalJS(); ?>
 </script>
 <?php
@@ -56,42 +65,5 @@ $onSuccessCode = $block->getJavascriptSuccess() . $trackCallbackCode['success'];
         onClose: <?= /* @noEscape */ $block->wrapWithCatch($trackCallbackCode['close']); ?>,
     };
 
-    ////////////////////////////////////////////////////////////////////////
-    // Wait for an object to be defined and
-    // execute a callback when it becomes available
-    ////////////////////////////////////////////////////////////////////////
-    window.whenDefinedCallbacks = new Map([]);
-    window.whenDefined = function(obj, property, callback, key) {
-        if (obj[property]) {
-            callback();
-        } else {
-            let prop = '_'+property;
-            if (!window.whenDefinedCallbacks.has(property)) {
-                window.whenDefinedCallbacks.set(property, new Map([]))
-            }
-            let propertyCallbacks = window.whenDefinedCallbacks.get(property);
-            if (key) {
-                propertyCallbacks.set(key, callback);
-            }
-            Object.defineProperty(obj, property, {
-                configurable: true,
-                enumerable: true,
-                writeable: true,
-                get: function() {
-                    return this[prop];
-                },
-                // calls callback when variable is set
-                set: function(value) {
-                    this[prop] = value;
-                    for (let propertyCallback of propertyCallbacks.values()) {
-                        propertyCallback();
-                    }
-                    if (!key) {
-                        callback();
-                    }
-                }
-            });
-        }
-    };
 </script>
 <?= $block->getAdditionalHtml() ?>

--- a/view/frontend/templates/js/custom_sso_buttons.phtml
+++ b/view/frontend/templates/js/custom_sso_buttons.phtml
@@ -36,7 +36,8 @@ $customSSOSelectors = $block->getCustomSSOSelectors();
 ?>
 <script>
     var boltSSOCustomClass = 'bolt-sso-custom';
-    window.whenDefined(window, 'BoltAccount', function () {
+    require(['Bolt_Boltpay/js/utils/when-defined'], function (whenDefined) {
+    whenDefined(window, 'BoltAccount', function () {
         var selectors = <?php echo json_encode($customSSOSelectors); ?>;
 
         /**
@@ -100,5 +101,6 @@ $customSSOSelectors = $block->getCustomSSOSelectors();
                 }
             });
         });
+    });
     });
 </script>

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -286,10 +286,11 @@ $isLoadOpenReplayJsDynamic = $block->isDisableOpenReplayJs();
         'jquery',
         'Magento_Customer/js/model/authentication-popup',
         'Magento_Customer/js/customer-data',
+        'Bolt_Boltpay/js/utils/when-defined',
         'mage/validation/validation',
         'mage/cookies',
         'domReady!'
-    ], function ($, authenticationPopup, customerData) {
+    ], function ($, authenticationPopup, customerData, whenDefined) {
         var sectionDataIds = $.cookieStorage.get('section_data_ids');
         if (sectionDataIds && sectionDataIds.b  !== undefined) {
             $.cookieStorage.set('section_data_ids','');

--- a/view/frontend/web/js/utils/when-defined.js
+++ b/view/frontend/web/js/utils/when-defined.js
@@ -1,0 +1,75 @@
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2022 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+define([], function () {
+    /**
+     * Map of watched objects to maps of their respective watched properties to configured callbacks
+     * @type {Map<Object, Map<string, function[]>>}
+     */
+    var whenDefinedCallbacks = new Map([]);
+
+    /**
+     * Executes provided callback when a property gets defined on provided object.
+     * The most common use is waiting for a variable to be defined by an external library
+     * using {@see window} as {@see object}
+     *
+     * @param {Object} object to check for property definition
+     * @param {number|string} property that is expected to be defined on {@see object}
+     * @param {Function} callback function to be called when {@see property} gets defined on {@see object}
+     * @param {null} key deprecated parameter used for setting multiple callbacks per property
+     */
+    function whenDefined(object, property, callback, key = null) {
+        if (object.hasOwnProperty(property)) {
+            callback();
+        } else {
+            var overloadedPropertyName = '_' + property;
+            if (!whenDefinedCallbacks.has(object)) {
+                whenDefinedCallbacks.set(object, new Map([]));
+            }
+            if (!whenDefinedCallbacks.get(object).has(property)) {
+                whenDefinedCallbacks.get(object).set(property, []);
+            }
+            var propertyCallbacks = whenDefinedCallbacks.get(object).get(property);
+            propertyCallbacks.push(callback);
+            Object.defineProperty(object, property, {
+                configurable: true,
+                enumerable: true,
+                writeable: true,
+                /**
+                 * Retrieves the watched property from overloaded index
+                 *
+                 * @returns {*} {@see property} value on {@see object}
+                 */
+                get: function () {
+                    return this[overloadedPropertyName];
+                },
+                /**
+                 * Sets the overloaded property index with the provided value then executes configured callbacks
+                 *
+                 * @param {mixed} value
+                 */
+                set: function (value) {
+                    this[overloadedPropertyName] = value;
+                    for (var propertyCallback of propertyCallbacks.values()) {
+                        propertyCallback();
+                    }
+                }
+            });
+        }
+    }
+
+    return whenDefined;
+});


### PR DESCRIPTION
# Description
When Bolt is disabled on minicart a dependency we use for SSO is not loaded. The dependency is now transformed to a proper requirejs module and required wherever needed.

The issue was reported in github:

https://github.com/BoltApp/bolt-magento2/issues/1575

Because window.whenDefined is declared in view/frontend/templates/js/boltglobaljs.phtml, which exits early in the following conditional:
//check if we need Bolt on this page
if (!$block->isOnPageFromWhiteList() && !$block->isMinicartEnabled() && !$block->isBoltProductPage()) { return;
}

And because view/frontend/templates/js/custom_sso_buttons.phtml was introduced in commit 75b2b248419fae09d0244d36f42274882f3b9e7c and does not include the same conditional (particularly, $block->isBoltProductPage()) yet depends on window.whenDefined, the titular TypeError is thrown on various page types including CMS and Category.

We're on Magento 2.4.4 with boltpay/bolt-magento2 version 2.25.1

Fixes: [link ticket](https://app.asana.com/0/941920570700290/1202472083867254/f)

#changelog Resolve reported issue with javascript dependencies - load whenDefined via requireJs

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my ticket link and provided a changelog message.
