### PR TITLE
php8 support: fixed strip_tags deprecated parameters calls

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -270,17 +270,17 @@ class Cart extends AbstractHelper
      * @var MsrpHelper
      */
     private $msrpHelper;
-    
+
     /**
      * @var PriceHelper
      */
     private $priceHelper;
-    
+
     /**
      * @var HttpContext
      */
     private $httpContext;
-    
+
     /**
      * @var StoreManagerInterface
      */
@@ -1526,7 +1526,7 @@ class Cart extends AbstractHelper
                 $itemSku = trim($item->getSku());
                 $itemReference = $item->getProductId();
                 $itemName = $item->getName();
-                
+
                 //By default this feature switch is enabled.
                 if ($this->deciderHelper->isCustomizableOptionsSupport()) {
                     try {
@@ -1573,7 +1573,7 @@ class Cart extends AbstractHelper
                 $product['unit_price']   = CurrencyUtils::toMinor($unitPrice, $currencyCode);
                 $product['quantity']     = $quantity;
                 $product['sku']          = $this->getSkuFromQuoteItem($item);
-                
+
                 if ($this->msrpHelper->canApplyMsrp($_product) && $_product->getMsrp() !== null) {
                     $product['msrp']     = CurrencyUtils::toMinor($_product->getMsrp(), $currencyCode);
                 }
@@ -1631,7 +1631,8 @@ class Cart extends AbstractHelper
                 ////////////////////////////////////
                 // Get product description and image
                 ////////////////////////////////////
-                $product['description'] = str_replace(["\r\n", "\n", "\r"], ' ', strip_tags($_product->getDescription()));
+                $product['description'] = ($_product->getDescription() !== null) ?
+                    str_replace(["\r\n", "\n", "\r"], ' ', strip_tags($_product->getDescription())) : '';
                 $variantProductToGetImage = $_product;
 
                 // This will override the $_product with the variant product to get the variant image rather than the main product image.
@@ -2114,13 +2115,13 @@ class Cart extends AbstractHelper
                     );
                     return [];
                 }
-                
+
                 if (!$this->isBackendSession()) {
                     $address->setCollectShippingRates(true);
                     $this->collectAddressTotals($quote, $address);
                     $address->save();
                 }
-                
+
                 // Shipping address
                 $shipAddress = [
                     'first_name' => $address->getFirstname(),
@@ -2138,7 +2139,7 @@ class Cart extends AbstractHelper
 
                 if ($this->isAddressComplete($shipAddress)) {
                     $cost = $address->getShippingAmount();
-                    $shippingService = $address->getShippingDescription();                    
+                    $shippingService = $address->getShippingDescription();
                     $shippingDiscountAmount = $this->eventsForThirdPartyModules->runFilter("collectShippingDiscounts", $address->getShippingDiscountAmount(), $quote, $address);
                     if ($shippingDiscountAmount >= DiscountHelper::MIN_NONZERO_VALUE && !$this->ignoreAdjustingShippingAmount($quote)) {
                         $cost = $cost - $shippingDiscountAmount;
@@ -2285,7 +2286,7 @@ class Cart extends AbstractHelper
         // check if getCouponCode is not null
         /////////////////////////////////////////////////////////////////////////////////
         if (($amount = abs($address->getDiscountAmount())) || $quote->getCouponCode()) {
-            $ruleDiscountDetails = $this->getSaleRuleDiscounts($quote);     
+            $ruleDiscountDetails = $this->getSaleRuleDiscounts($quote);
             list($ruleDiscountDetails, $discounts, $totalAmount) = $this->eventsForThirdPartyModules->runFilter('filterQuoteDiscountDetails', [$ruleDiscountDetails, $discounts, $totalAmount], $quote);
             foreach ($ruleDiscountDetails as $salesruleId => $ruleDiscountAmount) {
                 $rule = $this->ruleRepository->getById($salesruleId);
@@ -2925,7 +2926,7 @@ class Cart extends AbstractHelper
 
         return $this->checkIfQuoteHasCartFixedAmountAndApplyToShippingRule($quote);
     }
-    
+
     /**
      * @param $quote
      * @param $shippingMethod
@@ -2952,7 +2953,7 @@ class Cart extends AbstractHelper
 
         return false;
     }
-    
+
     /**
      * Collect discount amount from each applied sale rules.
      *
@@ -2992,7 +2993,7 @@ class Cart extends AbstractHelper
                 }
             }
         }
-        
+
         $ruleDiscountDetails = [];
         foreach ($salesRuleIds as $salesRuleId) {
             $rule = $this->ruleRepository->getById($salesRuleId);
@@ -3004,7 +3005,7 @@ class Cart extends AbstractHelper
         }
         return $ruleDiscountDetails;
     }
-    
+
     /**
      * If the Magento version < 2.3.4, we still collect discounts details via plugin methods.
      *
@@ -3041,7 +3042,7 @@ class Cart extends AbstractHelper
         }
         return false;
     }
-    
+
     /**
      * Get SKU of quote item
      *
@@ -3061,7 +3062,7 @@ class Cart extends AbstractHelper
             $product->setData('sku_type', $oldSkuType);
             return $itemSku;
         }
-        
+
         return trim($item->getSku());
     }
 }


### PR DESCRIPTION
# Description
Fixed issue with legacy approach for products without description, which is block bolt popup:

Deprecated Functionality: strip_tags(): Passing null to parameter #1 ($string) of type string is deprecated in \/var\/code\/magento\/app\/code\/Bolt\/Boltpay\/Helper\/Cart.php on line 1612

Fixes: https://app.asana.com/0/0/1202726792165718/f

#changelog php8 support: fixed strip_tags deprecated parameters calls

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
