### PR TITLE
Handle custom pricing for client orders

### DIFF
--- a/Observer/CustomPrice.php
+++ b/Observer/CustomPrice.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ *
+ * @copyright  Copyright (c) 2017-2023 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\Boltpay\Observer;
+
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\App\RequestInterface;
+
+class CustomPrice implements ObserverInterface
+{
+    public function execute(\Magento\Framework\Event\Observer $observer) {
+        $quote = $observer->getEvent()->getQuote();
+        if (!$quote || !$quote->getId()) {
+            return;
+        }
+
+        $subtotal = 0;
+        $boltItem = null;
+
+        foreach ($quote->getAllItems() as $item) {
+            if ($item->getSku() === 'BOLT_PRIVATE_CHECKOUT') {
+                $boltItem = $item;
+                continue;
+            }
+            $subtotal += $item->getRowTotal();
+        }
+
+        if ($boltItem && $subtotal > 0) {
+            $customPrice = round($subtotal * 0.01, 2); // 1% fee
+            $boltItem->setCustomPrice($customPrice);
+            $boltItem->setOriginalCustomPrice($customPrice);
+            $boltItem->getProduct()->setIsSuperMode(true);
+        }
+    }
+}

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -23,4 +23,7 @@
     <event name="catalog_product_save_commit_after">
         <observer name="publishBoltProductEventAfterProductSave" instance="Bolt\Boltpay\Observer\PublishBoltProductEventObserver" />
     </event>
+    <event name="sales_quote_collect_totals_before">
+        <observer name="boltCustomPrice" instance="Bolt\Boltpay\Observer\CustomPrice"/>
+    </event>
 </config>

--- a/etc/frontend/events.xml
+++ b/etc/frontend/events.xml
@@ -8,4 +8,7 @@
         <observer name="bolt_boltpay_controller_action_predispatch_prevent_customer_edit"
                   instance="Bolt\Boltpay\Observer\PreventCustomerEdit" />
     </event>
+    <event name="checkout_cart_product_add_after">
+        <observer name="boltpaycustomprice" instance="Webkul\Hello\Observer\CustomPrice" />
+    </event>
 </config>

--- a/etc/frontend/events.xml
+++ b/etc/frontend/events.xml
@@ -9,6 +9,6 @@
                   instance="Bolt\Boltpay\Observer\PreventCustomerEdit" />
     </event>
     <event name="checkout_cart_product_add_after">
-        <observer name="boltpaycustomprice" instance="Webkul\Hello\Observer\CustomPrice" />
+        <observer name="boltpaycustomprice" instance="Bolt\Boltpay\Observer\CustomPrice" />
     </event>
 </config>


### PR DESCRIPTION
# Description
Introduced functionality to manage custom pricing for client orders. The implementation allows setting a custom price via client-provided request parameters or JSON body. If no valid price is provided, it defaults to 1% of the subtotal, rounded using the price currency interface. Additionally:
- Added an observer to apply custom prices dynamically during quote total calculations.
- Fixed namespace issues.
- Implemented custom pricing for the `BOLT_PRIVATE_CHECKOUT` product item.

Fixes: (link ticket)

#changelog

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [x] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.