### PR TITLE
Catalog ingestion: fix transaction issue with legacy stock item

### DIFF
--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -537,4 +537,16 @@ class Decider extends AbstractHelper
     {
         return $this->isSwitchEnabled(Definitions::M2_FETCH_CART_VIA_API);
     }
+
+    /**
+     * Checks whether the feature switch for catalog ingestion instance update is disabled
+     *
+     * @return bool whether the feature switch is enabled
+     *
+     * @throws LocalizedException if the feature switch key is unknown
+     */
+    public function isCatalogIngestionInstancePipelineDisabled()
+    {
+        return $this->isSwitchEnabled(Definitions::M2_CATALOG_INGESTION_DISABLE_INSTANCE_PIPELINE);
+    }
 }

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -303,6 +303,11 @@ class Definitions
     const M2_SKIP_CART_DISCOUNT_TOTAL_MISMATCH = 'M2_SKIP_CART_DISCOUNT_TOTAL_MISMATCH';
 
     /**
+     * Disable catalog ingestion instant update process
+     */
+    const M2_CATALOG_INGESTION_DISABLE_INSTANCE_PIPELINE = 'M2_CATALOG_INGESTION_DISABLE_INSTANCE_PIPELINE';
+
+    /**
      * Enable M2 fetch cart via api
      */
     const M2_FETCH_CART_VIA_API = 'M2_FETCH_CART_VIA_API';
@@ -598,6 +603,12 @@ class Definitions
         ],
         self::M2_CATALOG_INGESTION => [
             self::NAME_KEY        => self::M2_CATALOG_INGESTION,
+            self::VAL_KEY         => true,
+            self::DEFAULT_VAL_KEY => false,
+            self::ROLLOUT_KEY     => 0
+        ],
+        self::M2_CATALOG_INGESTION_DISABLE_INSTANCE_PIPELINE => [
+            self::NAME_KEY        => self::M2_CATALOG_INGESTION_DISABLE_INSTANCE_PIPELINE,
             self::VAL_KEY         => true,
             self::DEFAULT_VAL_KEY => false,
             self::ROLLOUT_KEY     => 0

--- a/Model/CatalogIngestion/ProductEventManager.php
+++ b/Model/CatalogIngestion/ProductEventManager.php
@@ -226,9 +226,12 @@ class ProductEventManager implements ProductEventManagerInterface
             $productEvent->setProductId($productId);
             $productEvent->setType($type);
             $productEvent->setCreatedAt($this->dateTime->formatDate(true));
-            // publish product event always to avoid possible issues in diff magento versions
-            $this->publishProductEvent($productId, ProductEventInterface::TYPE_UPDATE);
             $this->sendProductEvent($productEvent);
+            try {
+                $this->deleteProductEvent($productId);
+            } catch (\Exception $e) {
+                // no product event registered in database
+            }
         }
 
         $this->alreadySentInstantProductIds[] = $productId;

--- a/Model/CatalogIngestion/ProductEventManager.php
+++ b/Model/CatalogIngestion/ProductEventManager.php
@@ -226,12 +226,9 @@ class ProductEventManager implements ProductEventManagerInterface
             $productEvent->setProductId($productId);
             $productEvent->setType($type);
             $productEvent->setCreatedAt($this->dateTime->formatDate(true));
+            // publish product event always to avoid possible issues in diff magento versions
+            $this->publishProductEvent($productId, ProductEventInterface::TYPE_UPDATE);
             $this->sendProductEvent($productEvent);
-            try {
-                $this->deleteProductEvent($productId);
-            } catch (\Exception $e) {
-                // no product event registered in database
-            }
         }
 
         $this->alreadySentInstantProductIds[] = $productId;

