### PR TITLE
Amasty promo rule coupon code duplication fix

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -2295,6 +2295,7 @@ class Cart extends AbstractHelper
                         $ruleDescription = $rule->getDescription();
                         $description = $ruleDescription !== '' ? $ruleDescription : 'Discount (' . $couponCode . ')';
                         $discounts[] = [
+                            'rule_id'           => $rule->getRuleId(),
                             'description'       => $description,
                             'amount'            => $roundedAmount,
                             'reference'         => $couponCode,
@@ -2312,6 +2313,7 @@ class Cart extends AbstractHelper
                             $description = $rule->getName();
                         }
                         $discounts[] = [
+                            'rule_id'           => $rule->getRuleId(),
                             'description'       => trim(__('Discount ') . $description),
                             'amount'            => $roundedAmount,
                             'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_AUTO_PROMO,

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -3952,17 +3952,19 @@ ORDER
         $quote->method('getAppliedRuleIds')->willReturn('2,3,4,5,6');
 
         $rule2 = $this->getMockBuilder(DataObject::class)
-        ->setMethods(['getCouponType', 'getDescription', 'getSimpleAction'])
+        ->setMethods(['getCouponType', 'getDescription', 'getSimpleAction', 'getRuleId'])
         ->disableOriginalConstructor()
         ->getMock();
         $rule2->expects(static::once())->method('getCouponType')
         ->willReturn('SPECIFIC_COUPON');
         $rule2->expects(static::once())->method('getDescription')
         ->willReturn(self::COUPON_DESCRIPTION);
+        $rule2->expects(static::once())->method('getRuleId')
+            ->willReturn(2);
         $rule2->method('getSimpleAction')->willReturn('by_fixed');
 
         $rule3 = $this->getMockBuilder(DataObject::class)
-        ->setMethods(['getCouponType', 'getDescription', 'getSimpleAction'])
+        ->setMethods(['getCouponType', 'getDescription', 'getSimpleAction', 'getRuleId'])
         ->disableOriginalConstructor()
         ->getMock();
         $rule3->expects(static::once())->method('getCouponType')
@@ -3970,9 +3972,11 @@ ORDER
         $rule3->expects(static::any())->method('getDescription')
         ->willReturn('Shopping cart price rule for the cart over $10');
         $rule3->method('getSimpleAction')->willReturn('by_fixed');
+        $rule3->expects(static::once())->method('getRuleId')
+            ->willReturn(3);
 
         $rule4 = $this->getMockBuilder(DataObject::class)
-        ->setMethods(['getCouponType', 'getDescription', 'getSimpleAction'])
+        ->setMethods(['getCouponType', 'getDescription', 'getSimpleAction', 'getRuleId'])
         ->disableOriginalConstructor()
         ->getMock();
         $rule4->expects(static::once())->method('getCouponType')
@@ -3980,9 +3984,11 @@ ORDER
         $rule4->expects(static::once())->method('getDescription')
         ->willReturn('');
         $rule4->method('getSimpleAction')->willReturn('by_fixed');
+        $rule4->expects(static::once())->method('getRuleId')
+            ->willReturn(4);
 
         $rule5 = $this->getMockBuilder(DataObject::class)
-        ->setMethods(['getCouponType', 'getDescription', 'getSimpleAction'])
+        ->setMethods(['getCouponType', 'getDescription', 'getSimpleAction', 'getRuleId'])
         ->disableOriginalConstructor()
         ->getMock();
         $rule5->expects(static::once())->method('getCouponType')
@@ -3990,9 +3996,11 @@ ORDER
         $rule5->expects(static::once())->method('getDescription')
         ->willReturn('');
         $rule5->method('getSimpleAction')->willReturn('by_fixed');
+        $rule5->expects(static::once())->method('getRuleId')
+            ->willReturn(5);
 
         $rule6 = $this->getMockBuilder(DataObject::class)
-            ->setMethods(['getCouponType', 'getDescription','getName','getSimpleAction'])
+            ->setMethods(['getCouponType', 'getDescription','getName','getSimpleAction', 'getRuleId'])
             ->disableOriginalConstructor()
             ->getMock();
         $rule6->expects(static::once())->method('getCouponType')
@@ -4000,6 +4008,8 @@ ORDER
         $rule6->expects(static::once())->method('getDescription')->willReturn(null);
         $rule6->expects(static::never())->method('getName');
         $rule6->method('getSimpleAction')->willReturn('by_fixed');
+        $rule6->expects(static::once())->method('getRuleId')
+            ->willReturn(6);
 
         $this->ruleRepository->expects(static::exactly(5))
         ->method('getById')
@@ -4033,6 +4043,7 @@ ORDER
         $expectedTotalAmount = $totalAmount - (2 * $expectedDiscountAmount) - 2 * $expectedDiscountAmountNoCoupon;
         $expectedDiscount = [
         [
+            'rule_id' => 2,
             'description' => self::COUPON_DESCRIPTION,
             'amount'      => $expectedDiscountAmount,
             'reference'   => self::COUPON_CODE,
@@ -4041,6 +4052,7 @@ ORDER
             'type'   => 'fixed_amount',
         ],
         [
+            'rule_id' => 3,
             'description' => trim(__('Discount ') . 'Shopping cart price rule for the cart over $10'),
             'amount'      => $expectedDiscountAmountNoCoupon,
             'discount_category' => 'automatic_promotion',
@@ -4048,6 +4060,7 @@ ORDER
             'type'   => 'fixed_amount',
         ],
         [
+            'rule_id' => 4,
             'description' => trim(__('Discount')),
             'amount'      => 0,
             'discount_category' => 'automatic_promotion',
@@ -4055,6 +4068,7 @@ ORDER
             'type'              => 'fixed_amount',
         ],
         [
+            'rule_id' => 5,
             'description' => trim(__('Discount (') . self::COUPON_CODE . ')'),
             'amount'      => $expectedDiscountAmount,
             'reference'   => self::COUPON_CODE,
@@ -4063,6 +4077,7 @@ ORDER
             'type'              => 'fixed_amount',
         ],
         [
+            'rule_id' => 6,
             'description' => trim(__('Discount ')),
             'amount'      => $expectedDiscountAmountNoCoupon,
             'discount_category' => 'automatic_promotion',
@@ -4400,7 +4415,7 @@ ORDER
         $quote->method('getAppliedRuleIds')->willReturn('2');
 
         $rule2 = $this->getMockBuilder(DataObject::class)
-        ->setMethods(['getCouponType', 'getDescription','getSimpleAction'])
+        ->setMethods(['getCouponType', 'getDescription','getSimpleAction', 'getRuleId'])
         ->disableOriginalConstructor()
         ->getMock();
         $rule2->expects(static::once())->method('getCouponType')
@@ -4408,6 +4423,7 @@ ORDER
         $rule2->expects(static::once())->method('getDescription')
         ->willReturn(self::COUPON_DESCRIPTION);
         $rule2->method('getSimpleAction')->willReturn('by_fixed');
+        $rule2->method('getRuleId')->willReturn(2);
 
         $this->ruleRepository->expects(static::once())
         ->method('getById')
@@ -4434,6 +4450,7 @@ ORDER
         $expectedTotalAmount = $totalAmount - $expectedRegularDiscountAmount - $expectedGiftVoucherAmount;
         $expectedDiscount = [
         [
+            'rule_id' => 2,
             'description' => self::COUPON_DESCRIPTION,
             'amount'      => $expectedRegularDiscountAmount,
             'reference'   => $giftVoucher,

--- a/ThirdPartyModules/Amasty/Promo.php
+++ b/ThirdPartyModules/Amasty/Promo.php
@@ -92,7 +92,7 @@ class Promo
                     if (
                         in_array($rule->getSimpleAction(), self::PROMO_RULES)
                         && !$rule->getExtensionAttributes()->getAmpromoRule()->getItemsDiscount()
-                        && !$this->isAmastyRuleAlreadyAppliedAsSalesRule($rule->getExtensionAttributes()->getAmpromoRule(), $discounts)
+                        && !$this->isAmastyRuleAlreadyApplied($rule, $discounts)
                     ) {
                         $amount = 0;
                         $roundedAmount = CurrencyUtils::toMinor($amount, $currencyCode);
@@ -120,20 +120,16 @@ class Promo
     }
 
     /**
-     * Check if amasty rule have relations to already applied sales rule
+     * Check if rule has been already applied
      *
-     * @param \Amasty\Promo\Api\Data\GiftRuleInterface $amastyRule
+     * @param \Magento\SalesRule\Api\Data\RuleInterface $rule
      * @param array $appliedDiscounts
      * @return bool
      */
-    private function isAmastyRuleAlreadyAppliedAsSalesRule($amastyRule, $appliedDiscounts)
+    private function isAmastyRuleAlreadyApplied($rule, $appliedDiscounts)
     {
-        $salesRuleId = $amastyRule->getSalesruleId();
-        if (!$salesRuleId) {
-            return false;
-        }
         foreach ($appliedDiscounts as $discount) {
-            if (isset($discount['rule_id']) && $discount['rule_id'] == $salesRuleId) {
+            if (isset($discount['rule_id']) && $discount['rule_id'] == $rule->getRuleId()) {
                 return true;
             }
         }

--- a/ThirdPartyModules/Amasty/Promo.php
+++ b/ThirdPartyModules/Amasty/Promo.php
@@ -92,6 +92,7 @@ class Promo
                     if (
                         in_array($rule->getSimpleAction(), self::PROMO_RULES)
                         && !$rule->getExtensionAttributes()->getAmpromoRule()->getItemsDiscount()
+                        && !$this->isAmastyRuleAlreadyAppliedAsSalesRule($rule->getExtensionAttributes()->getAmpromoRule(), $discounts)
                     ) {
                         $amount = 0;
                         $roundedAmount = CurrencyUtils::toMinor($amount, $currencyCode);
@@ -116,6 +117,27 @@ class Promo
         } finally {
             return [$discounts, $totalAmount, $diff];
         }
+    }
+
+    /**
+     * Check if amasty rule have relations to already applied sales rule
+     *
+     * @param \Amasty\Promo\Api\Data\GiftRuleInterface $amastyRule
+     * @param array $appliedDiscounts
+     * @return bool
+     */
+    private function isAmastyRuleAlreadyAppliedAsSalesRule($amastyRule, $appliedDiscounts)
+    {
+        $salesRuleId = $amastyRule->getSalesruleId();
+        if (!$salesRuleId) {
+            return false;
+        }
+        foreach ($appliedDiscounts as $discount) {
+            if (isset($discount['rule_id']) && $discount['rule_id'] == $salesRuleId) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
Amasty promo rule bolt modal coupon code duplication fix

# Description
Magento Legacy Mode:
- With "amasty/promo": "2.13.0", Magento 2.4.5-p1, Bolt 2.26.5 all types of amasty promo rules is applied on general discount collection step and not require additional 3th party module collect process.

Fixes: https://app.asana.com/0/951157735838091/1203645260964776/f

#changelog Amasty promo rule bolt modal coupon code duplication fix

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [x] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
