### PR TITLE
Support for Route.com Version 1.3.2: Transition from Session Variable to Quote (keeping both versions)

### DIFF
--- a/Model/Api/RouteInsuranceManagement.php
+++ b/Model/Api/RouteInsuranceManagement.php
@@ -124,7 +124,7 @@ class RouteInsuranceManagement implements \Bolt\Boltpay\Api\RouteInsuranceManage
         {
             throw new WebapiException(__('Quote does not found by given ID'), 0, WebapiException::HTTP_NOT_FOUND);
         }
-        $this->setRouteAndQuoteDataToSession($cartId, $routeIsInsured);
+        $this->setRouteAndQuoteDataToSession($cartId, $quote, $routeIsInsured);
         $quote->collectTotals();
         $this->quoteRepository->save($quote);
 
@@ -134,12 +134,12 @@ class RouteInsuranceManagement implements \Bolt\Boltpay\Api\RouteInsuranceManage
         ];
     }
 
-    private function setRouteAndQuoteDataToSession($cartId, $routeIsInsured)
+    private function setRouteAndQuoteDataToSession($cartId, $quote, $routeIsInsured)
     {
+        $isInsured = filter_var($routeIsInsured, FILTER_VALIDATE_BOOLEAN);
         $this->checkoutSession->setQuoteId($cartId);
-        $this->checkoutSession->setInsured(
-            filter_var($routeIsInsured, FILTER_VALIDATE_BOOLEAN)
-        );
+        $this->checkoutSession->setInsured($isInsured);
+        $quote->setRouteIsInsured($isInsured);
     }
 
     private function getResponseMessage($routeIsInsured) {


### PR DESCRIPTION
# Description
Add support for Route.com latest version 1.3.2

- Updated to align with the changes introduced in Route.com version 1.3.2.
- In this version, the Route module has deprecated the use of the session `insured` variable and now relies on the quote object for handling this functionality.

Fixes: https://app.devrev.ai/bolt-inc/works/ISS-1950

#changelog route.com route protection latest version support

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
