### PR TITLE
[subscriptions] Call setupProductPage when configurable product swatch options are changed

### DIFF
--- a/view/frontend/templates/subscription_freq_selector_product_page.phtml
+++ b/view/frontend/templates/subscription_freq_selector_product_page.phtml
@@ -161,5 +161,11 @@ if (!$block->isBoltProductPageForFrequencySelector()) { return;
         };
 
         setupProductPage();
+
+        $(document).on('updatePrice', function (event, data) {
+            if (data) {
+                setupProductPage();
+            }
+        });
     });
 </script>


### PR DESCRIPTION
# Description

We want to eventually support subscription offers at the product variant level. For example, we want to support offering a subscription for a red jacket, but not a yellow jacket variant. We need a way to listen for when the shopper changes the product color swatch. I found this code that adds a listener for the `updatePrice` event in the `button_product_page.phtml` file. I would like confirmation as to whether `updatePrice` is the correct event to listen on, and if it is, if there's any documentation for it.





#changelog [subscriptions] Call setupProductPage when configurable product swatch options are changed

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
