### PR TITLE
Bugfix: Incorrect amounts displayed at Bolt PPC for currency chosen

### DIFF
--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -5258,14 +5258,13 @@ ORDER
             ->willReturn($this->productMock);
         $this->quoteMock->expects(static::once())->method('setIsActive')->with(false);
         
-        $currencyMock = $this->getMockBuilder(\Magento\Directory\Model\Currency::class)
-                                            ->setMethods(['getCode'])
-                                            ->disableOriginalConstructor()
-                                            ->getMock();
-        $this->httpContext->expects(static::once())->method('setValue');
-        $this->storeManager->expects(static::once())->method('getStore')->with(self::STORE_ID)
-                           ->willReturn($currencyMock);
+        $currencyMock = $this->createMock(\Magento\Directory\Model\Currency::class);
         $currencyMock->expects(static::once())->method('getCode')->willReturn(self::CURRENCY_CODE);
+        $this->httpContext->expects(static::once())->method('setValue');
+        $storeMock = $this->createMock(\Magento\Store\Model\Store::class);
+        $storeMock->expects(static::once())->method('getDefaultCurrency')->willReturn($currencyMock);
+        $this->storeManager->expects(static::once())->method('getStore')->with(self::STORE_ID)
+                           ->willReturn($storeMock); 
                            
         static::assertEquals($expectedCartData, $cartMock->createCartByRequest($request));
     }
@@ -5387,14 +5386,13 @@ ORDER
             ->willReturn($this->productMock);
         $this->quoteMock->expects(static::once())->method('setIsActive')->with(false);
         
-        $currencyMock = $this->getMockBuilder(\Magento\Directory\Model\Currency::class)
-                                            ->setMethods(['getCode'])
-                                            ->disableOriginalConstructor()
-                                            ->getMock();
+        $currencyMock = $this->createMock(\Magento\Directory\Model\Currency::class);
+        $currencyMock->expects(static::once())->method('getCode')->willReturn(CartTest::CURRENCY_CODE);
         $this->httpContext->expects(static::once())->method('setValue');
-        $this->storeManager->expects(static::once())->method('getStore')->with(CartTest::STORE_ID)
-                           ->willReturn($currencyMock);
-        $currencyMock->expects(static::once())->method('getCode')->willReturn(self::CURRENCY_CODE);
+        $storeMock = $this->createMock(\Magento\Store\Model\Store::class);
+        $storeMock->expects(static::once())->method('getDefaultCurrency')->willReturn($currencyMock);
+        $this->storeManager->expects(static::once())->method('getStore')->with(self::STORE_ID)
+                           ->willReturn($storeMock);
 
         static::assertEquals($expectedCartData, $cartMock->createCartByRequest($request));
     }
@@ -5477,14 +5475,13 @@ ORDER
         ->willReturn($this->productMock);
         $this->quoteMock->expects(static::once())->method('setIsActive')->with(false);
         
-        $currencyMock = $this->getMockBuilder(\Magento\Directory\Model\Currency::class)
-                                            ->setMethods(['getCode'])
-                                            ->disableOriginalConstructor()
-                                            ->getMock();
-        $this->httpContext->expects(static::once())->method('setValue');
-        $this->storeManager->expects(static::once())->method('getStore')->with(self::STORE_ID)
-                           ->willReturn($currencyMock);
+        $currencyMock = $this->createMock(\Magento\Directory\Model\Currency::class);
         $currencyMock->expects(static::once())->method('getCode')->willReturn(self::CURRENCY_CODE);
+        $this->httpContext->expects(static::once())->method('setValue');
+        $storeMock = $this->createMock(\Magento\Store\Model\Store::class);
+        $storeMock->expects(static::once())->method('getDefaultCurrency')->willReturn($currencyMock);
+        $this->storeManager->expects(static::once())->method('getStore')->with(self::STORE_ID)
+                           ->willReturn($storeMock);
 
         static::assertEquals($expectedCartData, $cartMock->createCartByRequest($request));
     }
@@ -5511,14 +5508,13 @@ ORDER
         $this->customerRepository->method('getById')->willReturn($customer);
         $this->quoteMock->expects(static::once())->method('assignCustomer')->with($customer);
         
