### PR TITLE
Auto prefill customer first name and last name in Bolt modal if customer is logged in Magento

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -1074,6 +1074,14 @@ class Cart extends AbstractHelper
                 $prefill['email'] = $quote->getCustomerEmail();
             }
 
+            if (!$prefill['firstName'] && $this->customerSession->isLoggedIn()){
+                $prefill['firstName'] = $this->customerSession->getCustomer()->getData('firstname');
+            }
+
+            if (!$prefill['lastName'] && $this->customerSession->isLoggedIn()){
+                $prefill['lastName'] = $this->customerSession->getCustomer()->getData('lastname');
+            }
+
             // Skip pre-fill for Apple Pay related data.
             if ($prefill['email'] == 'na@bolt.com' || $prefill['phone'] == '8005550111' || $prefill['addressLine1'] == 'tbd') {
                 return;


### PR DESCRIPTION
# Description
Issue: The "First name" and "Last name" fields aren't autocompleted for Logged user on the Bolt pop up 

See more detail: https://app.asana.com/0/1204419514580775/1206470335185423

#changelog Auto prefill customer first name and last name in Bolt modal if customer is logged in Magento

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
