### PR TITLE
Bypass ClearBoltShippingTaxCacheObserver if M2 Api approach is enabled

### DIFF
--- a/Observer/ClearBoltShippingTaxCacheObserver.php
+++ b/Observer/ClearBoltShippingTaxCacheObserver.php
@@ -22,6 +22,7 @@ use Bolt\Boltpay\Model\Api\ShippingMethods;
 use Magento\Framework\App\CacheInterface;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
+use Bolt\Boltpay\Helper\FeatureSwitch\Decider;
 
 class ClearBoltShippingTaxCacheObserver implements ObserverInterface
 {
@@ -31,13 +32,24 @@ class ClearBoltShippingTaxCacheObserver implements ObserverInterface
     private $cache;
 
     /**
+     * @var Decider
+     */
+    private $featureSwitches;
+
+
+    /**
      * ClearBoltCacheObserver constructor.
      *
      * @param CacheInterface|null $cache
+     * @param Decider $featureSwitches
      */
-    public function __construct(CacheInterface $cache = null)
+    public function __construct(
+        CacheInterface $cache = null,
+        Decider $featureSwitches
+    )
     {
         $this->cache = $cache ?: \Magento\Framework\App\ObjectManager::getInstance()->get(CacheInterface::class);
+        $this->featureSwitches = $featureSwitches;
     }
 
     /**
@@ -47,6 +59,10 @@ class ClearBoltShippingTaxCacheObserver implements ObserverInterface
      */
     public function execute(Observer $observer)
     {
+        if ($this->featureSwitches->isAPIDrivenIntegrationEnabled()) {
+            return $this;
+        }
+
         $this->cache->clean([ShippingMethods::BOLT_SHIPPING_TAX_CACHE_TAG]);
     }
 }


### PR DESCRIPTION
# Description
In the legacy plugin approach, we store cache tag in this endpoint [store_url]/rest/V1/bolt/boltpay/shipping/methods and reuse it when needed. We also build this ClearBoltShippingTaxCacheObserver obsever to clear the bolt shipping and tax cache if the tax (Magento,Taxjar) setting is changed 
See more info in this PR https://github.com/BoltApp/bolt-magento2/pull/915

However, in the M2 API approach, we use Magento native API and don't use endpoint [store_url]/rest/V1/bolt/boltpay/shipping/methods anymore. So we don't need clear cache anymore and this obsever ClearBoltShippingTaxCacheObserver isn't needed. 

Fixes: (link ticket)

#changelog Not execute ClearBoltShippingTaxCacheObserver if M2 Api approach is enabled

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
