### PR TITLE
Bolt session params feature switcher updated to default enabled

### DIFF
--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -684,8 +684,8 @@ class Definitions
         self::M2_BOLT_SESSION_PARAMS => [
             self::NAME_KEY        => self::M2_BOLT_SESSION_PARAMS,
             self::VAL_KEY         => true,
-            self::DEFAULT_VAL_KEY => false,
-            self::ROLLOUT_KEY     => 0
+            self::DEFAULT_VAL_KEY => true,
+            self::ROLLOUT_KEY     => 100
         ],
     ];
 }


### PR DESCRIPTION
# Description
Made `M2_BOLT_SESSION_PARAMS` feature switcher enabled as default.

Fixes: https://app.asana.com/0/951157735838091/1205693441779617/f

#changelog M2_BOLT_SESSION_PARAMS enabled as default

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
