### PR TITLE
Show image for gift wrappping in Bolt modal

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1399,16 +1399,23 @@ class Cart extends AbstractHelper
         $total = $quote->getTotals();
         if (isset($total['giftwrapping']) && ($total['giftwrapping']->getGwId() || $total['giftwrapping']->getGwItemIds())) {
             $giftWrapping = $total['giftwrapping'];
+
+
             $totalPrice = $giftWrapping->getGwPrice() + $giftWrapping->getGwItemsPrice() + $quote->getGwCardPrice();
             $product = [];
-            $product['reference']    = $giftWrapping->getGwId();
+            $gwId = $giftWrapping->getGwId();
+            $product['reference']    = $gwId;
             $product['name']         = $giftWrapping->getTitle()->getText();
             $product['total_amount'] = CurrencyUtils::toMinor($totalPrice, $currencyCode);
             $product['unit_price']   = CurrencyUtils::toMinor($totalPrice, $currencyCode);
             $product['quantity']     = 1;
             $product['sku']          = trim($giftWrapping->getCode());
             $product['type']         = self::ITEM_TYPE_PHYSICAL;
-
+            $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
+            $giftWrappingModel = $objectManager->create('Magento\GiftWrapping\Model\Wrapping')->load($gwId);
+            if ($giftWrappingModel->getImageUrl()){
+                $product['image_url']    = $giftWrappingModel->getImageUrl();
+            }
             $totalAmount += $product['total_amount'];
             $products[] = $product;
         }

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -4863,7 +4863,15 @@ ORDER
             ->disableOriginalConstructor()
             ->setMethods(['getGwId','getGwItemsPrice','getGwCardPrice','getGwPrice','getText','getTitle','getCode'])
             ->getMock();
-
+        ObjectManager::setInstance($this->objectManagerMock);
+        $giftWrappingModel = $this->getMockBuilder('Magento\GiftWrapping\Model\Wrapping')
+            ->disableOriginalConstructor()
+            ->setMethods(['load','getImageUrl'])
+            ->getMock();
+        $giftWrappingModel->method('load')->willReturnSelf();
+        $giftWrappingModel->method('getImageUrl')->willReturn('https://gift-wrap-image.url');
+        $this->objectManagerMock->expects(static::once())->method('create')
+            ->with('Magento\GiftWrapping\Model\Wrapping')->willReturn($giftWrappingModel);
         $this->giftwrapping->method('getGwId')->willReturn(1);
         $this->giftwrapping->method('getGwItemsPrice')->willReturn('10');
         $this->giftwrapping->method('getGwCardPrice')->willReturn('0');
@@ -4898,6 +4906,7 @@ ORDER
                     'quantity' => 1,
                     'sku' => 'gift_id',
                     'type' => 'physical',
+                    'image_url' => 'https://gift-wrap-image.url',
                 ]
             ],
             $products


### PR DESCRIPTION
# Description
Issue: Gift wrapping image doesn't show in the Bolt modal
![image](https://user-images.githubusercontent.com/2002287/179019476-f087c4df-be11-4148-be3b-d149ea679587.png)

Fixes: https://app.asana.com/0/564264490825835/1202562914572686

#changelog Show image for gift wrappping in Bolt modal

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
