### PR TITLE
M2 Api Driven Card Integration Feature Switcher Implementation

### DIFF
--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -513,4 +513,16 @@ class Decider extends AbstractHelper
     {
         return $this->isSwitchEnabled(Definitions::M2_ENABLE_MODULE_RETRIEVER_FROM_SETUP_MODULE_TABLE);
     }
+
+    /**
+     * Checks whether the feature switch for api driven cart integration is enabled
+     *
+     * @return bool whether the feature switch is enabled
+     *
+     * @throws LocalizedException if the feature switch key is unknown
+     */
+    public function isAPIDrivenCartIntegrationEnabled()
+    {
+        return $this->isSwitchEnabled(Definitions::M2_ENABLE_API_DRIVEN_CART_INTEGRATION);
+    }
 }

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -297,6 +297,11 @@ class Definitions
      */
     const M2_ENABLE_SHOPPER_ASSISTANT = 'M2_ENABLE_SHOPPER_ASSISTANT';
 
+    /**
+     * Enable API driven cart integration
+     */
+    const M2_ENABLE_API_DRIVEN_CART_INTEGRATION = 'M2_ENABLE_API_DRIVEN_CART_INTEGRATION';
+
     const DEFAULT_SWITCH_VALUES = [
         self::M2_SAMPLE_SWITCH_NAME => [
             self::NAME_KEY        => self::M2_SAMPLE_SWITCH_NAME,
@@ -606,6 +611,12 @@ class Definitions
         ],
         self::M2_ENABLE_MODULE_RETRIEVER_FROM_SETUP_MODULE_TABLE => [
             self::NAME_KEY        => self::M2_ENABLE_MODULE_RETRIEVER_FROM_SETUP_MODULE_TABLE,
+            self::VAL_KEY         => true,
+            self::DEFAULT_VAL_KEY => false,
+            self::ROLLOUT_KEY     => 0
+        ],
+        self::M2_ENABLE_API_DRIVEN_CART_INTEGRATION => [
+            self::NAME_KEY        => self::M2_ENABLE_API_DRIVEN_CART_INTEGRATION,
             self::VAL_KEY         => true,
             self::DEFAULT_VAL_KEY => false,
             self::ROLLOUT_KEY     => 0

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -310,13 +310,13 @@ class CartTest extends BoltTestCase
 
     /** @var MockObject|ObjectManager */
     private $originalObjectManager;
-    
+
     /** @var MockObject|MsrpHelper */
     private $msrpHelper;
-    
+
     /** @var MockObject|PriceHelper */
     private $priceHelper;
-    
+
     /** @var MockObject|Store */
     private $store;
 
@@ -469,6 +469,7 @@ class CartTest extends BoltTestCase
         $this->store = $this->createMock(Store::class);
         $this->currentMock = $this->getCurrentMock(null);
         $this->objectsToClean = [];
+        TestUtils::saveFeatureSwitch(Definitions::M2_ENABLE_API_DRIVEN_CART_INTEGRATION, false);
     }
 
     protected function tearDownInternal()
@@ -3988,7 +3989,7 @@ ORDER
         $rule5->expects(static::once())->method('getDescription')
         ->willReturn('');
         $rule5->method('getSimpleAction')->willReturn('by_fixed');
-        
+
         $rule6 = $this->getMockBuilder(DataObject::class)
             ->setMethods(['getCouponType', 'getDescription','getName','getSimpleAction'])
             ->disableOriginalConstructor()
@@ -4526,7 +4527,7 @@ ORDER
         $this->productMock->method('getCustomOption')->with('option_ids')->willReturn([]);
         $this->productMock->method('getDescription')->willReturn('Product Description');
         $this->productMock->method('getTypeInstance')->willReturn($productTypeConfigurableMock);
-        
+
         $this->msrpHelper->method('canApplyMsrp')->with($this->productMock)->willReturn(true);
 
         $quoteItemMock = $this->getQuoteItemMock();
@@ -4594,7 +4595,7 @@ ORDER
         $this->productMock->method('getDescription')->willReturn('Product Description');
         $this->productMock->method('getTypeInstance')->willReturn($productTypeConfigurableMock);
         $this->productMock->method('getCustomOption')->with('option_ids')->willReturn([]);
-        
+
         $this->msrpHelper->method('canApplyMsrp')->with($this->productMock)->willReturn(false);
 
         $quoteItemMock = $this->getQuoteItemMock();
@@ -4667,7 +4668,7 @@ ORDER
         $quoteItem->method('getOptionByCode')->with('option_ids')->willReturn([]);
         $quoteItem->method('getProductType')->willReturn('simple');
         $productMock->expects(static::once())->method('getTypeInstance')->willReturnSelf();
-        
+
         $this->msrpHelper->method('canApplyMsrp')->with($productMock)->willReturn(false);
 
         $this->deciderHelper->expects(self::exactly(2))->method('isCustomizableOptionsSupport')->willReturn(true);
@@ -4768,7 +4769,7 @@ ORDER
         $quoteItem->method('getProductId')->willReturn(self::PRODUCT_ID);
         $quoteItem->method('getProduct')->willReturn($productMock);
         $productMock->expects(static::once())->method('getTypeInstance')->willReturnSelf();
-        
+
         $this->msrpHelper->method('canApplyMsrp')->with($productMock)->willReturn(false);
 
         $this->imageHelper->method('init')
@@ -4838,7 +4839,7 @@ ORDER
         $quoteItem->method('getProductId')->willReturn(self::PRODUCT_ID);
         $quoteItem->method('getProduct')->willReturn($productMock);
         $productMock->expects(static::once())->method('getTypeInstance')->willReturnSelf();
-        
+
         $this->msrpHelper->method('canApplyMsrp')->with($productMock)->willReturn(false);
 
         $this->imageHelper->method('init')
@@ -4934,7 +4935,7 @@ ORDER
 
         TestUtils::cleanupSharedFixtures([$order]);
     }
