### PR TITLE
Add support for AmazonPay 'in progress' refund

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -91,6 +91,7 @@ class Order extends AbstractHelper
     const TS_ZERO_AMOUNT           = 'zero_amount:completed';
     const TS_CREDIT_IN_PROGRESS    = 'cc_credit:in_progress';
     const TS_CREDIT_COMPLETED      = 'cc_credit:completed';
+    const TS_CREDIT_CREATED      = 'cc_credit:created';
 
     const MISMATCH_TOLERANCE = 1;
 
@@ -1937,6 +1938,7 @@ class Order extends AbstractHelper
             self::TS_REJECTED_REVERSIBLE => 'REVERSIBLE REJECTED',
             self::TS_REJECTED_IRREVERSIBLE => 'IRREVERSIBLE REJECTED',
             self::TS_CREDIT_IN_PROGRESS => 'Refund is in progress. See actual refund status in Bolt merchant dashboard',
+            self::TS_CREDIT_CREATED => 'Refund is in progress. See actual refund status in Bolt merchant dashboard',
             self::TS_CREDIT_COMPLETED => Hook::$fromBolt ? 'REFUNDED UNSYNCHRONISED' : 'REFUNDED'
         ][$transactionState];
     }
@@ -2074,7 +2076,7 @@ class Order extends AbstractHelper
      */
     public function transactionToOrderState($transactionState, $order)
     {
-        if ($transactionState == self::TS_CREDIT_IN_PROGRESS || $transactionState == self::TS_CREDIT_COMPLETED) {
+        if ($transactionState == self::TS_CREDIT_IN_PROGRESS || $transactionState == self::TS_CREDIT_CREATED || $transactionState == self::TS_CREDIT_COMPLETED) {
             if ($order->getTotalRefunded() == $order->getGrandTotal() && $order->getTotalRefunded() == $order->getTotalPaid() && !$order->canShip()) {
                 return OrderModel::STATE_CLOSED;
             }
@@ -2232,6 +2234,7 @@ class Order extends AbstractHelper
                 break;
 
             case self::TS_CREDIT_IN_PROGRESS:
+            case self::TS_CREDIT_CREATED:
             case self::TS_CREDIT_COMPLETED:
                 if (in_array($transaction->id, $processedRefunds)) {
                     return;
@@ -2304,7 +2307,7 @@ class Order extends AbstractHelper
         $orderState = $this->transactionToOrderState($transactionState, $order);
 
         // If the action is not triggered by Bolt API request and transaction type is credit, there is not need to save order.
-        $ifSaveOrder = Hook::$fromBolt || ($transactionState != self::TS_CREDIT_IN_PROGRESS && $transactionState != self::TS_CREDIT_COMPLETED);
+        $ifSaveOrder = Hook::$fromBolt || ($transactionState != self::TS_CREDIT_IN_PROGRESS && $transactionState != self::TS_CREDIT_COMPLETED && $transactionState != self::TS_CREDIT_CREATED);
         $this->setOrderState($order, $orderState, $ifSaveOrder);
 
         // Send order confirmation email to customer.

--- a/Model/Payment.php
+++ b/Model/Payment.php
@@ -55,6 +55,7 @@ use \Magento\Sales\Model\Order\Payment\Transaction\Repository as TransactionRepo
 class Payment extends AbstractMethod
 {
     const TRANSACTION_IN_PROGRESS = 'in_progress';
+    const TRANSACTION_CREATED = 'created';
     const TRANSACTION_AUTHORIZED = 'authorized';
     const TRANSACTION_COMPLETED = 'completed';
     const TRANSACTION_CANCELLED = 'cancelled';
@@ -530,7 +531,7 @@ class Payment extends AbstractMethod
             }
             $status = $response->status ?? null;
 
-            if (!in_array($status, [self::TRANSACTION_COMPLETED, self::TRANSACTION_IN_PROGRESS])) {
+            if (!in_array($status, [self::TRANSACTION_COMPLETED, self::TRANSACTION_IN_PROGRESS, self::TRANSACTION_CREATED])) {
                 throw new LocalizedException(__('Payment refund error.'));
             }
 


### PR DESCRIPTION
# Description
If the merchant refund online an Amazon pay order in Magento but for some reason (await the response from processor)
 Bolt server creates refund transaction with created status.
 
![image](https://user-images.githubusercontent.com/2002287/207733052-fa36dcf9-7d2d-44fd-8c1e-1ebf4783c59b.png)
Once the processor approves, a refund will be processed and the transaction status will be updated to refund.

By this PR, we handle the case: update Magento order to closed status and add to order comment to explain that refund is in progress.
<img width="669" alt="image" src="https://user-images.githubusercontent.com/2002287/207732814-ec917f79-3991-4ff1-954d-a02e7f73a7da.png">

Before this PR, we had exception "If the invoice was created offline, try creating an offline credit memo."  when users try to create credit memo online

FYI, this PR applies the same logic as https://github.com/BoltApp/bolt-magento2/pull/1003

Fixes: [(link ticket)](https://app.asana.com/0/1201495896048972/1203556781378701)

#changelog Add support for AmazonPay 'in progress' refund

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
