### PR TITLE
SSO: fix safari log-in by Bolt Assistant

### DIFF
--- a/Model/Api/OAuthRedirect.php
+++ b/Model/Api/OAuthRedirect.php
@@ -45,6 +45,10 @@ use Magento\Store\Model\StoreManagerInterface;
 use Magento\Customer\Model\EmailNotification;
 use Magento\Quote\Api\CartManagementInterface;
 use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Framework\Session\Config\ConfigInterface as SessionConfigInterface;
+use Magento\Framework\Data\Form\FormKey;
+use Magento\Framework\App\PageCache\FormKey as CookieFormKey;
+use Magento\Framework\Exception\LocalizedException;
 
 class OAuthRedirect implements OAuthRedirectInterface
 {
@@ -158,6 +162,12 @@ class OAuthRedirect implements OAuthRedirectInterface
      */
     private $cartRepository;
 
+    private $sessionConfig;
+
+    private $formKey;
+
+    private $cookieFormKey;
+
     /**
      * @param Response $response
      * @param DeciderHelper $deciderHelper
@@ -200,7 +210,10 @@ class OAuthRedirect implements OAuthRedirectInterface
         Bugsnag $bugsnag,
         EmailNotification $emailNotification,
         CartManagementInterface $cartManagement,
-        CartRepositoryInterface $cartRepository
+        CartRepositoryInterface $cartRepository,
+        SessionConfigInterface $sessionConfig,
+        FormKey $formKey,
+        CookieFormKey $cookieFormKey
     ) {
         $this->response = $response;
         $this->deciderHelper = $deciderHelper;
@@ -222,6 +235,9 @@ class OAuthRedirect implements OAuthRedirectInterface
         $this->emailNotification = $emailNotification;
         $this->cartManagement = $cartManagement;
         $this->cartRepository = $cartRepository;
+        $this->sessionConfig = $sessionConfig;
+        $this->formKey = $formKey;
+        $this->cookieFormKey = $cookieFormKey;
     }
 
     /**
@@ -391,6 +407,18 @@ class OAuthRedirect implements OAuthRedirectInterface
                 if ($checkoutSession) {
                     $quote = $checkoutSession->getQuote();
                     if ($quote->getId()) {
+                        try {
+                            // we should merge quote here for magento 2.3.0 version, because
+                            // https://github.com/magento/magento2/blob/44a7b6079bcac5ba92040b16f4f74024b4f34d09/app/code/Magento/Quote/Model/QuoteManagement.php#L297
+                            // doesn't have "quote merging part" as we have on magento 2.4.X
+                            // https://github.com/magento/magento2/blob/5844ade68b2f9632e3888c81c946068eba6328bb/app/code/Magento/Quote/Model/QuoteManagement.php#L337
+                            $customerActiveQuote = $this->cartRepository->getActiveForCustomer($customer->getId());
+                            $quote->merge($customerActiveQuote);
+                            $customerActiveQuote->setIsActive(false);
+                            $this->cartHelper->saveQuote($customerActiveQuote);
+                        } catch (NoSuchEntityException $e) {
+                            $this->bugsnag->notifyException($e);
+                        }
                         // call the function that merge 2 carts: guest cart and customer cart
                         $this->cartManagement->assignCustomer($quote->getId(),$customer->getId(),$customer->getStoreId());
                         $this->updateImmutableQuotes($quote, $customer);
@@ -474,7 +502,47 @@ class OAuthRedirect implements OAuthRedirectInterface
             $this->getCookieManager()->deleteCookie('mage-cache-sessid', $metadata);
         }
 
+        try {
+            // we should force to set new "form_key" cookie here to prevent safari "session expired" issue
+            // when we are logged-in by SSO without page redirect (by using Bolt Shopper Assistant for example)
+            // in this case magento removing cookie by backend here:
+            // https://github.com/magento/magento2/blob/5844ade68b2f9632e3888c81c946068eba6328bb/app/code/Magento/PageCache/Observer/FlushFormKey.php
+            // but on safari without redirect the cookie is removed from browser (you can't see cookie on the devtool) but not in window.document object
+            // (we can see the cookie "form_key" there by checking object in browser console: "document.cookie")
+            // therefore all future requests is being called without "form_key" which is the reason of  "session expire" issue.
+            // By normal flow Magento updates that cookie in file:
+            // 2.3.0 https://github.com/magento/magento2/blob/44a7b6079bcac5ba92040b16f4f74024b4f34d09/app/code/Magento/PageCache/view/frontend/web/js/page-cache.js#L115
+            // 2.4.0 https://github.com/magento/magento2/blob/5844ade68b2f9632e3888c81c946068eba6328bb/app/code/Magento/PageCache/view/frontend/web/js/form-key-provider.js#L87
+            // Magento js above sets new cookie only in case if cookie is not exist
+            // but in our issue case magento js file is able to read cookie from document object (because cookie was not removed by safari)
+            // and doesn't update browser cookie.
+            $this->updateFormKeyCookie();
+        } catch (\Exception $e) {
+            $this->bugsnag->notifyException($e);
+        }
         $this->response->setRedirect($this->url->getAccountUrl())->sendResponse();
 
+    }
+
+    /**
+     * Set form key cookie
+     *
+     * @return void
+     * @throws LocalizedException
+     */
+    private function updateFormKeyCookie()
+    {
+        $cookieMetadata = $this->getCookieMetadataFactory()->createPublicCookieMetadata();
+        $cookieMetadata->setDomain($this->sessionConfig->getCookieDomain());
+        $cookieMetadata->setPath($this->sessionConfig->getCookiePath());
+        $cookieMetadata->setSecure($this->sessionConfig->getCookieSecure());
+        $lifetime = $this->sessionConfig->getCookieLifetime();
+        if ($lifetime !== 0) {
+            $cookieMetadata->setDuration($lifetime);
+        }
+        $this->cookieFormKey->set(
+            $this->formKey->getFormKey(),
+            $cookieMetadata
+        );
     }
 }

