### PR TITLE
Ajax add to cart success event timeout feature switcher

### DIFF
--- a/Block/Js.php
+++ b/Block/Js.php
@@ -565,7 +565,7 @@ class Js extends Template
         if ($this->featureSwitches->isDisableOpenReplayJs()) {
             return true;
         }
-        
+
         return false;
     }
 
@@ -873,5 +873,20 @@ function($argName) {
                 )
                 : []
         );
+    }
+
+    /**
+     * Check if ajax add to cart success event timeout disabled
+     *
+     * @return bool
+     * @throws LocalizedException
+     */
+    public function isAjaxAddToCartSuccessTimeoutDisabled()
+    {
+        if ($this->featureSwitches->isAjaxAddToCartSuccessTimeoutDisabled()) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -561,4 +561,16 @@ class Decider extends AbstractHelper
     {
         return $this->isSwitchEnabled(Definitions::M2_CATALOG_INGESTION_DISABLE_INSTANCE_PIPELINE);
     }
+
+    /**
+     * Checks whether the feature switch for ajax add to cart success timeout disabled
+     *
+     * @return bool whether the feature switch is enabled
+     *
+     * @throws LocalizedException if the feature switch key is unknown
+     */
+    public function isAjaxAddToCartSuccessTimeoutDisabled()
+    {
+        return $this->isSwitchEnabled(Definitions::M2_AJAX_ADD_TO_CART_SUCCESS_DISABLE_TIME_OUT);
+    }
 }

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -317,6 +317,11 @@ class Definitions
      */
     const M2_PRE_FETCH_CART_VIA_API = 'M2_PRE_FETCH_CART_VIA_API';
 
+    /**
+     * Enable disabling ajax add to cart success event time out
+     */
+    const M2_AJAX_ADD_TO_CART_SUCCESS_DISABLE_TIME_OUT = 'M2_AJAX_ADD_TO_CART_SUCCESS_DISABLE_TIME_OUT';
+
     const DEFAULT_SWITCH_VALUES = [
         self::M2_SAMPLE_SWITCH_NAME => [
             self::NAME_KEY        => self::M2_SAMPLE_SWITCH_NAME,
@@ -653,6 +658,12 @@ class Definitions
             self::VAL_KEY         => true,
             self::DEFAULT_VAL_KEY => true,
             self::ROLLOUT_KEY     => 100
+        ],
+        self::M2_AJAX_ADD_TO_CART_SUCCESS_DISABLE_TIME_OUT => [
+            self::NAME_KEY        => self::M2_AJAX_ADD_TO_CART_SUCCESS_DISABLE_TIME_OUT,
+            self::VAL_KEY         => true,
+            self::DEFAULT_VAL_KEY => false,
+            self::ROLLOUT_KEY     => 0
         ],
     ];
 }

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -39,6 +39,7 @@ $connectJsUrl = $block->getConnectJsUrl();
 $isLoadConnectJsDynamic = $block->isLoadConnectJsDynamic();
 $isLoadTrackJsDynamic = $block->isDisableTrackJsOnNonBoltPages() && $isLoadConnectJsDynamic;
 $isLoadOpenReplayJsDynamic = $block->isDisableOpenReplayJs();
+$isAjaxAddToCartSuccessTimeoutDisabled = $block->isAjaxAddToCartSuccessTimeoutDisabled();
 ?>
 
 <script type="text/javascript">
@@ -1493,7 +1494,11 @@ $isLoadOpenReplayJsDynamic = $block->isDisableOpenReplayJs();
                 expectCartRendering = true;
                 // If merchant shows popup after add to cart
                 // delay 0 allows to render bolt button before we call configure
-                setTimeout(callConfigureWithPromises, 0);
+                <?php if ($isAjaxAddToCartSuccessTimeoutDisabled): ?>
+                    callConfigureWithPromises();
+                <?php else: ?>
+                    setTimeout(callConfigureWithPromises, 0);
+                <?php endif; ?>
                 // set flag to animate always present button when we catch cart updating
                 if (boltConfig.always_present_checkout) {
                     newItemAddedToCart = true;


### PR DESCRIPTION
# Description
- added new feature switcher: `M2_AJAX_ADD_TO_CART_SUCCESS_DISABLE_TIME_OUT`
- If the switcher above is enabled we are not using zero timeout for bolt configure call after `ajax:addToCart` js event.

Fixes: [(link ticket)](https://app.asana.com/0/1200879031426307/1204090292056675/f)

#changelog feature switcher to disable timeout on ajax:addToCart event bolt configure call

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
