### PR TITLE
Skip cart discount total mismatch when needed

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -2325,12 +2325,9 @@ class Cart extends AbstractHelper
             if ($this->deciderHelper->isAPIDrivenIntegrationEnabled()
                 && $this->deciderHelper->isSkipCartDiscountTotalMismatch()
                 && $amount) {
-                usort($discounts, function ($a, $b) {
-                    return $b['amount'] <=> $a['amount'];
-                });
                 $discounts[0]['amount'] += $amount;
                 $totalAmount -= $amount;
-                $this->bugsnag->notifyError('Cart discount total mismatch', "Skip cart discount total mismatch. Actual Mismatch {$amount}");
+                $this->bugsnag->notifyError('Cart discount total mismatch', "Skip cart discount total mismatch. Actual Mismatch {$amount}. Discounts details: " . var_export($discounts, true));
             }
         }
         /////////////////////////////////////////////////////////////////////////////////

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -2279,6 +2279,7 @@ class Cart extends AbstractHelper
         // check if getCouponCode is not null
         /////////////////////////////////////////////////////////////////////////////////
         if (($amount = abs((float)$address->getDiscountAmount())) || $quote->getCouponCode()) {
+            $amount = CurrencyUtils::toMinor($amount, $currencyCode);
             $ruleDiscountDetails = $this->getSaleRuleDiscounts($quote);     
             list($ruleDiscountDetails, $discounts, $totalAmount) = $this->eventsForThirdPartyModules->runFilter('filterQuoteDiscountDetails', [$ruleDiscountDetails, $discounts, $totalAmount], $quote);
             foreach ($ruleDiscountDetails as $salesruleId => $ruleDiscountAmount) {
@@ -2318,7 +2319,18 @@ class Cart extends AbstractHelper
 
                         break;
                 }
+                $amount -= $roundedAmount;
                 $totalAmount -= $roundedAmount;
+            }
+            if ($this->deciderHelper->isAPIDrivenIntegrationEnabled()
+                && $this->deciderHelper->isSkipCartDiscountTotalMismatch()
+                && $amount) {
+                usort($discounts, function ($a, $b) {
+                    return $b['amount'] <=> $a['amount'];
+                });
+                $discounts[0]['amount'] += $amount;
+                $totalAmount -= $amount;
+                $this->bugsnag->notifyError('Cart discount total mismatch', "Skip cart discount total mismatch. Actual Mismatch {$amount}");
             }
         }
         /////////////////////////////////////////////////////////////////////////////////

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -2325,9 +2325,14 @@ class Cart extends AbstractHelper
             if ($this->deciderHelper->isAPIDrivenIntegrationEnabled()
                 && $this->deciderHelper->isSkipCartDiscountTotalMismatch()
                 && $amount) {
-                $discounts[0]['amount'] += $amount;
+                uasort($discounts, function ($a, $b) {
+                    return $b['amount'] <=> $a['amount'];
+                });
+                $firstKey = array_key_first($discounts);
+                $discounts[$firstKey]['amount'] += $amount;
+                ksort($discounts);
                 $totalAmount -= $amount;
-                $this->bugsnag->notifyError('Cart discount total mismatch', "Skip cart discount total mismatch. Actual Mismatch {$amount}. Discounts details: " . var_export($discounts, true));
+                $this->bugsnag->notifyError('Cart discount total mismatch', "Skip cart discount total mismatch. Actual Mismatch {$amount}. Discounts details: (before rounding)" . var_export($ruleDiscountDetails, true) . " (after rounding) " .var_export($discounts, true));
             }
         }
         /////////////////////////////////////////////////////////////////////////////////

--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -501,4 +501,16 @@ class Decider extends AbstractHelper
     {
         return $this->isSwitchEnabled(Definitions::M2_ENABLE_SHOPPER_ASSISTANT);
     }
+    
+    /**
+     * Checks whether the feature switch for skipping cart discount total mismatch
+     *
+     * @return bool whether the feature switch is enabled
+     *
+     * @throws LocalizedException if the feature switch key is unknown
+     */
+    public function isSkipCartDiscountTotalMismatch()
+    {
+        return $this->isSwitchEnabled(Definitions::M2_SKIP_CART_DISCOUNT_TOTAL_MISMATCH);
+    }
 }

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -291,6 +291,11 @@ class Definitions
      * Enable shopper assistant
      */
     const M2_ENABLE_SHOPPER_ASSISTANT = 'M2_ENABLE_SHOPPER_ASSISTANT';
+    
+    /**
+     * Skip cart discount total mismatch
+     */
+    const M2_SKIP_CART_DISCOUNT_TOTAL_MISMATCH = 'M2_SKIP_CART_DISCOUNT_TOTAL_MISMATCH';
 
     const DEFAULT_SWITCH_VALUES = [
         self::M2_SAMPLE_SWITCH_NAME => [
@@ -595,6 +600,12 @@ class Definitions
         ],
         self::M2_ENABLE_SHOPPER_ASSISTANT => [
             self::NAME_KEY        => self::M2_ENABLE_SHOPPER_ASSISTANT,
+            self::VAL_KEY         => true,
+            self::DEFAULT_VAL_KEY => false,
+            self::ROLLOUT_KEY     => 0
+        ],
+        self::M2_SKIP_CART_DISCOUNT_TOTAL_MISMATCH => [
+            self::NAME_KEY        => self::M2_SKIP_CART_DISCOUNT_TOTAL_MISMATCH,
             self::VAL_KEY         => true,
             self::DEFAULT_VAL_KEY => false,
             self::ROLLOUT_KEY     => 0


### PR DESCRIPTION
# Description
We face cases that the discount total is different between Bolt cart and M2 cart when the native API is enabled, it could be caused by various reasons. For now we just add a new feature switch M2_SKIP_CART_DISCOUNT_TOTAL_MISMATCH to skip such mismatch when needed.

Fixes: https://app.asana.com/0/1201931884901947/1202975415590108/f

#changelog Skip cart discount total mismatch when needed

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
