### PR TITLE
Resolve issues with multiple calls to whenDefined

### DIFF
--- a/view/frontend/web/js/utils/when-defined.js
+++ b/view/frontend/web/js/utils/when-defined.js
@@ -17,9 +17,9 @@
 define([], function () {
     /**
      * Map of watched objects to maps of their respective watched properties to configured callbacks
-     * @type {Map<Object, Map<string, Map<string, Function>>>}
+     * @type {Map<Object, Map<string, Map<string, function>>>}
      */
-    var whenDefinedCallbacks = new Map([]);
+    var whenDefinedCallbacks = new Map();
 
     /**
      * Executes provided callback when a property gets defined on provided object.
@@ -29,48 +29,48 @@ define([], function () {
      * @param {Object} object to check for property definition
      * @param {number|string} property that is expected to be defined on {@see object}
      * @param {Function} callback function to be called when {@see property} gets defined on {@see object}
-     * @param {string} key used to prevent setting duplicate callbacks 
+     * @param {null} key deprecated parameter used for setting multiple callbacks per property
      */
     function whenDefined (object, property, callback, key) {
         if (object.hasOwnProperty(property) && typeof object[property] !== 'undefined') {
             callback();
-        } else {
-            var overloadedPropertyName = '_' + property;
-            if (!whenDefinedCallbacks.has(object)) {
-                whenDefinedCallbacks.set(object, new Map([]));
-            }
-            if (!whenDefinedCallbacks.get(object).has(property)) {
-                whenDefinedCallbacks.get(object).set(property, new Map([]));
-                Object.defineProperty(object, property, {
-                    configurable: true,
-                    enumerable: true,
-                    writeable: true,
-                    /**
-                     * Retrieves the watched property from overloaded index
-                     *
-                     * @returns {*} {@see property} value on {@see object}
-                     */
-                    get: function () {
-                        return this[overloadedPropertyName];
-                    },
-                    /**
-                     * Sets the overloaded property index with the provided value then executes configured callbacks
-                     *
-                     * @param {mixed} value
-                     */
-                    set: function (value) {
-                        this[overloadedPropertyName] = value;
-                        for (var propertyCallback of whenDefinedCallbacks.get(object).get(property).values()) {
-                            propertyCallback();
-                        }
-                    }
-                });
-            }
-            if (typeof key == 'undefined') {
-                key = whenDefinedCallbacks.get(object).get(property).size;
-            }
-            whenDefinedCallbacks.get(object).get(property).set(key, callback);
+            return;
         }
+        var overloadedPropertyName = '_' + property;
+        if (!whenDefinedCallbacks.has(object)) {
+            whenDefinedCallbacks.set(object, new Map());
+        }
+        if (!whenDefinedCallbacks.get(object).has(property)) {
+            whenDefinedCallbacks.get(object).set(property, new Map());
+            Object.defineProperty(object, property, {
+                configurable: true,
+                enumerable: true,
+                writeable: true,
+                /**
+                 * Retrieves the watched property from overloaded index
+                 *
+                 * @returns {*} {@see property} value on {@see object}
+                 */
+                get: function () {
+                    return this[overloadedPropertyName];
+                },
+                /**
+                 * Sets the overloaded property index with the provided value then executes configured callbacks
+                 *
+                 * @param {mixed} value
+                 */
+                set: function (value) {
+                    this[overloadedPropertyName] = value;
+                    for (var propertyCallback of whenDefinedCallbacks.get(object).get(property).values()) {
+                        propertyCallback();
+                    }
+                }
+            });
+        }
+        if (typeof key == 'undefined') {
+            key = whenDefinedCallbacks.get(object).get(property).size;
+        }
+        whenDefinedCallbacks.get(object).get(property).set(key, callback);
     }
 
     return whenDefined;

--- a/view/frontend/web/js/utils/when-defined.test.js
+++ b/view/frontend/web/js/utils/when-defined.test.js
@@ -1,0 +1,52 @@
+define(['Bolt_Boltpay/js/utils/when-defined'], function (whenDefined) {
+    'use strict';
+    describe('Bolt_Boltpay/js/utils/when-defined', function () {
+        var callback, callback2, object = {};
+
+        beforeEach(function () {
+            callback = jasmine.createSpy('callback');
+            callback2 = jasmine.createSpy('callback2');
+            object = {};
+        });
+        it('Check callback not to be called without assignment', function () {
+            whenDefined(object, 'prop', callback);
+            expect(callback).not.toHaveBeenCalled();
+        });
+        it('Check callback to be called on assignment', function () {
+            whenDefined(object, 'prop', callback);
+            object.prop = 'value';
+            expect(callback).toHaveBeenCalled();
+            expect(object.prop).toBe('value');
+        });
+        it('Check multiple callbacks on separate properties', function () {
+            whenDefined(object, 'prop1', callback);
+            whenDefined(object, 'prop2', callback);
+            object.prop1 = 'value1';
+            object.prop2 = 'value2';
+            expect(callback).toHaveBeenCalledTimes(2);
+            expect(object.prop1).toBe('value1');
+            expect(object.prop2).toBe('value2');
+        });
+        it('Check multiple callbacks with unique id', function () {
+            whenDefined(object, 'prop', callback, 'unique_id');
+            whenDefined(object, 'prop', callback, 'unique_id');
+            object.prop = 'value';
+            expect(callback).toHaveBeenCalledTimes(1);
+        });
+        it('Check multiple callbacks without id and order of execution', function () {
+            whenDefined(object, 'prop', callback);
+            whenDefined(object, 'prop', function () {
+                expect(callback).toHaveBeenCalledTimes(1);
+            });
+            object.prop = 'value';
+            expect(object.prop).toBe('value');
+        });
+        it('Check value to be set before callback', function () {
+            whenDefined(object, 'prop', function () {
+                expect(object.prop).toBe('value');
+            });
+            object.prop = 'value';
+            expect(object.prop).toBe('value');
+        });
+    });
+});


### PR DESCRIPTION
# Description
We have a bug in [whenDefined](https://github.com/BoltApp/bolt-magento2/blob/master/view/frontend/web/js/utils/when-defined.js). When called multiple times it can return false positive result. The issue manifested on Headlights Depot PPC [page](https://shop.headlightsdepot.com/tail-light-smoked-factory-style-left-driver-fits-2016-2019-toyota-tacoma.html).

Fixes: ([link ticket](https://app.asana.com/0/0/1204134908074103/f))

#changelog Resolve issues with multiple calls to whenDefined

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [x] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my ticket link and provided a changelog message.
