### PR TITLE
Added addItemToQuote func call to apply addons to immutable quote

### DIFF
--- a/Model/Api/UpdateCart.php
+++ b/Model/Api/UpdateCart.php
@@ -269,6 +269,9 @@ class UpdateCart extends UpdateCartCommon implements UpdateCartInterface
                         return false;
                     }
                     $removeFromImmutableQuote = true;
+                    if (!$immutableQuote->getItemById($quoteItem['quote_item_id'])) {
+                        $removeFromImmutableQuote = false;
+                    }
                     if ($parentQuote->getId() == $immutableQuoteId) {
                         $removeFromImmutableQuote = false;
                     }

--- a/Model/Api/UpdateCart.php
+++ b/Model/Api/UpdateCart.php
@@ -209,7 +209,7 @@ class UpdateCart extends UpdateCartCommon implements UpdateCartInterface
                     if ($immutableQuote->getItems()) {
                         $addToImmutableQuote = false;
                     }
-                    if ($addToImmutableQuote) {
+                    if ($addToImmutableQuote && !$parentQuote->getId() == $immutableQuoteId) {
                         $result = $this->addItemToQuote($product, $immutableQuote, $addItem, $quoteItem);
                         if (!$result) {
                             // Already sent a response with error, so just return.

--- a/Model/Api/UpdateCart.php
+++ b/Model/Api/UpdateCart.php
@@ -206,12 +206,19 @@ class UpdateCart extends UpdateCartCommon implements UpdateCartInterface
                     // Adding the same data into immutable quote
                     // in order to avoid missing addons in parent quote
                     $addToImmutableQuote = true;
-                    foreach ($immutableQuote->getItems() as $item) {
-                        if ($item->getSku() == $product->getSku()) {
+                    $immutableQuoteItems = $immutableQuote->getItems();
+                    if ($immutableQuoteItems) {
+                        foreach ($immutableQuoteItems as $item) {
+                            if ($item->getSku() == $product->getSku()) {
+                                $addToImmutableQuote = false;
+                            }
+                        }
+                        if ($parentQuote->getId() == $immutableQuoteId) {
                             $addToImmutableQuote = false;
                         }
                     }
-                    if ($addToImmutableQuote && !$parentQuote->getId() == $immutableQuoteId) {
+
+                    if ($addToImmutableQuote) {
                         $result = $this->addItemToQuote($product, $immutableQuote, $addItem, $quoteItem);
                         if (!$result) {
                             // Already sent a response with error, so just return.
@@ -260,6 +267,14 @@ class UpdateCart extends UpdateCartCommon implements UpdateCartInterface
                     if (!$result) {
                         // Already sent a response with error, so just return.
                         return false;
+                    }
+
+                    if ($addToImmutableQuote) {
+                        $result = $this->removeItemFromQuote($quoteItem, $removeItem, $immutableQuote);
+                        if (!$result) {
+                            // Already sent a response with error, so just return.
+                            return false;
+                        }
                     }
                 }
 

--- a/Model/Api/UpdateCart.php
+++ b/Model/Api/UpdateCart.php
@@ -205,10 +205,18 @@ class UpdateCart extends UpdateCartCommon implements UpdateCartInterface
                     }
                     // Adding the same data into immutable quote
                     // in order to avoid missing addons in parent quote
-                    $result = $this->addItemToQuote($product, $immutableQuote, $addItem, $quoteItem);
-                    if (!$result) {
-                        // Already sent a response with error, so just return.
-                        return false;
+                    $addToImmutableQuote = true;
+                    foreach ($immutableQuote->getItems() as $item) {
+                        if ($item->getSku() == $product->getSku()) {
+                            $addToImmutableQuote = false;
+                        }
+                    }
+                    if ($addToImmutableQuote) {
+                        $result = $this->addItemToQuote($product, $immutableQuote, $addItem, $quoteItem);
+                        if (!$result) {
+                            // Already sent a response with error, so just return.
+                            return false;
+                        }
                     }
                 }
 

--- a/Model/Api/UpdateCart.php
+++ b/Model/Api/UpdateCart.php
@@ -206,10 +206,8 @@ class UpdateCart extends UpdateCartCommon implements UpdateCartInterface
                     // Adding the same data into immutable quote
                     // in order to avoid missing addons in parent quote
                     $addToImmutableQuote = true;
-                    foreach ($immutableQuote->getItems() as $item) {
-                        if ($item->getSku() == $product->getSku()) {
-                            $addToImmutableQuote = false;
-                        }
+                    if ($immutableQuote->getItems()) {
+                        $addToImmutableQuote = false;
                     }
                     if ($addToImmutableQuote) {
                         $result = $this->addItemToQuote($product, $immutableQuote, $addItem, $quoteItem);

--- a/Model/Api/UpdateCart.php
+++ b/Model/Api/UpdateCart.php
@@ -206,16 +206,14 @@ class UpdateCart extends UpdateCartCommon implements UpdateCartInterface
                     // Adding the same data into immutable quote
                     // in order to avoid missing addons in parent quote
                     $addToImmutableQuote = true;
-                    $immutableQuoteItems = $immutableQuote->getItems();
-                    if ($immutableQuoteItems) {
-                        foreach ($immutableQuoteItems as $item) {
-                            if ($item->getSku() == $product->getSku()) {
-                                $addToImmutableQuote = false;
-                            }
-                        }
-                        if ($parentQuote->getId() == $immutableQuoteId) {
+
+                    foreach ($immutableQuote->getItems() as $item) {
+                        if ($item->getSku() == $product->getSku()) {
                             $addToImmutableQuote = false;
                         }
+                    }
+                    if ($parentQuote->getId() == $immutableQuoteId) {
+                        $addToImmutableQuote = false;
                     }
 
                     if ($addToImmutableQuote) {

--- a/Model/Api/UpdateCart.php
+++ b/Model/Api/UpdateCart.php
@@ -268,8 +268,12 @@ class UpdateCart extends UpdateCartCommon implements UpdateCartInterface
                         // Already sent a response with error, so just return.
                         return false;
                     }
+                    $removeFromImmutableQuote = true;
+                    if ($parentQuote->getId() == $immutableQuoteId) {
+                        $removeFromImmutableQuote = false;
+                    }
 
-                    if ($addToImmutableQuote) {
+                    if ($removeFromImmutableQuote) {
                         $result = $this->removeItemFromQuote($quoteItem, $removeItem, $immutableQuote);
                         if (!$result) {
                             // Already sent a response with error, so just return.

--- a/Model/Api/UpdateCart.php
+++ b/Model/Api/UpdateCart.php
@@ -206,8 +206,10 @@ class UpdateCart extends UpdateCartCommon implements UpdateCartInterface
                     // Adding the same data into immutable quote
                     // in order to avoid missing addons in parent quote
                     $addToImmutableQuote = true;
-                    if ($immutableQuote->getItems()) {
-                        $addToImmutableQuote = false;
+                    foreach ($immutableQuote->getItems() as $item) {
+                        if ($item->getSku() == $product->getSku()) {
+                            $addToImmutableQuote = false;
+                        }
                     }
                     if ($addToImmutableQuote && !$parentQuote->getId() == $immutableQuoteId) {
                         $result = $this->addItemToQuote($product, $immutableQuote, $addItem, $quoteItem);

--- a/Model/Api/UpdateCart.php
+++ b/Model/Api/UpdateCart.php
@@ -203,6 +203,13 @@ class UpdateCart extends UpdateCartCommon implements UpdateCartInterface
                         // Already sent a response with error, so just return.
                         return false;
                     }
+                    // Adding the same data into immutable quote
+                    // in order to avoid missing addons in parent quote
+                    $result = $this->addItemToQuote($product, $immutableQuote, $addItem, $quoteItem);
+                    if (!$result) {
+                        // Already sent a response with error, so just return.
+                        return false;
+                    }
                 }
 
                 $this->updateTotals($parentQuote);

--- a/Test/Unit/Model/Api/UpdateCartTest.php
+++ b/Test/Unit/Model/Api/UpdateCartTest.php
@@ -293,9 +293,9 @@ class UpdateCartTest extends BoltTestCase
         $quote->method('isVirtual')->willReturn($isVirtual);
         $quote->method('getQuoteCurrencyCode')->willReturn('USD');
         $quote->method('collectTotals')->willReturnSelf();
-        $quote->method('getItems')->willReturn(null);
+        $quote->method('getItems')->willReturn([$quoteItem]);
         $quote->method('getItemsCount')->willReturn(1);
-        $quote->method('getItemById')->willReturn(false);
+        $quote->method('getItemById')->willReturn($quoteItem);
         $quote->method('getCustomerId')->willReturn($customerId);
         $quote->expects(self::any())->method('setCouponCode')->willReturnSelf();
         $quote->method('getCouponCode')->willReturn($couponCode);

--- a/Test/Unit/Model/Api/UpdateCartTest.php
+++ b/Test/Unit/Model/Api/UpdateCartTest.php
@@ -828,8 +828,8 @@ class UpdateCartTest extends BoltTestCase
         $this->currentMock->expects(self::once())->method('verifyItemData')
             ->with($product, $add_items[0], $quoteItem, self::WEBSITE_ID)
             ->willReturn(true);
-        
-        $this->currentMock->expects(self::once())->method('addItemToQuote')
+
+        $this->currentMock->expects(self::atLeastOnce())->method('addItemToQuote')
             ->with($product, $parentQuoteMock, $add_items[0], $quoteItem)
             ->willReturn(true);
         

--- a/Test/Unit/Model/Api/UpdateCartTest.php
+++ b/Test/Unit/Model/Api/UpdateCartTest.php
@@ -267,6 +267,7 @@ class UpdateCartTest extends BoltTestCase
                     'isVirtual',
                     'collectTotals',
                     'getQuoteCurrencyCode',
+                    'getItems',
                     'getItemsCount',
                     'getCustomerId',
                     'setCouponCode',
@@ -291,6 +292,7 @@ class UpdateCartTest extends BoltTestCase
         $quote->method('isVirtual')->willReturn($isVirtual);
         $quote->method('getQuoteCurrencyCode')->willReturn('USD');
         $quote->method('collectTotals')->willReturnSelf();
+        $quote->method('getItems')->willReturn(null);
         $quote->method('getItemsCount')->willReturn(1);
         $quote->method('getCustomerId')->willReturn($customerId);
         $quote->expects(self::any())->method('setCouponCode')->willReturnSelf();

--- a/Test/Unit/Model/Api/UpdateCartTest.php
+++ b/Test/Unit/Model/Api/UpdateCartTest.php
@@ -269,6 +269,7 @@ class UpdateCartTest extends BoltTestCase
                     'getQuoteCurrencyCode',
                     'getItems',
                     'getItemsCount',
+                    'getItemById',
                     'getCustomerId',
                     'setCouponCode',
                     'getCouponCode',
@@ -294,6 +295,7 @@ class UpdateCartTest extends BoltTestCase
         $quote->method('collectTotals')->willReturnSelf();
         $quote->method('getItems')->willReturn(null);
         $quote->method('getItemsCount')->willReturn(1);
+        $quote->method('getItemById')->willReturn(false);
         $quote->method('getCustomerId')->willReturn($customerId);
         $quote->expects(self::any())->method('setCouponCode')->willReturnSelf();
         $quote->method('getCouponCode')->willReturn($couponCode);

--- a/Test/Unit/Model/Api/UpdateCartTest.php
+++ b/Test/Unit/Model/Api/UpdateCartTest.php
@@ -970,8 +970,8 @@ class UpdateCartTest extends BoltTestCase
         $this->currentMock->expects(self::once())->method('verifyItemData')
             ->with($product, $remove_items[0], $cartItems[0], self::WEBSITE_ID)
             ->willReturn(true);
-            
-        $this->currentMock->expects(self::once())->method('removeItemFromQuote')
+
+        $this->currentMock->expects(self::atLeastOnce())->method('removeItemFromQuote')
             ->with($cartItems[0], $remove_items[0], $parentQuoteMock)
             ->willReturn(true);
         


### PR DESCRIPTION
# Description
When we add addon and then request again shipping methods addon is removed from the cart. In order to solve it, we applying addons to immutable quote as well

Fixes: [(link ticket)](https://app.asana.com/0/1201931884901947/1203586216479563)

#changelog Added addItemToQuote func call to apply addons to immutable quote

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
