### PR TITLE
Bugfix: missing parent quote for direct API

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1883,6 +1883,7 @@ class Cart extends AbstractHelper
         // order API, otherwise skip this step
         ////////////////////////////////////////////////////////
         if ($this->deciderHelper->isAPIDrivenIntegrationEnabled()) {
+            $quote->setBoltParentQuoteId($quote->getId());
             if ($this->isBackendSession() && $quote->getBoltCheckoutType() != self::BOLT_CHECKOUT_TYPE_BACKOFFICE) {
                 $quote->setBoltCheckoutType(self::BOLT_CHECKOUT_TYPE_BACKOFFICE);
                 $quote->save();


### PR DESCRIPTION
# Description
For direct API, the quote does not have the property `parent quote id` anymore, as a result, some logic depending on parent quote (eg. support for Mirasvit Reward Points) does not work as expected.

Solution: Assign the property `parent quote id` with its own quote id.

Fixes: https://app.asana.com/0/0/1202504882047670/f

#changelog Bugfix: missing parent quote for direct API

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
