### PR TITLE
Show Amazon pay processor for payment method in order, invoice, credit memo, shipment grid

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -116,7 +116,8 @@ class Order extends AbstractHelper
         'afterpay' => 'Afterpay',
         'affirm' => 'Affirm',
         'braintree' => 'Braintree',
-        'applepay' => 'ApplePay'
+        'applepay' => 'ApplePay',
+        'amazon_pay' => 'AmazonPay'
     ];
 
     /**

--- a/Test/Unit/Plugin/Magento/Ui/Component/Form/Element/SelectPluginTest.php
+++ b/Test/Unit/Plugin/Magento/Ui/Component/Form/Element/SelectPluginTest.php
@@ -106,6 +106,11 @@ class SelectPluginTest extends BoltTestCase
                 '__disableTmpl' => true,
             ],
             [
+                'value'         => 'boltpay_amazon_pay',
+                'label'         => 'Bolt-AmazonPay',
+                '__disableTmpl' => true,
+            ],
+            [
                 'value'         => 'boltpay_amex',
                 'label'         => 'Bolt-Amex',
                 '__disableTmpl' => true,
@@ -124,7 +129,7 @@ class SelectPluginTest extends BoltTestCase
                 'value'         => 'boltpay_visa',
                 'label'         => 'Bolt-Visa',
                 '__disableTmpl' => true,
-            ],
+            ]
         ];
         return [
             'Order grid, payment method column - appends options' => [


### PR DESCRIPTION
# Description
Show Amazon pay processor for payment method in order grid

Fixes: (link ticket)

#changelog Show Amazon pay processor for payment method in order grid

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
