### PR TITLE
Pre-Fetch cart implementation

### DIFF
--- a/Helper/Api.php
+++ b/Helper/Api.php
@@ -106,6 +106,11 @@ class Api extends AbstractHelper
     const API_AUTHORIZE_TRANSACTION = 'merchant/transactions/authorize';
 
     /**
+     * Api pre fetch cart
+     */
+    const API_PRE_FETCH_CART = 'order/pre_fetch_cart';
+
+    /**
      * Api oauth token exchange
      */
     const API_OAUTH_TOKEN = 'oauth/token';
@@ -114,6 +119,7 @@ class Api extends AbstractHelper
      * Path for sandbox mode
      */
     const XML_PATH_SANDBOX_MODE = 'payment/boltpay/sandbox_mode';
+
 
     /**
      * @var ZendClientFactory

--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -539,6 +539,18 @@ class Decider extends AbstractHelper
     }
 
     /**
+     * Checks whether the feature switch for pre-fetching cart via api is enabled
+     *
+     * @return bool whether the feature switch is enabled
+     *
+     * @throws LocalizedException if the feature switch key is unknown
+     */
+    public function isEnabledPreFetchCartViaApi()
+    {
+        return $this->isSwitchEnabled(Definitions::M2_PRE_FETCH_CART_VIA_API);
+    }
+
+    /**
      * Checks whether the feature switch for catalog ingestion instance update is disabled
      *
      * @return bool whether the feature switch is enabled

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -651,8 +651,8 @@ class Definitions
         self::M2_PRE_FETCH_CART_VIA_API => [
             self::NAME_KEY        => self::M2_PRE_FETCH_CART_VIA_API,
             self::VAL_KEY         => true,
-            self::DEFAULT_VAL_KEY => false,
-            self::ROLLOUT_KEY     => 0
+            self::DEFAULT_VAL_KEY => true,
+            self::ROLLOUT_KEY     => 100
         ],
     ];
 }

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -312,6 +312,11 @@ class Definitions
      */
     const M2_FETCH_CART_VIA_API = 'M2_FETCH_CART_VIA_API';
 
+    /**
+     * Enable M2 pre-fetch cart via api
+     */
+    const M2_PRE_FETCH_CART_VIA_API = 'M2_PRE_FETCH_CART_VIA_API';
+
     const DEFAULT_SWITCH_VALUES = [
         self::M2_SAMPLE_SWITCH_NAME => [
             self::NAME_KEY        => self::M2_SAMPLE_SWITCH_NAME,
@@ -642,6 +647,12 @@ class Definitions
             self::VAL_KEY         => true,
             self::DEFAULT_VAL_KEY => false,
             self::ROLLOUT_KEY     => 0
-        ]
+        ],
+        self::M2_PRE_FETCH_CART_VIA_API => [
+            self::NAME_KEY        => self::M2_PRE_FETCH_CART_VIA_API,
+            self::VAL_KEY         => true,
+            self::DEFAULT_VAL_KEY => false,
+            self::ROLLOUT_KEY     => 0
+        ],
     ];
 }

