### PR TITLE
Public setAddress method in order helper class

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -464,7 +464,7 @@ class Order extends AbstractHelper
      *
      * @throws \Exception
      */
-    protected function setAddress($quoteAddress, $address)
+    public function setAddress($quoteAddress, $address)
     {
         $address = $this->cartHelper->handleSpecialAddressCases($address);
 

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -272,11 +272,7 @@ class OrderTest extends BoltTestCase
 
         $quote = TestUtils::createQuote();
         $quoteAddress = $quote->getShippingAddress();
-        TestHelper::invokeMethod(
-            $this->orderHelper,
-            'setAddress',
-            [$quoteAddress, $addressObject]
-        );
+        $this->orderHelper->setAddress($quoteAddress,$addressObject);
         self::assertEquals($quote->getShippingAddress()->getCity(), 'Beverly Hills');
         self::assertEquals($quote->getShippingAddress()->getCountryId(), 'US');
         self::assertEquals($quote->getShippingAddress()->getCompany(), 'Bolt');


### PR DESCRIPTION
# Description
This PR is to the public the setAddress method in the order helper class so we can use the method easier to do the integration

Here are examples:
https://github.com/BoltApp/bolt-magento2/blob/2.24.1.rossignol.bopis/ThirdPartyModules/Rossignol/Synolia/Store.php#L223
https://github.com/BoltApp/bolt-magento2/blob/2.26.1.metroplex/ThirdPartyModules/Grabagun/InStorePickup.php#L564

Fixes: (link ticket)

#changelog Public setAddress method in order helper class

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