--- a/Model/CatalogIngestion/ProductEventProcessor.php
+++ b/Model/CatalogIngestion/ProductEventProcessor.php
@@ -400,7 +400,8 @@ class ProductEventProcessor
         string $oldStatus = null
     ): bool {
         if (!$this->config->getIsCatalogIngestionInstantEnabled($websiteId) ||
-            !in_array(Events::STOCK_STATUS_CHANGES, $this->config->getCatalogIngestionEvents($websiteId))
+            !in_array(Events::STOCK_STATUS_CHANGES, $this->config->getCatalogIngestionEvents($websiteId)) ||
+            $this->featureSwitches->isCatalogIngestionInstancePipelineDisabled()
         ) {
             return false;
         }

--- a/Plugin/Magento/Inventory/Model/SourceItem/Command/SourceItemSavePlugin.php
+++ b/Plugin/Magento/Inventory/Model/SourceItem/Command/SourceItemSavePlugin.php
@@ -107,10 +107,10 @@ class SourceItemSavePlugin
         /**
          * Magento use two ways to store the stock data legacy(stock items based) and native(source item based with MSI)
          * In magento 2.4.4 for case when magento updating source items based on legacy stock item in plugin:
-         * https://github.com/magento/inventory/blob/develop/InventoryCatalog/Plugin/CatalogInventory/UpdateSourceItemAtLegacyStockItemSavePlugin.php
+         * https://github.com/magento/inventory/blob/f32b8f5e20627bdbf18e581727e3d5a7ccc17756/InventoryCatalog/Plugin/CatalogInventory/UpdateSourceItemAtLegacyStockItemSavePlugin.php
          * We have issue with non-actual source items data, because of transaction inside plugin above.
          * In this case we should ignore this plugin and actual data will be fetched based on stock item(legacy) in another plugin
-         * https://github.com/BoltApp/bolt-magento2/blob/master/Plugin/Magento/CatalogInventory/Api/StockItemRepositoryPlugin.php
+         * https://github.com/BoltApp/bolt-magento2/blob/21fb4991fba6cadc428e3da6a0725d691f67ce1b/Plugin/Magento/CatalogInventory/Api/StockItemRepositoryPlugin.php
          */
         if ($this->resourceConnection->getConnection()->getTransactionLevel() > 0 &&
             !$this->featureSwitches->isCatalogIngestionInstancePipelineDisabled()

--- a/Plugin/Magento/Inventory/Model/SourceItem/Command/SourceItemSavePlugin.php
+++ b/Plugin/Magento/Inventory/Model/SourceItem/Command/SourceItemSavePlugin.php
@@ -99,7 +99,20 @@ class SourceItemSavePlugin
     {
         if (!$this->featureSwitches->isCatalogIngestionEnabled() ||
             empty($sourceItems) ||
-            empty($this->beforeProductStatuses) ||
+            empty($this->beforeProductStatuses)
+        ) {
+            return;
+        }
+
+        /**
+         * Magento use two ways to store the stock data legacy(stock items based) and native(source item based with MSI)
+         * In magento 2.4.4 for case when magento updating source items based on legacy stock item in plugin:
+         * https://github.com/magento/inventory/blob/develop/InventoryCatalog/Plugin/CatalogInventory/UpdateSourceItemAtLegacyStockItemSavePlugin.php
+         * We have issue with non-actual source items data, because of transaction inside plugin above.
+         * In this case we should ignore this plugin and actual data will be fetched based on stock item(legacy) in another plugin
+         * https://github.com/BoltApp/bolt-magento2/blob/master/Plugin/Magento/CatalogInventory/Api/StockItemRepositoryPlugin.php
+         */
+        if (!$this->featureSwitches->isCatalogIngestionInstancePipelineDisabled() &&
             $this->resourceConnection->getConnection()->getTransactionLevel() > 0
         ) {
             return;

--- a/Plugin/Magento/Inventory/Model/SourceItem/Command/SourceItemSavePlugin.php
+++ b/Plugin/Magento/Inventory/Model/SourceItem/Command/SourceItemSavePlugin.php
@@ -112,8 +112,8 @@ class SourceItemSavePlugin
          * In this case we should ignore this plugin and actual data will be fetched based on stock item(legacy) in another plugin
          * https://github.com/BoltApp/bolt-magento2/blob/master/Plugin/Magento/CatalogInventory/Api/StockItemRepositoryPlugin.php
          */
-        if (!$this->featureSwitches->isCatalogIngestionInstancePipelineDisabled() &&
-            $this->resourceConnection->getConnection()->getTransactionLevel() > 0
+        if ($this->resourceConnection->getConnection()->getTransactionLevel() > 0 &&
+            !$this->featureSwitches->isCatalogIngestionInstancePipelineDisabled()
         ) {
             return;
         }


### PR DESCRIPTION
# Description
Fixed catalog ingestion wrong inventory level data during running instant flow. Caused by transaction in core magento legacy stock item save plugin.

Fixes: https://app.asana.com/0/1201931884901947/1203554804830150/f

#changelog catalog ingestion magento 2.4.4 wrong inventory level during instant run process

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
