### PR TITLE
Alert popup to force administrator fill billing address in the admin order creation page

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -2117,6 +2117,22 @@ class Cart extends AbstractHelper
                     $address->save();
                 }
 
+                if (
+                    $this->isBackendSession()
+                    && $requireBillingAddress
+                    && !$this->isAddressComplete($cartBillingAddress)
+                ) {
+                    $this->logAddressData($cartBillingAddress);
+                    $this->bugsnag->notifyError(
+                        'Order create error',
+                        'Billing address data insufficient.'
+                    );
+
+                    throw new LocalizedException(
+                        __('Billing address is missing. Please input all required fields in billing address form and try again')
+                    );
+                }
+
                 // Shipping address
                 $shipAddress = [
                     'first_name' => $address->getFirstname(),


### PR DESCRIPTION
# Description

Currently, customers still can place a Bolt order without filling billing address in the admin.  
See the screenshot here: https://prnt.sc/gBfBAfVUKVEx

So this PR fix issue by alerting popup to force the administrator fill billing address in the admin order creation page 
See screenshot here: https://prnt.sc/DkkFovSrrPkT

Fixes: 

#changelog Alert popup to force administrator fill billing address in the admin order creation form

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
