### PR TITLE
Magento 2.4.6 support: replaced zend http client to laminas http client

### DIFF
--- a/.circleci/phpstan/phpstan.neon
+++ b/.circleci/phpstan/phpstan.neon
@@ -18,3 +18,5 @@ parameters:
 		- ViewModel
 	scanDirectories:
 		- /home/circleci/magento
+	excludePaths:
+	    - Model/HttpClientAdapter.php

--- a/Helper/Geolocation.php
+++ b/Helper/Geolocation.php
@@ -20,7 +20,7 @@ namespace Bolt\Boltpay\Helper;
 use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Framework\App\Helper\Context;
 use Bolt\Boltpay\Helper\Config as ConfigHelper;
-use Magento\Framework\HTTP\ZendClientFactory;
+use Bolt\Boltpay\Model\HttpClientAdapterFactory;
 use Magento\Framework\App\CacheInterface;
 
 /**
@@ -45,9 +45,9 @@ class Geolocation extends AbstractHelper
     private $bugsnag;
 
     /**
-     * @var ZendClientFactory
+     * @var HttpClientAdapterFactory
      */
-    private $httpClientFactory;
+    private $httpClientAdapterFactory;
 
     /**
      * @var CacheInterface
@@ -62,20 +62,20 @@ class Geolocation extends AbstractHelper
      * @param Context $context
      * @param Config $configHelper
      * @param Bugsnag $bugsnag
-     * @param ZendClientFactory $httpClientFactory
+     * @param HttpClientAdapterFactory $httpClientFactory
      * @param CacheInterface $cache
      */
     public function __construct(
         Context $context,
         ConfigHelper $configHelper,
         Bugsnag $bugsnag,
-        ZendClientFactory $httpClientFactory,
+        HttpClientAdapterFactory $httpClientAdapterFactory,
         CacheInterface $cache
     ) {
         parent::__construct($context);
         $this->configHelper = $configHelper;
         $this->bugsnag = $bugsnag;
-        $this->httpClientFactory = $httpClientFactory;
+        $this->httpClientAdapterFactory = $httpClientAdapterFactory;
         $this->cache = $cache;
     }
 
@@ -102,7 +102,7 @@ class Geolocation extends AbstractHelper
 
         $endpoint = sprintf($this->endpointFormat, $ip, $apiKey);
 
-        $client = $this->httpClientFactory->create();
+        $client = $this->httpClientAdapterFactory->create();
         $client->setUri($endpoint);
         $client->setConfig(['maxredirects' => 0, 'timeout' => 30]);
 

--- a/Model/HttpClientAdapter.php
+++ b/Model/HttpClientAdapter.php
@@ -30,8 +30,6 @@ use Magento\Framework\HTTP\ZendClientFactory;
  * Instead, we should use "Magento\Framework\HTTP\LaminasClient" class
  * This class is created to avoid 2.26.0 client adapter issues related to deprecated classes.
  */
