### PR TITLE
Fetch Cart: fix fetching cart cart listener in case when "data_id" is missed

### DIFF
--- a/view/frontend/web/js/bolt-api-driven-checkout.js
+++ b/view/frontend/web/js/bolt-api-driven-checkout.js
@@ -438,7 +438,7 @@ define([
         magentoCartDataListener: function (magentoCart) {
             BoltCheckoutApiDriven.resolveReadyStatusPromise();
             //if timestamp is the same no checks needed
-            if (magentoCart.data_id === this.magentoCartTimeStamp) {
+            if (magentoCart.data_id && magentoCart.data_id === this.magentoCartTimeStamp) {
                 return;
             }
             //init default values


### PR DESCRIPTION
# Description
Fetch cart magento cart listener fix for case when "data_id" is not provided in cart section.

#changelog fetch cart fix empty "data_id" case

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
