### PR TITLE
Module Retriever Update

### DIFF
--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -501,4 +501,16 @@ class Decider extends AbstractHelper
     {
         return $this->isSwitchEnabled(Definitions::M2_ENABLE_SHOPPER_ASSISTANT);
     }
+
+    /**
+     * Checks whether the feature switch for module retriever fetching from setup_module m2 table is enabled
+     *
+     * @return bool whether the feature switch is enabled
+     *
+     * @throws LocalizedException if the feature switch key is unknown
+     */
+    public function isEnabledModuleRetrieverFromSetupModuleTable()
+    {
+        return $this->isSwitchEnabled(Definitions::M2_ENABLE_MODULE_RETRIEVER_FROM_SETUP_MODULE_TABLE);
+    }
 }

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -288,6 +288,11 @@ class Definitions
     const M2_STORE_CONFIGURATION_WEBHOOK = 'M2_STORE_CONFIGURATION_WEBHOOK';
 
     /**
+     * Enable fetching data from magento setup_module table instead of using core methods
+     */
+    const M2_ENABLE_MODULE_RETRIEVER_FROM_SETUP_MODULE_TABLE = 'M2_ENABLE_MODULE_RETRIEVER_FROM_SETUP_MODULE_TABLE';
+
+    /**
      * Enable shopper assistant
      */
     const M2_ENABLE_SHOPPER_ASSISTANT = 'M2_ENABLE_SHOPPER_ASSISTANT';
@@ -598,6 +603,12 @@ class Definitions
             self::VAL_KEY         => true,
             self::DEFAULT_VAL_KEY => false,
             self::ROLLOUT_KEY     => 0
-        ]
+        ],
+        self::M2_ENABLE_MODULE_RETRIEVER_FROM_SETUP_MODULE_TABLE => [
+            self::NAME_KEY        => self::M2_ENABLE_MODULE_RETRIEVER_FROM_SETUP_MODULE_TABLE,
+            self::VAL_KEY         => true,
+            self::DEFAULT_VAL_KEY => false,
+            self::ROLLOUT_KEY     => 0
+        ],
     ];
 }

--- a/Helper/ModuleRetriever.php
+++ b/Helper/ModuleRetriever.php
@@ -18,11 +18,23 @@
 namespace Bolt\Boltpay\Helper;
 
 use Magento\Framework\Module\FullModuleList;
+use Magento\Framework\App\ResourceConnection;
 use Bolt\Boltpay\Model\Api\Data\PluginVersionFactory;
