### PR TITLE
Fix empty message for new version notification

### DIFF
--- a/Model/System/Message/NewVersionNotification.php
+++ b/Model/System/Message/NewVersionNotification.php
@@ -61,7 +61,7 @@ class NewVersionNotification implements MessageInterface
      */
     public function isDisplayed()
     {
-        if ($this->config->getNewPluginVersionNotificationEnabled()) {
+        if ($this->config->getNewPluginVersionNotificationEnabled() && $this->getNewVersionInfo()) {
             return true;
         }
         return false;


### PR DESCRIPTION
# Description
Fix "new version of bolt plugin" admin notification: when new version is not available it is showing empty message.

Fixes: https://app.asana.com/0/951157735838091/1205663083703619/f

#changelog fix empty new version of bolt plugin admin notification

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
