### PR TITLE
Magento 2.4.6 support: zend calls replacing

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -2277,7 +2277,7 @@ class Cart extends AbstractHelper
      *
      * @param string $email
      * @return bool
-     * @throws \Zend_Validate_Exception
+     * @throws \Zend_Validate_Exception|\Magento\Framework\Validator\ValidateException
      */
     public function validateEmail($email)
     {
@@ -2287,7 +2287,11 @@ class Cart extends AbstractHelper
             '<'
         ) ? 'EmailAddress' : \Magento\Framework\Validator\EmailAddress::class;
 
-        return \Zend_Validate::is($email, $emailClass);
+        if (class_exists('\Magento\Framework\Validator\ValidatorChain')) {
+            return \Magento\Framework\Validator\ValidatorChain::is($email, $emailClass);
+        } else {
+            return \Zend_Validate::is($email, $emailClass);
+        }
     }
 
     /**

--- a/Plugin/LoginPlugin.php
+++ b/Plugin/LoginPlugin.php
@@ -49,7 +49,11 @@ class LoginPlugin extends AbstractLoginPlugin
                 return $this->$prop;
             }, $result, $result);
             $json = $propGetter('json');
-            $response = \Zend_Json::decode($json);
+            if (class_exists('\Laminas\Json\Json')) {
+                $response = \Laminas\Json\Json::decode($json);
+            } else {
+                $response = \Zend_Json::decode($json);
+            }
 
             // Sanity check. If result has an error flag set, pass the original result through unchainged
             if ($response['errors'] !== false) {


### PR DESCRIPTION
# Description
M 2.4.6 support:
- replaced deprecated zend framework method calls to laminas.

Fixes: https://app.asana.com/0/1200879031426307/1204271392550023/f

#changelog Magento 2.2.6 support: replaced zend to laminas

# Type of change m2 2.4.6 support: replaced deprecated zend framework calls to laminas.

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
