### PR TITLE
Fix bug sometimes order payment info isnt set on success page

### DIFF
--- a/Controller/ReceivedUrlTrait.php
+++ b/Controller/ReceivedUrlTrait.php
@@ -58,10 +58,10 @@ trait ReceivedUrlTrait
      * @var OrderHelper
      */
     private $orderHelper;
-    
+
     /** @var CacheInterface */
     private $cache;
-    
+
     /** @var Serialize */
     private $serialize;
 
@@ -97,7 +97,7 @@ trait ReceivedUrlTrait
                     return;
                 }
 
-                if ($order->getState() === Order::STATE_PENDING_PAYMENT) {
+                if ($order->getState() === Order::STATE_PENDING_PAYMENT || $order->getState() === Order::STATE_PAYMENT_REVIEW) {
                     $reference = $this->getReferenceFromPayload($payloadArray);
                     try {
                         if (
@@ -134,9 +134,9 @@ trait ReceivedUrlTrait
 
                 // add order information to the session
                 $this->clearOrderSession($order, $redirectUrl);
-                
+
                 $cacheIdentifier = ReceivedUrlInterface::BOLT_ORDER_SUCCESS_PREFIX . $this->checkoutSession->getSessionId();
-                
+
                 $sessionData = [
                     "LastQuoteId"   => $quote->getId(),
                     "LastSuccessQuoteId"   => $quote->getId(),
@@ -145,7 +145,7 @@ trait ReceivedUrlTrait
                     "LastRealOrderId"   => $order->getIncrementId(),
                     "LastOrderStatus"   => $order->getStatus(),
                 ];
-                
+
                 $this->cache->save($this->serialize->serialize($sessionData), $cacheIdentifier, [], 600);
 
                 $this->_redirect($redirectUrl);


### PR DESCRIPTION
# Description
Please include a summary of the change and which issue is fixed. Include the motivation for the changes, and comment on your PR if necessary for clarity.

Fixes: (link ticket)

#changelog Fix bug sometimes order payment info isnt set on success page

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
