### PR TITLE
Handle null customer in check callback

### DIFF
--- a/view/frontend/templates/button_product_page.phtml
+++ b/view/frontend/templates/button_product_page.phtml
@@ -183,7 +183,7 @@ foreach ($block->getAdditionalCheckoutButtonAttributes() as $attrName => $attrVa
                      * used.
                      */
                     // check if login is required
-                    if ( !customer().firstname && !isGuestCheckoutAllowed) {
+                    if ( (!customer() || !customer().firstname) && !isGuestCheckoutAllowed) {
                         // if authentication is required for checkout set a cookie
                         // for auto opening Bolt checkout after login
                         if (window.boltConfig.is_sso_enabled) {

--- a/view/frontend/templates/button_product_page.phtml
+++ b/view/frontend/templates/button_product_page.phtml
@@ -183,7 +183,7 @@ foreach ($block->getAdditionalCheckoutButtonAttributes() as $attrName => $attrVa
                      * used.
                      */
                     // check if login is required
-                    if ( (!customer() || !customer().firstname) && !isGuestCheckoutAllowed) {
+                    if ( (!customer || !customer() || !customer().firstname) && !isGuestCheckoutAllowed) {
                         // if authentication is required for checkout set a cookie
                         // for auto opening Bolt checkout after login
                         if (window.boltConfig.is_sso_enabled) {


### PR DESCRIPTION
# Description
Seeing an issue on https://vintageking.com product page checkout pages on first load in a new incognito window where the `customer()` call returns a null object and then we try to access `.firstname` on that null value, throwing an error. Added a check to make sure `customer()` is non null before evaluating `customer().firstname`

Fixes: (link ticket)
https://app.asana.com/0/951157735838091/1206026904004435

#changelog Handle null customer in check callback

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
