### PR TITLE
Bugfix: the event sales_order_save_after is dispatched before creating creditmemo

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -1973,8 +1973,9 @@ class Order extends AbstractHelper
      *
      * @param OrderModel $order
      * @param string $state
+     * @param bool $saveOrder
      */
-    public function setOrderState($order, $state)
+    public function setOrderState($order, $state, $saveOrder = false)
     {
         $prevState = $order->getState();
         if ($state == OrderModel::STATE_HOLDED) {
@@ -2004,7 +2005,9 @@ class Order extends AbstractHelper
             $order->setState($state);
             $order->setStatus($order->getConfig()->getStateDefaultStatus($state));
         }
-        $order->save();
+        if ($saveOrder) {
+           $order->save(); 
+        }
     }
 
     /**
@@ -2280,8 +2283,10 @@ class Order extends AbstractHelper
             $this->resetOrderState($order);
         }
         $orderState = $this->transactionToOrderState($transactionState, $order);
-
-        $this->setOrderState($order, $orderState);
+        
+        // If the action is not triggered by Bolt API request and transaction type is credit, there is not need to save order.
+        $ifSaveOrder = Hook::$fromBolt || ($transactionState != self::TS_CREDIT_IN_PROGRESS && $transactionState != self::TS_CREDIT_COMPLETED);      
+        $this->setOrderState($order, $orderState, $ifSaveOrder);
 
         // Send order confirmation email to customer.
         if (! $order->getEmailSent()) {
@@ -2338,7 +2343,9 @@ class Order extends AbstractHelper
 
         // save payment and order
         $payment->save();
-        $order->save();
+        if ($ifSaveOrder) {
+            $order->save();
+        }
 
         $this->eventsForThirdPartyModules->dispatchEvent(
             'afterUpdateOrderPayment',

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -1975,7 +1975,7 @@ class Order extends AbstractHelper
      * @param string $state
      * @param bool $saveOrder
      */
-    public function setOrderState($order, $state, $saveOrder = false)
+    public function setOrderState($order, $state, $saveOrder = true)
     {
         $prevState = $order->getState();
         if ($state == OrderModel::STATE_HOLDED) {


### PR DESCRIPTION
# Description
When creating a credit memo from M2 admin dashboard, the normal process would be
1. process a refund through payment gateway
2. create a credit memo
3. save order 
(please refer to https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Sales/Model/Service/CreditmemoService.php#L164)

So the event `sales_order_save_after` should be dispatched after creditmemo is created.

But for Bolt, the process is a bit different. 
1. process a refund through payment gateway
2. in the Bolt plugin, refund the amount through API (https://github.com/BoltApp/bolt-magento2/blob/refs/tags/2.25.2/Model/Payment.php#L478)
3. in the Bolt plugin, then update order payment / transaction data (https://github.com/BoltApp/bolt-magento2/blob/refs/tags/2.25.2/Helper/Order.php#L2068)
4. in the Bolt plugin, change order state taking transition constraints into account. At that point, order get saved and the event `sales_order_save_after` is dispatched (https://github.com/BoltApp/bolt-magento2/blob/refs/tags/2.25.2/Helper/Order.php#L1988)
5. create a credit memo
6. save order 

And we can see that the event `sales_order_save_after` is dispatched before creditmemo creation. It causes issue if 3p plugin has specific logic in the observer which is subscribed to event `sales_order_save_after`.

Actually since the order would be saved by M2 core code, there is no need for Bolt plugin to save order.


Fixes: https://app.asana.com/0/951157735838091/1202213325456036/f

#changelog Bugfix: the event sales_order_save_after is dispatched before creating creditmemo

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
