### PR TITLE
Bugfix: multiselect field is not supported for PPC

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -2623,6 +2623,13 @@ class Cart extends AbstractHelper
             unset($options['storeId']);
             unset($options['form_key']);
             $options['qty'] = $item['quantity'];
+            if (!empty($options['bundle_option'])) {
+                foreach ($options['bundle_option'] as $id => $bundleOption) {
+                    if (strpos($bundleOption, ',') !== false) {
+                        $options['bundle_option'][$id] = explode(',', $bundleOption);
+                    }
+                }
+            }
             $options = new \Magento\Framework\DataObject($options);
 
             try {

--- a/view/frontend/templates/button_product_page.phtml
+++ b/view/frontend/templates/button_product_page.phtml
@@ -257,7 +257,12 @@ foreach ($block->getAdditionalCheckoutButtonAttributes() as $attrName => $attrVa
                             if (!(compositeAttribute in options)) {
                                 options[compositeAttribute] = {};
                             }
-                            options[compositeAttribute][matchResult[1]] = value;
+                            if (matchResult[1] in options[compositeAttribute]
+                                && options[compositeAttribute][matchResult[1]]) {
+                                options[compositeAttribute][matchResult[1]] += ',' + value;
+                            } else {
+                                options[compositeAttribute][matchResult[1]] = value;
+                            }
                             return;
                         }
                     }
@@ -351,10 +356,12 @@ foreach ($block->getAdditionalCheckoutButtonAttributes() as $attrName => $attrVa
                 if (data) {
                     // the name of the property that holds the price data
                     // varies depending on the product type, eg. prices, options
-                    var key = Object.keys(data)[0];
-                    if (key) {
-                        var finalPrice = data[key].finalPrice;
-                        itemPrices[key] =
+                    for (var index in data) {
+                        if (!data.hasOwnProperty(index) || !data[index].hasOwnProperty('finalPrice')) {
+                            continue;
+                        }
+                        var finalPrice = data[index].finalPrice;
+                        itemPrices[index] =
                             finalPrice && typeof finalPrice === 'object' && finalPrice.amount ? finalPrice.amount : 0;
                         itemPrice = sum(itemPrices);
                     }


### PR DESCRIPTION
# Description
We have a bug in our PPC in the plugin where if a multiselect field is used to select product options we only send one of the values and the total only accounts for a single value as well.

What we need to do is modify the total to account for all values and also send all selected options. We are using this also for Native API flow and in native api flow we are expecting a string which contains comma separated values like: "1,2,3,4" to represent each option selected. 

Fixes: https://app.asana.com/0/1200879031426307/1202497849167312/f

#changelog Bugfix: multiselect field is not supported for PPC

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