-        $currencyMock = $this->getMockBuilder(\Magento\Directory\Model\Currency::class)
-                                            ->setMethods(['getCode'])
-                                            ->disableOriginalConstructor()
-                                            ->getMock();
+        $currencyMock = $this->createMock(\Magento\Directory\Model\Currency::class);
+        $currencyMock->expects(static::once())->method('getCode')->willReturn(CartTest::CURRENCY_CODE);
         $this->httpContext->expects(static::once())->method('setValue');
-        $this->storeManager->expects(static::once())->method('getStore')->with(CartTest::STORE_ID)
-                           ->willReturn($currencyMock);
-        $currencyMock->expects(static::once())->method('getCode')->willReturn(self::CURRENCY_CODE);
+        $storeMock = $this->createMock(\Magento\Store\Model\Store::class);
+        $storeMock->expects(static::once())->method('getDefaultCurrency')->willReturn($currencyMock);
+        $this->storeManager->expects(static::once())->method('getStore')->with(self::STORE_ID)
+                           ->willReturn($storeMock);
 
         static::assertEquals($expectedCartData, $currentMock->createCartByRequest($request));
     }
@@ -5544,14 +5540,13 @@ ORDER
         $this->expectExceptionCode(BoltErrorResponse::ERR_PPC_OUT_OF_STOCK);
         $this->expectExceptionMessage('Product that you are trying to add is not available.');
         
-        $currencyMock = $this->getMockBuilder(\Magento\Directory\Model\Currency::class)
-                                            ->setMethods(['getCode'])
-                                            ->disableOriginalConstructor()
-                                            ->getMock();
+        $currencyMock = $this->createMock(\Magento\Directory\Model\Currency::class);
+        $currencyMock->expects(static::once())->method('getCode')->willReturn(CartTest::CURRENCY_CODE);
         $this->httpContext->expects(static::once())->method('setValue');
-        $this->storeManager->expects(static::once())->method('getStore')->with(CartTest::STORE_ID)
-                           ->willReturn($currencyMock);
-        $currencyMock->expects(static::once())->method('getCode')->willReturn(self::CURRENCY_CODE);
+        $storeMock = $this->createMock(\Magento\Store\Model\Store::class);
+        $storeMock->expects(static::once())->method('getDefaultCurrency')->willReturn($currencyMock);
+        $this->storeManager->expects(static::once())->method('getStore')->with(self::STORE_ID)
+                           ->willReturn($storeMock);
 
         static::assertEquals($expectedCartData, $currentMock->createCartByRequest($request));
     }
@@ -5577,14 +5572,13 @@ ORDER
         $this->expectExceptionCode(BoltErrorResponse::ERR_PPC_INVALID_QUANTITY);
         $this->expectExceptionMessage('The requested qty is not available');
         
-        $currencyMock = $this->getMockBuilder(\Magento\Directory\Model\Currency::class)
-                                            ->setMethods(['getCode'])
-                                            ->disableOriginalConstructor()
-                                            ->getMock();
+        $currencyMock = $this->createMock(\Magento\Directory\Model\Currency::class);
+        $currencyMock->expects(static::once())->method('getCode')->willReturn(CartTest::CURRENCY_CODE);
         $this->httpContext->expects(static::once())->method('setValue');
-        $this->storeManager->expects(static::once())->method('getStore')->with(CartTest::STORE_ID)
-                           ->willReturn($currencyMock);
-        $currencyMock->expects(static::once())->method('getCode')->willReturn(self::CURRENCY_CODE);
+        $storeMock = $this->createMock(\Magento\Store\Model\Store::class);
+        $storeMock->expects(static::once())->method('getDefaultCurrency')->willReturn($currencyMock);
+        $this->storeManager->expects(static::once())->method('getStore')->with(self::STORE_ID)
+                           ->willReturn($storeMock);
 
         static::assertEquals($expectedCartData, $currentMock->createCartByRequest($request));
     }

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -5233,6 +5233,9 @@ ORDER
                     'sku'          => self::PRODUCT_SKU,
                     'type'         => 'physical',
                     'description'  => 'Product description',
+                    'options'      => json_encode(
+                        ['storeId' => self::STORE_ID, 'form_key' => 'Ai6JseqGStjryljF']
+                    ),
                 ],
             ],
             'discounts'       => [],
