### PR TITLE
M2 Bolt API GetProduct removed bundle dependency

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -540,7 +540,7 @@ class Config extends AbstractHelper
         \Magento\ConfigurableProduct\Model\Product\Type\Configurable::TYPE_CODE,
         \Magento\Downloadable\Model\Product\Type::TYPE_DOWNLOADABLE,
         \Magento\Catalog\Model\Product\Type::TYPE_BUNDLE,
-        \Magento\GroupedProduct\Model\Product\Type\Grouped::TYPE_CODE
+        'grouped'
     ];
 
     /**


### PR DESCRIPTION
# Description
Removed Magento_Bundle module dependency for "/V1/bolt/boltpay/product" API endpoint

Fixes: https://app.asana.com/0/1201931884901947/1203189967357439/f

#changelog M2 Bolt API GetProduct removed bundle dependency

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
