### PR TITLE
Add shipment type for items when creating order token

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1566,6 +1566,8 @@ class Cart extends AbstractHelper
                 $product['unit_price']   = CurrencyUtils::toMinor($unitPrice, $currencyCode);
                 $product['quantity']     = $quantity;
                 $product['sku']          = $this->getSkuFromQuoteItem($item);
+                $product['shipment_type'] = $this->eventsForThirdPartyModules->runFilter('filterCartItemShipmentType', 'unknown', $product, $storeId);
+
 
                 if ($this->msrpHelper->canApplyMsrp($_product) && $_product->getMsrp() !== null) {
                     $product['msrp']     = CurrencyUtils::toMinor($_product->getMsrp(), $currencyCode);

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -2807,6 +2807,7 @@ ORDER
                     'type'                => 'physical',
                     'description'         => 'Product Description',
                     'merchant_product_id' => $product->getId(),
+                    'shipment_type' => 'unknown',
                 ]
             ],
             'discounts'       => [],
@@ -2863,6 +2864,7 @@ ORDER
                     'type'                => 'physical',
                     'description'         => 'Product Description',
                     'merchant_product_id' => $product->getId(),
+                    'shipment_type' => 'unknown',
                 ]
             ],
             'discounts'       => [],
@@ -3019,6 +3021,7 @@ ORDER
                     'type'                => 'physical',
                     'description'         => 'Product Description',
                     'merchant_product_id' => $product->getId(),
+                    'shipment_type' => 'unknown',
                 ]
             ],
             'discounts' => [],
@@ -3167,6 +3170,7 @@ ORDER
                     'type'                => 'digital',
                     'description'         => 'Product Description',
                     'merchant_product_id' => $product->getId(),
+                    'shipment_type' => 'unknown',
                 ]
             ],
             'billing_address' =>
@@ -4727,6 +4731,7 @@ ORDER
                 'type'                => 'physical',
                 'description'         => '',
                 'merchant_product_id' => 20102,
+                'shipment_type' => 'unknown'
             ],
             ],
             $products
@@ -4797,6 +4802,7 @@ ORDER
                     'type'                => 'physical',
                     'description'         => '',
                     'merchant_product_id' => 20102,
+                    'shipment_type' => 'unknown'
                 ],
             ],
             $products
@@ -4890,6 +4896,7 @@ ORDER
                     'type'                => 'physical',
                     'description'         => '',
                     'merchant_product_id' => 20102,
+                    'shipment_type' => 'unknown'
                 ],
                 [
                     'reference' => 1,


### PR DESCRIPTION
# Description
This is used for split shipping integration 

Fixes: (link ticket)

#changelog Add shipment type for items when creating order token

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
