### PR TITLE
API calls update remote_ip value

### DIFF
--- a/Plugin/WebapiRest/Magento/Quote/Model/QuotePlugin.php
+++ b/Plugin/WebapiRest/Magento/Quote/Model/QuotePlugin.php
@@ -46,7 +46,7 @@ class QuotePlugin
      */
     public function __construct(
         State $appState,
-        Decider $featureSwitches = null,
+        Decider $featureSwitches = null
     ) {
         $this->featureSwitches = $featureSwitches ?? \Magento\Framework\App\ObjectManager::getInstance()
                 ->get(\Bolt\Boltpay\Helper\FeatureSwitch\Decider::class);

--- a/Plugin/WebapiRest/Magento/Quote/Model/QuotePlugin.php
+++ b/Plugin/WebapiRest/Magento/Quote/Model/QuotePlugin.php
@@ -17,6 +17,8 @@
 
 namespace Bolt\Boltpay\Plugin\WebapiRest\Magento\Quote\Model;
 
+use Magento\Framework\App\State;
+
 /**
  * Plugin for {@see \Magento\Quote\Model\Quote}
  */
@@ -33,22 +35,29 @@ class QuotePlugin
     private $isPreventSettingBoltIpsAsCustomerIpOnQuote;
 
     /**
-     * QuotePlugin constructor.
-     *
-     * @param \Bolt\Boltpay\Helper\FeatureSwitch\Decider $featureSwitches
+     * @var State
      */
-    public function __construct(\Bolt\Boltpay\Helper\FeatureSwitch\Decider $featureSwitches = null)
-    {
+    private $appState;
+
+    /**
+     * @param \Bolt\Boltpay\Helper\FeatureSwitch\Decider|null $featureSwitches
+     * @param State $appState
+     */
+    public function __construct(
+        \Bolt\Boltpay\Helper\FeatureSwitch\Decider $featureSwitches = null,
+        State $appState
+    ) {
         $this->featureSwitches = $featureSwitches ?? \Magento\Framework\App\ObjectManager::getInstance()
                 ->get(\Bolt\Boltpay\Helper\FeatureSwitch\Decider::class);
         $this->isPreventSettingBoltIpsAsCustomerIpOnQuote = $this->featureSwitches->isPreventSettingBoltIpsAsCustomerIpOnQuote();
+        $this->appState = $appState;
     }
 
     /**
      * Prevent IP from being set when requests are coming from Bolt, except initially
      *
      * @param \Magento\Quote\Model\Quote $subject intercepted quote object
-     * @param array|string               $key 
+     * @param array|string               $key
      * @param mixed                      $value
      *
      * @return array|void
@@ -56,8 +65,9 @@ class QuotePlugin
     public function beforeSetData(\Magento\Quote\Model\Quote $subject, $key, $value = null)
     {
         if ($this->isPreventSettingBoltIpsAsCustomerIpOnQuote
-            && $key === 'remote_ip'
-            && \Bolt\Boltpay\Helper\Hook::$fromBolt) {
+            && $key === 'remote_ip' &&
+            $this->appState->getAreaCode() === \Magento\Framework\App\Area::AREA_WEBAPI_REST
+        ) {
             return [$key, ($subject->getData('remote_ip') ?: $subject->getOrigData('remote_ip')) ?: $value];
         }
     }

--- a/Plugin/WebapiRest/Magento/Quote/Model/QuotePlugin.php
+++ b/Plugin/WebapiRest/Magento/Quote/Model/QuotePlugin.php
@@ -17,6 +17,7 @@
 
 namespace Bolt\Boltpay\Plugin\WebapiRest\Magento\Quote\Model;
 
+use Bolt\Boltpay\Helper\FeatureSwitch\Decider;
 use Magento\Framework\App\State;
 
 /**
@@ -40,12 +41,12 @@ class QuotePlugin
     private $appState;
 
     /**
-     * @param \Bolt\Boltpay\Helper\FeatureSwitch\Decider|null $featureSwitches
+     * @param Decider|null $featureSwitches
      * @param State $appState
      */
     public function __construct(
-        \Bolt\Boltpay\Helper\FeatureSwitch\Decider $featureSwitches = null,
-        State $appState
+        State $appState,
+        Decider $featureSwitches = null,
     ) {
         $this->featureSwitches = $featureSwitches ?? \Magento\Framework\App\ObjectManager::getInstance()
                 ->get(\Bolt\Boltpay\Helper\FeatureSwitch\Decider::class);
@@ -66,7 +67,7 @@ class QuotePlugin
     {
         if ($this->isPreventSettingBoltIpsAsCustomerIpOnQuote
             && $key === 'remote_ip' &&
-            $this->appState->getAreaCode() === \Magento\Framework\App\Area::AREA_WEBAPI_REST
+            ($this->appState->getAreaCode() === \Magento\Framework\App\Area::AREA_WEBAPI_REST || \Bolt\Boltpay\Helper\Hook::$fromBolt)
         ) {
             return [$key, ($subject->getData('remote_ip') ?: $subject->getOrigData('remote_ip')) ?: $value];
         }

--- a/Test/Unit/Plugin/WebapiRest/Magento/Quote/Model/QuotePluginTest.php
+++ b/Test/Unit/Plugin/WebapiRest/Magento/Quote/Model/QuotePluginTest.php
@@ -58,6 +58,7 @@ class QuotePluginTest extends \Bolt\Boltpay\Test\Unit\BoltTestCase
         $originalRemoteIp,
         $currentRemoteIp,
         $isWebApiRest,
+        $fromBolt,
         $isPreventSettingBoltIpsAsCustomerIpOnQuote,
         $changedArguments
     ) {
@@ -82,6 +83,7 @@ class QuotePluginTest extends \Bolt\Boltpay\Test\Unit\BoltTestCase
         $quote = $om->create(\Magento\Quote\Model\Quote::class);
         $quote->setOrigData('remote_ip', $originalRemoteIp);
         $quote->setData('remote_ip', $currentRemoteIp);
+        \Bolt\Boltpay\Helper\Hook::$fromBolt = $fromBolt;
         static::assertEquals($changedArguments, $pluginInstance->beforeSetData($quote, $key, $value));
     }
 
@@ -102,6 +104,7 @@ class QuotePluginTest extends \Bolt\Boltpay\Test\Unit\BoltTestCase
                 'originalRemoteIp'                           => $customerIP1,
                 'currentRemoteIp'                            => $customerIP1,
                 'isWebApiRest'                               => true,
+                'fromBolt'                                   => true,
                 'isPreventSettingBoltIpsAsCustomerIpOnQuote' => true,
                 'changedArguments'                           => ['remote_ip', $customerIP1],
             ],
@@ -111,6 +114,7 @@ class QuotePluginTest extends \Bolt\Boltpay\Test\Unit\BoltTestCase
                 'originalRemoteIp'                           => null,
                 'currentRemoteIp'                            => null,
                 'isWebApiRest'                               => true,
+                'fromBolt'                                   => true,
                 'isPreventSettingBoltIpsAsCustomerIpOnQuote' => true,
                 'changedArguments'                           => ['remote_ip', $customerIP1],
             ],
@@ -120,6 +124,7 @@ class QuotePluginTest extends \Bolt\Boltpay\Test\Unit\BoltTestCase
                 'originalRemoteIp'                           => $customerIP1,
                 'currentRemoteIp'                            => $customerIP2,
                 'isWebApiRest'                               => true,
+                'fromBolt'                                   => true,
                 'isPreventSettingBoltIpsAsCustomerIpOnQuote' => true,
                 'changedArguments'                           => ['remote_ip', $customerIP2],
             ],
