### PR TITLE
M 2.4.6 support: fixed incorrect response type of laminas json decode

### DIFF
--- a/Plugin/LoginPlugin.php
+++ b/Plugin/LoginPlugin.php
@@ -50,7 +50,7 @@ class LoginPlugin extends AbstractLoginPlugin
             }, $result, $result);
             $json = $propGetter('json');
             if (class_exists('\Laminas\Json\Json')) {
-                $response = \Laminas\Json\Json::decode($json);
+                $response = \Laminas\Json\Json::decode($json, \Laminas\Json\Json::TYPE_ARRAY);
             } else {
                 $response = \Zend_Json::decode($json);
             }


### PR DESCRIPTION
# Description
Fixed incorrect return type of laminas json decode method.

#changelog m2 2.4.6 support fix login post plugin

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
