### PR TITLE
Fetch cart: fix incorrect arguments list in hints when defined

### DIFF
--- a/view/frontend/web/js/bolt-api-driven-checkout.js
+++ b/view/frontend/web/js/bolt-api-driven-checkout.js
@@ -32,7 +32,7 @@ define([
         customerCart: null,
         boltCallbacks: {},
         boltParameters: {},
-        quoteMaskedId: null,
+        quoteMaskedId: undefined,
         boltCartHints: {prefill:{}},
         magentoCartTimeStamp: null,
         cartBarrier: null,


### PR DESCRIPTION
# Description
Fetch cart js component: fixed incorrect arguments list in hints `whenDefined` method call.
- updated initial value of `quoteMaskedId` from `null` to `undefined` to prevent infinite calls from [whenDefined.lib](https://github.com/BoltApp/bolt-magento2/blob/2bd0f65d3fc83a17b50c46111b9a49681407f74c/view/frontend/web/js/utils/when-defined.js#L35), because it checks object property for `undefined` value
- updated `updateHints` method to use correct argument list

Fixes: (link ticket)

#changelog fetch cart: fixed incorrect arguments list in hints whenDefined method call.

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