-// @codingStandardsIgnoreFile
-// phpcs:disable
 class HttpClientAdapter
 {
     /**
@@ -51,7 +49,6 @@ class HttpClientAdapter
     {
         $this->boltConfigHelper = $boltConfigHelper;
         $clientFactory = version_compare($this->boltConfigHelper->getStoreVersion(), '2.4.6', '>=')
-            // @codingStandardsIgnoreLine
             ? ObjectManager::getInstance()->get(LaminasClientFactory::class)
             : ObjectManager::getInstance()->get(ZendClientFactory::class);
         $this->client = $clientFactory->create();
@@ -77,7 +74,6 @@ class HttpClientAdapter
      */
     public function setConfig($config = array())
     {
-        // @codingStandardsIgnoreLine
         if ($this->client instanceof LaminasClient) {
             $this->client->setOptions($config);
         } else {
@@ -94,9 +90,7 @@ class HttpClientAdapter
      */
     public function setHeaders($headers)
     {
-        // @codingStandardsIgnoreLine
         if ($this->client instanceof LaminasClient) {
-            // @codingStandardsIgnoreLine
             $headersObject = new Headers();
             foreach ($headers as $headerName => $headerValue) {
                 $headersObject->addHeaderLine($headerName, $headerName . ':' . $headerValue);
@@ -117,7 +111,6 @@ class HttpClientAdapter
      */
     public function setRawData($rawData, $enctype = null)
     {
-        // @codingStandardsIgnoreLine
         if ($this->client instanceof LaminasClient) {
             $this->client->setEncType($enctype);
             $this->client->setRawBody($rawData);
@@ -147,7 +140,6 @@ class HttpClientAdapter
      */
     public function request($methodType)
     {
-        // @codingStandardsIgnoreLine
         if ($this->client instanceof LaminasClient) {
             $this->client->setMethod($methodType);
             return $this->client->send();

--- a/Model/HttpClientAdapter.php
+++ b/Model/HttpClientAdapter.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Bolt magento2 plugin
  *

--- a/Model/HttpClientAdapter.php
+++ b/Model/HttpClientAdapter.php
@@ -1,5 +1,4 @@
 <?php
-// @codingStandardsIgnoreFile
 /**
  * Bolt magento2 plugin
  *
@@ -31,6 +30,8 @@ use Magento\Framework\HTTP\ZendClientFactory;
  * Instead, we should use "Magento\Framework\HTTP\LaminasClient" class
  * This class is created to avoid 2.26.0 client adapter issues related to deprecated classes.
  */
+// @codingStandardsIgnoreFile
+// phpcs:disable
 class HttpClientAdapter
 {
     /**

--- a/Model/HttpClientAdapter.php
+++ b/Model/HttpClientAdapter.php
@@ -51,6 +51,7 @@ class HttpClientAdapter
     {
         $this->boltConfigHelper = $boltConfigHelper;
         $clientFactory = version_compare($this->boltConfigHelper->getStoreVersion(), '2.4.6', '>=')
+            // @codingStandardsIgnoreLine
             ? ObjectManager::getInstance()->get(LaminasClientFactory::class)
             : ObjectManager::getInstance()->get(ZendClientFactory::class);
         $this->client = $clientFactory->create();
@@ -76,6 +77,7 @@ class HttpClientAdapter
      */
     public function setConfig($config = array())
     {
+        // @codingStandardsIgnoreLine
         if ($this->client instanceof LaminasClient) {
             $this->client->setOptions($config);
         } else {
@@ -92,7 +94,9 @@ class HttpClientAdapter
      */
     public function setHeaders($headers)
     {
+        // @codingStandardsIgnoreLine
         if ($this->client instanceof LaminasClient) {
+            // @codingStandardsIgnoreLine
             $headersObject = new Headers();
             foreach ($headers as $headerName => $headerValue) {
                 $headersObject->addHeaderLine($headerName, $headerName . ':' . $headerValue);
@@ -113,6 +117,7 @@ class HttpClientAdapter
      */
     public function setRawData($rawData, $enctype = null)
     {
+        // @codingStandardsIgnoreLine
         if ($this->client instanceof LaminasClient) {
             $this->client->setEncType($enctype);
             $this->client->setRawBody($rawData);
@@ -142,6 +147,7 @@ class HttpClientAdapter
      */
     public function request($methodType)
     {
+        // @codingStandardsIgnoreLine
         if ($this->client instanceof LaminasClient) {
             $this->client->setMethod($methodType);
             return $this->client->send();

--- a/Model/HttpClientAdapter.php
+++ b/Model/HttpClientAdapter.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2022 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+namespace Bolt\Boltpay\Model;
+
+use Bolt\Boltpay\Helper\Config as BoltConfigHelper;
+use Laminas\Http\Headers;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\HTTP\LaminasClient;
+use Magento\Framework\HTTP\LaminasClientFactory;
+use Magento\Framework\HTTP\ZendClient;
+use Magento\Framework\HTTP\ZendClientFactory;
+
+/**
+ * Bolt http client adapter
+ * In magento 2.26.0 and above the "Magento\Framework\HTTP\ZendClient" class is deprecated and can't be used.
+ * Instead, we should use "Magento\Framework\HTTP\LaminasClient" class
+ * This class is created to avoid 2.26.0 client adapter issues related to deprecated classes.
+ */
+class HttpClientAdapter
+{
+    /**
+     * @var LaminasClient|ZendClient
+     */
+    private $client;
+
+    /**
+     * @var BoltConfigHelper
+     */
+    private $boltConfigHelper;
+
+    /**
+     * @param BoltConfigHelper $boltConfigHelper
+     */
+    public function __construct(BoltConfigHelper $boltConfigHelper)
+    {
+        $this->boltConfigHelper = $boltConfigHelper;
+        $clientFactory = version_compare($this->boltConfigHelper->getStoreVersion(), '2.4.6', '>=')
+            ? ObjectManager::getInstance()->get(LaminasClientFactory::class)
+            : ObjectManager::getInstance()->get(ZendClientFactory::class);
+        $this->client = $clientFactory->create();
+    }
+
+    /**
+     * Set the uri path
+     *
+     * @param string $uri
+     * @return $this
+     */
+    public function setUri($uri)
+    {
+        $this->client->setUri($uri);
+        return $this;
+    }
+
+    /**
+     * Set client config options
+     *
+     * @param array $config
+     * @return $this
+     */
+    public function setConfig($config = array())
+    {
+        if ($this->client instanceof LaminasClient) {
+            $this->client->setOptions($config);
+        } else {
+            $this->client->setConfig($config);
+        }
+        return $this;
+    }
+
+    /**
+     * Set client headers
+     *
+     * @param array $headers
+     * @return $this
+     */
+    public function setHeaders($headers)
+    {
+        if ($this->client instanceof LaminasClient) {
+            $headersObject = new Headers();
+            foreach ($headers as $headerName => $headerValue) {
+                $headersObject->addHeaderLine($headerName, $headerName . ':' . $headerValue);
+            }
+            $this->client->setHeaders($headersObject);
+        } else {
+            $this->client->setHeaders($headers);
+        }
+        return $this;
+    }
+
+    /**
+     * Set client raw body data
+     *
+     * @param string $rawData
+     * @param string $enctype
+     * @return $this
+     */
+    public function setRawData($rawData, $enctype = null)
+    {
+        if ($this->client instanceof LaminasClient) {
+            $this->client->setEncType($enctype);
+            $this->client->setRawBody($rawData);
+        } else {
+            $this->client->setRawData($rawData, $enctype);
+        }
+        return $this;
+    }
+
+    /**
+     * Set post parameters
+     *
+     * @param array $post
+     * @return $this
+     */
+    public function setParameterPost($post)
+    {
+        $this->client->setParameterPost($post);
+        return $this;
+    }
+
+    /**
+     * Send client request
+     *
+     * @param string $methodType
+     * @return \Laminas\Http\Response|void
+     */
+    public function request($methodType)
+    {
+        if ($this->client instanceof LaminasClient) {
+            $this->client->setMethod($methodType);
+            return $this->client->send();
+        } else {
+            return $this->client->request($methodType);
+        }
+    }
+}

--- a/Model/HttpClientAdapter.php
+++ b/Model/HttpClientAdapter.php
@@ -1,5 +1,5 @@
 <?php
-// phpcs:ignoreFile
+// @codingStandardsIgnoreFile
 /**
  * Bolt magento2 plugin
  *

--- a/Test/Unit/Helper/ApiTest.php
+++ b/Test/Unit/Helper/ApiTest.php
@@ -32,8 +32,8 @@ use Exception;
 use Magento\Framework\App\Helper\Context;
 use Magento\Framework\DataObject;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\HTTP\ZendClient;
-use Magento\Framework\HTTP\ZendClientFactory;
+use Bolt\Boltpay\Model\HttpClientAdapterFactory;
+use Bolt\Boltpay\Model\HttpClientAdapter;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Zend_Http_Response;
 
@@ -71,9 +71,9 @@ class ApiTest extends BoltTestCase
     private $configHelper;
 
     /**
-     * @var MockObject|ZendClientFactory
+     * @var MockObject|HttpClientAdapterFactory
      */
-    private $zendClientFactory;
+    private $httpClientAdapterFactory;
 
     /**
      * @var MockObject|Request
@@ -110,7 +110,7 @@ class ApiTest extends BoltTestCase
             ->setConstructorArgs(
                 [
                     $this->context,
-                    $this->zendClientFactory,
+                    $this->httpClientAdapterFactory,
                     $this->configHelper,
                     $this->responseFactory,
                     $this->requestFactory,
@@ -128,8 +128,8 @@ class ApiTest extends BoltTestCase
     private function initRequiredMocks()
     {
         $this->context = $this->createMock(Context::class);
-        $this->zendClientFactory = $this->createPartialMock(
-            ZendClientFactory::class,
+        $this->httpClientAdapterFactory = $this->createPartialMock(
+            HttpClientAdapterFactory::class,
             ['create', 'setUri']
         );
         $this->configHelper = $this->createMock(ConfigHelper::class);
@@ -170,7 +170,7 @@ class ApiTest extends BoltTestCase
     {
         $instance = new ApiHelper(
             $this->context,
-            $this->zendClientFactory,
+            $this->httpClientAdapterFactory,
             $this->configHelper,
             $this->responseFactory,
             $this->requestFactory,
@@ -178,7 +178,7 @@ class ApiTest extends BoltTestCase
             $this->bugsnag
         );
 
-        static::assertAttributeEquals($this->zendClientFactory, 'httpClientFactory', $instance);
+        static::assertAttributeEquals($this->httpClientAdapterFactory, 'httpClientAdapterFactory', $instance);
         static::assertAttributeEquals($this->configHelper, 'configHelper', $instance);
         static::assertAttributeEquals($this->responseFactory, 'responseFactory', $instance);
         static::assertAttributeEquals($this->requestFactory, 'requestFactory', $instance);
@@ -206,12 +206,12 @@ class ApiTest extends BoltTestCase
                 'content_type'   => 'application/x-www-form-urlencoded'
             ]
         );
-        $client = $this->createMock(ZendClient::class);
+        $client = $this->createMock(HttpClientAdapter::class);
 
         $resultMock = $this->createPartialMock(Response::class, ['setResponse']);
         $responseMock = $this->createPartialMock(Zend_Http_Response::class, ['getBody', 'getHeaders', 'getStatus']);
 
-        $this->zendClientFactory->expects(static::once())->method('create')->willReturn($client);
+        $this->httpClientAdapterFactory->expects(static::once())->method('create')->willReturn($client);
         $this->responseFactory->expects(static::once())->method('create')->willReturn($resultMock);
 
         $client->expects(static::once())->method('setUri')->with(self::API_URL);
@@ -278,11 +278,11 @@ class ApiTest extends BoltTestCase
                 'status_only'    => true
             ]
         );
-        $client = $this->createMock(ZendClient::class);
+        $client = $this->createMock(HttpClientAdapter::class);
 
         $responseMock = $this->createPartialMock(Response::class, ['getStatus', 'getBody']);
 
-        $this->zendClientFactory->expects(static::once())->method('create')->willReturn($client);
+        $this->httpClientAdapterFactory->expects(static::once())->method('create')->willReturn($client);
         $this->responseFactory->expects(static::once())->method('create')->willReturn($responseMock);
 
         $client->expects(static::once())->method('setUri')->with(self::API_URL);
@@ -316,8 +316,8 @@ class ApiTest extends BoltTestCase
                 'request_method' => 'POST'
             ]
         );
-        $client = $this->createMock(ZendClient::class);
-        $this->zendClientFactory->expects(static::once())->method('create')->willReturn($client);
+        $client = $this->createMock(HttpClientAdapter::class);
+        $this->httpClientAdapterFactory->expects(static::once())->method('create')->willReturn($client);
         $client->expects(static::once())->method('setRawData')->willReturnSelf();
         $client->expects(static::once())->method('request')->willThrowException(new LocalizedException(__('Expected exception message')));
         $this->expectException(LocalizedException::class);
@@ -343,12 +343,12 @@ class ApiTest extends BoltTestCase
                 'request_method' => 'POST'
             ]
         );
-        $client = $this->createMock(ZendClient::class);
+        $client = $this->createMock(HttpClientAdapter::class);
 
         $resultMock = $this->createPartialMock(Response::class, ['setResponse']);
         $responseMock = $this->createPartialMock(Zend_Http_Response::class, ['getBody', 'getHeaders', 'getStatus']);
 
-        $this->zendClientFactory->expects(static::once())->method('create')->willReturn($client);
+        $this->httpClientAdapterFactory->expects(static::once())->method('create')->willReturn($client);
         $this->responseFactory->expects(static::once())->method('create')->willReturn($resultMock);
 
         $client->expects(static::once())->method('setUri')->with(self::API_URL);

--- a/Test/Unit/Helper/GeolocationTest.php
+++ b/Test/Unit/Helper/GeolocationTest.php
@@ -22,7 +22,8 @@ use Bolt\Boltpay\Helper\Geolocation;
 use Magento\Framework\App\Helper\Context;
 use Bolt\Boltpay\Helper\Config as ConfigHelper;
 use Bolt\Boltpay\Helper\Bugsnag;
-use Magento\Framework\HTTP\ZendClientFactory;
+use Bolt\Boltpay\Model\HttpClientAdapterFactory;
+use Bolt\Boltpay\Model\HttpClientAdapter;
 use Magento\Framework\App\CacheInterface;
 
 /**
@@ -52,9 +53,9 @@ class GeolocationTest extends BoltTestCase
     private $bugsnag;
 
     /**
-     * @var ZendClientFactory
+     * @var HttpClientAdapterFactory
      */
-    private $httpClientFactory;
+    private $httpClientAdapterFactory;
 
     /**
      * @var CacheInterface
@@ -74,7 +75,7 @@ class GeolocationTest extends BoltTestCase
         $this->context = $this->createPartialMock(Context::class, ['getMpGiftCards']);
         $this->configHelper = $this->createPartialMock(ConfigHelper::class, ['getGeolocationApiKey', 'getClientIp']);
         $this->bugsnag = $this->createPartialMock(Bugsnag::class, ['notifyException']);
-        $this->httpClientFactory = $this->createPartialMock(ZendClientFactory::class, ['create', 'setUri', 'setConfig', 'request', 'getBody']);
+        $this->httpClientAdapterFactory = $this->createPartialMock(HttpClientAdapterFactory::class, ['create', 'setUri', 'setConfig', 'request', 'getBody']);
         $this->cache = $this->createPartialMock(CacheInterface::class, ['save', 'load', 'getFrontend', 'remove', 'clean']);
         $this->mock = $this->getMockBuilder(Geolocation::class)
             ->setMethods(['getLocationJson'])
@@ -83,7 +84,7 @@ class GeolocationTest extends BoltTestCase
                     $this->context,
                     $this->configHelper,
                     $this->bugsnag,
-                    $this->httpClientFactory,
+                    $this->httpClientAdapterFactory,
                     $this->cache
                 ]
             )
@@ -102,13 +103,13 @@ class GeolocationTest extends BoltTestCase
             $this->context,
             $this->configHelper,
             $this->bugsnag,
-            $this->httpClientFactory,
+            $this->httpClientAdapterFactory,
             $this->cache
         );
-        
+
         static::assertAttributeEquals($this->configHelper, 'configHelper', $instance);
         static::assertAttributeEquals($this->bugsnag, 'bugsnag', $instance);
-        static::assertAttributeEquals($this->httpClientFactory, 'httpClientFactory', $instance);
+        static::assertAttributeEquals($this->httpClientAdapterFactory, 'httpClientAdapterFactory', $instance);
         static::assertAttributeEquals($this->cache, 'cache', $instance);
     }
 
@@ -141,11 +142,11 @@ class GeolocationTest extends BoltTestCase
         $this->configHelper->expects(self::once())->method('getClientIp')->willReturn(self::CLIENT_IP);
         $this->cache->expects(self::once())->method('load')->willReturn(null);
 
-        $this->httpClientFactory->expects(self::once())->method('create')->willReturnSelf();
-        $this->httpClientFactory->expects(self::once())->method('setUri')->willReturnSelf();
-        $this->httpClientFactory->expects(self::once())->method('setConfig')->willReturnSelf();
-        $this->httpClientFactory->expects(self::once())->method('request')->willReturnSelf();
-        $this->httpClientFactory->expects(self::once())->method('getBody')->willReturn(self::LOCATION_JSON);
+        $this->httpClientAdapterFactory->expects(self::once())->method('create')->willReturnSelf();
+        $this->httpClientAdapterFactory->expects(self::once())->method('setUri')->willReturnSelf();
+        $this->httpClientAdapterFactory->expects(self::once())->method('setConfig')->willReturnSelf();
+        $this->httpClientAdapterFactory->expects(self::once())->method('request')->willReturnSelf();
+        $this->httpClientAdapterFactory->expects(self::once())->method('getBody')->willReturn(self::LOCATION_JSON);
 
         $this->cache->expects(self::once())
             ->method('save')
@@ -163,11 +164,11 @@ class GeolocationTest extends BoltTestCase
         $this->configHelper->expects(self::once())->method('getClientIp')->willReturn(self::CLIENT_IP);
         $this->cache->expects(self::once())->method('load')->willReturn(null);
 
-        $this->httpClientFactory->expects(self::once())->method('create')->willReturnSelf();
-        $this->httpClientFactory->expects(self::once())->method('setUri')->willReturnSelf();
-        $this->httpClientFactory->expects(self::once())->method('setConfig')->willReturnSelf();
-        $this->httpClientFactory->expects(self::once())->method('request')->willReturnSelf();
-        $this->httpClientFactory->expects(self::once())->method('getBody')->willThrowException(new \Exception('exception'));
+        $this->httpClientAdapterFactory->expects(self::once())->method('create')->willReturnSelf();
+        $this->httpClientAdapterFactory->expects(self::once())->method('setUri')->willReturnSelf();
+        $this->httpClientAdapterFactory->expects(self::once())->method('setConfig')->willReturnSelf();
+        $this->httpClientAdapterFactory->expects(self::once())->method('request')->willReturnSelf();
+        $this->httpClientAdapterFactory->expects(self::once())->method('getBody')->willThrowException(new \Exception('exception'));
         $this->bugsnag->expects(self::once())->method('notifyException')->with(new \Exception('exception'))->willReturnSelf();
 
         $this->assertNull($this->mock->getLocation());

--- a/Test/Unit/Helper/GraphQL/ClientTest.php
+++ b/Test/Unit/Helper/GraphQL/ClientTest.php
@@ -19,8 +19,8 @@ namespace Bolt\Boltpay\Test\Unit\Helper\GraphQL;
 
 use Bolt\Boltpay\Helper\Config as BoltConfig;
 use Bolt\Boltpay\Helper\GraphQL\Client;
-use Magento\Framework\HTTP\ZendClientFactory;
-use Magento\Framework\HTTP\ZendClient;
+use Bolt\Boltpay\Model\HttpClientAdapterFactory;
+use Bolt\Boltpay\Model\HttpClientAdapter;
 use Bolt\Boltpay\Model\ResponseFactory;
 use Bolt\Boltpay\Model\Response as BoltResponse;
 use Bolt\Boltpay\Model\RequestFactory;
@@ -45,9 +45,9 @@ class ClientTest extends BoltTestCase
     private $context;
 
     /**
-     * @var ZendClientFactory\
+     * @var HttpClientAdapterFactory
      */
-    private $zendClientFactory;
+    private $httpClientAdapterFactory;
 
     /**
      * @var BoltConfig
@@ -86,7 +86,7 @@ class ClientTest extends BoltTestCase
     {
 
         $this->context = $this->createMock(Context::class);
-        $this->zendClientFactory = $this->createMock(ZendClientFactory::class);
+        $this->httpClientAdapterFactory = $this->createMock(HttpClientAdapterFactory::class);
         $this->boltConfig = $this->createMock(BoltConfig::class);
         $this->responseFactory = $this->createMock(ResponseFactory::class);
         $this->requestFactory = $this->createMock(RequestFactory::class);
@@ -98,7 +98,7 @@ class ClientTest extends BoltTestCase
             Client::class,
             [
                 'context' => $this->context,
-                'httpClientFactory' => $this->zendClientFactory,
+                'httpClientAdapterFactory' => $this->httpClientAdapterFactory,
                 'configHelper' => $this->boltConfig,
                 'responseFactory' => $this->responseFactory,
                 'requestFactory' => $this->requestFactory,
@@ -118,15 +118,15 @@ class ClientTest extends BoltTestCase
     {
         $instance = new Client(
             $this->context,
-            $this->zendClientFactory,
+            $this->httpClientAdapterFactory,
             $this->boltConfig,
             $this->responseFactory,
             $this->requestFactory,
             $this->logger,
             $this->bugsnag
         );
-        
-        static::assertAttributeEquals($this->zendClientFactory, 'httpClientFactory', $instance);
+
+        static::assertAttributeEquals($this->httpClientAdapterFactory, 'httpClientAdapterFactory', $instance);
         static::assertAttributeEquals($this->boltConfig, 'configHelper', $instance);
         static::assertAttributeEquals($this->responseFactory, 'responseFactory', $instance);
         static::assertAttributeEquals($this->requestFactory, 'requestFactory', $instance);
@@ -139,10 +139,10 @@ class ClientTest extends BoltTestCase
      */
     public function getFeatureSwitches_success()
     {
-        $httpClient = $this->createMock(ZendClient::class);
+        $httpClient = $this->createMock(HttpClientAdapter::class);
         $response = $this->createMock(Response::class);
 
-        $this->zendClientFactory
+        $this->httpClientAdapterFactory
             ->method('create')
             ->willReturn($httpClient);
 
@@ -166,10 +166,10 @@ class ClientTest extends BoltTestCase
      */
     public function getFeatureSwitches_fail()
     {
-        $httpClient = $this->createMock(ZendClient::class);
+        $httpClient = $this->createMock(HttpClientAdapter::class);
         $response = $this->createMock(Response::class);
 
-        $this->zendClientFactory
+        $this->httpClientAdapterFactory
             ->method('create')
             ->willReturn($httpClient);
 
@@ -193,10 +193,10 @@ class ClientTest extends BoltTestCase
      */
     public function sendLogs_success()
     {
-        $httpClient = $this->createMock(ZendClient::class);
+        $httpClient = $this->createMock(HttpClientAdapter::class);
         $response = $this->createMock(Response::class);
 
-        $this->zendClientFactory
+        $this->httpClientAdapterFactory
             ->method('create')
             ->willReturn($httpClient);
 
@@ -220,10 +220,10 @@ class ClientTest extends BoltTestCase
      */
     public function sendLogs_fail()
     {
-        $httpClient = $this->createMock(ZendClient::class);
+        $httpClient = $this->createMock(HttpClientAdapter::class);
         $response = $this->createMock(Response::class);
 
-        $this->zendClientFactory
+        $this->httpClientAdapterFactory
             ->method('create')
             ->willReturn($httpClient);
 


### PR DESCRIPTION
# Description
M 2.4.6 support:
- replaced deprecated zend http client to laminas http client, by creating custom bolt client adapter class which incapsulated both itself.

Fixes: https://app.asana.com/0/1200879031426307/1204271392550023/f

#changelog Magento 2.2.6 support: replaced zend http client to laminas http client

# Type of change m2 2.4.6 support: updated replaced zend http client to laminas

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
