### PR TITLE
On success callback: added transaction data as argument

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -635,7 +635,7 @@ $isLoadOpenReplayJsDynamic = $block->isDisableOpenReplayJs();
                         if (typeof data !== 'undefined') {
                             callbacks.success_url = data.success_url;
                         }
-                        trackCallbacks.onSuccess(data);
+                        trackCallbacks.onSuccess(transaction);
                     } finally {
                         callback();
                     }

--- a/view/frontend/web/js/bolt-api-driven-checkout.js
+++ b/view/frontend/web/js/bolt-api-driven-checkout.js
@@ -637,7 +637,7 @@ define([
                             if (typeof data !== 'undefined') {
                                 BoltCheckoutApiDriven.boltCallbacks.success_url = data.success_url;
                             }
-                            window.boltConfig.trackCallbacks.onSuccess(data);
+                            window.boltConfig.trackCallbacks.onSuccess(transaction);
                         } finally {
                             callback();
                         }


### PR DESCRIPTION
# Description
- Replaced  `onSuccess` callback argument `data` whith `transaction` data without renaming of argument name to save possible backward functionality.(if one of merchants is checking existing `data` argument)
- Did the same for "fetch cart project" js file.

Fixes: https://app.asana.com/0/951157735838091/1203434860273469/f

#changelog fixed onSuccess callback argument data

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
