### PR TITLE
Legacy: php issues when immutable quote is missed in db.

### DIFF
--- a/Controller/Adminhtml/Order/Save.php
+++ b/Controller/Adminhtml/Order/Save.php
@@ -105,6 +105,10 @@ class Save extends Action
             // call order save and update
             list($quote, $order) = $this->orderHelper->saveUpdateOrder($reference, $storeId);
 
+            if (!$order || !$quote) {
+                throw new Exception('save and update order call failed');
+            }
+
             $orderId = $order->getId();
             // clear quote session
             $this->clearQuoteSession($quote);

--- a/Controller/Order/Save.php
+++ b/Controller/Order/Save.php
@@ -104,6 +104,11 @@ class Save extends Action
             $reference = $this->getRequest()->getParam('reference');
             // call order save and update
             list($quote, $order) = $this->orderHelper->saveUpdateOrder($reference);
+
+            if (!$order || !$quote) {
+                throw new Exception('save and update order call failed');
+            }
+
             if ($sessionQuote && $sessionQuote->getId() != $quote->getId()) {
                 // If we had quote linked to session and it's not immutableQuote
                 // then we in product page, non-pre-auth checkout flow

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -1016,7 +1016,7 @@ class Order extends AbstractHelper
 
                     if (!$this->featureSwitches->isLogMissingQuoteFailedHooksEnabled()) {
                         $this->bugsnag->notifyException($exception);
-                        return $this;
+                        return [null, null];
                     }
 
                     /** @var \Bolt\Boltpay\Model\ResourceModel\WebhookLog\Collection $webhookLogCollection */
@@ -1026,7 +1026,7 @@ class Order extends AbstractHelper
                         $numberOfMissingQuoteFailedHooks = $webhookLog->getNumberOfMissingQuoteFailedHooks();
                         if ($numberOfMissingQuoteFailedHooks > 10) {
                             $this->bugsnag->notifyException($exception);
-                            return $this;
+                            return [null, null];
                         }
 
                         $webhookLog->incrementAttemptCount();

--- a/Model/Api/CreateOrder.php
+++ b/Model/Api/CreateOrder.php
@@ -211,12 +211,20 @@ class CreateOrder implements CreateOrderInterface
                     self::E_BOLT_GENERAL_ERROR
                 );
             }
-            
+
             $this->cartHelper->setCurrentCurrencyCode($currency);
 
             $immutableQuoteId = $this->getQuoteIdFromPayloadOrder($order);
             /** @var Quote $immutableQuote */
             $immutableQuote = $this->loadQuoteData($immutableQuoteId);
+
+            if (!$immutableQuote) {
+                throw new BoltException(
+                    __('Immutable quote does not exist. Quote id: ' . $immutableQuoteId),
+                    null,
+                    self::E_BOLT_GENERAL_ERROR
+                );
+            }
 
             $this->preProcessWebhook($immutableQuote->getStoreId());
 
@@ -429,7 +437,6 @@ class CreateOrder implements CreateOrderInterface
                     ]
                 ]);
             });
-            $quote = null;
 
             throw new BoltException(
                 __('There is no quote with ID: %1', $quoteId),

--- a/Model/Api/OrderManagement.php
+++ b/Model/Api/OrderManagement.php
@@ -336,11 +336,13 @@ class OrderManagement implements OrderManagementInterface
             $request
         );
 
-        $orderData = json_encode($order->getData());
+        $displayId = ($order !== null) ? $order->getIncrementId() : '';
+        $orderData = ($order !== null) ? json_encode($order->getData()) : '';
+
         $this->response->setHttpResponseCode(200);
         $this->response->setBody(json_encode([
             'status' => 'success',
-            'display_id' => $order->getIncrementId(),
+            'display_id' => $displayId,
             'message' => "Order creation / update was successful. Order Data: $orderData",
         ]));
     }


### PR DESCRIPTION
# Description
The merchant "LD Products" found critical php issues in our code related to cases when immutuable quote is missed in database:

- Error: Cannot use object of type Bolt\Boltpay\Helper\Order\Interceptor as array in /vendor/boltpay/bolt-magento2/Model/Api/OrderManagement.php:313

caused by 2 PR's:
https://github.com/BoltApp/bolt-magento2/pull/537 - was added `return $this` statement to the [saveUpdateOrder method](https://github.com/BoltApp/bolt-magento2/blob/2672f635d5beb04f6d4c5ce85a50b9060794b1a4/Helper/Order.php#L956)

https://github.com/BoltApp/bolt-magento2/pull/633 - [added additional debug order data json](https://github.com/BoltApp/bolt-magento2/blob/2672f635d5beb04f6d4c5ce85a50b9060794b1a4/Model/Api/OrderManagement.php#L339) and ignoring previous change with `return $this` for [saveUpdateOrder method](https://github.com/BoltApp/bolt-magento2/blob/2672f635d5beb04f6d4c5ce85a50b9060794b1a4/Helper/Order.php#L956) the case when order was not created.

- Error: Call to a member function getStoreId() on bool in /vendor/boltpay/bolt-magento2/Model/Api/CreateOrder.php:221

[doesn't catch the case](https://github.com/BoltApp/bolt-magento2/blob/2672f635d5beb04f6d4c5ce85a50b9060794b1a4/Model/Api/CreateOrder.php#L221) when `immutableQuote` is not loaded.

Fixes: https://app.asana.com/0/951157735838091/1205944567265174/f

#changelog legacy php issues fix
# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
