### PR TITLE
Get product by ID if exception thrown when we unable to find it via SKU

### DIFF
--- a/Model/Api/UpdateCartCommon.php
+++ b/Model/Api/UpdateCartCommon.php
@@ -333,6 +333,7 @@ abstract class UpdateCartCommon
         foreach ($items as $item) {
             $product = [];
 
+            $itemReference = $item->getProductId();
             //By default this feature switch is enabled.
             if ($this->featureSwitches->isCustomizableOptionsSupport()) {
                 $itemProduct = $item->getProduct();
@@ -343,10 +344,12 @@ abstract class UpdateCartCommon
                     $itemSku = $this->cartHelper->getProductActualSkuByCustomizableOptions($itemSku, $customizableOptions);
                 }
 
-                $_product = $this->productRepository->get($itemSku);
-                $itemReference = $_product->getId();
-            } else {
-                $itemReference = $item->getProductId();
+                try {
+                    $_product = $this->productRepository->get($itemSku);
+                    $itemReference = $_product->getId();
+                } catch (\Exception $e) {
+                    $this->bugsnag->notifyException($e);
+                }
             }
 
             $product['reference']    = $itemReference;


### PR DESCRIPTION
Under some condition it's possible that we are unable to find product via SKU in update_cart call.
In this case we'd rather want to continue with product found by ID then throw an error.

See details:
https://app.asana.com/0/1200879031426307/1202975571339919/f

#changelog Get product by ID if exception thrown when we unable to find it via SKU