### PR TITLE
Fetch Cart: product image endpoint implementation

### DIFF
--- a/Api/GetProductImageUrlInterface.php
+++ b/Api/GetProductImageUrlInterface.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2022 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Api;
+
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Webapi\Exception as WebapiException;
+
+interface GetProductImageUrlInterface
+{
+    const DEFAULT_IMAGE_ID = 'product_page_image_small';
+
+    /**
+     * Get product image url and stock information for specified product
+     *
+     * @api
+     *
+     * @param int $productId
+     * @param string $imageId
+     *
+     * @return string
+     *
+     * @throws NoSuchEntityException
+     * @throws WebapiException
+     */
+    public function execute(int $productId, string $imageId = self::DEFAULT_IMAGE_ID): string;
+}

--- a/Model/Api/GetProductImageUrl.php
+++ b/Model/Api/GetProductImageUrl.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2022 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Model\Api;
+
+use Bolt\Boltpay\Api\GetProductImageUrlInterface;
+use Bolt\Boltpay\Helper\Bugsnag;
+use Magento\Framework\App\Area;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Catalog\Helper\Image as ImageHelper;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Webapi\Exception as WebapiException;
+use Magento\Store\Model\App\Emulation;
+use Magento\Store\Model\StoreManagerInterface;
+
+/**
+ * Class for fetching product image url
+ */
+class GetProductImageUrl implements GetProductImageUrlInterface
+{
+    /**
+     * @var ProductRepositoryInterface
+     */
+    private $productRepository;
+
+    /**
+     * @var ImageHelper
+     */
+    private $imageHelper;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @var Emulation
+     */
+    private $emulation;
+
+    /**
+     * @var Bugsnag
+     */
+    private $bugsnag;
+
+    /**
+     * @param ProductRepositoryInterface $productRepository
+     * @param ImageHelper $imageHelper
+     * @param StoreManagerInterface $storeManager
+     * @param Emulation $emulation
+     * @param Bugsnag $bugsnag
+     */
+    public function __construct(
+        ProductRepositoryInterface $productRepository,
+        ImageHelper $imageHelper,
+        StoreManagerInterface $storeManager,
+        Emulation $emulation,
+        Bugsnag $bugsnag
+    ) {
+        $this->productRepository = $productRepository;
+        $this->imageHelper = $imageHelper;
+        $this->storeManager = $storeManager;
+        $this->emulation = $emulation;
+        $this->bugsnag = $bugsnag;
+    }
+    /**
+     * @inheriDoc
+     */
+    public function execute(int $productId, string $imageId = self::DEFAULT_IMAGE_ID): string
+    {
+        try {
+            $this->emulation->startEnvironmentEmulation($this->storeManager->getStore()->getId(), Area::AREA_FRONTEND, true);
+            $product = $this->productRepository->getById($productId);
+            $image = $this->imageHelper->init($product, $imageId)->getUrl();
+            $this->emulation->stopEnvironmentEmulation();
+            return $image;
+        } catch (NoSuchEntityException $e) {
+            throw new NoSuchEntityException(__('Product not found with given identifier.'));
+        } catch (\Exception $e) {
+            $this->bugsnag->notifyException($e);
+            throw new WebapiException(__($e->getMessage()), 0, WebapiException::HTTP_INTERNAL_ERROR);
+        }
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -343,4 +343,5 @@
 
     <preference for="Bolt\Boltpay\Api\Data\PluginVersionNotificationInterface" type="Bolt\Boltpay\Model\VersionNotifier\PluginVersionNotification" />
     <preference for="Bolt\Boltpay\Api\PluginVersionNotificationRepositoryInterface" type="Bolt\Boltpay\Model\VersionNotifier\PluginVersionNotificationRepository" />
+    <preference for="Bolt\Boltpay\Api\GetProductImageUrlInterface" type="Bolt\Boltpay\Model\Api\GetProductImageUrl" />
 </config>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -205,4 +205,11 @@
             <resource ref="Magento_Cart::manage" />
         </resources>
     </route>
+    <!--Get product image url by product id, imageId can be as parameter -->
+    <route url="/V1/bolt/boltpay/product/:productId/image-url" method="GET">
+        <service class="Bolt\Boltpay\Api\GetProductImageUrlInterface" method="execute"/>
+        <resources>
+            <resource ref="Magento_Catalog::products" />
+        </resources>
+    </route>
 </routes>


### PR DESCRIPTION
# Description
Implemented new endpoint  which is retrurning cachable url of image like:
https://m2.ygarmash.dev.bolt.me/media/catalog/product/cache/78f8cf97d02c8723e0bc8c00b62c4cd3/s/m/small_image.jpg

This request have additional param `imageId` which is the type of product image in magento terms like:
- product_page_image_small
- product_page_image_medium
- product_page_image_large
- .....

The request with parameter looks like: 
https://m2.ygarmash.dev.bolt.me/rest/default/V1/bolt/boltpay/product/1/image-url?imageId=product_page_image_large

if we are using this endpoint without imageId parameter the default parameter is: `product_page_image_small`

Return value is `string` type

```
    <route url="/V1/bolt/boltpay/product/:productId/image-url" method="GET">
        <service class="Bolt\Boltpay\Api\GetProductImageUrlInterface" method="execute"/>
        <resources>
            <resource ref="Magento_Catalog::products" />
        </resources>
    </route>
```


Fixes: https://app.asana.com/0/1201931884901947/1203149984454994/f

#changelog fetch cart product image endpoint implemented

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
