### PR TITLE
[subscriptions] Reposition PDP frequency selector to be before add to cart

### DIFF
--- a/view/frontend/layout/catalog_product_view.xml
+++ b/view/frontend/layout/catalog_product_view.xml
@@ -7,8 +7,10 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
+       <referenceBlock name="product.info.form.content">
+            <block class="Bolt\Boltpay\Block\JsProductPage" name="bolt.frequencySelector" template="Bolt_Boltpay::subscription_freq_selector_product_page.phtml" before="product.info.addtocart" />
+        </referenceBlock>
         <referenceBlock name="product.info.addtocart">
-            <block class="Bolt\Boltpay\Block\JsProductPage" name="bolt.frequencySelector" template="Bolt_Boltpay::subscription_freq_selector_product_page.phtml" before="-" />
             <block class="Bolt\Boltpay\Block\JsProductPage" name="bolt.button" template="Bolt_Boltpay::button_product_page.phtml" before="-" />
         </referenceBlock>
         <referenceBlock name="product.info.addtocart.additional">

--- a/view/frontend/layout/catalog_product_view.xml
+++ b/view/frontend/layout/catalog_product_view.xml
@@ -7,8 +7,8 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-       <referenceBlock name="product.info.form.content">
-            <block class="Bolt\Boltpay\Block\JsProductPage" name="bolt.frequencySelector" template="Bolt_Boltpay::subscription_freq_selector_product_page.phtml" before="product.info.addtocart" />
+        <referenceBlock name="product.info.form.content">
+            <block class="Bolt\Boltpay\Block\JsProductPage" name="bolt.frequencySelector" template="Bolt_Boltpay::subscription_freq_selector_product_page.phtml" before="-" />
         </referenceBlock>
         <referenceBlock name="product.info.addtocart">
             <block class="Bolt\Boltpay\Block\JsProductPage" name="bolt.button" template="Bolt_Boltpay::button_product_page.phtml" before="-" />

--- a/view/frontend/layout/catalog_product_view_type_configurable.xml
+++ b/view/frontend/layout/catalog_product_view_type_configurable.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <move element="bolt.frequencySelector" destination="product.info.options.wrapper.bottom" before="-"/>
+    </body>
+</page>


### PR DESCRIPTION
# Description
Our initial plugin change to add the subscription frequency selector component just put it together with the product page checkout button. This PR aims to reposition the component to be above the "add to cart" button, which is more in line with the design we're going for:
<img width="691" alt="image" src="https://user-images.githubusercontent.com/9687177/207991245-eb2673e7-65c2-4f82-bfcc-12ff365c8bd4.png">
<img width="604" alt="Screen Shot 2022-12-21 at 12 24 29 PM" src="https://user-images.githubusercontent.com/7818084/208966564-7c816739-314a-4dc7-8f7e-99338a105387.png">

[Figma link](https://www.figma.com/file/214BFW3oTs7bAhxcDFNCGi/22-Q3-FP-%E2%80%A2-Bolt-Subscriptions-%E2%80%94-Storefront-%26-Shopper-Experience-%E2%80%A2-P0?node-id=792%3A12617&t=vcrPkA6j3Z0AtHS8-1)

It doesn't look perfect in the screenshot, but Oat is handling the styling adjustments.

We are adding 2 new reference blocks:
```
        <referenceBlock name="product.info.options.wrapper.bottom">
            <block class="Bolt\Boltpay\Block\JsProductPage" name="bolt.frequencySelector.additional" template="Bolt_Boltpay::subscription_freq_selector_product_page.phtml" before="-" />
        </referenceBlock>
        <referenceBlock name="product.info.form.content">
            <block class="Bolt\Boltpay\Block\JsProductPage" name="bolt.frequencySelector" template="Bolt_Boltpay::subscription_freq_selector_product_page.phtml" before="-" />
        </referenceBlock>
```
`product.info.form.content` adds the selector to the simple product page, but however, it doesnt add it to configurable product pages. `product.info.options.wrapper.bottom` adds to the configurable product pages, but not to the simple product pages.

Figured this out from [this blog post](https://meetanshi.com/blog/add-block-before-add-to-cart-button-in-magento-2-product-page/) and official magento documentation.

Fixes: https://app.asana.com/0/1202967843415720/1203476182113751

#changelog [subscriptions] Reposition PDP frequency selector to be before add to cart

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
