### PR TITLE
Magento onSuccess callback fix

### DIFF
--- a/Block/Js.php
+++ b/Block/Js.php
@@ -874,4 +874,14 @@ function($argName) {
                 : []
         );
     }
+
+    /**
+     * Returns success redirect url
+     *
+     * @return string
+     */
+    public function getSuccessPageRedirectUrl()
+    {
+        return $this->getUrl($this->configHelper->getSuccessPageRedirect());
+    }
 }

--- a/view/frontend/templates/js/boltglobaljs.phtml
+++ b/view/frontend/templates/js/boltglobaljs.phtml
@@ -61,7 +61,7 @@ $onSuccessCode = $block->getJavascriptSuccess() . $trackCallbackCode['success'];
         onShippingOptionsComplete: <?= /* @noEscape */ $block->wrapWithCatch($onShippingOptionsCompleteCode);
         ?>,
         onPaymentSubmit: <?= /* @noEscape */ $block->wrapWithCatch($trackCallbackCode['payment_submit']); ?>,
-        onSuccess: <?= /* @noEscape */ $block->wrapWithCatch($onSuccessCode, 'data') ?>,
+        onSuccess: <?= /* @noEscape */ $block->wrapWithCatch($onSuccessCode, 'transaction') ?>,
         onClose: <?= /* @noEscape */ $block->wrapWithCatch($trackCallbackCode['close']); ?>,
     };
 

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -635,7 +635,7 @@ $isLoadOpenReplayJsDynamic = $block->isDisableOpenReplayJs();
                         if (typeof data !== 'undefined') {
                             callbacks.success_url = data.success_url;
                         }
-                        trackCallbacks.onSuccess(data);
+                        trackCallbacks.onSuccess(transaction);
                     } finally {
                         callback();
                     }
@@ -663,7 +663,7 @@ $isLoadOpenReplayJsDynamic = $block->isDisableOpenReplayJs();
                         }
                         return;
                     }
-                    processSuccess(data);
+                    processSuccess(transaction);
                 };
                 var showError = function() {
                     showBoltErrorMessage('', transaction.reference);

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -39,6 +39,7 @@ $connectJsUrl = $block->getConnectJsUrl();
 $isLoadConnectJsDynamic = $block->isLoadConnectJsDynamic();
 $isLoadTrackJsDynamic = $block->isDisableTrackJsOnNonBoltPages() && $isLoadConnectJsDynamic;
 $isLoadOpenReplayJsDynamic = $block->isDisableOpenReplayJs();
+$successPageRedirectUrl = $block->getSuccessPageRedirectUrl();
 ?>
 
 <script type="text/javascript">
@@ -618,6 +619,10 @@ $isLoadOpenReplayJsDynamic = $block->isDisableOpenReplayJs();
             },
 
             success: function (transaction, callback) {
+                // fill success url to transaction object
+                if (!transaction.success_url) {
+                    transaction.success_url = "<?= $successPageRedirectUrl; ?>";
+                }
                 /**
                  * Success transaction handler.
                  * Sets the success url for the non-preauth flow.
@@ -663,7 +668,7 @@ $isLoadOpenReplayJsDynamic = $block->isDisableOpenReplayJs();
                         }
                         return;
                     }
-                    processSuccess(transaction);
+                    processSuccess(data);
                 };
                 var showError = function() {
                     showBoltErrorMessage('', transaction.reference);


### PR DESCRIPTION
# Description
- Fixed `onSuccess` callback argument replaced from `data` to `transaction`
Tested with both options "is_pre_auth"  = true/false
Have correct transaction data from here: https://help.bolt.com/products/managed-checkout/bigcommerce-setup-guide/bigcommerce-callbacks/
- Addded success_url to transaction object, it is the same value which we used before for non pre-auth calls from [here](https://github.com/BoltApp/bolt-magento2/blob/b3312fa7f8aa88aead233f183ecae9217f23b448/Controller/Order/Save.php#L125)


Fixes: https://app.asana.com/0/951157735838091/1203434860273469/f

#changelog fixed onSuccess callback.

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
