### PR TITLE
Bugfix: unable to get discount details for bundle product

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ commands:
                   - run:
                       name: << parameters.php_version >> << parameters.m2_version >> Magento integration
                       command: |
-                        export COMPOSER_MEMORY_LIMIT=3G
+                        export COMPOSER_MEMORY_LIMIT=4G
                         Test/scripts/ci-magento-integration.sh
             - unless:
                 condition: << parameters.is_magento_integration >>

--- a/Block/Js.php
+++ b/Block/Js.php
@@ -112,6 +112,16 @@ class Js extends Template
         return $this->configHelper->getCdnUrl() . '/track.js';
     }
 
+     /**
+     * Get shopper widget js url
+     *
+     * @return  string
+     */
+    public function getShopperWidgetJsUrl()
+    {
+        return $this->configHelper->getCdnUrl() . '/embedded/shopper-widget/embed-shopper-widget.js';
+    }
+
     /**
      * Get open replay js url
      *
@@ -331,6 +341,7 @@ class Js extends Template
             'account_url'                           => $this->getAccountJsUrl(),
             'order_management_selector'             => $this->getOrderManagementSelector(),
             'api_integration'                       => $this->featureSwitches->isAPIDrivenIntegrationEnabled(),
+            'shopper_widget_url'                    => $this->getShopperWidgetJsUrl(),
         ]);
     }
 
@@ -549,6 +560,18 @@ class Js extends Template
             return true;
         }
         
+        return false;
+    }
+
+    /**
+     * If feature switch M2_ENABLE_SHOPPER_ASSISTANT is enabled
+     */
+    public function isShopperAssistantEnabled()
+    {
+        if ($this->featureSwitches->isShopperAssistantEnabled()) {
+            return true;
+        }
+
         return false;
     }
 

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -2992,10 +2992,27 @@ class Cart extends AbstractHelper
      */
     public function isCollectDiscountsByPlugin($quote)
     {
+        // For bundle product, there is a bug in M2 core (https://github.com/magento/magento2/commit/5dabdb6a104159458fd9c0847447d641e75daa0e, fixed in M2 v2.4.4),
+        // as a result, if the cart contains any bundle product, $address->getExtensionAttributes()->getDiscounts() returns incomplete discounts data.
+        // Then we have to use plugin methods to collect discounts details if M2 version of merchant's store is older than v2.4.4
+        $toFixBundleProductDiscountBug = false;
+        if (version_compare($this->configHelper->getStoreVersion(), '2.4.4', '<')) {
+            $items = $quote->getAllVisibleItems();
+            foreach ($items as $item) {
+                $_product = $item->getProduct();
+                if (!$_product) {
+                    continue;
+                }
+                if ($item->getProductType() == \Magento\Bundle\Model\Product\Type::TYPE_CODE) {
+                    $toFixBundleProductDiscountBug = true;
+                    break;
+                }
+            }
+        }
         //By default this feature switch is disabled.
         return $this->deciderHelper->isCollectDiscountsByPlugin()
             || ($this->configHelper->isActive($quote->getStore()->getId())
-            && version_compare($this->configHelper->getStoreVersion(), '2.3.4', '<'));
+            && (version_compare($this->configHelper->getStoreVersion(), '2.3.4', '<') || $toFixBundleProductDiscountBug));
     }
     
     /**

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1399,16 +1399,23 @@ class Cart extends AbstractHelper
         $total = $quote->getTotals();
         if (isset($total['giftwrapping']) && ($total['giftwrapping']->getGwId() || $total['giftwrapping']->getGwItemIds())) {
             $giftWrapping = $total['giftwrapping'];
+
+
             $totalPrice = $giftWrapping->getGwPrice() + $giftWrapping->getGwItemsPrice() + $quote->getGwCardPrice();
             $product = [];
-            $product['reference']    = $giftWrapping->getGwId();
+            $gwId = $giftWrapping->getGwId();
+            $product['reference']    = $gwId;
             $product['name']         = $giftWrapping->getTitle()->getText();
             $product['total_amount'] = CurrencyUtils::toMinor($totalPrice, $currencyCode);
             $product['unit_price']   = CurrencyUtils::toMinor($totalPrice, $currencyCode);
             $product['quantity']     = 1;
             $product['sku']          = trim($giftWrapping->getCode());
             $product['type']         = self::ITEM_TYPE_PHYSICAL;
-
+            $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
+            $giftWrappingModel = $objectManager->create('Magento\GiftWrapping\Model\Wrapping')->load($gwId);
+            if ($giftWrappingModel->getImageUrl()){
+                $product['image_url']    = $giftWrappingModel->getImageUrl();
+            }
             $totalAmount += $product['total_amount'];
             $products[] = $product;
         }

--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -487,4 +487,16 @@ class Decider extends AbstractHelper
     {
         return $this->isSwitchEnabled(Definitions::M2_STORE_CONFIGURATION_WEBHOOK);
     }
+
+    /**
+     * Checks whether the feature switch for shopper assistant is enabled
+     *
+     * @return bool whether the feature switch is enabled
+     *
+     * @throws LocalizedException if the feature switch key is unknown
+     */
+    public function isShopperAssistantEnabled()
+    {
+        return $this->isSwitchEnabled(Definitions::M2_ENABLE_SHOPPER_ASSISTANT);
+    }
 }

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -287,6 +287,11 @@ class Definitions
      */
     const M2_STORE_CONFIGURATION_WEBHOOK = 'M2_STORE_CONFIGURATION_WEBHOOK';
 
