### PR TITLE
Fix undefined bug js in success page

### DIFF
--- a/Block/Checkout/Success.php
+++ b/Block/Checkout/Success.php
@@ -53,5 +53,14 @@ class Success extends Template
         $this->featureSwitches = $featureSwitches;
         $this->checkoutSession = $checkoutSession;
         $this->eventsForThirdPartyModules = $eventsForThirdPartyModules;
+
+    }
+
+    /**
+     * Get Magento version
+     * @return string
+     */
+    public function getMagentoVersion() {
+        return $this->configHelper->getStoreVersion();
     }
 }

--- a/view/frontend/templates/checkout/success.phtml
+++ b/view/frontend/templates/checkout/success.phtml
@@ -30,6 +30,9 @@ if ($block->shouldDisableBoltCheckout()) { return;
         'Magento_Customer/js/customer-data'
     ], function (customerData) {
         var sections = ['cart'];
+        <?php if (version_compare($block->getMagentoVersion(), '2.4.0') >= 0): ?>
+        customerData.initStorage();
+        <?php endif; ?>
         customerData.invalidate(sections);
         customerData.reload(sections, true);
     });


### PR DESCRIPTION
# Description
Currently, the undefined bug js throws in the console tab on the checkout success page. And this causes google tag manager issue for Metroplex
See screenshot: https://prnt.sc/mn0rsDwB2km9

In order to fix this, we need to add initStorage before reloading the cart. FYI, the error just throws if Magento version >= 2.4.0. This is because Adobe moves storage logic into the initStorage method in the file customer-data.js
See here: https://github.com/magento/magento2/commit/5983e1733d56b1b2f15fb4f0e64094a3a4f3145d in Magento 2.4.0


Fixes: (link ticket)

#changelog Fix undefined bug js in success page

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
