### PR TITLE
Product page checkout: Show Bolt SSO popup instead of Magento authentication popup if SSO is enabled

### DIFF
--- a/view/frontend/templates/button_product_page.phtml
+++ b/view/frontend/templates/button_product_page.phtml
@@ -162,6 +162,15 @@ foreach ($block->getAdditionalCheckoutButtonAttributes() as $attrName => $attrVa
                 },
 
                 check: function () {
+
+                    var showBoltSSOPopup = function() {
+                        // set a cookie for auto opening Bolt checkout after login
+                        $('#bolt-sso-popup .bolt-account-sso [data-tid="shopperDashboardButton"]').click();
+                    }
+
+                    var showMagentoAuthenticationPopup = function () {
+                        authenticationPopup.showModal();
+                    }
                     /**
                      * On Bolt button click check if guest checkout is allowed.
                      * Display login popup to guest customers if it is not. The
@@ -172,7 +181,11 @@ foreach ($block->getAdditionalCheckoutButtonAttributes() as $attrName => $attrVa
                     if ( !customer().firstname && !isGuestCheckoutAllowed) {
                         // if authentication is required for checkout set a cookie
                         // for auto opening Bolt checkout after login
-                        authenticationPopup.showModal();
+                        if (window.boltConfig.is_sso_enabled) {
+                            showBoltSSOPopup()
+                        } else {
+                            showMagentoAuthenticationPopup();
+                        }
                         return false;
                     }
                     // wait for validation module init


### PR DESCRIPTION
Steps for replicating the issue:
- Ensure guest checkout is disabled in Magento site, Bolt and SSO, product page checkout is enabled
- Go to product detail page, and clicks Bolt checkout button

Actual result: Magento authentication popup display 
Expected result: Bolt SSO popup should be displayed

So this PR is to show Bolt SSO popup instead of Magento authentication popup on product detail page  if SSO is enabled 

Fixes: https://app.asana.com/0/1204419514580775/1205241392267730 

#changelog Product page checkout: Show Bolt SSO popup instead of Magento authentication popup if SSO is enabled

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
