### PR TITLE
Do not allow create order by clicking Magento submit order button if the publishable back-office key is not filled

### DIFF
--- a/view/adminhtml/templates/boltpay/button.phtml
+++ b/view/adminhtml/templates/boltpay/button.phtml
@@ -17,8 +17,12 @@ foreach ($block->getAdditionalCheckoutButtonAttributes() as $attrName => $attrVa
 ?>
 
 <?php if (!$backofficePublishableKey && !$paymentOnlyKey): ?>
-    <?= /* @noEscape */ __('In order to use Bolt from admin, please set "Publishable Key - Back Office" or "Publishable 
-    Key - Payment Only" in the magento config (Stores > Configuration > Sales > Payment methods > Bolt Pay).'); ?>
+    <fieldset class="admin__fieldset payment-method" id="payment_form_<?= /* @noEscape */ $code; ?>">
+        <span>
+            <?= /* @noEscape */ __('In order to use Bolt from admin, please set "Publishable Key - Back Office" or "Publishable Key - Payment Only" in the magento config (Stores > Configuration > Sales > Payment methods > Bolt Pay).'); ?>
+        </span>
+        <input type="hidden" name="bolt-required-field" class="required-entry" id="bolt-required-field">
+    </fieldset>
 <?php else: ?>
 <fieldset class="admin__fieldset payment-method" id="payment_form_<?= /* @noEscape */ $code; ?>" style="display:none">
     <?php if ($isAdminReorderForLoggedInCustomerFeatureEnabled && $customerCreditCardInfos): ?>


### PR DESCRIPTION
# Description

Do not allow create order by clicking Magento submit order button if the publishable back-office key is not filled

See screenshot: https://prnt.sc/PJei_ENs6btC


Fixes: (link ticket)

#changelog Not allowing creating order by clicking Magento submit order button if the publishable back-office key is not filled

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
