### PR TITLE
Partial capture wrong order data fix

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -2439,14 +2439,14 @@ class Order extends AbstractHelper
         ) && !$invoice->getEmailSent()) {
             try {
                 $this->invoiceSender->send($invoice);
-                // restore order data
-                $order->setBaseSubtotal($baseSubtotal);
-                $order->setBaseTaxAmount($baseTaxAmount);
-                $order->setBaseShippingAmount($baseShippingAmount);
             } catch (\Exception $e) {
                 $this->bugsnag->notifyException($e);
             }
 
+            // restore order data
+            $order->setBaseSubtotal($baseSubtotal);
+            $order->setBaseTaxAmount($baseTaxAmount);
+            $order->setBaseShippingAmount($baseShippingAmount);
             //Add notification comment to order
             $order->addStatusHistoryComment(
                 __('Invoice #%1 is created. Notification email is sent to customer.', $invoice->getId())


### PR DESCRIPTION
# Description
Fixed partial capture process. During partial capture creation critical order data overwritten by email sender [here](https://github.com/magento/magento2/blob/fd5b8d002a1bc62e0bd3c76c67432d9e104cdf47/app/code/Magento/Sales/Model/Order/Email/Sender/InvoiceSender.php#L125), which makes future refund webhooks calls incorrect, because during magento creditmemo totals calculation the overwritten(missed) data required.

Fixes: https://app.asana.com/0/1201931884901947/1204329729409242/f

#changelog fixed partial capture

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
