### PR TITLE
Bugfix: unable to read properties from non-json object

### DIFF
--- a/view/adminhtml/web/js/bolt-api-driven-checkout.js
+++ b/view/adminhtml/web/js/bolt-api-driven-checkout.js
@@ -313,7 +313,15 @@ define([
 
             // set cart and hints data in a response callback
             let onSuccess = function(data) {
-
+                if (typeof data == 'string') {
+                    try {
+                        data = $.parseJSON(data);
+                    } catch(err) {
+                        BoltCheckoutApiDriven.createRequest = null;
+                        console.error(err);
+                        return;
+                    }     
+                }
                 BoltCheckoutApiDriven.cart = data.cart;
                 let prefill = BoltCheckoutApiDriven.isObject(data.hints.prefill)
                     ? BoltCheckoutApiDriven.deepMergeObjects(BoltCheckoutApiDriven.hints.prefill, data.hints.prefill)


### PR DESCRIPTION
# Description
We are seeing this issue when trying to place a Backoffice Order in the merchant TrucksEverything's staging site, and it is a bug of the Bolt plugin. For some reasons, the [return data](https://github.com/BoltApp/bolt-magento2/blob/6748f03f6de47f9806628dabf4bc4d1c2cbded6b/view/adminhtml/web/js/bolt-api-driven-checkout.js#L317) is a string rather than a json object, and it throws an error "Cannot read properties of undefined".

To fix this, we need to check if the return data is a json object or a string, and convert it if needed.

Fixes: https://app.devrev.ai/bolt-inc/works/ISS-1977

#changelog Bugfix: unable to read properties from non-json object

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
