### PR TITLE
[API-driven] Bugfix: Total mismatch between Bolt cart and Magento cart

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -882,7 +882,10 @@ class Cart extends AbstractHelper
             $this->deactivateSessionQuote($quote);
             return;
         }
-
+        
+        if (version_compare($this->configHelper->getStoreVersion(), '2.3.6', '<') && $this->deciderHelper->isAPIDrivenIntegrationEnabled()) {
+            $this->saveQuote($quote);
+        }
 
         // If storeId was missed through request, then try to get it from the session quote.
         if ($storeId === null) {


### PR DESCRIPTION
# Description
Due to a bug in Magento core (https://github.com/magento/magento2/commit/c5563f254f3e28d9c1b6cc4ae04bcad4fd7faf56), if we add a configurable product to cart and there is a "Fixed amount discount for whole cart" sale rule being automatically applied to cart, both child item and parent item get discounted, but Magento cart only collect discounts of child item. Then the total mismatch happens. 

Solution : save quote via repository once Bolt cart is created.

Fixes: https://app.asana.com/0/1201669303758312/1202880033146584/f

#changelog [API-driven] Bugfix: Total mismatch between Bolt cart and Magento cart

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