@@ -5254,7 +5257,16 @@ ORDER
         $this->productRepository->expects(static::once())->method('getById')->with(self::PRODUCT_ID)
             ->willReturn($this->productMock);
         $this->quoteMock->expects(static::once())->method('setIsActive')->with(false);
-
+        
+        $currencyMock = $this->getMockBuilder(\Magento\Directory\Model\Currency::class)
+                                            ->setMethods(['getCode'])
+                                            ->disableOriginalConstructor()
+                                            ->getMock();
+        $this->httpContext->expects(static::once())->method('setValue');
+        $this->storeManager->expects(static::once())->method('getStore')->with(self::STORE_ID)
+                           ->willReturn($currencyMock);
+        $currencyMock->expects(static::once())->method('getCode')->willReturn(self::CURRENCY_CODE);
+                           
         static::assertEquals($expectedCartData, $cartMock->createCartByRequest($request));
     }
 
@@ -5374,6 +5386,15 @@ ORDER
         $this->productRepository->expects(static::exactly(2))->method('getById')->with(self::PRODUCT_ID)
             ->willReturn($this->productMock);
         $this->quoteMock->expects(static::once())->method('setIsActive')->with(false);
+        
+        $currencyMock = $this->getMockBuilder(\Magento\Directory\Model\Currency::class)
+                                            ->setMethods(['getCode'])
+                                            ->disableOriginalConstructor()
+                                            ->getMock();
+        $this->httpContext->expects(static::once())->method('setValue');
+        $this->storeManager->expects(static::once())->method('getStore')->with(CartTest::STORE_ID)
+                           ->willReturn($currencyMock);
+        $currencyMock->expects(static::once())->method('getCode')->willReturn(self::CURRENCY_CODE);
 
         static::assertEquals($expectedCartData, $cartMock->createCartByRequest($request));
     }
@@ -5455,6 +5476,15 @@ ORDER
         $this->productRepository->expects(static::once())->method('getById')->with(self::PRODUCT_ID)
         ->willReturn($this->productMock);
         $this->quoteMock->expects(static::once())->method('setIsActive')->with(false);
+        
+        $currencyMock = $this->getMockBuilder(\Magento\Directory\Model\Currency::class)
+                                            ->setMethods(['getCode'])
+                                            ->disableOriginalConstructor()
+                                            ->getMock();
+        $this->httpContext->expects(static::once())->method('setValue');
+        $this->storeManager->expects(static::once())->method('getStore')->with(self::STORE_ID)
+                           ->willReturn($currencyMock);
+        $currencyMock->expects(static::once())->method('getCode')->willReturn(self::CURRENCY_CODE);
 
         static::assertEquals($expectedCartData, $cartMock->createCartByRequest($request));
     }
@@ -5480,6 +5510,15 @@ ORDER
         $customer = $this->createMock(CustomerInterface::class);
         $this->customerRepository->method('getById')->willReturn($customer);
         $this->quoteMock->expects(static::once())->method('assignCustomer')->with($customer);
+        
+        $currencyMock = $this->getMockBuilder(\Magento\Directory\Model\Currency::class)
+                                            ->setMethods(['getCode'])
+                                            ->disableOriginalConstructor()
+                                            ->getMock();
+        $this->httpContext->expects(static::once())->method('setValue');
+        $this->storeManager->expects(static::once())->method('getStore')->with(CartTest::STORE_ID)
+                           ->willReturn($currencyMock);
+        $currencyMock->expects(static::once())->method('getCode')->willReturn(self::CURRENCY_CODE);
 
         static::assertEquals($expectedCartData, $currentMock->createCartByRequest($request));
     }
@@ -5504,6 +5543,15 @@ ORDER
         $this->expectException(BoltException::class);
         $this->expectExceptionCode(BoltErrorResponse::ERR_PPC_OUT_OF_STOCK);
         $this->expectExceptionMessage('Product that you are trying to add is not available.');
+        
+        $currencyMock = $this->getMockBuilder(\Magento\Directory\Model\Currency::class)
+                                            ->setMethods(['getCode'])
+                                            ->disableOriginalConstructor()
+                                            ->getMock();
+        $this->httpContext->expects(static::once())->method('setValue');
+        $this->storeManager->expects(static::once())->method('getStore')->with(CartTest::STORE_ID)
+                           ->willReturn($currencyMock);
+        $currencyMock->expects(static::once())->method('getCode')->willReturn(self::CURRENCY_CODE);
 
         static::assertEquals($expectedCartData, $currentMock->createCartByRequest($request));
     }