@@ -129,6 +134,7 @@ class QuotePluginTest extends \Bolt\Boltpay\Test\Unit\BoltTestCase
                 'originalRemoteIp'                           => $customerIP1,
                 'currentRemoteIp'                            => null,
                 'isWebApiRest'                               => true,
+                'fromBolt'                                   => true,
                 'isPreventSettingBoltIpsAsCustomerIpOnQuote' => true,
                 'changedArguments'                           => ['remote_ip', $customerIP1],
             ],
@@ -138,6 +144,7 @@ class QuotePluginTest extends \Bolt\Boltpay\Test\Unit\BoltTestCase
                 'originalRemoteIp'                           => $customerIP1,
                 'currentRemoteIp'                            => $customerIP2,
                 'isWebApiRest'                               => false,
+                'fromBolt'                                   => false,
                 'isPreventSettingBoltIpsAsCustomerIpOnQuote' => false,
                 'changedArguments'                           => null,
             ],
@@ -147,6 +154,7 @@ class QuotePluginTest extends \Bolt\Boltpay\Test\Unit\BoltTestCase
                 'originalRemoteIp'                           => $customerIP1,
                 'currentRemoteIp'                            => $customerIP2,
                 'isWebApiRest'                               => false,
+                'fromBolt'                                   => false,
                 'isPreventSettingBoltIpsAsCustomerIpOnQuote' => false,
                 'changedArguments'                           => null,
             ],
@@ -156,6 +164,7 @@ class QuotePluginTest extends \Bolt\Boltpay\Test\Unit\BoltTestCase
                 'originalRemoteIp'                           => $customerIP1,
                 'currentRemoteIp'                            => $customerIP1,
                 'isWebApiRest'                               => false,
+                'fromBolt'                                   => false,
                 'isPreventSettingBoltIpsAsCustomerIpOnQuote' => true,
                 'changedArguments'                           => null,
             ],
@@ -165,6 +174,7 @@ class QuotePluginTest extends \Bolt\Boltpay\Test\Unit\BoltTestCase
                 'originalRemoteIp'                           => $customerIP1,
                 'currentRemoteIp'                            => $customerIP1,
                 'isWebApiRest'                               => true,
+                'fromBolt'                                   => true,
                 'isPreventSettingBoltIpsAsCustomerIpOnQuote' => false,
                 'changedArguments'                           => null,
             ],


### PR DESCRIPTION
# Description
Orders which was created by m2 API has incorrect remote_ip value. We have "M2_PREVENT_SETTING_BOLT_IPS_AS_CUSTOMER_IP_ON_QUOTE" feature switcher for this, but it is true only for specific webhooks and looks like it was created for legacy mode. I've updated the condiition to run for all web api calls. Unfortunately magento doesn't return "remote_ip" field data during GET cart API call, so we can't fetch quote ip on backend side without adding additional endpoint to plugin.

Fixes: https://app.asana.com/0/951157735838091/1204198418877969/f

#changelog fix remote_ip quote data during magento api calls

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
