### PR TITLE
[API-driven] Add support for Amasty Extrafee extension

### DIFF
--- a/ThirdPartyModules/Amasty/Extrafee.php
+++ b/ThirdPartyModules/Amasty/Extrafee.php
@@ -87,6 +87,7 @@ class Extrafee
         list($products, $totalAmount, $diff) = $result;
         $totals = $quote->getTotals();
         if ($totals && key_exists(self::AMASTY_EXTRAFEE, $totals) && $totals[self::AMASTY_EXTRAFEE]['value'] > 0) {
+            $this->_extrafeeCollectionFactory = $extrafeeCollectionFactory;
             $feeDatas = $this->getFeesDataFromQuote($quote)->addFieldToFilter('option_id', ['neq' => '0'])->getItems();
             foreach ($feeDatas as $feeOption) {
                 $currencyCode = $quote->getQuoteCurrencyCode();


### PR DESCRIPTION
# Description
For native API, the property $this->_extrafeeCollectionFactory is null when trying to add extra fee in the filter method.

Fixes: https://app.asana.com/0/1201931884901947/1202731054395069/f

#changelog [API-driven] Add support for Amasty Extrafee extension

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
