### PR TITLE
Hyva: add card reload after success

### DIFF
--- a/view/frontend/templates/hyva/js/replacejs-cart-api-driven.phtml
+++ b/view/frontend/templates/hyva/js/replacejs-cart-api-driven.phtml
@@ -800,6 +800,10 @@ $isLoadOpenReplayJsDynamic = $block->isDisableOpenReplayJs();
                         let processSuccess = function (data) {
                             hyva.setCookie('mage-cache-sessid', '', -1, true);
                             try {
+                                 window.dispatchEvent(new CustomEvent("reload-customer-section-data"));
+                                 setTimeout(() => {
+                                    window.dispatchEvent(new CustomEvent('reload-cart'));
+                                 }, 200);
                                 if (typeof data !== 'undefined') {
                                     BoltCheckoutApiDriven.boltCallbacks.success_url = data.success_url;
                                 }


### PR DESCRIPTION
# Description
With the Hyva + Bolt API integration, the customer cart is not reloaded after a successful order placement, which may result in outdated card information being displayed on the frontend.

Fixes: (link ticket)

#changelog: fix hyva api cart reloading.

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
