### PR TITLE
Show detail error message if customer cannot place order in admin

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -904,7 +904,6 @@ class Cart extends AbstractHelper
             throw new LocalizedException(
                 __('Order was created. Please reload the page and try again')
             );
-            return;
         }
 
         if (version_compare($this->configHelper->getStoreVersion(), '2.3.6', '<') && $this->deciderHelper->isAPIDrivenIntegrationEnabled()) {
@@ -2124,8 +2123,6 @@ class Cart extends AbstractHelper
                     throw new LocalizedException(
                         __('Billing address is missing. Please input all required fields in billing address form and try again')
                     );
-
-                    return [];
                 }
             } else {
                 // assign parent shipping method to clone
@@ -2142,8 +2139,6 @@ class Cart extends AbstractHelper
                     throw new LocalizedException(
                         __('Shipping method is missing. Please select shipping method and try again')
                     );
-
-                    return [];
                 }
 
                 if (!$this->isBackendSession()) {
@@ -2219,8 +2214,6 @@ class Cart extends AbstractHelper
                     throw new LocalizedException(
                         __('Shipping address is missing. Please input all required fields in shipping address form and try again')
                     );
-
-                    return [];
                 }
             }
 

--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -901,6 +901,9 @@ class Cart extends AbstractHelper
 
         if ($this->doesOrderExist($cart, $quote)) {
             $this->deactivateSessionQuote($quote);
+            throw new LocalizedException(
+                __('Order was created. Please reload the page and try again')
+            );
             return;
         }
 
@@ -2117,6 +2120,11 @@ class Cart extends AbstractHelper
                         'Order create error',
                         'Billing address data insufficient.'
                     );
+
+                    throw new LocalizedException(
+                        __('Billing address is missing. Please input all required fields in billing address form and try again')
+                    );
+
                     return [];
                 }
             } else {
@@ -2130,6 +2138,11 @@ class Cart extends AbstractHelper
                         'Order create error',
                         'Shipping method not set.'
                     );
+
+                    throw new LocalizedException(
+                        __('Shipping method is missing. Please select shipping method and try again')
+                    );
+
                     return [];
                 }
 
@@ -2202,6 +2215,11 @@ class Cart extends AbstractHelper
                         'Order create error',
                         'Shipping address data insufficient.'
                     );
+
+                    throw new LocalizedException(
+                        __('Shipping address is missing. Please input all required fields in shipping address form and try again')
+                    );
+
                     return [];
                 }
             }

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -2521,7 +2521,9 @@ ORDER
         $this->currentMock->expects(static::never())->method('isBoltOrderCachingEnabled')->with(static::STORE_ID)
         ->willReturn(false);
 
-        static::assertNull($this->currentMock->getBoltpayOrder(false, ''));
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage('Order was created. Please reload the page and try again');
+        $this->currentMock->getBoltpayOrder(false, '');
     }
 
         /**
@@ -3072,7 +3074,9 @@ ORDER
         $this->objectsToClean[] = $product;
         $quote->addProduct($product, 1);
         TestUtils::setQuoteToSession($quote);
-        $result = $boltHelperCart->getCartData(true, json_encode(
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage('Billing address is missing. Please input all required fields in billing address form and try again');
+        $boltHelperCart->getCartData(true, json_encode(
             [
                 'billingAddress' => [
                     'firstname'    => "IntegrationBolt",
@@ -3089,8 +3093,6 @@ ORDER
                 ]
             ]
         ));
-
-        static::assertEquals([], $result);
     }
 
         /**
@@ -3731,7 +3733,9 @@ ORDER
         $quote->getShippingAddress()->setShippingMethod(null)->setCollectShippingRates(true);
         $quote->collectTotals()->save();
         TestUtils::setQuoteToSession($quote);
-        $result = $boltHelperCart->getCartData(
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage('Shipping method is missing. Please select shipping method and try again');
+        $boltHelperCart->getCartData(
             true,
             json_encode(
                 [
@@ -3750,10 +3754,6 @@ ORDER
                     ]
                 ]
             )
-        );
-        static::assertEquals(
-            [],
-            $result
         );
     }
 
@@ -3818,8 +3818,9 @@ ORDER
         $this->bugsnag->expects(static::once())->method('notifyError')
         ->with('Order create error', 'Shipping address data insufficient.');
         $this->deciderHelper->expects(self::once())->method('isAddSessionIdToCartMetadata')->willReturn(true);
-        $result = $currentMock->getCartData(true, json_encode([]));
-        static::assertEquals([], $result);
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage('Shipping address is missing. Please input all required fields in shipping address form and try again');
+        $currentMock->getCartData(true, json_encode([]));
     }
 
         /**


### PR DESCRIPTION
# Description
Currently, Bolt displays a general error message "Bolt order was not created successfully." if customer forgets filling require fields (Ex: shipping address, shipping method, etc) in the admin sale order creation form and clicks the Bolt button. This confuses customers since they do not know which steps they're missing  So this PR is to display the detailed error message.
See screenshot here: https://prnt.sc/KnfyxSAuYdD4


Fixes: (link ticket)

#changelog Show detail error message if customer cannot place order in admin

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
