### PR TITLE
M2 PDP: button rendering fix due to race conditions

### DIFF
--- a/view/frontend/templates/button_product_page.phtml
+++ b/view/frontend/templates/button_product_page.phtml
@@ -482,11 +482,5 @@ foreach ($block->getAdditionalCheckoutButtonAttributes() as $attrName => $attrVa
             if ($('#product_addtocart_form').is('[novalidate]')) {
                 $(".bolt-product-checkout-button-disabled").removeClass("bolt-product-checkout-button-disabled")
             }
-
-            // finally, remove the disabled class after 5 seconds if it hasn't been removed yet
-            // to unblock the checkout button in case of any errors
-            setTimeout(function() {
-                $(".bolt-product-checkout-button-disabled").removeClass("bolt-product-checkout-button-disabled")
-            }, 5000);
         });
     </script>


### PR DESCRIPTION
# Description

Sometimes the PDP Bolt checkout button gets stuck in a disabled state. This issue is caused by a race condition with Magento's widget add-to-cart form validation. Occasionally, due to specific merchant configurations, the validation initialization occurs before our script is loaded, leaving the Bolt button disabled. In this PR, I've addressed this issue by adding additional conditions to check if the validation script has already been initialized and by ensuring the button is unblocked in any case after 5 seconds.

Fixes: https://app.asana.com/0/1201748965125532/1207426223269131/f

#changelog M2 PDP: button rendering fix due to race conditions, sometimes it stuck as disabled button.

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
