### PR TITLE
Add support to remove store credit in Bolt modal

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -2427,6 +2427,7 @@ class Cart extends AbstractHelper
                     $discounts[] = [
                         'description'       => 'Store Credit',
                         'amount'            => $roundedAmount,
+                        'reference'         => \Bolt\Boltpay\ThirdPartyModules\Magento\CustomerBalance::STORE_CREDIT,
                         'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_STORE_CREDIT,
                         'discount_type'     => Discount::BOLT_DISCOUNT_TYPE_FIXED, // For v1/discounts.code.apply and v2/cart.update
                         'type'              => Discount::BOLT_DISCOUNT_TYPE_FIXED, // For v1/merchant/order

--- a/Model/EventsForThirdPartyModules.php
+++ b/Model/EventsForThirdPartyModules.php
@@ -43,6 +43,7 @@ use Bolt\Boltpay\ThirdPartyModules\Magecomp\Extrafee as Magecomp_Extrafee;
 use Bolt\Boltpay\ThirdPartyModules\Webkul\Odoomagentoconnect as Webkul_Odoomagentoconnect;
 use Bolt\Boltpay\ThirdPartyModules\J2t\Rewardpoints as J2t_Rewardpoints;
 use Bolt\Boltpay\ThirdPartyModules\BagRiders\StoreCredit as BagRiders_StoreCredit;
+use Bolt\Boltpay\ThirdPartyModules\Magento\CustomerBalance as Magento_CustomerBalance;
 use Bolt\Boltpay\ThirdPartyModules\Teamwork\Token as Teamwork_Token;
 use Bolt\Boltpay\ThirdPartyModules\Teamwork\StoreCredit as Teamwork_StoreCredit;
 use Bolt\Boltpay\ThirdPartyModules\SomethingDigital\InStorePickupBoltIntegration as SomethingDigital_InStorePickupBoltIntegration;
@@ -264,6 +265,11 @@ class EventsForThirdPartyModules
                     "sendClasses" => ["BagRiders\StoreCredit\Model\StoreCredit\ApplyStoreCreditToQuote"],
                     "boltClass" => BagRiders_StoreCredit::class,
                 ],
+                [
+                    "module" => "Magento_CustomerBalance",
+                    "checkClasses" => ["Magento\CustomerBalance\Model\Balance"],
+                    "boltClass" => Magento_CustomerBalance::class,
+                ],
             ]
         ],
         'beforeValidateQuoteDataForProcessNewOrder' => [
@@ -426,7 +432,7 @@ class EventsForThirdPartyModules
                     'module'      => 'Route_Route',
                     'checkClasses' => ['Route\Route\Model\Quote\Total\RouteFee'],
                     'sendClasses' => ['Route\Route\Model\Route\Merchant',
-                                      'Route\Route\Helper\Data'],
+                        'Route\Route\Helper\Data'],
                     'boltClass'   => Route_Route::class,
                 ],
             ],
@@ -938,6 +944,11 @@ class EventsForThirdPartyModules
                     "module" => "BagRiders_StoreCredit",
                     "checkClasses" => ["BagRiders\StoreCredit\Api\Data\SalesFieldInterface"],
                     "boltClass" => BagRiders_StoreCredit::class,
+                ],
+                [
+                    "module" => "Magento_CustomerBalance",
+                    "checkClasses" => ["Magento\CustomerBalance\Model\Balance"],
+                    "boltClass" => Magento_CustomerBalance::class,
                 ],
             ]
         ],

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -4203,6 +4203,7 @@ ORDER
             'discount_category' => 'store_credit',
             'discount_type'   => 'fixed_amount',
             'type'   => 'fixed_amount',
+            'reference' => 'Store Credit'
         ]
         ];
         static::assertEquals($expectedDiscount, $discounts);

--- a/ThirdPartyModules/Magento/CustomerBalance.php
+++ b/ThirdPartyModules/Magento/CustomerBalance.php
@@ -21,6 +21,8 @@ use Bolt\Boltpay\Helper\Config;
 
 class CustomerBalance
 {
+    const STORE_CREDIT = 'Store Credit';
+
     /**
      * @var Config
      */
@@ -53,5 +55,41 @@ class CustomerBalance
             ];
         }
         return $layout;
+    }
+
+    /**
+     * @param $result
+     * @param $couponCode
+     * @param $quote
+     * @return array
+     */
+    public function filterVerifyAppliedStoreCredit (
+        $result,
+        $couponCode,
+        $quote
+    )
+    {
+        if ($couponCode == self::STORE_CREDIT && $quote->getUseCustomerBalance()) {
+            $result[] = $couponCode;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param $result
+     * @param $couponCode
+     * @param $quote
+     * @return array
+     */
+    public function removeAppliedStoreCredit(
+        $couponCode,
+        $quote,
+        $websiteId,
+        $storeId
+    ) {
+        if ($couponCode == self::STORE_CREDIT) {
+            $quote->setUseCustomerBalance(false)->collectTotals()->save();
+        }
     }
 }


### PR DESCRIPTION
# Description
Currently, the customer is unable to remove Magento store credit in the Bolt modal. https://prnt.sc/PMUStz7ZARJd
I created this PR to fix the issue. 

Fixes: (link ticket)

#changelog Add support to remove store credit in Bolt modal

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
