### PR TITLE
M2 API approach: validate order creation form before opening Bolt popup in Magento admin

### DIFF
--- a/view/adminhtml/web/js/bolt-api-driven-checkout.js
+++ b/view/adminhtml/web/js/bolt-api-driven-checkout.js
@@ -54,6 +54,9 @@ define([
         ],
         callbacks: {
             close: function () {
+                if(!$('#bolt-required-field').hasClass('required-entry')){
+                    $('#bolt-required-field').addClass('required-entry');
+                }
                 // redirect on success order save
                 if (BoltCheckoutApiDriven.callbacks.success_url) {
                     location.href = BoltCheckoutApiDriven.callbacks.success_url;
@@ -105,7 +108,10 @@ define([
             // the Bolt order is created right after the checkout button is clicked
             // and the checkout modal popup is opened only if order creation was successfull
             check: function () {
-                return BoltCheckoutApiDriven.isValidToken();
+                if($('#bolt-required-field').hasClass('required-entry')){
+                    $('#bolt-required-field').removeClass('required-entry');
+                }
+                return $('#edit_form').valid() && BoltCheckoutApiDriven.isValidToken();
             }
         },
 


### PR DESCRIPTION
# Description
Currently, if the administrator doesn't fill up required fields in admin order creation form, and click Bolt button, Bolt popup loads but shows a general error message "An error occurred. Reload the page and try again." In somecase, this confuse merchant because they don't know the root cause and which steps they missed
See screenshot: https://prnt.sc/PgVk3qZLRDD5
See video for issue here: https://watch.screencastify.com/v/Hi4D26wHa09QfpeI4gq0

So I created this PR to validate order creation form before opening Bolt popup in Magento admin
See video after applying my PR here: https://watch.screencastify.com/v/xwGxw2BNEDkwpVmQ3sbr

Fixes: https://app.asana.com/0/1204419514580775/1205956205732791 

#changelog M2 API approach: Not allow Bolt checkout popup open if administrator doesnt fill up required fields in admin order creation form

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