-    
+
     /**
      * @test
      * that getCartItemsForOrder returns expected data and attributes
@@ -5257,9 +5258,9 @@ ORDER
         $this->productRepository->expects(static::once())->method('getById')->with(self::PRODUCT_ID)
             ->willReturn($this->productMock);
         $this->quoteMock->expects(static::once())->method('setIsActive')->with(false);
-        
+
         $this->store->expects(static::once())->method('setCurrentCurrencyCode')->with(self::CURRENCY_CODE);
-                           
+
         static::assertEquals($expectedCartData, $cartMock->createCartByRequest($request));
     }
 
@@ -5379,7 +5380,7 @@ ORDER
         $this->productRepository->expects(static::exactly(2))->method('getById')->with(self::PRODUCT_ID)
             ->willReturn($this->productMock);
         $this->quoteMock->expects(static::once())->method('setIsActive')->with(false);
-        
+
         $this->store->expects(static::once())->method('setCurrentCurrencyCode')->with(CartTest::CURRENCY_CODE);
 
         static::assertEquals($expectedCartData, $cartMock->createCartByRequest($request));
@@ -5462,7 +5463,7 @@ ORDER
         $this->productRepository->expects(static::once())->method('getById')->with(self::PRODUCT_ID)
         ->willReturn($this->productMock);
         $this->quoteMock->expects(static::once())->method('setIsActive')->with(false);
-        
+
         $this->store->expects(static::once())->method('setCurrentCurrencyCode')->with(self::CURRENCY_CODE);
 
         static::assertEquals($expectedCartData, $cartMock->createCartByRequest($request));
@@ -5489,7 +5490,7 @@ ORDER
         $customer = $this->createMock(CustomerInterface::class);
         $this->customerRepository->method('getById')->willReturn($customer);
         $this->quoteMock->expects(static::once())->method('assignCustomer')->with($customer);
-        
+
         $this->store->expects(static::once())->method('setCurrentCurrencyCode')->with(CartTest::CURRENCY_CODE);
 
         static::assertEquals($expectedCartData, $currentMock->createCartByRequest($request));
@@ -5515,7 +5516,7 @@ ORDER
         $this->expectException(BoltException::class);
         $this->expectExceptionCode(BoltErrorResponse::ERR_PPC_OUT_OF_STOCK);
         $this->expectExceptionMessage('Product that you are trying to add is not available.');
-        
+
         $this->store->expects(static::once())->method('setCurrentCurrencyCode')->with(CartTest::CURRENCY_CODE);
 
         static::assertEquals($expectedCartData, $currentMock->createCartByRequest($request));
@@ -6963,14 +6964,14 @@ ORDER
     public function getSaleRuleDiscounts_withFreeShippingCouponSpecificCoupon_collectsCoupon()
     {
         $currentMock = $this->getCurrentMock(['getCalculationAddress', 'isCollectDiscountsByPlugin']);
-        
+
         $shippingAddress = $this->getAddressMock();
         $shippingAddress->expects(static::once())->method('getAppliedRuleIds')->willReturn('2');
-        
+
         $quote = $this->getQuoteMock($this->getAddressMock(), $shippingAddress);
         $currentMock->expects(static::once())->method('getCalculationAddress')->with($quote)->willReturn($shippingAddress);
         $currentMock->expects(static::once())->method('isCollectDiscountsByPlugin')->with($quote)->willReturn(true);
-    
+
         $checkoutSession = $this->createPartialMock(
             CheckoutSession::class,
             ['getBoltCollectSaleRuleDiscounts']
@@ -6981,7 +6982,7 @@ ORDER
         $this->sessionHelper->expects(static::once())
             ->method('getCheckoutSession')
             ->willReturn($checkoutSession);
-        
+
         $rule2 = $this->getMockBuilder(DataObject::class)
             ->setMethods(['getCouponType'])
             ->disableOriginalConstructor()
@@ -6997,7 +6998,7 @@ ORDER
         $ruleDiscountDetails = $currentMock->getSaleRuleDiscounts($quote);
         static::assertEquals([2 => 0], $ruleDiscountDetails);
     }
-    
+
         /**
          * @test
          * that getSaleRuleDiscounts properly handles free shipping promotion (no coupon code)
@@ -7009,14 +7010,14 @@ ORDER
     public function getSaleRuleDiscounts_withFreeShippingCouponNoCoupon_collectsCoupon()
     {
         $currentMock = $this->getCurrentMock(['getCalculationAddress', 'isCollectDiscountsByPlugin']);
-        
+
         $shippingAddress = $this->getAddressMock();
         $shippingAddress->expects(static::once())->method('getAppliedRuleIds')->willReturn('2');
-        
+
         $quote = $this->getQuoteMock($this->getAddressMock(), $shippingAddress);
         $currentMock->expects(static::once())->method('getCalculationAddress')->with($quote)->willReturn($shippingAddress);
         $currentMock->expects(static::once())->method('isCollectDiscountsByPlugin')->with($quote)->willReturn(true);
-    
+
         $checkoutSession = $this->createPartialMock(
             CheckoutSession::class,
             ['getBoltCollectSaleRuleDiscounts']
@@ -7027,7 +7028,7 @@ ORDER
         $this->sessionHelper->expects(static::once())
             ->method('getCheckoutSession')
             ->willReturn($checkoutSession);
-        
+
         $rule2 = $this->getMockBuilder(DataObject::class)
             ->setMethods(['getCouponType'])
             ->disableOriginalConstructor()
@@ -7043,10 +7044,10 @@ ORDER
         $ruleDiscountDetails = $currentMock->getSaleRuleDiscounts($quote);
         static::assertEquals([], $ruleDiscountDetails);
     }
-    
+
     /**
      * @test
-     * 
+     *
      * @covers ::getSkuFromQuoteItem
      */
     public function getSkuFromQuoteItem_withBundleItem()

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -455,8 +455,11 @@ class CartTest extends BoltTestCase
             DeciderHelper::class,
             ['ifShouldDisablePrefillAddressForLoggedInCustomer', 'handleVirtualProductsAsPhysical',
              'isIncludeUserGroupIntoCart', 'isAddSessionIdToCartMetadata', 'isCustomizableOptionsSupport',
-             'isPreventBoltCartForQuotesWithError','isAPIDrivenIntegrationEnabled','isUseRuleNameIfDescriptionEmpty']
+             'isPreventBoltCartForQuotesWithError','isAPIDrivenIntegrationEnabled','isUseRuleNameIfDescriptionEmpty',
+             'isAPIDrivenCartIntegrationEnabled'
+            ]
         );
