### PR TITLE
Bump up memory for Integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ commands:
                   - run:
                       name: << parameters.php_version >> << parameters.m2_version >> Magento integration
                       command: |
-                        export COMPOSER_MEMORY_LIMIT=3G
+                        export COMPOSER_MEMORY_LIMIT=4G
                         Test/scripts/ci-magento-integration.sh
             - unless:
                 condition: << parameters.is_magento_integration >>


### PR DESCRIPTION
# Description
We are being blocked on our PR's because memory running out during integration tests. 
Example workflow where this occurs:
https://app.circleci.com/pipelines/github/BoltApp/bolt-magento2/15607/workflows/61a7bb93-3bdc-499e-b1ea-4e40c0356940/jobs/50389

#changelog Bump up memory for Integration tests

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
