### PR TITLE
M2 API: collect totals if route is enabled

### DIFF
--- a/ThirdPartyModules/Route/Route.php
+++ b/ThirdPartyModules/Route/Route.php
@@ -19,6 +19,7 @@ namespace Bolt\Boltpay\ThirdPartyModules\Route;
 
 use Bolt\Boltpay\Helper\Bugsnag;
 use Bolt\Boltpay\Helper\ArrayHelper;
+use Bolt\Boltpay\Helper\FeatureSwitch\Decider as DeciderHelper;
 use Bolt\Boltpay\Helper\Shared\CurrencyUtils;
 use Bolt\Boltpay\Helper\Session as BoltSession;
 use Magento\Quote\Model\Quote;
@@ -57,21 +58,29 @@ class Route
     private $bugsnagHelper;
 
     /**
+     * @var DeciderHelper
+     */
+    private $deciderHelper;
+
+    /**
      * @param CacheInterface  $cache
      * @param BoltSession     $boltSessionHelper
      * @param State           $appState
      * @param Bugsnag         $bugsnagHelper
+     * @param DeciderHelper   $deciderHelper
      */
     public function __construct(
         CacheInterface  $cache,
         BoltSession     $boltSessionHelper,
         State           $appState,
-        Bugsnag         $bugsnagHelper
+        Bugsnag         $bugsnagHelper,
+        DeciderHelper   $deciderHelper
     ) {
         $this->cache = $cache;
         $this->boltSessionHelper = $boltSessionHelper;
         $this->appState = $appState;
         $this->bugsnagHelper = $bugsnagHelper;
+        $this->deciderHelper = $deciderHelper;
     }
 
     /**
@@ -266,11 +275,17 @@ class Route
      */
     public function beforeGetCartDataForCreateCart($merchantClient, $routeDataHelper, $quote, $checkoutSession)
     {
-        if (!$routeDataHelper->isRouteModuleEnable() || (!$routeDataHelper->isFullCoverage() && !$merchantClient->isOptOut())) {
+        if (!$routeDataHelper->isRouteModuleEnable()) {
             return false;
         }
-        
-        $checkoutSession->setInsured(true);
+
+        if ($routeDataHelper->isFullCoverage() || $merchantClient->isOptOut()) {
+            $checkoutSession->setInsured(true);
+        }
+
+        if ($this->deciderHelper->isAPIDrivenIntegrationEnabled()) {
+            $quote->collectTotals();
+        }
     }
     
     private function saveRouteFeeEnabledBeforeUpdateCart($flag, $item, $checkoutSession, $routeFeeEnabled)


### PR DESCRIPTION
When we first time added the product into the cart and the quote created total calculation is done before Route set its data to checkout session.
So we need to recalculate totals one more time.

This is not an issue for the legacy approach because we create a child quote and calculate totals for it.
https://app.asana.com/0/1201931884901947/1203273057259994/f

#changelog M2 API: collect totals if route is enabled