### PR TITLE
Integration Manager: fixed oauth error case logger

### DIFF
--- a/Helper/IntegrationManagement.php
+++ b/Helper/IntegrationManagement.php
@@ -412,7 +412,9 @@ class IntegrationManagement extends AbstractHelper
             if ( (method_exists($response, 'getStatus') && $response->getStatus() != 200) ||
                 (method_exists($response, 'getStatusCode') && $response->getStatusCode() != 200)
             ) {
-                $errorLog[$key . ' attempt'] = (method_exists($response, 'getMessage')) ? $response->getMessage() : $response->getReasonPhrase();
+                $errorLog[$key . ' attempt'] = (method_exists($response, 'getMessage'))
+                    ? $response->getMessage()
+                    : (method_exists($response, 'getReasonPhrase') ? $response->getReasonPhrase() : 'error response code for token exchange request');
             } else {
                 return true;
             }


### PR DESCRIPTION
# Description
In laminas client response object doesn't have legacy method `getMessage` instead it has `getReasonPhrase` method which should be used instead.

Fixes: -

#changelog Integration Manager: fixed oauth error case logger

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
