### PR TITLE
Fix product page checkout for magento 2.4.5

### DIFF
--- a/view/frontend/templates/button_product_page.phtml
+++ b/view/frontend/templates/button_product_page.phtml
@@ -58,7 +58,6 @@ foreach ($block->getAdditionalCheckoutButtonAttributes() as $attrName => $attrVa
             'Bolt_Boltpay/js/utils/when-defined',
             'mage/validation/validation',
             'mage/cookies',
-            'jquery/jquery.cookie',
             'domReady!'
         ], function ($, authenticationPopup, customerData, whenDefined) {
 


### PR DESCRIPTION
# Description
Fixed product page for magento 2.4.5-p1
Magento 2.4.5-p1 doesn't have jquery/jquery.cookie and it is blocking bolt script loading process. It is enought to have only 'mage/cookies'

Fixes: https://app.asana.com/0/1201931884901947/1203499616221175/f

#changelog Fix product page checkout for magento 2.4.5

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
