### PR TITLE
Fix bug: Boltpay order is created with Magento submit order button in admin

### DIFF
--- a/view/adminhtml/templates/boltpay/button.phtml
+++ b/view/adminhtml/templates/boltpay/button.phtml
@@ -41,7 +41,7 @@ foreach ($block->getAdditionalCheckoutButtonAttributes() as $attrName => $attrVa
     <div class="bolt-checkout-button with-cards" <?= /* @noEscape */ $additionalCheckoutButtonAttributes ?>></div>
     <div class="bolt-checkout-options-separator" style="padding: 20px; display: none;">-- <?= /* @noEscape */ __('OR')?> --</div>
     <div class="bolt-checkout-pay-by-link"></div>
-    <input type="hidden" class="required-entry" id="bolt-required-field">
+    <input type="hidden" name="bolt-require-field" class="required-entry" id="bolt-required-field">
 </fieldset>
 
     <?php if ($isAdminReorderForLoggedInCustomerFeatureEnabled && $customerCreditCardInfos): ?>


### PR DESCRIPTION
# Description
Currently, the Boltpay order is still created with Magento submit order button in admin.

Before we had the PR https://github.com/BoltApp/bolt-magento2/pull/416 to force admin users to use the Bolt checkout button instead of the Magento submit order button by adding a required field with a hidden type. However, In some cases, this won't work since the input field is missing the name. So this PR is to add name for the input field

See screenshot: https://prnt.sc/rjB1rXCHIAY2

Fixes: (link ticket)

#changelog Fix bug: Boltpay order is created with Magento submit order button in admin

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
