### PR TITLE
Bugsnag: remove sensitive data logging

### DIFF
--- a/Helper/Api.php
+++ b/Helper/Api.php
@@ -237,19 +237,6 @@ class Api extends AbstractHelper
                     $headers = $headers->toArray();
                 }
                 $report->setMetaData([
-                    'BOLT API RESPONSE' => [
-                        'headers' => $headers,
-                        'body'    => $response->getBody(),
-                    ]
-                ]);
-            });
-
-            $this->bugsnag->registerCallback(function ($report) use ($response) {
-                $headers = $response->getHeaders();
-                if (!is_array($headers) && is_object($headers) && method_exists($headers, 'toArray')) {
-                    $headers = $headers->toArray();
-                }
-                $report->setMetaData([
                     'META DATA' => [
                         'bolt_trace_id' => $headers[ConfigHelper::BOLT_TRACE_ID_HEADER] ?? null,
                     ]

--- a/Helper/Api.php
+++ b/Helper/Api.php
@@ -223,12 +223,6 @@ class Api extends AbstractHelper
 
         $request->setHeaders($headers);
 
-        $this->bugsnag->registerCallback(function ($report) use ($request) {
-            $report->setMetaData([
-                'BOLT API REQUEST' => $request->getData()
-            ]);
-        });
-
         $client->setHeaders($headers);
 
         $responseBody = null;

--- a/Test/Unit/Helper/ApiTest.php
+++ b/Test/Unit/Helper/ApiTest.php
@@ -220,10 +220,7 @@ class ApiTest extends BoltTestCase
         $reportMock = $this->createPartialMock(Report::class, ['setMetaData']);
         $dummyResponseBody = '{"data": {"logMerchantLogs": {"isSuccessful": true}}}';
 
-        $reportMock->expects(self::exactly(3))->method('setMetaData')->withConsecutive(
-            [
-                TestHelper::buildArraySubset(['BOLT API REQUEST' => $request->getData()])
-            ],
+        $reportMock->expects(self::exactly(2))->method('setMetaData')->withConsecutive(
             [
                 [
                     'BOLT API RESPONSE' => [
@@ -357,10 +354,7 @@ class ApiTest extends BoltTestCase
         $reportMock = $this->createPartialMock(Report::class, ['setMetaData']);
         $emptyResponseBody = '';
 
-        $reportMock->expects(self::exactly(3))->method('setMetaData')->withConsecutive(
-            [
-                TestHelper::buildArraySubset(['BOLT API REQUEST' => $request->getData()])
-            ],
+        $reportMock->expects(self::exactly(2))->method('setMetaData')->withConsecutive(
             [
                 [
                     'BOLT API RESPONSE' => [

--- a/Test/Unit/Helper/ApiTest.php
+++ b/Test/Unit/Helper/ApiTest.php
@@ -220,15 +220,7 @@ class ApiTest extends BoltTestCase
         $reportMock = $this->createPartialMock(Report::class, ['setMetaData']);
         $dummyResponseBody = '{"data": {"logMerchantLogs": {"isSuccessful": true}}}';
 
-        $reportMock->expects(self::exactly(2))->method('setMetaData')->withConsecutive(
-            [
-                [
-                    'BOLT API RESPONSE' => [
-                        'headers' => [],
-                        'body'    => $dummyResponseBody,
-                    ]
-                ]
-            ],
+        $reportMock->expects(self::exactly(1))->method('setMetaData')->withConsecutive(
             [
                 [
                     'META DATA' => [
@@ -237,7 +229,7 @@ class ApiTest extends BoltTestCase
                 ]
             ]
         );
-        $this->bugsnag->expects(self::exactly(2))->method('registerCallback')->willReturnCallback(
+        $this->bugsnag->expects(self::exactly(1))->method('registerCallback')->willReturnCallback(
             function (callable $callback) use ($reportMock) {
                 $callback($reportMock);
             }
@@ -354,15 +346,7 @@ class ApiTest extends BoltTestCase
         $reportMock = $this->createPartialMock(Report::class, ['setMetaData']);
         $emptyResponseBody = '';
 
-        $reportMock->expects(self::exactly(2))->method('setMetaData')->withConsecutive(
-            [
-                [
-                    'BOLT API RESPONSE' => [
-                        'headers' => [],
-                        'body'    => $emptyResponseBody,
-                    ]
-                ]
-            ],
+        $reportMock->expects(self::exactly(1))->method('setMetaData')->withConsecutive(
             [
                 [
                     'META DATA' => [
@@ -371,7 +355,7 @@ class ApiTest extends BoltTestCase
                 ]
             ]
         );
-        $this->bugsnag->expects(self::exactly(2))->method('registerCallback')->willReturnCallback(
+        $this->bugsnag->expects(self::exactly(1))->method('registerCallback')->willReturnCallback(
             function (callable $callback) use ($reportMock) {
                 $callback($reportMock);
             }

--- a/Test/Unit/Helper/ApiTest.php
+++ b/Test/Unit/Helper/ApiTest.php
@@ -240,7 +240,7 @@ class ApiTest extends BoltTestCase
         $client->expects(static::once())->method('request')->willReturn($responseMock);
 
         $responseMock->expects(static::exactly(1))->method('getHeaders')->willReturn([]);
-        $responseMock->expects(static::exactly(2))->method('getBody')->willReturn($dummyResponseBody);
+        $responseMock->expects(static::exactly(1))->method('getBody')->willReturn($dummyResponseBody);
 
         $resultMock->expects(static::once())->method('setResponse')->with(json_decode($dummyResponseBody));
 
@@ -366,7 +366,7 @@ class ApiTest extends BoltTestCase
         $client->expects(static::once())->method('request')->willReturn($responseMock);
 
         $responseMock->expects(static::exactly(1))->method('getHeaders')->willReturn([]);
-        $responseMock->expects(static::exactly(2))->method('getBody')->willReturn($emptyResponseBody);
+        $responseMock->expects(static::exactly(1))->method('getBody')->willReturn($emptyResponseBody);
 
         $this->expectException(LocalizedException::class);
         $this->expectExceptionMessage('Something went wrong in the payment gateway.');

--- a/Test/Unit/Helper/ApiTest.php
+++ b/Test/Unit/Helper/ApiTest.php
@@ -237,7 +237,7 @@ class ApiTest extends BoltTestCase
                 ]
             ]
         );
-        $this->bugsnag->expects(self::exactly(3))->method('registerCallback')->willReturnCallback(
+        $this->bugsnag->expects(self::exactly(2))->method('registerCallback')->willReturnCallback(
             function (callable $callback) use ($reportMock) {
                 $callback($reportMock);
             }
@@ -371,7 +371,7 @@ class ApiTest extends BoltTestCase
                 ]
             ]
         );
-        $this->bugsnag->expects(self::exactly(3))->method('registerCallback')->willReturnCallback(
+        $this->bugsnag->expects(self::exactly(2))->method('registerCallback')->willReturnCallback(
             function (callable $callback) use ($reportMock) {
                 $callback($reportMock);
             }

--- a/Test/Unit/Helper/ApiTest.php
+++ b/Test/Unit/Helper/ApiTest.php
@@ -239,7 +239,7 @@ class ApiTest extends BoltTestCase
 
         $client->expects(static::once())->method('request')->willReturn($responseMock);
 
-        $responseMock->expects(static::exactly(2))->method('getHeaders')->willReturn([]);
+        $responseMock->expects(static::exactly(1))->method('getHeaders')->willReturn([]);
         $responseMock->expects(static::exactly(2))->method('getBody')->willReturn($dummyResponseBody);
 
         $resultMock->expects(static::once())->method('setResponse')->with(json_decode($dummyResponseBody));
@@ -365,7 +365,7 @@ class ApiTest extends BoltTestCase
 
         $client->expects(static::once())->method('request')->willReturn($responseMock);
 
-        $responseMock->expects(static::exactly(2))->method('getHeaders')->willReturn([]);
+        $responseMock->expects(static::exactly(1))->method('getHeaders')->willReturn([]);
         $responseMock->expects(static::exactly(2))->method('getBody')->willReturn($emptyResponseBody);
 
         $this->expectException(LocalizedException::class);


### PR DESCRIPTION
# Description
In this PR we are removing logging bugsnag `BOLT API REQUEST` meta-data, because it [contains](https://app.bugsnag.com/bolt/magento-2/errors/644a57a50f876600085d7ac2?filters[event.since]=2023-05-22T19%3A43%3A00.000Z&filters[app.release_stage]=production&filters[error.status]=for_review&filters[search]=https%3A%2F%2Fwww.burtsbeesbaby.com%2F) sensitive data like "api key".

Fixes: https://app.asana.com/0/1201688509544833/1204661131427338/f

#changelog Bugsnag: remove sensitive data bugsnag logging

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [x] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [x] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
