### PR TITLE
Use default placeholder image for Amasty extra fee

### DIFF
--- a/ThirdPartyModules/Amasty/Extrafee.php
+++ b/ThirdPartyModules/Amasty/Extrafee.php
@@ -64,7 +64,7 @@ class Extrafee
                     "name" => $option['label'],
                     "description" => $option['label'],
                     "productId" => self::AMASTY_EXTRAFEE_PREFIX . '_' . $feeId . '_' . $optionId,
-                    "imageUrl" => "https://cdn.routeapp.io/route-widget/images/RouteLogoIcon.png",
+                    "imageUrl" => "",
                     "price" => CurrencyUtils::toMinor($option['price'], $currencyCode),
                 ];
             }


### PR DESCRIPTION
# Description
Use default placeholder image instead of Route fee icon for Amasty extra fee

Fixes: (link ticket)

#changelog Use default placeholder image for Amasty extra fee

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
