### PR TITLE
Request magento cart from backend if it's not present

### DIFF
--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -1253,6 +1253,14 @@ $isAjaxAddToCartSuccessTimeoutDisabled = $block->isAjaxAddToCartSuccessTimeoutDi
                 // check if magento section was initialized before our code execution
                 if (customerData.get('cart')().data_id !== undefined) {
                     magentoCartDataListener(customerData.get('cart')());
+                } else {
+                    // if magento cart is not present for some reason (wrong setup)
+                    // we need to get it ourself
+                    setTimeout(function () {
+                        if (BoltState.magentoCart === null) {
+                            customerData.invalidate(['cart']);
+                        }
+                    }, 4000);
                 }
                 if (customerData.get('boltcart')().data_id !== undefined) {
                     boltCartDataListener(customerData.get('boltcart')());

--- a/view/frontend/templates/js/replacejs.phtml
+++ b/view/frontend/templates/js/replacejs.phtml
@@ -1259,6 +1259,7 @@ $isAjaxAddToCartSuccessTimeoutDisabled = $block->isAjaxAddToCartSuccessTimeoutDi
                     setTimeout(function () {
                         if (BoltState.magentoCart === null) {
                             customerData.invalidate(['cart']);
+                            customerData.reload(['cart']);
                         }
                     }, 4000);
                 }

--- a/view/frontend/web/js/bolt-api-driven-checkout.js
+++ b/view/frontend/web/js/bolt-api-driven-checkout.js
@@ -33,7 +33,7 @@ define([
         boltCallbacks: {},
         boltParameters: {},
         quoteMaskedId: null,
-        boltCartHints: null,
+        boltCartHints: {prefill:{}},
         magentoCartTimeStamp: null,
         cartBarrier: null,
         hintsBarrier: null,
@@ -459,9 +459,8 @@ define([
                 if (!BoltCheckoutApiDriven.cartBarrier.isResolved()) {
                     BoltCheckoutApiDriven.cartBarrier.resolve(cart);
                     BoltCheckoutApiDriven.isPromisesResolved = true;
-                } else {
-                    isBoltCheckoutConfigureCallRequired = true;
                 }
+                isBoltCheckoutConfigureCallRequired = true;
             }
 
             //resolve hints promise if not resolved or prepare hints data for bolt config call
@@ -474,9 +473,8 @@ define([
                 if (!BoltCheckoutApiDriven.hintsBarrier.isResolved()) {
                     BoltCheckoutApiDriven.hintsBarrier.resolve(hints);
                     BoltCheckoutApiDriven.isPromisesResolved = true;
-                } else {
-                    isBoltCheckoutConfigureCallRequired = true;
                 }
+                isBoltCheckoutConfigureCallRequired = true;
             }
 
             //update bolt configuration if data was changed
@@ -1038,14 +1036,6 @@ define([
             //сall magento card initialisation if event happened before we subscribed to it
             if (this.customerCart()) {
                 BoltCheckoutApiDriven.magentoCartDataListener(this.customerCart());
-            } else {
-                // if magento cart is not present for some reason (wrong setup)
-                 // we need to get it ourself
-                setTimeout(function () {
-                    if (!this.customerCart()) {
-                        customerData.invalidate(['cart']);
-                    }
-                }, 4000);
             }
             //call bolt checkout configure immediately with promise parameters
             this.boltCheckoutConfigureCall(this.cartBarrier.promise, this.hintsBarrier.promise);
@@ -1057,6 +1047,14 @@ define([
             this.initPaymentOnly();
             this.initHintsObservers();
             if (!this.customerCart()) {
+                // if magento cart is not present for some reason (wrong setup)
+                // we need to get it ourself
+                setTimeout(function () {
+                    if (!BoltCheckoutApiDriven.customerCart()) {
+                        customerData.invalidate(['cart']);
+                        customerData.reload(['cart']);
+                    }
+                }, 4000);
                 return;
             }
 

--- a/view/frontend/web/js/bolt-api-driven-checkout.js
+++ b/view/frontend/web/js/bolt-api-driven-checkout.js
@@ -1038,6 +1038,14 @@ define([
             //сall magento card initialisation if event happened before we subscribed to it
             if (this.customerCart()) {
                 BoltCheckoutApiDriven.magentoCartDataListener(this.customerCart());
+            } else {
+                // if magento cart is not present for some reason (wrong setup)
+                 // we need to get it ourself
+                setTimeout(function () {
+                    if (!this.customerCart()) {
+                        customerData.invalidate(['cart']);
+                    }
+                }, 4000);
             }
             //call bolt checkout configure immediately with promise parameters
             this.boltCheckoutConfigureCall(this.cartBarrier.promise, this.hintsBarrier.promise);


### PR DESCRIPTION
Our frontend integration relies on Magento cart section data persisting and updating in local storage.
This works fine, but if the env is broken for some third-party integration Magento cart may not be retrieved and the bolt button doesn't work.
See an example in asana.

In this PR we catch this situation and requested magento cart from backend manually.

Asana:
https://app.asana.com/0/1200879031426307/1204081354756081/f

#changelog Request magento cart from backend if it's not present

