### PR TITLE
Bugfix: unable to get discount details for bundle product

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -2993,9 +2993,31 @@ class Cart extends AbstractHelper
     public function isCollectDiscountsByPlugin($quote)
     {
         //By default this feature switch is disabled.
-        return $this->deciderHelper->isCollectDiscountsByPlugin()
-            || ($this->configHelper->isActive($quote->getStore()->getId())
-            && version_compare($this->configHelper->getStoreVersion(), '2.3.4', '<'));
+        if ($this->deciderHelper->isCollectDiscountsByPlugin()) {
+            return true;
+        }
+        if (!$this->configHelper->isActive($quote->getStore()->getId())) {
+            return false;
+        }
+        if (version_compare($this->configHelper->getStoreVersion(), '2.3.4', '<')) {
+            return true;
+        }
+        // For bundle product, there is a bug in M2 core (https://github.com/magento/magento2/commit/5dabdb6a104159458fd9c0847447d641e75daa0e, fixed in M2 v2.4.4),
+        // as a result, if the cart contains any bundle product, $address->getExtensionAttributes()->getDiscounts() returns incomplete discounts data.
+        // Then we have to use plugin methods to collect discounts details if M2 version of merchant's store is older than v2.4.4
+        if (version_compare($this->configHelper->getStoreVersion(), '2.4.4', '<')) {
+            $items = $quote->getAllVisibleItems();
+            foreach ($items as $item) {
+                $_product = $item->getProduct();
+                if (!$_product) {
+                    continue;
+                }
+                if ($item->getProductType() == \Magento\Bundle\Model\Product\Type::TYPE_CODE) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
     
     /**


### PR DESCRIPTION
If the cart contains any bundle product, the Bolt plugin is unable to get discount details for bundle product. This is related to a bug in M2 core (https://support.magento.com/hc/en-us/articles/4412563019661-MDVA-40435-Discount-on-bundle-product-is-not-applied-correctly-via-GraphQL) and it has been fixed in M2 v2.4.4
And if the merchant still has M2 version older than 2.4.4 installed in the store, we have to use plugin method to collect discount details for cart including bundle product.

Fixes: https://app.asana.com/0/1200879031426307/1202621165399576/f

#changelog Bugfix: unable to get discount details for bundle product

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
