### PR TITLE
Store credova_public_id and credova_application_id in payment and order info object

### DIFF
--- a/Block/Info.php
+++ b/Block/Info.php
@@ -50,6 +50,14 @@ class Info extends \Magento\Payment\Block\Info
             $data[(string)__('Credit Card Number')] = sprintf('xxxx-%s', $ccLast4);
         }
 
+        if ($credovaPublicId = $info->getAdditionalInformation('credova_public_id')) {
+            $data[(string)__('Credova Public Id')]  = $credovaPublicId;
+        }
+
+        if ($credovaApplicationId = $info->getAdditionalInformation('credova_application_id')) {
+            $data[(string)__('Credova Application Id')]  = $credovaApplicationId;
+        }
+
         if ($data) {
             $transport->setData(array_merge($transport->getData(), $data));
         }

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -118,7 +118,8 @@ class Order extends AbstractHelper
         'affirm' => 'Affirm',
         'braintree' => 'Braintree',
         'applepay' => 'ApplePay',
-        'amazon_pay' => 'AmazonPay'
+        'amazon_pay' => 'AmazonPay',
+        'credova' => 'Credova'
     ];
 
     /**
@@ -834,6 +835,20 @@ class Order extends AbstractHelper
             ];
             $payment->setAdditionalInformation(array_merge((array)$payment->getAdditionalInformation(), $paymentData));
         }
+
+        if (
+            !empty($transaction->processor)
+            && $transaction->processor == 'credova'
+            && !empty($transaction->transaction_properties->credova_public_id)
+            && !empty($transaction->transaction_properties->credova_application_id)
+        ) {
+            $paymentData = [
+                'credova_public_id' => $transaction->transaction_properties->credova_public_id,
+                'credova_application_id' => $transaction->transaction_properties->credova_application_id
+            ];
+            $payment->setAdditionalInformation(array_merge((array)$payment->getAdditionalInformation(), $paymentData));
+        }
+
 
         $payment->save();
     }

--- a/Test/Unit/Plugin/Magento/Ui/Component/Form/Element/SelectPluginTest.php
+++ b/Test/Unit/Plugin/Magento/Ui/Component/Form/Element/SelectPluginTest.php
@@ -111,6 +111,11 @@ class SelectPluginTest extends BoltTestCase
                 '__disableTmpl' => true,
             ],
             [
+                'value'         => 'boltpay_credova',
+                'label'         => 'Bolt-Credova',
+                '__disableTmpl' => true,
+            ],
+            [
                 'value'         => 'boltpay_amex',
                 'label'         => 'Bolt-Amex',
                 '__disableTmpl' => true,


### PR DESCRIPTION
# Description
Store credova_public_id and credova_application_id in the payment info object and show it in admin order
See screenshot: https://prnt.sc/v883yEXjADzm

This is from Metroplex's requirement
Fixes: https://app.asana.com/0/1201495896048972/1202938624902004

#changelog Store credova_public_id and credova_application_id in payment and order info object

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
