### PR TITLE
[subscriptions] Implement new template file for subscription PDP frequency selector

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -464,7 +464,7 @@ class Order extends AbstractHelper
      *
      * @throws \Exception
      */
-    protected function setAddress($quoteAddress, $address)
+    public function setAddress($quoteAddress, $address)
     {
         $address = $this->cartHelper->handleSpecialAddressCases($address);
 

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -273,11 +273,7 @@ class OrderTest extends BoltTestCase
 
         $quote = TestUtils::createQuote();
         $quoteAddress = $quote->getShippingAddress();
-        TestHelper::invokeMethod(
-            $this->orderHelper,
-            'setAddress',
-            [$quoteAddress, $addressObject]
-        );
+        $this->orderHelper->setAddress($quoteAddress,$addressObject);
         self::assertEquals($quote->getShippingAddress()->getCity(), 'Beverly Hills');
         self::assertEquals($quote->getShippingAddress()->getCountryId(), 'US');
         self::assertEquals($quote->getShippingAddress()->getCompany(), 'Bolt');

--- a/ThirdPartyModules/Amasty/Extrafee.php
+++ b/ThirdPartyModules/Amasty/Extrafee.php
@@ -98,7 +98,7 @@ class Extrafee
                 $totalAmount += $roundedTotalAmount;
                 $product = [
                     'reference' => self::AMASTY_EXTRAFEE_PREFIX . '_' . $feeOption->getFeeId() . '_' . $feeOption->getOptionId(),
-                    'image_url' => 'https://cdn.routeapp.io/route-widget/images/RouteLogoIcon.png',
+                    'image_url' => '',
                     'name' => $feeOption->getLabel(),
                     'sku' => self::AMASTY_EXTRAFEE_PREFIX . '_' . $feeOption->getFeeId() . '_' . $feeOption->getOptionId(),
                     'description' => '',

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -88,6 +88,7 @@ tr.shipping.totals td.amount span.price,
                 <catalog_ingestion_instant_async_enabled>0</catalog_ingestion_instant_async_enabled>
                 <catalog_ingestion_instant_events>product_stock_status</catalog_ingestion_instant_events>
                 <catalog_ingestion_system_configuration_update_request_enabled>1</catalog_ingestion_system_configuration_update_request_enabled>
+                <pdp_frequency_selector>0</pdp_frequency_selector>
             </boltpay>
         </payment>
     </default>

--- a/view/frontend/layout/catalog_product_view.xml
+++ b/view/frontend/layout/catalog_product_view.xml
@@ -13,5 +13,9 @@
         <referenceBlock name="product.info.addtocart.additional">
             <block class="Bolt\Boltpay\Block\JsProductPage" name="bolt.button.additional" template="Bolt_Boltpay::button_product_page.phtml" before="-" />
         </referenceBlock>
+        <!-- add new block here -->
+        <referenceBlock name="product.info.subscriptionFrequency">
+            <block class="Bolt\Boltpay\Block\JsProductPage" name="bolt.frequencySelector" template="Bolt_Boltpay::subscription_freq_selector_product_page.phtml" before="-" />
+        </referenceBlock>
     </body>
 </page>

--- a/view/frontend/layout/catalog_product_view.xml
+++ b/view/frontend/layout/catalog_product_view.xml
@@ -14,9 +14,5 @@
         <referenceBlock name="product.info.addtocart.additional">
             <block class="Bolt\Boltpay\Block\JsProductPage" name="bolt.button.additional" template="Bolt_Boltpay::button_product_page.phtml" before="-" />
         </referenceBlock>
-        <!-- add new block here -->
-        <referenceBlock name="product.info.subscriptionFrequency">
-            <block class="Bolt\Boltpay\Block\JsProductPage" name="bolt.frequencySelector" template="Bolt_Boltpay::subscription_freq_selector_product_page.phtml" before="-" />
-        </referenceBlock>
     </body>
 </page>

--- a/view/frontend/templates/subscription_freq_selector_product_page.phtml
+++ b/view/frontend/templates/subscription_freq_selector_product_page.phtml
@@ -15,61 +15,42 @@
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-// return if PDP FS option is disabled or we aren't on product page
 if (!$block->isBoltProductPageForFrequencySelector()) { return;
 }
 ?>
 
 
-<!--
-    We will potentially embed the frequency selector into this selector.
-    If product is subscribable - it will load the frequency options
-    If not - it will load nothing (empty div)
- -->
 <div class="bolt-freq-selector"></div>
+
 
 <script>
     require([
-        'jquery',
-        'Magento_Customer/js/model/authentication-popup',
-        'Magento_Customer/js/customer-data',
-        'Bolt_Boltpay/js/utils/when-defined',
-        'mage/validation/validation',
-        'mage/cookies',
-        'jquery/jquery.cookie',
-        'domReady!'
-    ], function ($, authenticationPopup, customerData, whenDefined) {
+            'jquery',
+            'Magento_Customer/js/model/authentication-popup',
+            'Magento_Customer/js/customer-data',
+            'Bolt_Boltpay/js/utils/when-defined',
+            'mage/validation/validation',
+            'mage/cookies',
+            'jquery/jquery.cookie',
+            'domReady!'
+        ], function ($, authenticationPopup, customerData, whenDefined) {
 
         var callbacks = {
-            /**
-             * This callback is triggered by the frequency selector's onChange
-             * User has selected a different frequency
-             * 
-             * We update the localStorage value that is accessible when shopper checks out
-             * LocalStorage value is a dictionary with
-             * - key as merchant product id ("reference" here)
-             * - value is the selected frequency (value, unit eg: 2, 'weeks')
-             */
             onSubscriptionChanged: function(reference, frequency) {
-                console.log("subscription frequency changed! ", reference, frequency);
-                const frequencies = JSON.parse(localStorage.getItem("BOLT_SUBSCRIPTION_PDP")) ?? {}
-                if (!frequency) {
-                    delete frequencies[reference]
-                } else {
-                    const { unit, value } = frequency
-                    frequencies[reference] = {
-                        unit,
-                        value
+                const freqs = JSON.parse(localStorage.getItem("BOLT_SUBSCRIPTION_PDP")) ?? {}
+                    if (!frequency) {
+                        delete freqs[reference]
+                    } else {
+                        const { unit, value } = frequency
+                        freqs[reference] = {
+                            unit,
+                            value
+                        }
                     }
-                }
-                localStorage.setItem("BOLT_SUBSCRIPTION_PDP", JSON.stringify(frequencies))
+                localStorage.setItem("BOLT_SUBSCRIPTION_PDP", JSON.stringify(freqs))
             }
         }
 
-        /**
-         * Below are util funcs used to retrieve full product info
-         * referenced from button_product_page.phtml
-         */
         var getQty = function () {
             var quantity = Number($('#qty').val());
             return quantity > 0 ? quantity : 1;
@@ -174,7 +155,7 @@ if (!$block->isBoltProductPageForFrequencySelector()) { return;
 
             // if connect.js is not loaded postpone until it is
             whenDefined(window, 'BoltCheckout', function(){
-                BoltCheckout.configureProductFrequencySelector(cart, null, callbacks);
+                BoltCheckout.configureProductFrequencySelector(cart, callbacks);
             }, 'configureProductFrequencySelector');
         };
 

--- a/view/frontend/templates/subscription_freq_selector_product_page.phtml
+++ b/view/frontend/templates/subscription_freq_selector_product_page.phtml
@@ -1,0 +1,45 @@
+<?php
+    // return if PPC option is disabled or we aren't on product page
+    if (!$block->isBoltProductPage()) { return;
+    }
+    ?>
+<div class="bolt-freq-selector"></div>
+<script>
+    require([
+        'jquery',
+        'Bolt_Boltpay/js/utils/when-defined',
+        'domReady!'
+    ], function ($, whenDefined) {
+        var callbacks = {
+            onSubscriptionChanged: function(reference, frequency) {
+                console.log("subscription frequency changed! ", reference, frequency);
+            }
+        }
+
+        var getQty = function () {
+           // copy from button_product_page.phtml getQty()
+        }
+
+        var getGroupedProductChildQty = function () {
+           // copy from button_product_page.phtml getGroupedProductChildQty()
+        }
+    
+        var getItemsData = function () {
+           // copy from button_product_page.phtml getItemsData()
+        };
+    
+        var cart;
+        var setupProductPage = function () {
+            cart = {
+                items: getItemsData()
+            };
+        
+            // if connect.js is not loaded postpone until it is
+            whenDefined(window, 'BoltCheckout', function(){
+                BoltCheckout.configureProductFrequencySelector(cart, callbacks);
+            }, 'configureProductFrequencySelector');
+        };
+        
+        setupProductPage();
+    });
+</script>


### PR DESCRIPTION
# Description
This PR contains all the necessary changes to add a subscription frequency selector to the product details page.

[Template file task](https://app.asana.com/0/1202967843415720/1203093658712998)
[Magento admin setting task](https://app.asana.com/0/1202967843415720/1203093658713000)

![Screen Shot 2022-11-17 at 1 25 15 PM](https://user-images.githubusercontent.com/7818084/202527640-68cd51ae-3c8d-4761-882d-2dae34efc2e5.png)

This is a core functionality for our Subscription team's MVP in January for First-part Physical Subscription offerings.

**This PR contains 3 sections:**
## 1. Adding a new Magento config setting of type `YesNo`
Whether to display the product details page frequency selector. This is the flag that our beta merchants will manually enable to see the rest of the changes, and consequently see the frequency selector on their subscribable product detail pages.

Changes: 
- Define and added the config in system.xml
- `getPDPFrequencySelectorFlag()` in Config.php that checks for that flag
- Create `isPDPFrequencySelectorEnabled()` that checks if the above config returns `true`, and `isBoltProductPageForFrequencySelector()` that checks for the prior and if the Shopper is currently on the product page.

## 2. Loading a new .phtml template into the product details page
We want the plugin to load a new file into the PDP page and place it in a similar position to the existing product page checkout button. We will call the template `subscription_freq_selector_product_page.phtml`.

We also want to enable loading the BoltConnect script when `isBoltProductPageForFrequencySelector()` is true

Changes:
- Add a `block in catalog_product_view.xml` in the `addtocart` section, for the template to be placed in that area of the product details page.
- update `$isLoadBoltJs` load condition to include `isBoltProductPageForFrequencySelector()`

## 3. Create the `subscription_freq_selector_product_page.phtml`template
Create a new template that encapsulates all the rendering/script loading for this frequency selector.

Notes:
- It checks for `isBoltProductPageForFrequencySelector()` before doing anything else.
- It has a new empty selector `<div class="bolt-freq-selector"></div>` that we will inject the freq selector into
- It loads the bolt script in a similar manner as the product checkout button does
- it gets product details similar to the product checkout button
- there is one callback `onSubscriptionChanged` which is called when the Shopper selects a frequency.
- It loads the BoltConnect script.

Fixes: (link ticket)

#changelog [subscriptions] Implement new template file for subscription PDP frequency selector

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