+        $this->deciderHelper->method('isAPIDrivenCartIntegrationEnabled')->willReturn(false);
         $this->eventsForThirdPartyModules = $this->createPartialMock(EventsForThirdPartyModules::class, ['runFilter','dispatchEvent']);
         $this->eventsForThirdPartyModules->method('runFilter')->will($this->returnArgument(1));
         $this->eventsForThirdPartyModules->method('dispatchEvent')->willReturnSelf();
@@ -469,7 +472,6 @@ class CartTest extends BoltTestCase
         $this->store = $this->createMock(Store::class);
         $this->currentMock = $this->getCurrentMock(null);
         $this->objectsToClean = [];
-        TestUtils::saveFeatureSwitch(Definitions::M2_ENABLE_API_DRIVEN_CART_INTEGRATION, false);
     }
 
     protected function tearDownInternal()


### PR DESCRIPTION
# Description
Added new feature switcher: 'M2_ENABLE_API_DRIVEN_CART_INTEGRATION' which is enable fetching cart data by M2 API instead preparing cart data on magento side.

When this feature is enabled the request to Bolt will contains only 'order_reference' => $quote->getId()

Fixes: https://app.asana.com/0/1201931884901947/1203068861777662/f


#changelog new feature switcher added M2_ENABLE_API_DRIVEN_CART_INTEGRATION (is required for future changes on Bolt side)

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [x] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my ticket link and provided a changelog message.
