### PR TITLE
[API-driven] Enable token-based authentication

### DIFF
--- a/Controller/Adminhtml/System/ProcessIntegrationToken.php
+++ b/Controller/Adminhtml/System/ProcessIntegrationToken.php
@@ -30,6 +30,11 @@ use Bolt\Boltpay\Helper\IntegrationManagement;
 class ProcessIntegrationToken extends Action
 {
     /**
+     * XML Path for Enable Integration as Bearer
+     */
+    const CONFIG_PATH_INTEGRATION_BEARER = 'oauth/consumer/enable_integration_as_bearer';
+    
+    /**
      * @var \Magento\Framework\Controller\Result\JsonFactory
      */
     protected $resultJsonFactory;
@@ -112,6 +117,9 @@ class ProcessIntegrationToken extends Action
                     $boltMode = $this->boltConfigHelper->isSandboxModeSet($storeId) ? IntegrationManagement::BOLT_INTEGRATION_MODE_SANDBOX : IntegrationManagement::BOLT_INTEGRATION_MODE_PRODUCTION;
                     // Update related config.
                     $this->resourceConfig->saveConfig(BoltConfigHelper::XML_PATH_CONNECT_INTEGRATION_MODE, $boltMode);
+                    if (version_compare($this->boltConfigHelper->getStoreVersion(), '2.4.4', '>=')) {
+                        $this->resourceConfig->saveConfig(self::CONFIG_PATH_INTEGRATION_BEARER, true);
+                    }
                     $this->cache->cleanType('config');
                     return $result->setData(['status' => 'success',
                                              'integration_mode' => $boltMode,


### PR DESCRIPTION
# Description
From Magento 2.4.4, the integration tokens can no longer be used for API Bearer token authentication. Previously, an integration token could be used as a standalone key for token-based authentication. However, this behavior has been disabled by default due to the security implications of a never-expiring access token. 
Then to restore this behavior for API-driven, we have to update the related setting (Stores > Configuration > Services > OAuth > Consumer Settings > Allow OAuth Access Tokens to be used as standalone Bearer tokens option to Yes.) when sending API keys to Bolt.

Fixes: https://app.asana.com/0/1200879031426307/1202585550729365/f

#changelog [API-driven] Enable token-based authentication

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