+use Bolt\Boltpay\Helper\FeatureSwitch\Decider;
 
 class ModuleRetriever
 {
     private const UNDEFINED_MODULE_VERSION = 'undefined';
+
+    /**
+     * @var ResourceConnection $resource
+     */
+    private $resource;
+
+    /**
+     * @var Decider
+     */
+    private $featureSwitches;
 
     /**
      * @var PluginVersionFactory
@@ -40,15 +52,20 @@ class ModuleRetriever
     private $bugsnag;
 
     /**
+     * @param Decider $featureSwitches
      * @param PluginVersionFactory $pluginVersionFactory
      * @param FullModuleList $fullModuleList
      * @param Bugsnag $bugsnag
      */
     public function __construct(
+        Decider $featureSwitches,
+        ResourceConnection $resource,
         PluginVersionFactory $pluginVersionFactory,
         FullModuleList $fullModuleList,
         Bugsnag $bugsnag
     ) {
+        $this->featureSwitches = $featureSwitches;
+        $this->resource = $resource;
         $this->pluginVersionFactory = $pluginVersionFactory;
         $this->fullModuleList = $fullModuleList;
         $this->bugsnag = $bugsnag;
@@ -58,12 +75,16 @@ class ModuleRetriever
     {
         $installedModules = [];
         try {
-            foreach ($this->fullModuleList->getAll() as $module) {
-                $pluginName = $module['name'];
-                $pluginVersion = ($module['setup_version']) ?: self::UNDEFINED_MODULE_VERSION;
+            $isUseModulesListFromDatabase = $this->featureSwitches->isEnabledModuleRetrieverFromSetupModuleTable();
+            $modulesList = ($isUseModulesListFromDatabase)
+                ? $this->getModulesListFromSetupModuleTable()
+                : $this->getModulesList();
+            foreach ($modulesList as $module) {
+                $moduleName = $this->getModuleName($module, $isUseModulesListFromDatabase);
+                $moduleVersion = $this->getModuleVersion($module, $isUseModulesListFromDatabase);
                 $plugin = $this->pluginVersionFactory->create()
-                    ->setName($pluginName)
-                    ->setVersion($pluginVersion);
+                    ->setName($moduleName)
+                    ->setVersion($moduleVersion);
                 $installedModules[] = $plugin;
             }
         } catch (\Exception $e) {
@@ -71,5 +92,53 @@ class ModuleRetriever
         } finally {
             return $installedModules;
         }
+    }
+
+    /**
+     * Returns module version
+     *
+     * @param array $module
+     * @param bool $isUseModulesListFromDatabase
+     * @return string
+     */
+    private function getModuleVersion(array $module, bool $isUseModulesListFromDatabase): string
+    {
+        if ($isUseModulesListFromDatabase) {
+            return $module['schema_version'];
+        }
+        return ($module['setup_version']) ?: self::UNDEFINED_MODULE_VERSION;
+    }
+
+    /**
+     * Returns module name
+     *
+     * @param array $module
+     * @param bool $isUseModulesListFromDatabase
+     * @return string
+     */
+    private function getModuleName(array $module, bool $isUseModulesListFromDatabase): string
+    {
+        return ($isUseModulesListFromDatabase) ? $module['module'] : $module['name'];
+    }
+
+    /**
+     * Returns modules list by CORE methods
+     *
+     * @return array|string[]
+     */
+    private function getModulesList(): array
+    {
+        return $this->fullModuleList->getAll();
+    }
+
+    /**
+     * Returns modules list from `setup_module` table
+     *
+     * @return array
+     */
+    private function getModulesListFromSetupModuleTable(): array
+    {
+        $connection = $this->resource->getConnection();
+        return $connection->fetchAll('SELECT module, schema_version FROM setup_module');
     }
 }

--- a/Test/Unit/Helper/ModuleRetrieverTest.php
+++ b/Test/Unit/Helper/ModuleRetrieverTest.php
@@ -18,8 +18,10 @@
 namespace Bolt\Boltpay\Test\Unit\Helper;
 
 use Bolt\Boltpay\Helper\Bugsnag;
+use Bolt\Boltpay\Helper\FeatureSwitch\Definitions;
 use Bolt\Boltpay\Helper\ModuleRetriever;
 use Bolt\Boltpay\Test\Unit\TestHelper;
+use Bolt\Boltpay\Test\Unit\TestUtils;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\DB\Adapter\AdapterInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
@@ -50,7 +52,7 @@ class ModuleRetrieverTest extends BoltTestCase
     /**
      * @test
      */
-    public function getInstalledModules_success()
+    public function getInstalledModules_success_using_core_methods()
     {
         $actual = $this->moduleRetriever->getInstalledModules();
         $this->assertGreaterThan(1, count($actual));
@@ -59,8 +61,19 @@ class ModuleRetrieverTest extends BoltTestCase
     /**
      * @test
      */
-    public function getInstalledModules_fail()
+    public function getInstalledModules_success_using_database()
     {
+        TestUtils::saveFeatureSwitch(Definitions::M2_ENABLE_MODULE_RETRIEVER_FROM_SETUP_MODULE_TABLE, true);
+        $actual = $this->moduleRetriever->getInstalledModules();
+        $this->assertGreaterThan(1, count($actual));
+    }
+
+    /**
+     * @test
+     */
+    public function getInstalledModules_fail_using_database()
+    {
+        TestUtils::saveFeatureSwitch(Definitions::M2_ENABLE_MODULE_RETRIEVER_FROM_SETUP_MODULE_TABLE, true);
         $dbConnection = $this->createMock(AdapterInterface::class);
         $dbConnection->method('fetchAll')->willThrowException(new \Exception());
         $resource = $this->createMock(ResourceConnection::class);


### PR DESCRIPTION
# Description
The Magento Bolt\Boltpay\Helper\ModuleRetriever::getInstalledModules()
is not returning all available magento modules, because if a module uses only db_schema.xml and doesn't have upgrade scripts (the latest version of Amasty_Giftcard, Magento_GiftCards for example) a module doesn't have any record in magento "setup_module" table. In this case we have mismatch with backend "merchant_division_platform_plugin_third_party_plugins" table and some features is not working as expected. By this fix we are using the Magento Core Functionality for fetching available modules. 

Fixes: https://app.asana.com/0/1201931884901947/1202947319621682/f

#changelog Module Retriever Update

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
