### PR TITLE
magento api driven: shipperhq custom shipping rates on admin support

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -88,6 +88,8 @@ class Cart extends AbstractHelper
     const BOLT_CHECKOUT_TYPE_PPC_COMPLETE = 4;
 
     const MAGENTO_SKU_DELIMITER = '-';
+    const SHIPPER_HQ_ADMIN_SHIPPING_METHOD = 'shipperadmin_adminshipping';
+    const SHIPPER_HQ_SKIP_QUOTE_COLLECT_TOTALS = 'shipperhq_skip_quote_collect';
 
     /** @var CacheInterface */
     private $cache;
@@ -269,12 +271,12 @@ class Cart extends AbstractHelper
      * @var MsrpHelper
      */
     private $msrpHelper;
-    
+
     /**
      * @var PriceHelper
      */
     private $priceHelper;
-    
+
     /**
      * @var Store
      */
@@ -1517,7 +1519,7 @@ class Cart extends AbstractHelper
                 $itemSku = trim($item->getSku());
                 $itemReference = $item->getProductId();
                 $itemName = $item->getName();
-                
+
                 //By default this feature switch is enabled.
                 if ($this->deciderHelper->isCustomizableOptionsSupport()) {
                     try {
@@ -1564,7 +1566,7 @@ class Cart extends AbstractHelper
                 $product['unit_price']   = CurrencyUtils::toMinor($unitPrice, $currencyCode);
                 $product['quantity']     = $quantity;
                 $product['sku']          = $this->getSkuFromQuoteItem($item);
-                
+
                 if ($this->msrpHelper->canApplyMsrp($_product) && $_product->getMsrp() !== null) {
                     $product['msrp']     = CurrencyUtils::toMinor($_product->getMsrp(), $currencyCode);
                 }
@@ -2105,13 +2107,13 @@ class Cart extends AbstractHelper
                     );
                     return [];
                 }
-                
+
                 if (!$this->isBackendSession()) {
                     $address->setCollectShippingRates(true);
                     $this->collectAddressTotals($quote, $address);
                     $address->save();
                 }
