### PR TITLE
M2: Bolt Session Params Multiple Currencies Support

### DIFF
--- a/view/frontend/templates/button_product_page.phtml
+++ b/view/frontend/templates/button_product_page.phtml
@@ -66,7 +66,7 @@ foreach ($block->getAdditionalCheckoutButtonAttributes() as $attrName => $attrVa
 
             var customer = customerData.get('customer');
             var isGuestCheckoutAllowed = <?= /* @noEscape */ $block->isGuestCheckoutAllowed(); ?>;
-            var itemPrice = <?= /* @noEscape */ $block->getProduct()->getFinalPrice(); ?>;
+            var itemPrice = <?= /* @noEscape */ $block->getProduct()->getPriceInfo()->getPrice('final_price')->getValue(); ?>;
 
             var settings = window.boltConfig;
             var trackCallbacks = settings.trackCallbacks;
@@ -433,7 +433,7 @@ foreach ($block->getAdditionalCheckoutButtonAttributes() as $attrName => $attrVa
             // options change in updatePrice event listened below.
             // The final item price is the sum of all prices stored here.
             var itemPrices = {
-                basePrice: <?= /* @noEscape */ $block->getProduct()->getFinalPrice(); ?>
+                basePrice: <?= /* @noEscape */ $block->getProduct()->getPriceInfo()->getPrice('final_price')->getValue(); ?>
             };
 
             /**


### PR DESCRIPTION
# Description
- Refactored bolt session params flow to use request header `X-Bolt-Session-Params` for fetching session params instead body
- Fixed final price value getter on PDP page, now it returns final price value in current currency selected instead base currency value.

Fixes: https://app.asana.com/0/951157735838091/1205693441779617/f

#changelog M2: Bolt Session Params Multiple Currencies Support

# Type of change

- [x] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
