### PR TITLE
Magento 2.4.8 support fix empty header

### DIFF
--- a/Helper/Shared/ApiUtils.php
+++ b/Helper/Shared/ApiUtils.php
@@ -75,7 +75,7 @@ class ApiUtils
         $contentType,
         $additionalHeaders = []
     ) {
-        return [
+        $defaultHeaders = [
             'User-Agent'            => 'BoltPay/Magento-'.$storeVersion . '/' . $moduleVersion,
             'X-Bolt-Plugin-Version' => $moduleVersion,
             'Content-Type'          => $contentType,
@@ -84,6 +84,10 @@ class ApiUtils
             'X-Nonce'               => rand(100000000000, 999999999999),
             'X-BOLT-SOURCE-NAME'    => 'magento2',
             'X-BOLT-SOURCE-VERSION' => $moduleVersion
-        ] + $additionalHeaders;
+        ];
+        if ($requestData) {
+            $defaultHeaders['Content-Length'] = strlen($requestData);
+        }
+        return $defaultHeaders + $additionalHeaders;
     }
 }

--- a/Model/HttpClientAdapter.php
+++ b/Model/HttpClientAdapter.php
@@ -96,7 +96,9 @@ class HttpClientAdapter
             $isVersionWithFixedHeaders = version_compare($this->boltConfigHelper->getStoreVersion(), '2.4.8', '>=');
             foreach ($headers as $headerName => $headerValue) {
                 $value = $isVersionWithFixedHeaders ? $headerValue : $headerName . ':' . $headerValue;
-                $headersObject->addHeaderLine($headerName, $value);
+                if ($value !== null) {
+                    $headersObject->addHeaderLine($headerName, $value);
+                }
             }
             $this->client->setHeaders($headersObject);
         } else {


### PR DESCRIPTION
# Description
Magento 2.4.8 no longer supports null values in HTTP headers.
We encountered this issue when sending a request without a body, while still attempting to set the `Content-Length `header to null. This is no longer allowed by the Laminas framework in this version.

Fixes: (link ticket)

#changelog magento 2.4.8 fix adapter header null error

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