--- a/Model/Api/OAuthRedirect.php
+++ b/Model/Api/OAuthRedirect.php
@@ -408,7 +408,7 @@ class OAuthRedirect implements OAuthRedirectInterface
                     $quote = $checkoutSession->getQuote();
                     if ($quote->getId()) {
                         try {
-                            // we should merge quote here for magento 2.3.0 version, because
+                            // we should merge quote here for magento 2.3.X version and below, because
                             // https://github.com/magento/magento2/blob/44a7b6079bcac5ba92040b16f4f74024b4f34d09/app/code/Magento/Quote/Model/QuoteManagement.php#L297
                             // doesn't have "quote merging part" as we have on magento 2.4.X
                             // https://github.com/magento/magento2/blob/5844ade68b2f9632e3888c81c946068eba6328bb/app/code/Magento/Quote/Model/QuoteManagement.php#L337
@@ -511,7 +511,7 @@ class OAuthRedirect implements OAuthRedirectInterface
             // (we can see the cookie "form_key" there by checking object in browser console: "document.cookie")
             // therefore all future requests is being called without "form_key" which is the reason of  "session expire" issue.
             // By normal flow Magento updates that cookie in file:
-            // 2.3.0 https://github.com/magento/magento2/blob/44a7b6079bcac5ba92040b16f4f74024b4f34d09/app/code/Magento/PageCache/view/frontend/web/js/page-cache.js#L115
+            // 2.2.0 - 2.3.0 https://github.com/magento/magento2/blob/44a7b6079bcac5ba92040b16f4f74024b4f34d09/app/code/Magento/PageCache/view/frontend/web/js/page-cache.js#L115
             // 2.4.0 https://github.com/magento/magento2/blob/5844ade68b2f9632e3888c81c946068eba6328bb/app/code/Magento/PageCache/view/frontend/web/js/form-key-provider.js#L87
             // Magento js above sets new cookie only in case if cookie is not exist
             // but in our issue case magento js file is able to read cookie from document object (because cookie was not removed by safari)


### PR DESCRIPTION
# Description
Fixed 2 issues related to SSO
- safari: unable to add products to card(session expired) after log-in by "Bolt Shopper Assistant":

When we are logged-in by SSO without page redirect (by using Bolt Shopper Assistant for example) in this case Magento removing cookie by backend [here](https://github.com/magento/magento2/blob/5844ade68b2f9632e3888c81c946068eba6328bb/app/code/Magento/PageCache/Observer/FlushFormKey.php). But on safari without redirect the cookie is removed from browser (you can't see cookie on the devtool) but not in window.document object(we can see the cookie "form_key" there by checking object in browser console: "document.cookie") therefore all future requests is being called without "form_key" which is the reason of  "session expire" issue.
By normal flow Magento updates that cookie in files:
[2.3.0](https://github.com/magento/magento2/blob/44a7b6079bcac5ba92040b16f4f74024b4f34d09/app/code/Magento/PageCache/view/frontend/web/js/page-cache.js#L115)
[2.4.0](https://github.com/magento/magento2/blob/5844ade68b2f9632e3888c81c946068eba6328bb/app/code/Magento/PageCache/view/frontend/web/js/form-key-provider.js#L87) 
Magento js above sets new cookie only in case if cookie is not exist, but in our issue case Magento js file is able to read cookie from document object (because cookie was not removed by safari) and doesn't update browser cookie which is the root cause of "session expired error".

- Fixed guest cart merging issue for Magento 2.3.0

In Magento 2.3.0 the [code](https://github.com/magento/magento2/blob/44a7b6079bcac5ba92040b16f4f74024b4f34d09/app/code/Magento/Quote/Model/QuoteManagement.php#L297) doesn't have "merging" part as we have [here](https://github.com/magento/magento2/blob/5844ade68b2f9632e3888c81c946068eba6328bb/app/code/Magento/Quote/Model/QuoteManagement.php#L337) in Magento 2.4.0
Fixes: https://app.asana.com/0/1201931884901947/1203517869067339/f

Tested locally in chrome/safari with guest cards without/with products log-in by normal sso flow, bolt modal, bolt shopper assistant

#changelog fix sso safari flow by log-in by "Bolt Shopper Assistant"

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
