### PR TITLE
Bugfix: Notice Undefined property on the checkout success page

### DIFF
--- a/Block/Checkout/Success.php
+++ b/Block/Checkout/Success.php
@@ -21,6 +21,8 @@ namespace Bolt\Boltpay\Block\Checkout;
 use Bolt\Boltpay\Block\BlockTrait;
 use Bolt\Boltpay\Helper\Config;
 use Bolt\Boltpay\Helper\FeatureSwitch\Decider;
+use Bolt\Boltpay\Model\EventsForThirdPartyModules;
+use Magento\Framework\Session\SessionManager as CheckoutSession;
 use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Element\Template\Context;
 
@@ -29,21 +31,37 @@ class Success extends Template
     use BlockTrait;
 
     /**
+     * @var CheckoutSession
+     */
+    private $checkoutSession;
+
+    /**
+     * @var EventsForThirdPartyModules
+     */
+    protected $eventsForThirdPartyModules;
+
+    /**
      * Success constructor.
      *
      * @param Config  $configHelper
      * @param Context $context
      * @param Decider $featureSwitches
+     * @param CheckoutSession $checkoutSession
+     * @param EventsForThirdPartyModules $eventsForThirdPartyModules
      * @param array   $data
      */
     public function __construct(
         Config $configHelper,
         Context $context,
         Decider $featureSwitches,
+        CheckoutSession $checkoutSession,
+        EventsForThirdPartyModules $eventsForThirdPartyModules,
         array $data = []
     ) {
         parent::__construct($context, $data);
         $this->configHelper = $configHelper;
         $this->featureSwitches = $featureSwitches;
+        $this->checkoutSession = $checkoutSession;
+        $this->eventsForThirdPartyModules = $eventsForThirdPartyModules;
     }
 }


### PR DESCRIPTION
# Description
This PR is to fix an error that the client reported happened on the checkout success page:

> Notice: Undefined property: Bolt\Boltpay\Block\Checkout\Success\Interceptor::$eventsForThirdPartyModules in /app/p2f3xbqpgpxow/vendor/boltpay/bolt-magento2/Block/BlockTrait.php on line 161 {"exception":"[object] (Exception(code: 0): Notice: Undefined property: Bolt\\Boltpay\\Block\\Checkout\\Success\\Interceptor::$eventsForThirdPartyModules in /app/p2f3xbqpgpxow/vendor/boltpay/bolt-magento2/Block/BlockTrait.php on line 161 at /app/p2f3xbqpgpxow/vendor/magento/framework/App/ErrorHandler.php:61)"} []

This happened because the `shouldDisableBoltCheckout()` function was called in `view/frontend/templates/checkout/success.phtml`

That function used `$eventsForThirdPartyModules` and `$checkoutSession`, but they do not exist on `Bolt\Boltpay\Block\Checkout\Success`

I think this issue is not unique to this merchant but also happens to others. It was just ignored in production mode, so they did not realise it happened.

#changelog Bugfix: Notice Undefined property on the checkout success page

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server
