### PR TITLE
Bugfix: Gift wrapping image for item level doesn't show in the Bolt modal

### DIFF
--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -295,6 +295,12 @@ class ShippingMethods implements ShippingMethodsInterface
             if (!isset($quoteItems['total'][$sku])) {
                 $quoteItems['total'][$sku] = 0;
             }
+            if ($total['giftwrapping']->getGwId()) {
+                $quoteItems['quantity'][$sku] += 1;
+            }
+            if ($total['giftwrapping']->getGwItemIds()) {
+                $quoteItems['quantity'][$sku] += count($total['giftwrapping']->getGwItemIds());
+            }
             $quoteItems['quantity'][$sku] += 1;
             $quoteItems['total'][$sku] += CurrencyUtils::toMinor($giftWrapping->getGwPrice() + $giftWrapping->getGwItemsPrice() + $giftWrapping->getGwCardPrice(), $this->quote->getQuoteCurrencyCode());
         }

--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -301,7 +301,6 @@ class ShippingMethods implements ShippingMethodsInterface
             if ($total['giftwrapping']->getGwItemIds()) {
                 $quoteItems['quantity'][$sku] += count($total['giftwrapping']->getGwItemIds());
             }
-            $quoteItems['quantity'][$sku] += 1;
             $quoteItems['total'][$sku] += CurrencyUtils::toMinor($giftWrapping->getGwPrice() + $giftWrapping->getGwItemsPrice() + $giftWrapping->getGwCardPrice(), $this->quote->getQuoteCurrencyCode());
         }
 

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -4861,21 +4861,21 @@ ORDER
 
         $this->giftwrapping = $this->getMockBuilder('\Magento\GiftWrapping\Model\Total\Quote\Giftwrapping')
             ->disableOriginalConstructor()
-            ->setMethods(['getGwId','getGwItemsPrice','getGwCardPrice','getGwPrice','getText','getTitle','getCode'])
+            ->setMethods(['getGwId','getGwItemsPrice','getGwCardPrice','getGwPrice','getText','getTitle','getCode','getGwItemIds'])
             ->getMock();
         ObjectManager::setInstance($this->objectManagerMock);
         $giftWrappingModel = $this->getMockBuilder('Magento\GiftWrapping\Model\Wrapping')
             ->disableOriginalConstructor()
-            ->setMethods(['load','getImageUrl'])
+            ->setMethods(['load','getImageUrl','getBasePrice', 'getDesign'])
             ->getMock();
         $giftWrappingModel->method('load')->willReturnSelf();
         $giftWrappingModel->method('getImageUrl')->willReturn('https://gift-wrap-image.url');
+        $giftWrappingModel->method('getBasePrice')->willReturn('15');
+        $giftWrappingModel->method('getDesign')->willReturn('Design');
         $this->objectManagerMock->expects(static::once())->method('create')
             ->with('Magento\GiftWrapping\Model\Wrapping')->willReturn($giftWrappingModel);
         $this->giftwrapping->method('getGwId')->willReturn(1);
-        $this->giftwrapping->method('getGwItemsPrice')->willReturn('10');
-        $this->giftwrapping->method('getGwCardPrice')->willReturn('0');
-        $this->giftwrapping->method('getGwPrice')->willReturn('5');
+        $this->giftwrapping->method('getGwItemIds')->willReturn(null);
         $this->giftwrapping->method('getTitle')->willReturnSelf();
         $this->giftwrapping->method('getText')->willReturn('Gift Wrapping');
         $this->giftwrapping->method('getCode')->willReturn('gift_id');
@@ -4900,7 +4900,7 @@ ORDER
                 ],
                 [
                     'reference' => 1,
-                    'name' => 'Gift Wrapping',
+                    'name' => 'Gift Wrapping [Design]',
                     'total_amount' => 1500,
                     'unit_price' => 1500,
                     'quantity' => 1,


### PR DESCRIPTION
# Description
Currently, if a customer use gift wrapping on item level, the gift wrapping image doesn't show in the Bolt modal
![image](https://user-images.githubusercontent.com/2002287/180792709-9701cbe7-2bb0-4737-bb81-da2d5cc16a2c.png)

So the PR is to fix the issue by correcting the gift wrapping integration logic

Fixes: 

#changelog Bugfix: Gift wrapping image for item level doesn't show in the Bolt modal

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
