### PR TITLE
Store CVV and AVS response in payment info object

### DIFF
--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -515,6 +515,18 @@ class Decider extends AbstractHelper
     }
 
     /**
+     * Checks whether the feature switch for storing CVV and AVS response in payment info is enabled
+     *
+     * @return bool whether the feature switch is enabled
+     *
+     * @throws LocalizedException if the feature switch key is unknown
+     */
+    public function isStoringCvvAndAvsResponseInPaymentInfoEnabled()
+    {
+        return $this->isSwitchEnabled(Definitions::M2_STORE_CVV_AND_AVS_RESPONSE_IN_PAYMENT_INFO);
+    }
+
+    /**
      * Checks whether the feature switch for module retriever fetching from setup_module m2 table is enabled
      *
      * @return bool whether the feature switch is enabled

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -322,6 +322,11 @@ class Definitions
      */
     const M2_AJAX_ADD_TO_CART_SUCCESS_DISABLE_TIME_OUT = 'M2_AJAX_ADD_TO_CART_SUCCESS_DISABLE_TIME_OUT';
 
+    /**
+     * Store CVV and AVS response in payment info object
+     */
+    const M2_STORE_CVV_AND_AVS_RESPONSE_IN_PAYMENT_INFO = 'M2_STORE_CVV_AND_AVS_RESPONSE_IN_PAYMENT_INFO';
+
     const DEFAULT_SWITCH_VALUES = [
         self::M2_SAMPLE_SWITCH_NAME => [
             self::NAME_KEY        => self::M2_SAMPLE_SWITCH_NAME,
@@ -661,6 +666,12 @@ class Definitions
         ],
         self::M2_AJAX_ADD_TO_CART_SUCCESS_DISABLE_TIME_OUT => [
             self::NAME_KEY        => self::M2_AJAX_ADD_TO_CART_SUCCESS_DISABLE_TIME_OUT,
+            self::VAL_KEY         => true,
+            self::DEFAULT_VAL_KEY => false,
+            self::ROLLOUT_KEY     => 0
+        ],
+        self::M2_STORE_CVV_AND_AVS_RESPONSE_IN_PAYMENT_INFO => [
+            self::NAME_KEY        => self::M2_STORE_CVV_AND_AVS_RESPONSE_IN_PAYMENT_INFO,
             self::VAL_KEY         => true,
             self::DEFAULT_VAL_KEY => false,
             self::ROLLOUT_KEY     => 0

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -849,19 +849,22 @@ class Order extends AbstractHelper
             $payment->setAdditionalInformation(array_merge((array)$payment->getAdditionalInformation(), $paymentData));
         }
 
-        if (!empty($transaction->authorization) && !empty($transaction->authorization->avs_response)) {
-            $paymentData = [
-                'avs_response' => $transaction->authorization->avs_response,
-            ];
-            $payment->setAdditionalInformation(array_merge((array)$payment->getAdditionalInformation(), $paymentData));
+        if ($this->featureSwitches->isStoringCvvAndAvsResponseInPaymentInfoEnabled()) {
+            if (!empty($transaction->authorization) && !empty($transaction->authorization->avs_response)) {
+                $paymentData = [
+                    'avs_response' => $transaction->authorization->avs_response,
+                ];
+                $payment->setAdditionalInformation(array_merge((array)$payment->getAdditionalInformation(), $paymentData));
+            }
+
+            if (!empty($transaction->authorization) && !empty($transaction->authorization->cvv_response)) {
+                $paymentData = [
+                    'cvv_response' => $transaction->authorization->cvv_response,
+                ];
+                $payment->setAdditionalInformation(array_merge((array)$payment->getAdditionalInformation(), $paymentData));
+            }
         }
 
-        if (!empty($transaction->authorization) && !empty($transaction->authorization->cvv_response)) {
-            $paymentData = [
-                'cvv_response' => $transaction->authorization->cvv_response,
-            ];
-            $payment->setAdditionalInformation(array_merge((array)$payment->getAdditionalInformation(), $paymentData));
-        }
 
         $payment->save();
     }

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -849,6 +849,19 @@ class Order extends AbstractHelper
             $payment->setAdditionalInformation(array_merge((array)$payment->getAdditionalInformation(), $paymentData));
         }
 
+        if (!empty($transaction->authorization) && !empty($transaction->authorization->avs_response)) {
+            $paymentData = [
+                'avs_response' => $transaction->authorization->avs_response,
+            ];
+            $payment->setAdditionalInformation(array_merge((array)$payment->getAdditionalInformation(), $paymentData));
+        }
+
+        if (!empty($transaction->authorization) && !empty($transaction->authorization->cvv_response)) {
+            $paymentData = [
+                'cvv_response' => $transaction->authorization->cvv_response,
+            ];
+            $payment->setAdditionalInformation(array_merge((array)$payment->getAdditionalInformation(), $paymentData));
+        }
 
         $payment->save();
     }

--- a/Test/Unit/Controller/ReceivedUrlTraitTest.php
+++ b/Test/Unit/Controller/ReceivedUrlTraitTest.php
@@ -260,6 +260,7 @@ class ReceivedUrlTraitTest extends BoltTestCase
         
         $this->deciderMock->method('isSetOrderPaymentInfoDataOnSuccessPage')
             ->willReturn($isSetOrderPaymentInfoDataOnSuccessPage);
+        $this->deciderMock->method('isStoringCvvAndAvsResponseInPaymentInfoEnabled')->willReturn(false);
         $this->order->method('getPayment')->willReturn($isPaymentAvailable ? $this->paymentMock : null);
         $this->orderHelper->method('fetchTransactionInfo')->willReturn(json_decode(self::DECODED_BOLT_PAYLOAD));
 

--- a/Test/Unit/Model/Api/OrderManagementTest.php
+++ b/Test/Unit/Model/Api/OrderManagementTest.php
@@ -1291,11 +1291,12 @@ class OrderManagementTest extends BoltTestCase
         
         $featureSwitch = $this->getMockBuilder(Decider::class)
             ->disableOriginalConstructor()
-            ->setMethods(['isCreatingCreditMemoFromWebHookEnabled', 'isIgnoreHookForInvoiceCreationEnabled','isIgnoreTotalValidationWhenCreditHookIsSentToMagentoEnabled'])
+            ->setMethods(['isCreatingCreditMemoFromWebHookEnabled', 'isIgnoreHookForInvoiceCreationEnabled','isIgnoreTotalValidationWhenCreditHookIsSentToMagentoEnabled','isStoringCvvAndAvsResponseInPaymentInfoEnabled'])
             ->getMock();
         $featureSwitch->expects($this->any())->method('isCreatingCreditMemoFromWebHookEnabled')->willReturn(true);
         $featureSwitch->expects($this->any())->method('isIgnoreHookForInvoiceCreationEnabled')->willReturn(false);
         $featureSwitch->expects($this->any())->method('isIgnoreTotalValidationWhenCreditHookIsSentToMagentoEnabled')->willReturn(false);
+        $featureSwitch->expects($this->any())->method('isStoringCvvAndAvsResponseInPaymentInfoEnabled')->willReturn(false);
 
         $featureSwitchProperty = new \ReflectionProperty(
             OrderHelper::class,


### PR DESCRIPTION
# Description
Store CVV and AVS response in the payment info object. Merchant (Metroplex) needs fields in Magento to do their integration.

Fixes: https://app.asana.com/0/1201495896048972/1204737432767889

#changelog Store CVV and AVS response in payment info object

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
