### PR TITLE
Fix bug: Error popup trigger multi times in admin

### DIFF
--- a/view/adminhtml/templates/boltpay/button.phtml
+++ b/view/adminhtml/templates/boltpay/button.phtml
@@ -47,8 +47,8 @@ foreach ($block->getAdditionalCheckoutButtonAttributes() as $attrName => $attrVa
     <?php if ($isAdminReorderForLoggedInCustomerFeatureEnabled && $customerCreditCardInfos): ?>
     <script>
         require(['jquery', 'jquery/ui'], function($){
-            $(document).on('change', 'select[name="bolt-credit-cards"]', function(){
-
+            $(document).on('change', 'select[name="bolt-credit-cards"]', function(e){
+                e.stopImmediatePropagation();
                 var $creditCardsValue = $(this).val();
                 var $boltRequiredField = $('#bolt-required-field');
 


### PR DESCRIPTION
# Description
Currently, the Error popup triggers multi times in the admin. 
See the video for replicating the issue here: https://drive.google.com/file/d/18weqoQykbegXPcKWBJzeqLbRec54_AIZ
The cause is that sometimes, the on-change event call multi-times. And in order to fix this, we add an e.stopImmediatePropagation() into the function.

Fixes: (link ticket)

#changelog Fix bug: Error popup trigger multi times in admin

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