-                
+
                 // Shipping address
                 $shipAddress = [
                     'first_name' => $address->getFirstname(),
@@ -2129,7 +2131,7 @@ class Cart extends AbstractHelper
 
                 if ($this->isAddressComplete($shipAddress)) {
                     $cost = $address->getShippingAmount();
-                    $shippingService = $address->getShippingDescription();                    
+                    $shippingService = $address->getShippingDescription();
                     $shippingDiscountAmount = $this->eventsForThirdPartyModules->runFilter("collectShippingDiscounts", $address->getShippingDiscountAmount(), $quote, $address);
                     if ($shippingDiscountAmount >= DiscountHelper::MIN_NONZERO_VALUE && !$this->ignoreAdjustingShippingAmount($quote)) {
                         $cost = $cost - $shippingDiscountAmount;
@@ -2276,7 +2278,7 @@ class Cart extends AbstractHelper
         // check if getCouponCode is not null
         /////////////////////////////////////////////////////////////////////////////////
         if (($amount = abs((float)$address->getDiscountAmount())) || $quote->getCouponCode()) {
-            $ruleDiscountDetails = $this->getSaleRuleDiscounts($quote);     
+            $ruleDiscountDetails = $this->getSaleRuleDiscounts($quote);
             list($ruleDiscountDetails, $discounts, $totalAmount) = $this->eventsForThirdPartyModules->runFilter('filterQuoteDiscountDetails', [$ruleDiscountDetails, $discounts, $totalAmount], $quote);
             foreach ($ruleDiscountDetails as $salesruleId => $ruleDiscountAmount) {
                 $rule = $this->ruleRepository->getById($salesruleId);
@@ -2913,7 +2915,7 @@ class Cart extends AbstractHelper
 
         return $this->checkIfQuoteHasCartFixedAmountAndApplyToShippingRule($quote);
     }
-    
+
     /**
      * @param $quote
      * @param $shippingMethod
@@ -2940,7 +2942,7 @@ class Cart extends AbstractHelper
 
         return false;
     }
-    
+
     /**
      * Collect discount amount from each applied sale rules.
      *
@@ -2980,7 +2982,7 @@ class Cart extends AbstractHelper
                 }
             }
         }
-        
+
         $ruleDiscountDetails = [];
         foreach ($salesRuleIds as $salesRuleId) {
             $rule = $this->ruleRepository->getById($salesRuleId);
@@ -2992,7 +2994,7 @@ class Cart extends AbstractHelper
         }
         return $ruleDiscountDetails;
     }
-    
+
     /**
      * If the Magento version < 2.3.4, we still collect discounts details via plugin methods.
      *
@@ -3029,7 +3031,7 @@ class Cart extends AbstractHelper
         }
         return false;
     }
-    
+
     /**
      * Get SKU of quote item
      *
@@ -3049,10 +3051,10 @@ class Cart extends AbstractHelper
             $product->setData('sku_type', $oldSkuType);
             return $itemSku;
         }
-        
+
         return trim($item->getSku());
     }
-    
+
     /**
      * Set current store currency code
      *

--- a/Plugin/Magento/Checkout/Model/ShippingInformationManagementPlugin.php
+++ b/Plugin/Magento/Checkout/Model/ShippingInformationManagementPlugin.php
@@ -55,7 +55,9 @@ class ShippingInformationManagementPlugin
         ShippingInformationInterface $addressInformation
     ) {
         $quote = $this->cartRepository->getActive($cartId);
-        $quote->setData(Cart::SHIPPER_HQ_SKIP_QUOTE_COLLECT_TOTALS, true);
+        if ($quote->getShippingAddress()->getShippingMethod() === Cart::SHIPPER_HQ_ADMIN_SHIPPING_METHOD) {
+            $quote->setData(Cart::SHIPPER_HQ_SKIP_QUOTE_COLLECT_TOTALS, true);
+        }
         return [$cartId, $addressInformation];
     }
 }

--- a/Plugin/Magento/Checkout/Model/ShippingInformationManagementPlugin.php
+++ b/Plugin/Magento/Checkout/Model/ShippingInformationManagementPlugin.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2022 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+namespace Bolt\Boltpay\Plugin\Magento\Checkout\Model;
+
+use Magento\Checkout\Api\Data\ShippingInformationInterface;
+use Magento\Checkout\Api\ShippingInformationManagementInterface;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Bolt\Boltpay\Helper\Cart;
+
+/**
+ * Shipping information management plugin for supporting ShipperHQ custom admin shipping rate ability
+ */
+class ShippingInformationManagementPlugin
+{
+    /**
+     * @var CartRepositoryInterface
+     */
+    private $cartRepository;
+
+    /**
+     * @param CartRepositoryInterface $cartRepository
+     */
+    public function __construct(CartRepositoryInterface $cartRepository)
+    {
+        $this->cartRepository = $cartRepository;
+    }
+
+    /**
+     * Set skipping collect totals flag for quote with shipper hq custom admin shipping rate
+     *
+     * @param ShippingInformationManagementInterface $subject
+     * @param $cartId
+     * @param ShippingInformationInterface $addressInformation
+     * @return array
+     * @throws NoSuchEntityException
+     */
+    public function beforeSaveAddressInformation(
+        ShippingInformationManagementInterface $subject,
+        $cartId,
+        ShippingInformationInterface $addressInformation
+    ) {
+        $quote = $this->cartRepository->getActive($cartId);
+        $quote->setData(Cart::SHIPPER_HQ_SKIP_QUOTE_COLLECT_TOTALS, true);
+        return [$cartId, $addressInformation];
+    }
+}

--- a/Plugin/Magento/Quote/Model/PaymentMethodManagementPlugin.php
+++ b/Plugin/Magento/Quote/Model/PaymentMethodManagementPlugin.php
@@ -55,7 +55,9 @@ class PaymentMethodManagementPlugin
         PaymentInterface $method
     ) {
         $quote = $this->cartRepository->get($cartId);
-        $quote->setData(Cart::SHIPPER_HQ_SKIP_QUOTE_COLLECT_TOTALS, true);
+        if ($quote->getShippingAddress()->getShippingMethod() === Cart::SHIPPER_HQ_ADMIN_SHIPPING_METHOD) {
+            $quote->setData(Cart::SHIPPER_HQ_SKIP_QUOTE_COLLECT_TOTALS, true);
+        }
         return [$cartId, $method];
     }
 }

--- a/Plugin/Magento/Quote/Model/PaymentMethodManagementPlugin.php
+++ b/Plugin/Magento/Quote/Model/PaymentMethodManagementPlugin.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2022 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+namespace Bolt\Boltpay\Plugin\Magento\Quote\Model;
+
+use Magento\Quote\Api\PaymentMethodManagementInterface;
+use Magento\Quote\Api\Data\PaymentInterface;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Bolt\Boltpay\Helper\Cart;
+
+/**
+ * Payment method management plugin for supporting ShipperHQ custom admin shipping rate ability
+ */
+class PaymentMethodManagementPlugin
+{
+    /**
+     * @var CartRepositoryInterface
+     */
+    private $cartRepository;
+
+    /**
+     * @param CartRepositoryInterface $cartRepository
+     */
+    public function __construct(CartRepositoryInterface $cartRepository)
+    {
+        $this->cartRepository = $cartRepository;
+    }
+
+    /**
+     * Set skipping collect totals flag for quote with shipper hq custom admin shipping rate
+     *
+     * @param PaymentMethodManagementInterface $subject
+     * @param $cartId
+     * @param PaymentInterface $method
+     * @return array
+     * @throws NoSuchEntityException
+     */
+    public function beforeSet(
+        PaymentMethodManagementInterface $subject,
+        $cartId,
+        PaymentInterface $method
+    ) {
+        $quote = $this->cartRepository->get($cartId);
+        $quote->setData(Cart::SHIPPER_HQ_SKIP_QUOTE_COLLECT_TOTALS, true);
+        return [$cartId, $method];
+    }
+}

--- a/Plugin/Magento/Quote/Model/QuotePlugin.php
+++ b/Plugin/Magento/Quote/Model/QuotePlugin.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2022 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+namespace Bolt\Boltpay\Plugin\Magento\Quote\Model;
+
+use Magento\Quote\Model\Quote;
+use Bolt\Boltpay\Helper\Cart;
+
+/**
+ * Quote plugin for supporting ShipperHQ custom admin shipping rate ability
+ */
+class QuotePlugin
+{
+    /**
+     * Skipping collect totals for quote with shipper hq custom admin shipping rate and marked flag
+     *
+     * @param Quote $subject
+     * @param callable $proceed
+     * @return Quote
+     */
+    public function aroundCollectTotals(
+        Quote $subject,
+        callable $proceed
+    ) {
+        if ($subject->getData(Cart::SHIPPER_HQ_SKIP_QUOTE_COLLECT_TOTALS) &&
+            $subject->getShippingAddress()->getShippingMethod() === Cart::SHIPPER_HQ_ADMIN_SHIPPING_METHOD
+        ) {
+            return $subject;
+        }
+
+        return $proceed();
+    }
+}

--- a/etc/webapi_rest/di.xml
+++ b/etc/webapi_rest/di.xml
@@ -32,4 +32,18 @@
                 type="Bolt\Boltpay\Plugin\WebapiRest\Magento\Quote\Model\QuotePlugin"
                 sortOrder="1"/>
     </type>
+
+    <!-- ShipperHQ admin custom shipping rate api driven integration support -->
+    <type name="Magento\Checkout\Api\ShippingInformationManagementInterface">
+        <plugin name="Bolt_BoltPay_Checkout_Api_ShippingInformationManagement"
+                type="Bolt\Boltpay\Plugin\Magento\Checkout\Model\ShippingInformationManagementPlugin"/>
+    </type>
+    <type name="Magento\Quote\Api\PaymentMethodManagementInterface">
+        <plugin name="Bolt_BoltPay_Checkout_Api_PaymentMethodManagement"
+                type="Bolt\Boltpay\Plugin\Magento\Quote\Model\PaymentMethodManagementPlugin"/>
+    </type>
+    <type name="Magento\Quote\Model\Quote">
+        <plugin name="Bolt_BoltPay_Quote_Model_Quote"
+                type="Bolt\Boltpay\Plugin\Magento\Quote\Model\QuotePlugin"/>
+    </type>
 </config>


### PR DESCRIPTION
# Description
Fixed shipperhq custom shipping rate issue on admin create order by using enabled API_DRIVEN_INTEGRRATION_ENABLED feature. Skipped quote collect totals calls during creating an order with shipperhq custom shipping rates method: quote is not require recalculation on this step on admin, a quota already have correct values when we are placing an order on admin page.

Issue was caused by missed custom shipperHQ shipping rate during collect totals calls witch is required for shipping-information/payment-information magento api calls during placing an order with api driven enabled on backend.
By default shipperHQ use default magento createOrder controller for placing an order and use admin session to save custom rate data and also blocking recalculation collect totals in ShipperHQ\Shipper\Observer\SaveShippingAdmin::execute() ->

` $isCustomMethodSelected = strstr((string) $shippingMethod, 'shipperadmin');
                    if ($isCustomMethodSelected) {
                        $shipData = $this->getAdminShipData->execute();
                        $customMethodTitle = $shipData ? 'Custom Shipping Rate - ' . $shipData->getCustomCarrier() : 'Custom Shipping Rate';
                        $this->carrierGroupHelper->setCustomShippingOnItems(
                            $quote->getShippingAddress(),
                            $customMethodTitle
                        );
                    } else {
                        $this->carrierGroupHelper->saveCarrierGroupInformation(
                            $quote->getShippingAddress(),
                            $shippingMethod,
                            $additionalDetailArray
                        );
                    }
                    if ($isCustomMethodSelected && $requestData['collect_shipping_rates'] === 1) {
                        $observer->getRequestModel()->setPostValue('collect_shipping_rates', 0);
                    }`

Fixes: [(link ticket)](https://app.asana.com/0/1201931884901947/1202768603334668/f)]

#changelog magento api driven: shipperhq custom shipping rates on admin support

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
