### PR TITLE
Add the payment Source to the admin order page

### DIFF
--- a/Block/Info.php
+++ b/Block/Info.php
@@ -66,6 +66,10 @@ class Info extends \Magento\Payment\Block\Info
             if ($avsResponse = $info->getAdditionalInformation('avs_response')) {
                 $data[(string)__('AVS Response')]  = $avsResponse;
             }
+
+            if ($source = $info->getAdditionalInformation('source')) {
+                $data[(string)__('Source')]  = $source;
+            }
         }
 
         if ($data) {


### PR DESCRIPTION
# Description
Add "Source" field to admin order payment information

Display the source value from payment additional_information on the admin Sales Order view, alongside existing fields (Credit Card Type, Credit Card Number, AVS/CVV Response).

<img width="1076" height="536" alt="Screenshot 2026-02-13 at 21 31 06" src="https://github.com/user-attachments/assets/71c6de4e-21f9-49df-bb81-8776d0eede0c" />


Fixes: (link ticket) added the payment source type to the admin order page view

#changelog Add the payment Source to the admin order page

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
