### PR TITLE
Catalog ingestion: remove product event after instant sent call

### DIFF
--- a/Model/CatalogIngestion/ProductEventManager.php
+++ b/Model/CatalogIngestion/ProductEventManager.php
@@ -230,6 +230,11 @@ class ProductEventManager implements ProductEventManagerInterface
             $productEvent->setType($type);
             $productEvent->setCreatedAt($this->dateTime->formatDate(true));
             $this->sendProductEvent($productEvent);
+            try {
+                $this->deleteProductEvent($productId);
+            } catch (\Exception $e) {
+                // no product event registered in database
+            }
         }
 
         $this->alreadySentInstantProductIds[] = $productId;


### PR DESCRIPTION
# Description
Catalog ingestion: added removing "product event" from database after successfully sending instant product event

Fixes: https://app.asana.com/0/1201931884901947/1203475759864888/f

#changelog catalog ingestion: instant product event added removing database "bolt event" after successfully sending process.

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
