### PR TITLE
Legacy capture hook: total paid fix

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -2485,10 +2485,12 @@ class Order extends AbstractHelper
         $order->addRelatedObject($invoice);
 
         // in unexpected case order total paid could be empty, we should set it
-        if (!$order->getTotalPaid() && $order->getTotalInvoiced()) {
-            $order->setTotalPaid((float)$order->getTotalInvoiced());
-        } elseif (!$order->getTotalPaid() && !$order->getTotalInvoiced()) {
-            $order->setTotalPaid($amount);
+        if (!$order->getTotalPaid()) {
+            if ($order->getTotalInvoiced()) {
+                $order->setTotalPaid((float)$order->getTotalInvoiced());
+            } else {
+                $order->setTotalPaid($amount);
+            }
         }
 
         // pre-save required order data with will be overwritten during invoice email sending


### PR DESCRIPTION
# Description
The bug was caught in `2.27.2 ` after [this commit](https://github.com/BoltApp/bolt-magento2/pull/1818). The total paid sum is doubled. In this PR i avoid this case by adding additional check.

Fixes: https://app.asana.com/0/951157735838091/1205445649639705/f

#changelog Legacy capture hook: total paid fix

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
