### PR TITLE
Fix error when applied rule ids is null

### DIFF
--- a/Model/Api/ShippingMethods.php
+++ b/Model/Api/ShippingMethods.php
@@ -589,9 +589,12 @@ class ShippingMethods implements ShippingMethodsInterface
             }
 
             // include applied rule ids (discounts) in cache key
-            $ruleIds = str_replace(',', '_', $quote->getAppliedRuleIds());
-            if ($ruleIds) {
-                $cacheIdentifier .= '_'.$ruleIds;
+            $appliedRuleIds = $quote->getAppliedRuleIds();
+            if ($appliedRuleIds) {
+                $ruleIds = str_replace(',', '_', $appliedRuleIds);
+                if ($ruleIds) {
+                    $cacheIdentifier .= '_'.$ruleIds;
+                }
             }
 
             // extend cache identifier with custom address fields


### PR DESCRIPTION
# Description
Fix error which block checkout when applied rule ids are null
Issue is reproducable if prefetch shipping is enabled (payment/boltpay/prefetch_shipping) & user trying to checkout without any discounts applied.

Fixes: [(link ticket)](https://app.asana.com/0/1201931884901947/1203339630490034)

#changelog Fix error when applied rule ids is null

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
