### PR TITLE
Add Aheadworks api permission

### DIFF
--- a/etc/integration/api.xml
+++ b/etc/integration/api.xml
@@ -58,6 +58,7 @@
             <resource name="Magento_Backend::stores_settings" />
             <resource name="Magento_Backend::store" />
             <resource name="Magento_GiftCardAccount::customer_giftcardaccount"/>
+            <resource name="Aheadworks_Giftcard::giftcard_codes"/>
         </resources>
     </integration>
 </integrations>


### PR DESCRIPTION
# Description
Adding permission to our API integration to allow calling Aheadworks GetGiftCard endpoint. Following is response received without permission active when calling{{base_domain}}/rest/V1/awGiftcard/{code}:

```
{
    "message": "The consumer isn't authorized to access %resources.",
    "parameters": {
        "resources": "Aheadworks_Giftcard::giftcard_codes"
    }
}
```

Fixes: https://app.asana.com/0/1201931884901947/1204167784025530/f

#changelog
Added permission to support Aheadworks GiftCard API usage.

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