@@ -5528,6 +5576,15 @@ ORDER
         $this->expectException(BoltException::class);
         $this->expectExceptionCode(BoltErrorResponse::ERR_PPC_INVALID_QUANTITY);
         $this->expectExceptionMessage('The requested qty is not available');
+        
+        $currencyMock = $this->getMockBuilder(\Magento\Directory\Model\Currency::class)
+                                            ->setMethods(['getCode'])
+                                            ->disableOriginalConstructor()
+                                            ->getMock();
+        $this->httpContext->expects(static::once())->method('setValue');
+        $this->storeManager->expects(static::once())->method('getStore')->with(CartTest::STORE_ID)
+                           ->willReturn($currencyMock);
+        $currencyMock->expects(static::once())->method('getCode')->willReturn(self::CURRENCY_CODE);
 
         static::assertEquals($expectedCartData, $currentMock->createCartByRequest($request));
     }

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -92,6 +92,8 @@ use Magento\SalesRule\Model\RuleRepository;
 use Bolt\Boltpay\Helper\FeatureSwitch\Definitions;
 use Magento\Msrp\Helper\Data as MsrpHelper;
 use Magento\Framework\Pricing\Helper\Data as PriceHelper;
+use Magento\Framework\App\Http\Context as HttpContext;
+use Magento\Store\Model\StoreManagerInterface;
 
 /**
  * @coversDefaultClass \Bolt\Boltpay\Helper\Cart
@@ -316,6 +318,12 @@ class CartTest extends BoltTestCase
     
     /** @var MockObject|PriceHelper */
     private $priceHelper;
+    
+    /** @var MockObject|HttpContext */
+    private $httpContext;
+    
+    /** @var MockObject|StoreManagerInterface */
+    private $storeManager;
 
     /**
      * Setup test dependencies, called before each test
@@ -463,6 +471,8 @@ class CartTest extends BoltTestCase
         );
         $this->msrpHelper = $this->createPartialMock(MsrpHelper::class, ['canApplyMsrp']);
         $this->priceHelper = $this->createPartialMock(PriceHelper::class, ['currency']);
+        $this->httpContext = $this->createMock(HttpContext::class);
+        $this->storeManager = $this->createMock(StoreManagerInterface::class);
         $this->currentMock = $this->getCurrentMock(null);
         $this->objectsToClean = [];
     }
@@ -517,7 +527,9 @@ class CartTest extends BoltTestCase
                     $this->eventsForThirdPartyModules,
                     $this->ruleRepository,
                     $this->msrpHelper,
-                    $this->priceHelper
+                    $this->priceHelper,
+                    $this->httpContext,
+                    $this->storeManager
                 ]
             )
             ->getMock();
@@ -724,7 +736,9 @@ class CartTest extends BoltTestCase
             $this->eventsForThirdPartyModules,
             $this->ruleRepository,
             $this->msrpHelper,
-            $this->priceHelper
+            $this->priceHelper,
+            $this->httpContext,
+            $this->storeManager
         );
         static::assertAttributeEquals($this->checkoutSession, 'checkoutSession', $instance);
         static::assertAttributeEquals($this->productRepository, 'productRepository', $instance);
@@ -755,6 +769,8 @@ class CartTest extends BoltTestCase
         static::assertAttributeEquals($this->ruleRepository, 'ruleRepository', $instance);
         static::assertAttributeEquals($this->msrpHelper, 'msrpHelper', $instance);
         static::assertAttributeEquals($this->priceHelper, 'priceHelper', $instance);
+        static::assertAttributeEquals($this->httpContext, 'httpContext', $instance);
+        static::assertAttributeEquals($this->storeManager, 'storeManager', $instance);
     }
 
     /**


### PR DESCRIPTION
# Description
For Bolt PPC, the plugin does not setup proper currency when creating empty quote and the cart still uses default currency.

Solution: We have correct currency in the api request, and just apply it before creating empty quote.

Fixes: https://app.asana.com/0/951157735838091/1202452720391991/f

#changelog Bugfix: Incorrect amounts displayed at Bolt PPC for currency chosen

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
