### PR TITLE
Add integration scopes parent for Magento_Backend::store

### DIFF
--- a/etc/integration/api.xml
+++ b/etc/integration/api.xml
@@ -52,9 +52,11 @@
             <resource name="Magento_Sales::emails" />
             <resource name="Magento_Sales::sales_creditmemo" />
             <resource name="Magento_Backend::marketing" />
-            <resource name="Magento_Backend::store" />
             <resource name="Magento_CatalogRule::promo" />
             <resource name="Magento_SalesRule::quote"/>
+            <resource name="Magento_Backend::stores" />
+            <resource name="Magento_Backend::stores_settings" />
+            <resource name="Magento_Backend::store" />
             <resource name="Magento_GiftCardAccount::customer_giftcardaccount"/>
         </resources>
     </integration>


### PR DESCRIPTION
Add parent scopes to have a proper list of scopes in Magento admin.
Before PR:
![Screenshot 2022-10-27 at 11 21 33](https://user-images.githubusercontent.com/7270718/198232233-9a2d3636-0864-46b9-9a0a-25d36a57136b.png)
After PR:
![Screenshot 2022-10-27 at 11 24 49](https://user-images.githubusercontent.com/7270718/198232256-71a16cdf-8400-4d08-be92-32ec4d776c7a.png)
https://app.asana.com/0/1201931884901947/1203242144329499/f

#changelog Add integration scopes parent for Magento_Backend::store