### PR TITLE
Added setter for total_paid value for order during capture transaction invoice creation

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -2427,6 +2427,7 @@ class Order extends AbstractHelper
         $invoice->save();
 
         $order->addRelatedObject($invoice);
+        $order->setTotalPaid($amount);
 
         // pre-save required order data with will be overwritten during invoice email sending
         $baseSubtotal = $order->getBaseSubtotal();

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -2427,7 +2427,7 @@ class Order extends AbstractHelper
         $invoice->save();
 
         $order->addRelatedObject($invoice);
-        $order->setTotalPaid($amount);
+        $order->setTotalPaid((float)$order->getTotalInvoiced() + $amount);
 
         // pre-save required order data with will be overwritten during invoice email sending
         $baseSubtotal = $order->getBaseSubtotal();

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -3411,7 +3411,7 @@ class OrderTest extends BoltTestCase
             ]
         );
         $order->method('getOrderCurrencyCode')->willReturn(self::CURRENCY_CODE);
-        $order->expects(static::once())->method('getTotalInvoiced')->willReturn($totalInvoiced);
+        $order->expects(static::atLeastOnce())->method('getTotalInvoiced')->willReturn($totalInvoiced);
         $order->expects(static::once())->method('getGrandTotal')->willReturn($grandTotal);
         $order->method('addStatusHistoryComment')->willReturn($order);
         $order->method('setIsCustomerNotified')->willReturn($order);

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -3525,7 +3525,7 @@ class OrderTest extends BoltTestCase
             ]
         );
         $order->method('getOrderCurrencyCode')->willReturn(self::CURRENCY_CODE);
-        $order->expects(static::once())->method('getTotalInvoiced')->willReturn(5);
+        $order->expects(static::atLeastOnce())->method('getTotalInvoiced')->willReturn(5);
         $order->expects(static::once())->method('getGrandTotal')->willReturn(5);
         $order->expects(static::once())->method('getStoreId')->willReturn(self::STORE_ID);
         $order->method('addStatusHistoryComment')->willReturn($order);

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -3661,7 +3661,7 @@ class OrderTest extends BoltTestCase
             ]
         );
         $order->method('getOrderCurrencyCode')->willReturn(self::CURRENCY_CODE);
-        $order->expects(static::once())->method('getTotalInvoiced')->willReturn(5);
+        $order->expects(static::atLeastOnce())->method('getTotalInvoiced')->willReturn(5);
         $order->expects(static::once())->method('getGrandTotal')->willReturn(5);
         $order->expects(static::once())->method('getStoreId')->willReturn(self::STORE_ID);
         $order->method('addStatusHistoryComment')->willReturn($order);


### PR DESCRIPTION
# Description
Credit Memo button on admin dashboard is not rendered. No webhook errors for affected orders. Legacy approach. 
During investigations figured out that invoice creation in legacy approach works differently from default magento, total_paid value is missing in legacy approach. 
Link to m2 default function which is responsible for validation of Credit Memo button rendering - https://github.com/magento/magento2/blob/adc4105fcfbeee29d534482d8c6d9c5c1a193a0c/app/code/Magento/Sales/Model/Order.php#L727 

Fixes: [(link ticket)](https://app.asana.com/0/1201931884901947/1204718084460094)

#changelog Added setter for total_paid value for order during capture transaction invoice creation

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
