### PR TITLE
UpdateDiscountTrait refactoring

### DIFF
--- a/Model/Api/DiscountCodeValidation.php
+++ b/Model/Api/DiscountCodeValidation.php
@@ -35,7 +35,6 @@ class DiscountCodeValidation extends UpdateCartCommon implements DiscountCodeVal
 {
     use UpdateDiscountTrait {
         __construct as private UpdateDiscountTraitConstructor;
-        applyingGiftCardCode as private UpdateDiscountTraitApplyingGiftCardCode;
     }
 
     /**

--- a/Model/Api/UpdateDiscountTrait.php
+++ b/Model/Api/UpdateDiscountTrait.php
@@ -202,7 +202,7 @@ trait UpdateDiscountTrait
         if ($coupon && ($coupon->getCouponId() || $this->eventsForThirdPartyModules->runFilter("isValidCouponObj", false, $coupon, $couponCode))) {
             $result = $this->applyingCouponCode($couponCode, $coupon, $quote);
         } elseif ($giftCard && $giftCard->getId()) {
-            $result = $this->applyingGiftCardCode($couponCode, $giftCard, $quote);
+            $result = $this->applyGiftCardCode($couponCode, $giftCard, $quote);
         } else {
             throw new WebApiException(__('Something happened with current code.'));
         }
@@ -421,7 +421,7 @@ trait UpdateDiscountTrait
      * @return boolean
      * @throws BoltException
      */
-    private function applyingGiftCardCode($couponCode, $giftCard, $quote)
+    private function applyGiftCardCode($couponCode, $giftCard, $quote)
     {
         try {
             $result = $this->eventsForThirdPartyModules->runFilter(

--- a/Test/Unit/Model/Api/UpdateDiscountTraitTest.php
+++ b/Test/Unit/Model/Api/UpdateDiscountTraitTest.php
@@ -1143,9 +1143,9 @@ class UpdateDiscountTraitTest extends BoltTestCase
     /**
      * @test
      *
-     * @covers \Bolt\Boltpay\Model\Api\UpdateDiscountTrait::applyingGiftCardCode
+     * @covers \Bolt\Boltpay\Model\Api\UpdateDiscountTrait::applyGiftCardCode
      */
-    public function applyingGiftCardCode_amastyGiftCard()
+    public function applyGiftCardCode_amastyGiftCard()
     {
         global $ifRunFilter;
         $quote = $this->getQuoteMock();
@@ -1157,7 +1157,7 @@ class UpdateDiscountTraitTest extends BoltTestCase
         $ifRunFilter = $giftcardMock;
         $giftcardMock->expects(static::never())->method('getCodeId')->willReturn(self::COUPON_ID);
 
-        $result = TestHelper::invokeMethod($this->currentMock, 'applyingGiftCardCode', [self::COUPON_CODE, $giftcardMock, $quote]);
+        $result = TestHelper::invokeMethod($this->currentMock, 'applyGiftCardCode', [self::COUPON_CODE, $giftcardMock, $quote]);
 
         $this->assertTrue($result);
     }


### PR DESCRIPTION
- Remove applyingGiftCardCode which we do not use
- Rename applyingGiftCardCode to applyGiftCardCode to fix issue with static type checker

Class Model/Api/DiscountCodeValidation has its own applyingGiftCardCode method with 4 arguments, so when we include the trait into this class with a function with the same name but the different number of arguments it shows an error.

Asana:
https://app.asana.com/0/1201931884901947/1204028793252855/f

#changelog UpdateDiscountTrait refactoring