### PR TITLE
Legacy Flow Webhook: missed immutable quote

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -981,7 +981,7 @@ class Order extends AbstractHelper
         ///////////////////////////////////////////////////////////////
         $immutableQuote = $this->cartHelper->getQuoteById($quoteId);
         if (!$immutableQuote && $parentQuoteId) {
-            // if the immutable quote ID is not found, attempt to load the original quote and use it as immutable.
+            // if the immutable quote is not found, attempt to load the original quote and use it as immutable.
             $immutableQuote = $this->cartHelper->getQuoteById($parentQuoteId);
         }
 


### PR DESCRIPTION
# Description
**Fixing the Legacy Flow WebHook Error**

Error: `{"status":"error","code":"6009","message":"Unprocessable Entity: Unknown quote id: *"}`

This error occurs in Bolt’s Legacy flow in the following location:
[Order.php#L1038](https://github.com/BoltApp/bolt-magento2/blob/b645ba922b494ec252ad0768217dd6810bbc6619/Helper/Order.php#L1038).

The method is triggered during webhook calls in legacy mode at the endpoint:
[/V1/bolt/boltpay/order/manage](https://github.com/BoltApp/bolt-magento2/blob/b645ba922b494ec252ad0768217dd6810bbc6619/Model/Api/OrderManagement.php#L226).

**Cause of the Issue**

The error occurs under the following conditions in legacy mode:
1. Order Creation Failure
- When an order is not successfully created on the Magento side during the `/v1/merchantproxy/internal/create_order` call due to an unexpected `500` error.
- Example Datadog log: [Link to Logs](https://app.datadoghq.com/logs?query=%40trace_id%3A1-675850b4-1a8804501978dc197aa64ee5...).
- Common reasons include unexpected errors on the Magento side, such as custom cart validations (e.g., out-of-stock checks) or other application errors.

2. Bolt Behavior
- On the Bolt side, the order is still created if the `preauth_fail_abnormal_errors` division feature is **DISABLED**.
- Bolt assumes the order will be created later during the first `pending webhook call`.

_btw in the Bolt API Flow the `preauth_fail_abnormal_errors` is required to be enabled. With it, the order is not created on the Bolt side if Magento fails to process the order. No webhooks in this case_
	
3. Immutable Quote Issue
- During subsequent webhook calls, Bolt attempts to retrieve the immutable quote to build the order:
[Order.php#L1001](https://github.com/BoltApp/bolt-magento2/blob/b645ba922b494ec252ad0768217dd6810bbc6619/Helper/Order.php#L1001).
- However, merchants may have a short lifetime for inactive quotes. This can lead to quotes being deleted via:
Magento’s built-in cron job: `sales_clean_quotes` OR any other 3rd-party quote cleanup jobs. In such cases, the quote cannot be retrieved, resulting in the exception -> `Unprocessable Entity: Unknown quote id`
	
 **Proposed Fixes**

Merchants can resolve this issue using one of the following approaches:
 1. Enable the Division Feature
- Activate the `preauth_fail_abnormal_errors` feature to ensure orders are not created on Bolt if Magento order creation fails.

2. Extend Quote Lifetime
- Increase the lifetime for inactive quotes in `sales_clean_quotes` or any `3rd-party` cleanup jobs.

3. Apply the Patch
- Apply the changes from this PR to handle cases where quotes are removed.
- Alternatively, follow the recommendations outlined in Bolt’s [Hook Failure Runbook](https://boltpay.atlassian.net/wiki/spaces/EN/pages/2123367614/Hook+failure+runbook).
<img width="837" alt="Screenshot 2024-12-17 at 11 40 30" src="https://github.com/user-attachments/assets/8395798d-664d-44fe-9178-d66fd00cac4a" />

**This PR implements a similar solution** but on magento side, the solution in doc is about updating our database by replacing the quote id we send via webhooks. 

Fixes: https://app.devrev.ai/bolt-inc/works/ISS-1390

#changelog fixed legacy webhook's in case when immutable quote was removed on the merchant's side

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
