### PR TITLE
Fetch Cart: Cart2Quote 3-th party module support

### DIFF
--- a/view/frontend/web/js/bolt-api-driven-checkout.js
+++ b/view/frontend/web/js/bolt-api-driven-checkout.js
@@ -70,6 +70,7 @@ define([
         createRequest: false,
         cartRestricted: false,
         allowAutoOpen: true,
+        quotation: null,
         inputNameToHintsPrefill: {
             'firstname': 'firstName',
             'lastname':  'lastName',
@@ -1086,6 +1087,12 @@ define([
             BoltCheckoutApiDriven.readyStatusBarrier = BoltCheckoutApiDriven.initBarrier();
             BoltCheckoutApiDriven.initiateCheckout = window.boltConfig.initiate_checkout && BoltCheckoutApiDriven.getInitiateCheckoutCookie();
             BoltCheckoutApiDriven.customerCart = customerData.get('cart');
+            // Cart2Quote_Quotation 3-th arty module compatibility. It uses additional customer-section = 'quote' for quotation carts.
+            // We need to subscribe to it as well.
+            BoltCheckoutApiDriven.quotation = customerData.get('quote');
+            if (BoltCheckoutApiDriven.quotation) {
+                BoltCheckoutApiDriven.quotation.subscribe(BoltCheckoutApiDriven.magentoCartDataListener);
+            }
             //subscription of 'customer-data' cart
             BoltCheckoutApiDriven.customerCart.subscribe(BoltCheckoutApiDriven.magentoCartDataListener);
 


### PR DESCRIPTION
# Description
Added support for 3-th party magento module `Cart2Quote_Quotation`. This module rewrite default magento customer section `cart` by `quote` for quatation quota's. It has the same strucure as default magento. We should be subscribed to this section too.

Fixes: https://app.asana.com/0/1201748965125532/1207746027816422/f

#changelog Fetch Cart: Cart2Quote 3-th party module support

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
