### PR TITLE
Bypass clearQuote plugin if the product page checkout is disabled

### DIFF
--- a/Plugin/ClearQuote.php
+++ b/Plugin/ClearQuote.php
@@ -27,7 +27,7 @@ class ClearQuote
      * @var CartHelper
      */
     private $cartHelper;
-    
+
     /**
      * @var ConfigHelper
      */
@@ -57,6 +57,9 @@ class ClearQuote
      */
     public function beforeClearQuote(CheckoutSession $subject)
     {
+        if (!$this->configHelper->getProductPageCheckoutFlag()) {
+            return null;
+        }
         // We don't want to clear quote
         // in Product page checkout (PPC) flow
         $this->quoteToRestore = null;
@@ -87,7 +90,7 @@ class ClearQuote
      */
     public function afterClearQuote(CheckoutSession $subject)
     {
-        if ($this->quoteToRestore) {
+        if ($this->configHelper->getProductPageCheckoutFlag() && $this->quoteToRestore) {
             $subject->replaceQuote($this->quoteToRestore);
             return $subject;
         }

--- a/Test/Unit/Plugin/ClearQuoteTest.php
+++ b/Test/Unit/Plugin/ClearQuoteTest.php
@@ -17,11 +17,13 @@
 
 namespace Bolt\Boltpay\Test\Unit\Plugin;
 
+use Bolt\Boltpay\Helper\Config as HelperConfig;
 use Bolt\Boltpay\Plugin\ClearQuote;
 use Bolt\Boltpay\Test\Unit\BoltTestCase;
 use Bolt\Boltpay\Test\Unit\TestHelper;
 use Bolt\Boltpay\Test\Unit\TestUtils;
 use Magento\Checkout\Model\Session as CheckoutSession;
+use Magento\Store\Model\ScopeInterface;
 use Magento\TestFramework\Helper\Bootstrap;
 
 /**
@@ -51,6 +53,16 @@ class ClearQuoteTest extends BoltTestCase
      */
     public function afterClearQuote()
     {
+        TestUtils::setupBoltConfig(
+            [
+                [
+                    'path'    => \Bolt\Boltpay\Helper\Config::XML_PATH_PRODUCT_PAGE_CHECKOUT,
+                    'value'   => true,
+                    'scope'   => ScopeInterface::SCOPE_STORE,
+                    'scopeId' => 0,
+                ]
+            ]
+        );
         $checkoutSession = $this->objectManager->create(CheckoutSession::class);
         $quote = TestUtils::createQuote();
         TestHelper::setInaccessibleProperty($this->plugin,'quoteToRestore', $quote);
@@ -68,6 +80,17 @@ class ClearQuoteTest extends BoltTestCase
      */
     public function beforeClearQuote_withGetQuoteByIdIsNotCalled_returnNull($currentQuoteId, $orderQuoteId)
     {
+        TestUtils::setupBoltConfig(
+            [
+                [
+                    'path'    => \Bolt\Boltpay\Helper\Config::XML_PATH_PRODUCT_PAGE_CHECKOUT,
+                    'value'   => true,
+                    'scope'   => ScopeInterface::SCOPE_STORE,
+                    'scopeId' => 0,
+                ]
+            ]
+        );
+
         $checkoutSession = $this->objectManager->create(CheckoutSession::class);
         $checkoutSession->getQuote()->setId($currentQuoteId);
         $checkoutSession->setLastSuccessQuoteId($orderQuoteId);
@@ -92,6 +115,17 @@ class ClearQuoteTest extends BoltTestCase
      */
     public function beforeClearQuote_withGetQuoteByIdIsCalled_returnNull()
     {
+        TestUtils::setupBoltConfig(
+            [
+                [
+                    'path'    => \Bolt\Boltpay\Helper\Config::XML_PATH_PRODUCT_PAGE_CHECKOUT,
+                    'value'   => true,
+                    'scope'   => ScopeInterface::SCOPE_STORE,
+                    'scopeId' => 0,
+                ]
+            ]
+        );
+
         $sessionQuote = TestUtils::createQuote();
         /** @var CheckoutSession $checkoutSession */
         $checkoutSession = $this->objectManager->create(CheckoutSession::class);
@@ -103,5 +137,26 @@ class ClearQuoteTest extends BoltTestCase
         $checkoutSession->setLastSuccessQuoteId($quoteSuccess->getId());
         $this->assertNull($this->plugin->beforeClearQuote($checkoutSession));
         $this->assertEquals($sessionQuote->getId(), TestHelper::getProperty($this->plugin,'quoteToRestore')->getId());
+    }
+
+    /**
+     * @test
+     * @covers ::beforeClearQuote
+     */
+    public function beforeClearQuote_ifPpcIsDisabled_returnNull()
+    {
+        TestUtils::setupBoltConfig(
+            [
+                [
+                    'path'    => \Bolt\Boltpay\Helper\Config::XML_PATH_PRODUCT_PAGE_CHECKOUT,
+                    'value'   => false,
+                    'scope'   => ScopeInterface::SCOPE_STORE,
+                    'scopeId' => 0,
+                ]
+            ]
+        );
+
+        $checkoutSession = $this->objectManager->create(CheckoutSession::class);
+        $this->assertNull($this->plugin->beforeClearQuote($checkoutSession));
     }
 }


### PR DESCRIPTION
# Description
**Issue:**
The ClearQuote plugin causes an Infinite loop for RTA Store because of the conflict with their module Magecomm\Shipping\Model\Data.  Their DevOps engineer dug into and found that the code line $subject->getQuote()->getId();  in method beforeClearQuote is causing an Infinite loop.

Before, we created this plugin to handle the logic for product page checkout. See PR here: https://github.com/BoltApp/bolt-magento2/pull/543/files

So a simple solution here is to bypass clearQuote plugin if the product page checkout is disabled  so it will resolve the Infinite loop for RTA Store. FYI, the merchant doesn't use the product page checkout feature. 

Fixes: https://app.asana.com/0/1200879031426307/1205798880294122

#changelog Not execute clearQuote plugin if product page checkout is disabled

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
