### PR TITLE
Set the country code of the pickup store depending on the current customer's address

### DIFF
--- a/Block/Checkout/Success.php
+++ b/Block/Checkout/Success.php
@@ -21,6 +21,8 @@ namespace Bolt\Boltpay\Block\Checkout;
 use Bolt\Boltpay\Block\BlockTrait;
 use Bolt\Boltpay\Helper\Config;
 use Bolt\Boltpay\Helper\FeatureSwitch\Decider;
+use Bolt\Boltpay\Model\EventsForThirdPartyModules;
+use Magento\Framework\Session\SessionManager as CheckoutSession;
 use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Element\Template\Context;
 
@@ -29,21 +31,37 @@ class Success extends Template
     use BlockTrait;
 
     /**
+     * @var CheckoutSession
+     */
+    private $checkoutSession;
+
+    /**
+     * @var EventsForThirdPartyModules
+     */
+    protected $eventsForThirdPartyModules;
+
+    /**
      * Success constructor.
      *
      * @param Config  $configHelper
      * @param Context $context
      * @param Decider $featureSwitches
+     * @param CheckoutSession $checkoutSession
+     * @param EventsForThirdPartyModules $eventsForThirdPartyModules
      * @param array   $data
      */
     public function __construct(
         Config $configHelper,
         Context $context,
         Decider $featureSwitches,
+        CheckoutSession $checkoutSession,
+        EventsForThirdPartyModules $eventsForThirdPartyModules,
         array $data = []
     ) {
         parent::__construct($context, $data);
         $this->configHelper = $configHelper;
         $this->featureSwitches = $featureSwitches;
+        $this->checkoutSession = $checkoutSession;
+        $this->eventsForThirdPartyModules = $eventsForThirdPartyModules;
     }
 }

--- a/ThirdPartyModules/Rossignol/Synolia/Store.php
+++ b/ThirdPartyModules/Rossignol/Synolia/Store.php
@@ -139,8 +139,6 @@ class Store
                             }
 
                             $distance = $this->vincentyGreatCircleDistance($coordinates['lat'], $coordinates['lng'], $resultStore->getLatitude(), $resultStore->getLongitude());      
-                            // Convert Kilometer to Mile
-                            $distance = $distance * 0.6213711922;
                             
                             if ($distance < $searchRadius) {
                                 $validStores[$distance * 100] = $resultStore;                       
@@ -163,7 +161,7 @@ class Store
                             $shipToStoreOption->setStoreName(is_null($store->getName()) ? '' : $store->getName());
                             $shipToStoreOption->setAddress($storeAddress);
                             $shipToStoreOption->setDistance(round($distance / 100, 2));
-                            $shipToStoreOption->setDistanceUnit('mi');
+                            $shipToStoreOption->setDistanceUnit('km');
 
                             $shipToStoreOptions[] = $shipToStoreOption;
                         }    

--- a/ThirdPartyModules/Rossignol/Synolia/Store.php
+++ b/ThirdPartyModules/Rossignol/Synolia/Store.php
@@ -133,8 +133,15 @@ class Store
                     if (!empty($collectionResultSearch)) {
                         $validStores = [];
                         foreach ($collectionResultSearch as $resultStore) {
-                            $distance = $this->vincentyGreatCircleDistance($coordinates['lat'], $coordinates['lng'], $resultStore->getLatitude(), $resultStore->getLongitude());         
+                            // Only show stores from the shipping country
+                            if(!is_null($resultStore->getCountry()) && $resultStore->getCountry() !== $addressData['country_code']) {
+                                continue;
+                            }
 
+                            $distance = $this->vincentyGreatCircleDistance($coordinates['lat'], $coordinates['lng'], $resultStore->getLatitude(), $resultStore->getLongitude());      
+                            // Convert Kilometer to Mile
+                            $distance = $distance * 0.6213711922;
+                            
                             if ($distance < $searchRadius) {
                                 $validStores[$distance * 100] = $resultStore;                       
                             }
@@ -156,7 +163,7 @@ class Store
                             $shipToStoreOption->setStoreName(is_null($store->getName()) ? '' : $store->getName());
                             $shipToStoreOption->setAddress($storeAddress);
                             $shipToStoreOption->setDistance(round($distance / 100, 2));
-                            $shipToStoreOption->setDistanceUnit('km');
+                            $shipToStoreOption->setDistanceUnit('mi');
 
                             $shipToStoreOptions[] = $shipToStoreOption;
                         }    

--- a/ThirdPartyModules/Rossignol/Synolia/Store.php
+++ b/ThirdPartyModules/Rossignol/Synolia/Store.php
@@ -219,7 +219,7 @@ class Store
                 if ($this->checkIfRossignolSynoliaInStorePickupByCode($referenceCodes)) {
                     $address = $transaction->order->cart->in_store_shipments[0]->address ?? null;
                     if ($address) {
-                        $address->country_code = 'US'; 
+                        $address->country_code = $transaction->order->cart->in_store_shipments[0]->shipment->shipping_address->country_code;
                         $this->orderHelper->setAddress($quote->getShippingAddress(), $address);
                     }
                 }


### PR DESCRIPTION
# Description
Remove the hard-coded country ID "US" and set the country code of the pickup store depending on the current customer's address.

We don't have the country_id of the selected store for pick up at this point, but since we already have a customization to show only stores that match the country_id of customer's shipping address, we can use it here.

Fixes: BOPIS cannot be used to check out at the Canada store. 

#changelog Set the country code of the pickup store depending on the current customer's address

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server
