### PR TITLE
Prevent Amnasty from adding duplicate giftcards to bolt cart

### DIFF
--- a/ThirdPartyModules/Amasty/GiftCard.php
+++ b/ThirdPartyModules/Amasty/GiftCard.php
@@ -140,6 +140,15 @@ class GiftCard
                     ->getGiftCardsByQuoteId($quote->getId());
                 /** @var \Amasty\GiftCard\Model\Quote|\Amasty\GiftCard\Model\Account $giftcard */
                 foreach ($giftcardQuotes->getItems() as $giftcard) {
+                    $alreadyExists = false;
+                    foreach ($discounts as $discount) {
+                        if($discount->reference == $giftCardCode){
+                            $alreadyExists = true;
+                            break;
+                        }
+                    }
+                    if($alreadyExists) continue;
+
                     $amount = abs((float)$giftcard->getCurrentValue());
                     $roundedAmount = CurrencyUtils::toMinor($amount, $currencyCode);
                     $giftCardCode = $giftcard->getCode();


### PR DESCRIPTION
# Description
Fixing a bug which caused the same gift card to be added to the cart multiple times. This should prevent adding a giftcard if the code/reference is already added

Fixes: (link ticket)
https://app.asana.com/0/951157735838091/1203645260964776/f

#changelog Prevent Amnasty from adding duplicate giftcards to bolt cart
Do not add Amnasty giftcard if code already exists in cart

# Type of change

- [ x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ x] I have added my ticket link and provided a changelog message.
