### PR TITLE
Include details error information into 500 answer when Bolt call Magento API to site even in production mode

### DIFF
--- a/Plugin/WebapiRest/Magento/Framework/Webapi/ErrorProcessorPlugin.php
+++ b/Plugin/WebapiRest/Magento/Framework/Webapi/ErrorProcessorPlugin.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2024 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Plugin\WebapiRest\Magento\Framework\Webapi;
+
+use Magento\Framework\Phrase;
+use Magento\Framework\Webapi\Exception as WebapiException;
+use Magento\Framework\Webapi\Rest\Request;
+use Bolt\Boltpay\Model\RestApiRequestValidator as BoltRestApiRequestValidator;
+use Bolt\Boltpay\Helper\Bugsnag;
+
+class ErrorProcessorPlugin
+{
+    /**
+     * @var Request
+     */
+    private $restRequest;
+
+    /**
+     * @var Bugsnag
+     */
+    private $bugSnag;
+
+    /**
+     * @var BoltRestApiRequestValidator
+     */
+    private $boltRestApiRequestValidator;
+
+    /**
+     * @param Request $restRequest
+     * @param BoltRestApiRequestValidator $boltRestApiRequestValidator
+     * @param Bugsnag $bugsnag
+     */
+    public function __construct(
+        Request                     $restRequest,
+        BoltRestApiRequestValidator $boltRestApiRequestValidator,
+        Bugsnag                     $bugsnag
+    )
+    {
+        $this->restRequest = $restRequest;
+        $this->boltRestApiRequestValidator = $boltRestApiRequestValidator;
+        $this->bugSnag = $bugsnag;
+    }
+
+    /**
+     * @param \Magento\Framework\Webapi\ErrorProcessor $subject
+     * @param $maskedException
+     * @param \Exception $exception
+     * @return WebapiException|mixed
+     */
+    public function afterMaskException(
+        \Magento\Framework\Webapi\ErrorProcessor $subject,
+        $maskedException,
+        \Exception                               $exception
+    )
+    {
+        if (
+            $this->boltRestApiRequestValidator->isValidBoltRequest($this->restRequest) &&
+            $maskedException->getHttpCode() == WebapiException::HTTP_INTERNAL_ERROR
+        ) {
+            $maskedException = new WebapiException(
+                new Phrase($exception->getMessage() . $exception->getTraceAsString()),
+                $exception->getCode(),
+                WebapiException::HTTP_INTERNAL_ERROR,
+                [],
+                '',
+                null,
+                $exception->getTraceAsString()
+            );
+        }
+
+        return $maskedException;
+    }
+}

--- a/etc/webapi_rest/di.xml
+++ b/etc/webapi_rest/di.xml
@@ -44,4 +44,8 @@
         <plugin name="bolt_boltpay_webapirest_magento_framework_session_manager"
                 type="Bolt\Boltpay\Plugin\Magento\Framework\Session\SessionManagerPlugin"/>
     </type>
+    <type name="Magento\Framework\Webapi\ErrorProcessor">
+        <plugin name="bolt_boltpay_webapirest_magento_error_processor"
+                type="Bolt\Boltpay\Plugin\WebapiRest\Magento\Framework\Webapi\ErrorProcessorPlugin"/>
+    </type>
 </config>


### PR DESCRIPTION
# Description

Currently we call magento API and it is in production mode it doesn't include details error information into 500 answer, just "An error has happened during application run. See exception log for details."
See screenshot: https://prnt.sc/Gimlmh7RXnlh

So this PR is to add plugin to shares detailed error information with bolt even in production mode
See screenshot for testing: https://prnt.sc/lJRoX-0SY3Yg

Fixes: https://app.asana.com/0/1200879031426307/1206178861644311

#changelog Include details error information into 500 answer when Bolt call Magento API to site on production mode

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
