### PR TITLE
PPC out of stock products

### DIFF
--- a/view/frontend/templates/button_product_page.phtml
+++ b/view/frontend/templates/button_product_page.phtml
@@ -30,6 +30,9 @@ if (!$block->isBoltProductPage()) { return;
 if (!$block->isSupportableType()) { return;
 }
 
+if (!$block->getProduct()->isSaleable()) { return;
+}
+
 $additionalClass = $block->getAdditionalCheckoutButtonClass();
 $additionalCheckoutButtonAttributes = '';
 foreach ($block->getAdditionalCheckoutButtonAttributes() as $attrName => $attrValue) {


### PR DESCRIPTION
# Description
- Fixed unexpected "product page checkout" button rendering for out of stock products.

We include our ppc template in magento addtocart.phtml [here](https://github.com/magento/magento2/blob/647b34eb3d8bc13c02adca1262aaab389dec1324/app/code/Magento/Catalog/view/frontend/templates/product/view/addtocart.phtml#L37) you can see that this default magento template have product saleable check conditition [here](https://github.com/magento/magento2/blob/647b34eb3d8bc13c02adca1262aaab389dec1324/app/code/Magento/Catalog/view/frontend/templates/product/view/addtocart.phtml#L11). If merchant use default template the ppc bolt button won't rendered. But if merchant have some diff structure which calls `<?= $block->getChildHtml('', true) ?>` not under saleable check condition bolt button will be rendered. I fixed this by adding saleable check in our ppc template.

Fixes: https://app.asana.com/0/951157735838091/1204026807839711/f

#changelog ppc out of stock products button rendered fix

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
