### PR TITLE
Legacy flow: wrong gift card never shown error messages

### DIFF
--- a/Model/Api/UpdateDiscountTrait.php
+++ b/Model/Api/UpdateDiscountTrait.php
@@ -229,11 +229,11 @@ trait UpdateDiscountTrait
             $quote,
             $addQuote
         );
-        
+
         if ($result) {
             return $result;
         }
-        
+
         // get coupon entity id and load the coupon discount rule
         $couponId = $coupon->getId();
         try {
@@ -396,7 +396,7 @@ trait UpdateDiscountTrait
                 $quote
             );
         }
-        
+
         $description = $rule->getDescription();
         $display = $description != '' ? $description : 'Discount (' . $couponCode . ')';
 
@@ -430,9 +430,7 @@ trait UpdateDiscountTrait
                 $quote
             );
 
-            if ($result) {
-                return true;
-            }
+            return (bool)$result;
         } catch (\Exception $e) {
             throw new BoltException(
                 $e->getMessage(),
@@ -440,8 +438,6 @@ trait UpdateDiscountTrait
                 BoltErrorResponse::ERR_SERVICE
             );
         }
-
-        return true;
     }
 
     /**


### PR DESCRIPTION
# Description
Legacy flow:
- The gift card always returns true when attempting to apply it, even when it fails to apply, which results in the error message being missed on the frontend.

Fixes: https://app.asana.com/0/inbox/1201748965122422/1208489277324364/1208249631536622/f

#changelog Legacy flow: wrong gift card never shown error messages

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
