### PR TITLE
Legacy: failed payment webhook fix

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -1238,6 +1238,19 @@ class Order extends AbstractHelper
             $this->cancelFailedPaymentOrder($display_id, $immutableQuoteId);
             return 'Order was canceled: ' . $display_id;
         }
+
+        $order = $this->getExistingOrder($display_id);
+
+        if (!$order) {
+            return 'Order is already deleted: ' . $display_id;
+        }
+
+        // the order may already be in a canceled state due to the rejected_irreversible hook before authorization.
+        // in this case, we don't need to delete it.
+        if ($order->isCanceled()) {
+            return 'Order is already canceled:' . $display_id;
+        }
+
         $this->deleteOrderByIncrementId($display_id, $immutableQuoteId);
         return 'Order was deleted: ' . $display_id;
     }
@@ -1526,7 +1539,7 @@ class Order extends AbstractHelper
     }
 
     /**
-     * @param $displayId
+     * @param $incrementId
      * @throws \Exception
      */
     public function deleteOrderByIncrementId($incrementId, $immutableQuoteId)


### PR DESCRIPTION
# Description
In legacy mode, the `failed_payment` webhook could be triggered after the `rejected_irreversible` webhook, which may cause it to fail because the `failed_payment` webhook tries to remove the order, but it’s impossible due to `rejected_irreversible` setting the order to a canceled state. In this case, I believe we should ignore the order deletion and leave it canceled.

Fixes: https://app.asana.com/0/1200879031426307/1208239349887432/f

#changelog Legacy: failed payment webhook fix

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