--- a/Plugin/Magento/Checkout/CustomerData/Cart.php
+++ b/Plugin/Magento/Checkout/CustomerData/Cart.php
@@ -216,7 +216,7 @@ class Cart
             // makes bolt pre-fetch cart request if customer-data is not in cache
             if (!$this->getCustomerDataFromCache($customerDataHash)) {
                 $this->preFetchCartBoltRequest($quote, $customerData);
-                $this->saveCustomerDataToCache($customerData, $customerDataHash);
+                $this->saveCustomerDataToCache($customerDataHash);
             }
         } catch (\Exception $e) {
             $this->bugsnag->notifyException($e);
@@ -236,8 +236,8 @@ class Cart
     {
 
         $apiKey = $this->configHelper->getApiKey($quote->getStoreId());
-        $publishKey = $this->configHelper->getPublishableKeyCheckout($quote->getStoreId());
-        if (!$apiKey || !$publishKey) {
+        $publishableKey = $this->configHelper->getPublishableKeyCheckout($quote->getStoreId());
+        if (!$apiKey || !$publishableKey) {
             throw new LocalizedException(
                 __('Bolt API Key or Publishable Key - Multi Step is not configured')
             );
@@ -249,7 +249,7 @@ class Cart
             ->setRequestMethod('POST')
             ->setHeaders(
                 [
-                    'X-Publishable-Key' => $publishKey
+                    'X-Publishable-Key' => $publishableKey
                 ]
             )->setApiData(
                 [
@@ -275,13 +275,12 @@ class Cart
      * Save customer data to cache
      *
      * @param string $customerDataHash
-     * @param array $customerData
      * @return bool
      */
-    private function saveCustomerDataToCache(array $customerData, string $customerDataHash): bool
+    private function saveCustomerDataToCache(string $customerDataHash): bool
     {
         return $this->cache->save(
-            $this->serializer->serialize($customerData),
+            'true',
             $customerDataHash, [self::PRE_FETCH_CART_CUSTOMER_DATA_CACHE_TAG],
             self::PRE_FETCH_CART_CUSTOMER_DATA_CACHE_LIFETIME
         );

--- a/Plugin/Magento/Checkout/CustomerData/Cart.php
+++ b/Plugin/Magento/Checkout/CustomerData/Cart.php
@@ -268,7 +268,7 @@ class Cart
      */
     private function getCustomerDataHash(array $customerData): string
     {
-        return md5($this->serializer->serialize($customerData));
+        return hash('md5', $this->serializer->serialize($customerData));
     }
 
     /**

--- a/Plugin/Magento/Checkout/CustomerData/Cart.php
+++ b/Plugin/Magento/Checkout/CustomerData/Cart.php
@@ -214,9 +214,9 @@ class Cart
         $customerDataHash = $this->getCustomerDataHash($customerData);
         try {
             // makes bolt pre-fetch cart request if customer-data is not in cache
-            if (!$this->getCustomerDataFromCache($customerDataHash)) {
+            if (!$this->getCustomerDataHashFromCache($customerDataHash)) {
                 $this->preFetchCartBoltRequest($quote, $customerData);
-                $this->saveCustomerDataToCache($customerDataHash);
+                $this->saveCustomerDataHashToCache($customerDataHash);
             }
         } catch (\Exception $e) {
             $this->bugsnag->notifyException($e);
@@ -277,7 +277,7 @@ class Cart
      * @param string $customerDataHash
      * @return bool
      */
-    private function saveCustomerDataToCache(string $customerDataHash): bool
+    private function saveCustomerDataHashToCache(string $customerDataHash): bool
     {
         return $this->cache->save(
             'true',
@@ -292,7 +292,7 @@ class Cart
      * @param string $customerDataHash
      * @return string|null
      */
-    private function getCustomerDataFromCache(string $customerDataHash): ?string
+    private function getCustomerDataHashFromCache(string $customerDataHash): ?string
     {
         return $this->cache->load($customerDataHash);
     }


### PR DESCRIPTION
# Description
Pre-Fetch cart implementated:
- added new feature switcher `M2_PRE_FETCH_CART_VIA_API` 
- now we are sending request to bolt API `/v1/order/pre_fetch_cart` when magento card is requested by JS customer-data (it happens in cases when card updated/created). The current customer-data is stored in magento cache by tag `PRE_FETCH_CART_CUSTOMER_DATA_CACHE_TAG` with lifetime 1h with hash  identity md5 of serialized customer-data array. If customer-data has diff hash value it means customer-data contains diff data and we must send pre-fetch request to bolt api.

Fixes: https://app.asana.com/0/1201931884901947/1203149984455025/f

#changelog Pre-Fetch cart implementation

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
