### PR TITLE
Amasty extra fee support: use default placeholder image

### DIFF
--- a/ThirdPartyModules/Amasty/Extrafee.php
+++ b/ThirdPartyModules/Amasty/Extrafee.php
@@ -98,7 +98,7 @@ class Extrafee
                 $totalAmount += $roundedTotalAmount;
                 $product = [
                     'reference' => self::AMASTY_EXTRAFEE_PREFIX . '_' . $feeOption->getFeeId() . '_' . $feeOption->getOptionId(),
-                    'image_url' => 'https://cdn.routeapp.io/route-widget/images/RouteLogoIcon.png',
+                    'image_url' => '',
                     'name' => $feeOption->getLabel(),
                     'sku' => self::AMASTY_EXTRAFEE_PREFIX . '_' . $feeOption->getFeeId() . '_' . $feeOption->getOptionId(),
                     'description' => '',


### PR DESCRIPTION
In PR https://github.com/BoltApp/bolt-magento2/pull/1632 we fixed placeholder image URL but only in one place, for an add-on.
In this PR we fix the same URL in the other place, for a cart item.

https://app.asana.com/0/1200879031426307/1202780668772807/f

#changelog Amasty extra fee support: use default placeholder image