+    /**
+     * Enable shopper assistant
+     */
+    const M2_ENABLE_SHOPPER_ASSISTANT = 'M2_ENABLE_SHOPPER_ASSISTANT';
+
     const DEFAULT_SWITCH_VALUES = [
         self::M2_SAMPLE_SWITCH_NAME => [
             self::NAME_KEY        => self::M2_SAMPLE_SWITCH_NAME,
@@ -587,6 +592,12 @@ class Definitions
             self::VAL_KEY         => true,
             self::DEFAULT_VAL_KEY => false,
             self::ROLLOUT_KEY     => 100
+        ],
+        self::M2_ENABLE_SHOPPER_ASSISTANT => [
+            self::NAME_KEY        => self::M2_ENABLE_SHOPPER_ASSISTANT,
+            self::VAL_KEY         => true,
+            self::DEFAULT_VAL_KEY => false,
+            self::ROLLOUT_KEY     => 0
         ]
     ];
 }

--- a/Model/CatalogIngestion/ProductEventRequestBuilder.php
+++ b/Model/CatalogIngestion/ProductEventRequestBuilder.php
@@ -123,14 +123,21 @@ class ProductEventRequestBuilder
     {
         try {
             $defaultStore = $this->storeManager->getWebsite($websiteId)->getDefaultStore();;
+            $apiKey = $this->config->getApiKey($defaultStore->getId());
+            $publishKey = $this->config->getPublishableKeyCheckout($defaultStore->getId());
+            if (!$apiKey || !$publishKey) {
+                throw new LocalizedException(
+                    __('Bolt API Key or Publishable Key - Multi Step is not configured')
+                );
+            }
             $requestData = $this->dataObjectFactory->create();
             $requestData->setDynamicApiUrl(self::API_REQUEST_API_URL);
-            $requestData->setApiKey($this->config->getApiKey($defaultStore->getId()));
+            $requestData->setApiKey($apiKey);
             $requestData->setRequestMethod(self::API_REQUEST_METHOD_TYPE);
             $requestData->setStatusOnly(true);
             $requestData->setHeaders(
                 [
-                    'X-Publishable-Key' => $this->config->getPublishableKeyCheckout($defaultStore->getId())
+                    'X-Publishable-Key' => $publishKey
                 ]
             );
             $requestProductData = $this->productDataProcessor->getRequestProductData(

--- a/Model/CatalogIngestion/StoreConfigurationRequestBuilder.php
+++ b/Model/CatalogIngestion/StoreConfigurationRequestBuilder.php
@@ -81,13 +81,20 @@ class StoreConfigurationRequestBuilder
     public function getRequest(string $storeCode): Request
     {
         $store = $this->storeRepository->get($storeCode);
+        $apiKey = $this->config->getApiKey($store->getId());
+        $publishKey = $this->config->getPublishableKeyCheckout($store->getId());
+        if (!$apiKey || !$publishKey) {
+            throw new LocalizedException(
+                __('Bolt API Key or Publishable Key - Multi Step is not configured')
+            );
+        }
         $requestData = $this->dataObjectFactory->create();
         $requestData->setDynamicApiUrl(self::API_REQUEST_API_URL);
-        $requestData->setApiKey($this->config->getApiKey($store->getId()));
+        $requestData->setApiKey($apiKey);
         $requestData->setStatusOnly(true);
         $requestData->setHeaders(
             [
-                'X-Publishable-Key' => $this->config->getPublishableKeyCheckout($store->getId())
+                'X-Publishable-Key' => $publishKey
             ]
         );
         $requestData->setRequestMethod(self::API_REQUEST_METHOD_TYPE);

--- a/Plugin/Magento/Config/Model/ConfigPlugin.php
+++ b/Plugin/Magento/Config/Model/ConfigPlugin.php
@@ -124,7 +124,9 @@ class ConfigPlugin
                 }
             }
 
-            if ($subject->getScope() == ScopeInterface::SCOPE_STORES) {
+            if ($subject->getScope() == ScopeInterface::SCOPE_STORES &&
+                $this->boltConfig->getIsSystemConfigurationUpdateRequestEnabled($subject->getScopeId())
+            ) {
                 $this->storeConfigurationManager->requestStoreConfigurationUpdated($subject->getScopeCode());
             }
         } catch (\Exception $e) {

--- a/Plugin/Magento/Config/Model/ConfigPlugin.php
+++ b/Plugin/Magento/Config/Model/ConfigPlugin.php
@@ -89,18 +89,18 @@ class ConfigPlugin
      * Send request to bolt after magento configuration update
      *
      * @param Config $subject
-     * @param $result
-     * @return Config
+     * @param mixed $result
+     * @return mixed
      */
     public function afterSave(
         Config $subject,
-        Config $result
-    ): Config {
+        $result
+    ) {
         if (!$this->featureSwitches->isStoreConfigurationWebhookEnabled()) {
             return $result;
         }
         try {
-            if ($result->getScope() == AppScopeInterface::SCOPE_DEFAULT) {
+            if ($subject->getScope() == AppScopeInterface::SCOPE_DEFAULT) {
                 $websites = $this->websiteRepository->getList();
                 foreach ($websites as $website) {
                     if ($website->getWebsiteId() == 0) {
@@ -115,17 +115,17 @@ class ConfigPlugin
                 }
             }
 
-            if ($result->getScope() == ScopeInterface::SCOPE_WEBSITES &&
-                $this->boltConfig->getIsSystemConfigurationUpdateRequestEnabled($result->getWebsite())
+            if ($subject->getScope() == ScopeInterface::SCOPE_WEBSITES &&
+                $this->boltConfig->getIsSystemConfigurationUpdateRequestEnabled($subject->getWebsite())
             ) {
-                $website = $this->websiteRepository->getById((int)$result->getWebsite());
+                $website = $this->websiteRepository->getById((int)$subject->getWebsite());
                 foreach ($website->getStores() as $store) {
                     $this->storeConfigurationManager->requestStoreConfigurationUpdated($store->getCode());
                 }
             }
 
-            if ($result->getScope() == ScopeInterface::SCOPE_STORES) {
-                $this->storeConfigurationManager->requestStoreConfigurationUpdated($result->getScopeCode());
+            if ($subject->getScope() == ScopeInterface::SCOPE_STORES) {
+                $this->storeConfigurationManager->requestStoreConfigurationUpdated($subject->getScopeCode());
             }
         } catch (\Exception $e) {
             $this->logger->critical($e);

--- a/Test/Unit/Block/JsTest.php
+++ b/Test/Unit/Block/JsTest.php
@@ -67,7 +67,7 @@ class JsTest extends BoltTestCase
     /**
      * @var int expected number of settings returned by {@see \Bolt\Boltpay\Block\Js::getSettings}
      */
-    const SETTINGS_NUMBER = 29;
+    const SETTINGS_NUMBER = 30;
 
     /**
      * @var int expeced number of tracking callback returned by {@see \Bolt\Boltpay\Block\Js::getTrackCallbacks}

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -4863,7 +4863,15 @@ ORDER
             ->disableOriginalConstructor()
             ->setMethods(['getGwId','getGwItemsPrice','getGwCardPrice','getGwPrice','getText','getTitle','getCode'])
             ->getMock();
-
+        ObjectManager::setInstance($this->objectManagerMock);
+        $giftWrappingModel = $this->getMockBuilder('Magento\GiftWrapping\Model\Wrapping')
+            ->disableOriginalConstructor()
+            ->setMethods(['load','getImageUrl'])
+            ->getMock();
+        $giftWrappingModel->method('load')->willReturnSelf();
+        $giftWrappingModel->method('getImageUrl')->willReturn('https://gift-wrap-image.url');
+        $this->objectManagerMock->expects(static::once())->method('create')
+            ->with('Magento\GiftWrapping\Model\Wrapping')->willReturn($giftWrappingModel);
         $this->giftwrapping->method('getGwId')->willReturn(1);
         $this->giftwrapping->method('getGwItemsPrice')->willReturn('10');
         $this->giftwrapping->method('getGwCardPrice')->willReturn('0');
@@ -4898,6 +4906,7 @@ ORDER
                     'quantity' => 1,
                     'sku' => 'gift_id',
                     'type' => 'physical',
+                    'image_url' => 'https://gift-wrap-image.url',
                 ]
             ],
             $products

--- a/Test/Unit/Model/CatalogIngestion/ProductEventRequestBuilderTest.php
+++ b/Test/Unit/Model/CatalogIngestion/ProductEventRequestBuilderTest.php
@@ -28,7 +28,9 @@ use Bolt\Boltpay\Model\CatalogIngestion\ProductEventRequestBuilder;
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product\Type as ProductType;
+use Magento\Config\Model\ResourceModel\Config as ResourceConfig;
 use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Encryption\EncryptorInterface;
 use Magento\Framework\Module\Manager;
 use Magento\Store\Model\ScopeInterface;
 use Magento\TestFramework\Helper\Bootstrap;
@@ -50,6 +52,10 @@ class ProductEventRequestBuilderTest extends BoltTestCase
     private const PRODUCT_PRICE = 100;
 
     private const PRODUCT_QTY = 100;
+
+    private const API_KEY = '3c2d5104e7f9d99b66e1c9c550f6566677bf81de0d6f25e121fdb57e47c2eafc';
+
+    private const PUBLISH_KEY = 'ifssM6pxV64H.FXY3JhSL7w9f.c243fecf459ed259019ea58d7a30307edf2f65442c305f086105b2f66fe6c006';
 
     /**
      * @var ObjectManagerInterface
@@ -103,11 +109,26 @@ class ProductEventRequestBuilderTest extends BoltTestCase
         $featureSwitches->method('isCatalogIngestionEnabled')->willReturn(true);
         TestHelper::setProperty($productEventProcessor, 'featureSwitches', $featureSwitches);
         $websiteId = $this->storeManager->getWebsite()->getId();
+        $encryptor = $this->objectManager->get(EncryptorInterface::class);
+        $apikey = $encryptor->encrypt(self::API_KEY);
+        $publishKey = $encryptor->encrypt(self::PUBLISH_KEY);
         $configData = [
             [
                 'path' => BoltConfig::XML_PATH_CATALOG_INGESTION_ENABLED,
                 'value' => 1,
                 'scope' => ScopeInterface::SCOPE_WEBSITES,
+                'scopeId' => $websiteId,
+            ],
+            [
+                'path'    => BoltConfig::XML_PATH_PUBLISHABLE_KEY_CHECKOUT,
+                'value'   => $publishKey,
+                'scope'   => ScopeInterface::SCOPE_STORES,
+                'scopeId' => $websiteId,
+            ],
+            [
+                'path'    => BoltConfig::XML_PATH_API_KEY,
+                'value'   => $apikey,
+                'scope'   => ScopeInterface::SCOPE_STORES,
                 'scopeId' => $websiteId,
             ]
         ];
@@ -191,12 +212,39 @@ class ProductEventRequestBuilderTest extends BoltTestCase
     }
 
     /**
+     * @test
+     */
+    public function testGetRequest_WithoutApiKeys()
+    {
+        $this->expectExceptionMessage('Bolt API Key or Publishable Key - Multi Step is not configured');
+        $websiteId = $this->storeManager->getWebsite()->getId();
+        $configData = [
+            [
+                'path'    => BoltConfig::XML_PATH_PUBLISHABLE_KEY_CHECKOUT,
+                'value'   => '',
+                'scope'   => ScopeInterface::SCOPE_STORES,
+                'scopeId' => $websiteId,
+            ]
+        ];
+        TestUtils::setupBoltConfig($configData);
+
+        $product = $this->createProduct();
+        $productEvent = $this->productEventRepository->getByProductId($product->getId());
+        $this->productEventRequestBuilder->getRequest($productEvent, $this->storeManager->getWebsite()->getId());
+    }
+
+    /**
      * Cleaning test data from database
      *
      * @return void
      */
     private function cleanDataBase(): void
     {
+        $websiteId = $this->storeManager->getWebsite()->getId();
+        $configResource = $this->objectManager->get(ResourceConfig::class);
+        $configResource->deleteConfig(BoltConfig::XML_PATH_CATALOG_INGESTION_ENABLED, ScopeInterface::SCOPE_WEBSITES, $websiteId);
+        $configResource->deleteConfig(BoltConfig::XML_PATH_PUBLISHABLE_KEY_CHECKOUT, ScopeInterface::SCOPE_STORES, $websiteId);
+        $configResource->deleteConfig(BoltConfig::XML_PATH_API_KEY, ScopeInterface::SCOPE_STORES, $websiteId);
         $connection = $this->resource->getConnection('default');
         $connection->truncateTable($this->resource->getTableName('bolt_product_event'));
         $connection->delete($connection->getTableName('catalog_product_entity'));

--- a/Test/Unit/Model/CatalogIngestion/StoreConfigurationManagerTest.php
+++ b/Test/Unit/Model/CatalogIngestion/StoreConfigurationManagerTest.php
@@ -24,11 +24,13 @@ use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Test\Unit\TestHelper;
 use Bolt\Boltpay\Test\Unit\TestUtils;
 use Bolt\Boltpay\Helper\Config as BoltConfig;
+use Magento\Framework\Encryption\EncryptorInterface;
 use Magento\TestFramework\Helper\Bootstrap;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Config\Model\Config;
+use Magento\Config\Model\ResourceModel\Config as ResourceConfig;
 
 /**
  * Class StoreConfigurationManagerTest
@@ -39,6 +41,10 @@ class StoreConfigurationManagerTest extends BoltTestCase
     private const RESPONSE_SUCCESS_STATUS = 200;
 
     private const RESPONSE_FAIL_STATUS = 404;
+
+    private const API_KEY = '3c2d5104e7f9d99b66e1c9c550f6566677bf81de0d6f25e121fdb57e47c2eafc';
+
+    private const PUBLISH_KEY = 'ifssM6pxV64H.FXY3JhSL7w9f.c243fecf459ed259019ea58d7a30307edf2f65442c305f086105b2f66fe6c006';
 
     /**
      * @var ObjectManagerInterface
@@ -74,15 +80,43 @@ class StoreConfigurationManagerTest extends BoltTestCase
         $featureSwitches->method('isStoreConfigurationWebhookEnabled')->willReturn(true);
 
         $websiteId = $this->storeManager->getWebsite()->getId();
+        $encryptor = $this->objectManager->get(EncryptorInterface::class);
+        $apikey = $encryptor->encrypt(self::API_KEY);
+        $publishKey = $encryptor->encrypt(self::PUBLISH_KEY);
         $configData = [
             [
                 'path' => BoltConfig::XML_PATH_CATALOG_INGESTION_SYSTEM_CONFIGURATION_UPDATE_REQUEST,
                 'value' => 1,
                 'scope' => ScopeInterface::SCOPE_WEBSITES,
                 'scopeId' => $websiteId,
+            ],
+            [
+                'path'    => BoltConfig::XML_PATH_PUBLISHABLE_KEY_CHECKOUT,
+                'value'   => $publishKey,
+                'scope'   => ScopeInterface::SCOPE_STORES,
+                'scopeId' => $websiteId,
+            ],
+            [
+                'path'    => BoltConfig::XML_PATH_API_KEY,
+                'value'   => $apikey,
+                'scope'   => ScopeInterface::SCOPE_STORES,
+                'scopeId' => $websiteId,
             ]
         ];
         TestUtils::setupBoltConfig($configData);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function tearDownInternal(): void
+    {
+        $websiteId = $this->storeManager->getWebsite()->getId();
+        $configResource = $this->objectManager->get(ResourceConfig::class);
+        $configResource->deleteConfig(BoltConfig::XML_PATH_CATALOG_INGESTION_ENABLED, ScopeInterface::SCOPE_WEBSITES, $websiteId);
+        $configResource->deleteConfig(BoltConfig::XML_PATH_PUBLISHABLE_KEY_CHECKOUT, ScopeInterface::SCOPE_STORES, $websiteId);
+        $configResource->deleteConfig(BoltConfig::XML_PATH_API_KEY, ScopeInterface::SCOPE_STORES, $websiteId);
+        parent::tearDownInternal();
     }
 
     /**

--- a/Test/Unit/Model/CatalogIngestion/StoreConfigurationRequestBuilderTest.php
+++ b/Test/Unit/Model/CatalogIngestion/StoreConfigurationRequestBuilderTest.php
@@ -19,9 +19,14 @@ namespace Bolt\Boltpay\Test\Unit\Model\CatalogIngestion;
 
 use Bolt\Boltpay\Model\CatalogIngestion\StoreConfigurationRequestBuilder;
 use Bolt\Boltpay\Test\Unit\BoltTestCase;
+use Bolt\Boltpay\Helper\Config as BoltConfig;
+use Bolt\Boltpay\Test\Unit\TestUtils;
+use Magento\Config\Model\ResourceModel\Config as ResourceConfig;
+use Magento\Framework\Encryption\EncryptorInterface;
 use Magento\TestFramework\Helper\Bootstrap;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\Store\Model\StoreManagerInterface;
+use Magento\Store\Model\ScopeInterface;
 
 /**
  * Class ProductEventRequestBuilderTest
@@ -29,6 +34,10 @@ use Magento\Store\Model\StoreManagerInterface;
  */
 class StoreConfigurationRequestBuilderTest extends BoltTestCase
 {
+    private const API_KEY = '3c2d5104e7f9d99b66e1c9c550f6566677bf81de0d6f25e121fdb57e47c2eafc';
+
+    private const PUBLISH_KEY = 'ifssM6pxV64H.FXY3JhSL7w9f.c243fecf459ed259019ea58d7a30307edf2f65442c305f086105b2f66fe6c006';
+
     /**
      * @var ObjectManagerInterface
      */
@@ -44,7 +53,6 @@ class StoreConfigurationRequestBuilderTest extends BoltTestCase
      */
     private $storeManager;
 
-
     /**
      * @inheritDoc
      */
@@ -53,6 +61,44 @@ class StoreConfigurationRequestBuilderTest extends BoltTestCase
         $this->objectManager = Bootstrap::getObjectManager();
         $this->storeConfigurationRequestBuilder =$this->objectManager->get(StoreConfigurationRequestBuilder::class);
         $this->storeManager = $this->objectManager->get(StoreManagerInterface::class);
+        $websiteId = $this->storeManager->getWebsite()->getId();
+        $encryptor = $this->objectManager->get(EncryptorInterface::class);
+        $apikey = $encryptor->encrypt(self::API_KEY);
+        $publishKey = $encryptor->encrypt(self::PUBLISH_KEY);
+        $configData = [
+            [
+                'path' => BoltConfig::XML_PATH_CATALOG_INGESTION_SYSTEM_CONFIGURATION_UPDATE_REQUEST,
+                'value' => 1,
+                'scope' => ScopeInterface::SCOPE_WEBSITES,
+                'scopeId' => $websiteId,
+            ],
+            [
+                'path'    => BoltConfig::XML_PATH_PUBLISHABLE_KEY_CHECKOUT,
+                'value'   => $publishKey,
+                'scope'   => ScopeInterface::SCOPE_STORES,
+                'scopeId' => $websiteId,
+            ],
+            [
+                'path'    => BoltConfig::XML_PATH_API_KEY,
+                'value'   => $apikey,
+                'scope'   => ScopeInterface::SCOPE_STORES,
+                'scopeId' => $websiteId,
+            ]
+        ];
+        TestUtils::setupBoltConfig($configData);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function tearDownInternal(): void
+    {
+        $websiteId = $this->storeManager->getWebsite()->getId();
+        $configResource = $this->objectManager->get(ResourceConfig::class);
+        $configResource->deleteConfig(BoltConfig::XML_PATH_CATALOG_INGESTION_ENABLED, ScopeInterface::SCOPE_WEBSITES, $websiteId);
+        $configResource->deleteConfig(BoltConfig::XML_PATH_PUBLISHABLE_KEY_CHECKOUT, ScopeInterface::SCOPE_STORES, $websiteId);
+        $configResource->deleteConfig(BoltConfig::XML_PATH_API_KEY, ScopeInterface::SCOPE_STORES, $websiteId);
+        parent::tearDownInternal();
     }
 
     /**
@@ -66,5 +112,24 @@ class StoreConfigurationRequestBuilderTest extends BoltTestCase
             'store_code' => $this->storeManager->getStore()->getCode()
         ];
         $this->assertEquals($apiData, $expectedApiData);
+    }
+
+    /**
+     * @test
+     */
+    public function testGetRequest_WithoutApiKeys()
+    {
+        $this->expectExceptionMessage('Bolt API Key or Publishable Key - Multi Step is not configured');
+        $websiteId = $this->storeManager->getWebsite()->getId();
+        $configData = [
+            [
+                'path'    => BoltConfig::XML_PATH_PUBLISHABLE_KEY_CHECKOUT,
+                'value'   => '',
+                'scope'   => ScopeInterface::SCOPE_STORES,
+                'scopeId' => $websiteId,
+            ]
+        ];
+        TestUtils::setupBoltConfig($configData);
+        $this->storeConfigurationRequestBuilder->getRequest($this->storeManager->getStore()->getCode());
     }
 }

--- a/view/frontend/templates/js/boltjs.phtml
+++ b/view/frontend/templates/js/boltjs.phtml
@@ -33,6 +33,7 @@ $isDisableTrackJs = ($block->isDisableTrackJsOnHomePage() && $block->isOnHomePag
                     || ($block->isDisableTrackJsOnNonBoltPages() && (!$isLoadBoltJs || !$isLoadConnectJs));
 $isLoadAccountJs = ($block->isBoltSSOEnabled() || $block->isOrderManagementEnabled());
 $isDisableOpenReplayJs = $block->isDisableOpenReplayJs();
+$isShopperAssistantEnabledJs = $block->isShopperAssistantEnabled();
 
 if (!$isDisableTrackJs) {
     $trackJsUrl = $block->getTrackJsUrl();
@@ -86,6 +87,15 @@ if ($isLoadBoltJs && $isLoadConnectJs) {
         id="bolt-account"
         type="text/javascript"
         src="<?= /* @noEscape */ $block->getAccountJsUrl(); ?>"
+        async
+        data-publishable-key="<?= /* @noEscape */ $checkoutKey; ?>">
+    </script>
+<?php endif; ?>
+<?php if ($isShopperAssistantEnabledJs): ?>
+    <script
+        id="bolt-shopper-widget"
+        type="text/javascript"
+        src="<?= /* @noEscape */ $block->getShopperWidgetJsUrl(); ?>"
         async
         data-publishable-key="<?= /* @noEscape */ $checkoutKey; ?>">
     </script>


### PR DESCRIPTION
# Description
If the cart contains any bundle product, the Bolt plugin is unable to get discount details for bundle product. This is related to a bug in M2 core (https://support.magento.com/hc/en-us/articles/4412563019661-MDVA-40435-Discount-on-bundle-product-is-not-applied-correctly-via-GraphQL) and it has been fixed in M2 v2.4.4
And if the merchant still has M2 version older than 2.4.4 installed in the store, we have to use plugin method to collect discount details for cart including bundle product.

Fixes: https://app.asana.com/0/1200879031426307/1202621165399576/f

#changelog Bugfix: unable to get discount details for bundle product

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
