### PR TITLE
Fetch Card: bolt is not active improvements

### DIFF
--- a/Plugin/Magento/Checkout/CustomerData/Cart.php
+++ b/Plugin/Magento/Checkout/CustomerData/Cart.php
@@ -115,7 +115,7 @@ class Cart
      */
     public function afterGetSectionData(CustomerDataCart $subject, array $customerData)
     {
-        if (!$this->featureSwitches->isEnabledFetchCartViaApi()) {
+        if (!$this->featureSwitches->isEnabledFetchCartViaApi() || !$this->configHelper->isActive()) {
             return $customerData;
         }
         $quote = $this->getQuote();


### PR DESCRIPTION
# Description
Stop fetch-cart/pre-fetch-cart flow if bolt checkout is disabled in magento admin.

Fixes: https://app.asana.com/0/1200879031426307/1205935663676719/f
#changelog stop fetchcart/pre-fetch cart flow when bolt is disabled in magento admin

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
