### PR TITLE
Magento 2.4.8 fix adapter headers

### DIFF
--- a/Model/HttpClientAdapter.php
+++ b/Model/HttpClientAdapter.php
@@ -89,8 +89,14 @@ class HttpClientAdapter
     {
         if ($this->client instanceof LaminasClient) {
             $headersObject = new Headers();
+            // see ACP2E-3096 https://experienceleague.adobe.com/en/docs/commerce-operations/release/notes/magento-open-source/2-4-8
+            // commit: https://github.com/magento/magento2/commit/60c6de12627f520916ca0e3acea9b552b5c5d3f7
+            // line: https://github.com/magento/magento2/blob/94b8544e82fd84d1443060cddb5481b7fd462de2/lib/internal/Magento/Framework/HTTP/Adapter/Curl.php#L193
+            // for more details about the magento headers fix
+            $isVersionWithFixedHeaders = version_compare($this->boltConfigHelper->getStoreVersion(), '2.4.8', '>=');
             foreach ($headers as $headerName => $headerValue) {
-                $headersObject->addHeaderLine($headerName, $headerName . ':' . $headerValue);
+                $value = $isVersionWithFixedHeaders ? $headerValue : $headerName . ':' . $headerValue;
+                $headersObject->addHeaderLine($headerName, $value);
             }
             $this->client->setHeaders($headersObject);
         } else {


### PR DESCRIPTION
# Description
Magento 2.4.8 includes a fix for the cURL adapter headers ([ACP2E-3096](https://experienceleague.adobe.com/en/docs/commerce-operations/release/notes/magento-open-source/2-4-8)).
We need to update our code accordingly; otherwise, all our API requests to Bolt will fail.

Fixes: https://app.devrev.ai/bolt-inc/works/ISS-4237

#changelog fix 2.4.8 curl adapter issues

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
