### PR TITLE
Catalog ingestion: Fix issues with Product.Options

### DIFF
--- a/Model/CatalogIngestion/Request/Product/DataProcessor.php
+++ b/Model/CatalogIngestion/Request/Product/DataProcessor.php
@@ -543,7 +543,7 @@ class DataProcessor
             if ($values = $option->getValues()) {
                 foreach ($values as $valueId => $value) {
                     $optionData['Values'][] = [
-                        'Value' => $valueId,
+                        'Value' => string($valueId),
                         'DisplayValue' => $value->getTitle(),
                         'SortOrder' => (int)$value->getSortOrder()
                     ];

--- a/Model/CatalogIngestion/Request/Product/DataProcessor.php
+++ b/Model/CatalogIngestion/Request/Product/DataProcessor.php
@@ -536,7 +536,6 @@ class DataProcessor
                 'Name' => $option->getDefaultTitle(),
                 'DisplayType' => $option->getType(),
                 'DisplayName' => $option->getTitle(),
-                'Values' => [],
                 'Visibility' => 'true',
                 'SortOrder' => (int)$option->getSortOrder(),
             ];


### PR DESCRIPTION
We did a typo "values" instead of "Values" which lead to payload like

```
          "Values": [],
          "values": [
            {
              "DisplayValue": "Standard Chair Cart - Black",
              "SortOrder": "0",
              "Value": 1177
            },
            {
              "DisplayValue": "Heavy Duty Chair Cart - Tan",
              "SortOrder": "1",
              "Value": 1178
            },
            {
              "DisplayValue": "Chair Cart Cover",
              "SortOrder": "2",
              "Value": 1179
            }
```

Another issue with type of Product.Options.Values.Value. It should be string, not int

Asana:
https://app.asana.com/0/1201307079775363/1203413404142283/f

UPD: This PR is almost empty because issue is already resolved in https://github.com/BoltApp/bolt-magento2/pull/1703/files

#changelog Catalog ingestion: Fix issues with Product.Options