### PR TITLE
SSO: wrong form_key cookie after login

### DIFF
--- a/Model/Api/OAuthRedirect.php
+++ b/Model/Api/OAuthRedirect.php
@@ -504,24 +504,6 @@ class OAuthRedirect implements OAuthRedirectInterface
             $this->getCookieManager()->deleteCookie('mage-cache-sessid', $metadata);
         }
 
-        try {
-            // we should force to set new "form_key" cookie here to prevent safari "session expired" issue
-            // when we are logged-in by SSO without page redirect (by using Bolt Shopper Assistant for example)
-            // in this case magento removing cookie by backend here:
-            // https://github.com/magento/magento2/blob/5844ade68b2f9632e3888c81c946068eba6328bb/app/code/Magento/PageCache/Observer/FlushFormKey.php
-            // but on safari without redirect the cookie is removed from browser (you can't see cookie on the devtool) but not in window.document object
-            // (we can see the cookie "form_key" there by checking object in browser console: "document.cookie")
-            // therefore all future requests is being called without "form_key" which is the reason of  "session expire" issue.
-            // By normal flow Magento updates that cookie in file:
-            // 2.2.0 - 2.3.0 https://github.com/magento/magento2/blob/44a7b6079bcac5ba92040b16f4f74024b4f34d09/app/code/Magento/PageCache/view/frontend/web/js/page-cache.js#L115
-            // 2.4.0 https://github.com/magento/magento2/blob/5844ade68b2f9632e3888c81c946068eba6328bb/app/code/Magento/PageCache/view/frontend/web/js/form-key-provider.js#L87
-            // Magento js above sets new cookie only in case if cookie is not exist
-            // but in our issue case magento js file is able to read cookie from document object (because cookie was not removed by safari)
-            // and doesn't update browser cookie.
-            $this->updateFormKeyCookie();
-        } catch (\Exception $e) {
-            $this->bugsnag->notifyException($e);
-        }
         $redirectUrl = $this->url->getUrl('customer/account');
         $checkoutSession = $this->sessionHelper->getCheckoutSession();
 
@@ -545,40 +527,5 @@ class OAuthRedirect implements OAuthRedirectInterface
     {
         return $checkoutSession->hasQuote()
             && count($checkoutSession->getQuote()->getAllVisibleItems()) > 0;
-    }
-    /**
-     * Set form key cookie
-     *
-     * @return void
-     * @throws LocalizedException
-     */
-    private function updateFormKeyCookie()
-    {
-        $formKey = ($this->cookieFormKey->get())
-            // if form key cookie was already initialized on front we should use it
-            ? $this->cookieFormKey->get()
-            // otherwise get it from the session or generate new one
-            : $this->formKey->getFormKey();
-
-        // temporary log data
-        if (!$this->cookieFormKey->get()) {
-            $this->bugsnag->notifyError('form_key_sso', sprintf('form_key is missed in cookies after sso login, new cookie generated: %s', $formKey));
-        }
-
-        $cookieMetadata = $this->getCookieMetadataFactory()->createPublicCookieMetadata();
-        $cookieMetadata->setDomain($this->sessionConfig->getCookieDomain());
-        $cookieMetadata->setPath($this->sessionConfig->getCookiePath());
-        $cookieMetadata->setSecure($this->sessionConfig->getCookieSecure());
-        $lifetime = $this->sessionConfig->getCookieLifetime();
-        if ($lifetime !== 0) {
-            $cookieMetadata->setDuration($lifetime);
-        }
-        $this->cookieFormKey->set(
-            $formKey,
-            $cookieMetadata
-        );
-        $this->formKey->set(
-            $this->cookieFormKey->get()
-        );
     }
 }


### PR DESCRIPTION
# Description
Updated: removed safari fix for "Bolt Assistant"

We discovered an issue with the `Filson` merchant's `form_key` cookie following a single sign-on (SSO) login action.

When we successfully perform an SSO login, we set a cookie at [this location](https://github.com/BoltApp/bolt-magento2/blob/4a3cca08da2fc2389075f690a6e46ce640d700bd/Model/Api/OAuthRedirect.php#L566). This is done to address the specific issue of Safari SSO logins through the Bolt Assistant. We don't expect the `form_key` cookie to be generated on our frontend during this process. Consequently, we attempt to obtain the `form_key` cookie using `\Magento\Framework\Data\Form\FormKey::getFormKey`, which retrieves the cookie from the session. If it's not present, a new one is generated.

However, in the case of `Filson`, the `_form_key` in the session is missing, causing us to consistently generate a new `form_key` at the same time as the one already generated and stored in the cookie. As a result, we end up with two cookies containing different values.

In this pull request (PR), I have updated the current workflow to match the default Magento `form_key` plugin's behavior, which can be found [here](https://github.com/magento/magento2/blob/16cdf2567e52cd85b5ea67d007f174a9173ad5e1/app/code/Magento/PageCache/Plugin/RegisterFormKeyFromCookie.php#L77). This plugin checks if a cookie has been generated on the frontend [by this js code](https://github.com/magento/magento2/blob/5844ade68b2f9632e3888c81c946068eba6328bb/app/code/Magento/PageCache/view/frontend/web/js/form-key-provider.js#L87), updates the cookie with that value, and adds it to the session.

Fixes: https://app.asana.com/0/1200879031426307/1205391486348958/f

#changelog SSO: wrong cookie form_key after login

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
