### PR TITLE
Legacy amasty promo items mismatch fix

### DIFF
--- a/Plugin/Amasty/Promo/Quote/Model/Quote/TotalsCollectorPlugin.php
+++ b/Plugin/Amasty/Promo/Quote/Model/Quote/TotalsCollectorPlugin.php
@@ -29,6 +29,9 @@ class TotalsCollectorPlugin
     )
     {
         // legacy flow: skip amasty promo calculation for immutable quote collect total calls
+        // amasty promo define the db table with relations between quote id and promo items
+        // because id's of immutable quote and original quote are different, amasty promo can't find promo items status during immutable quote collect totals
+        // which leads to mismatch between original quote and immutable quote which leads to restoring already removed items in card
         if ($quote->getBoltParentQuoteId() != null && $quote->getBoltParentQuoteId() != $quote->getId()) {
             $address->setData('amastyFreeGiftProcessed', true);
         }


### PR DESCRIPTION
# Description
Resolved the issue of automatically re-adding previously removed promotional products to the cart after a quote update (during item addition or removal). The root cause of this problem was identified as the legacy immutable quote [collect totals call](https://github.com/BoltApp/bolt-magento2/blob/3a7e2846f7b016a65bb96322eff66c02ad024b27/Helper/Cart.php#L1959). The Amasty plugin, which has its own collect total plugin incorporating an "auto add product" functionality, updates the immutable quote items list without considering the actual status of quote items (already removed or not).

Fixes: https://app.asana.com/0/951157735838091/1206177135128401/f

#changelog legacy flow: amasty promo items mismatch fix

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
