### PR TITLE
Legacy mode fix: release reserved increment_id after cancel/submit to…

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -1222,6 +1222,13 @@ class Order extends AbstractHelper
             ]
         );
 
+        // Release the reserved increment id after a successful submit so any
+        // subsequent getBoltpayOrder call on the same (admin) session reserves
+        // a fresh one and does not trip doesOrderExist() on the placed order.
+        // Must run AFTER checkout_submit_all_after so observers still see the id.
+        $quote->setBoltReservedOrderId(null);
+        $quote->setReservedOrderId(null);
+
         // Set dispatched to be true. Prevents dispatching more then once.
         $quote->setBoltDispatched(true);
         $this->cartHelper->quoteResourceSave($quote);
@@ -2779,6 +2786,17 @@ class Order extends AbstractHelper
             $parentQuote->setBoltCheckoutType(CartHelper::BOLT_CHECKOUT_TYPE_PPC);
             $this->cartHelper->quoteResourceSave($parentQuote->setIsActive(false));
         }
+
+        // Release the reserved increment id so a retry on the same session
+        // reserves a fresh one. Without this, doesOrderExist() keeps finding
+        // the canceled order by increment_id and the merchant sees the
+        // "Order was created. Please reload the page and try again" popup.
+        if ($parentQuote) {
+            $parentQuote->setBoltReservedOrderId(null);
+            $parentQuote->setReservedOrderId(null);
+            $this->cartHelper->quoteResourceSave($parentQuote);
+        }
+
         $this->eventsForThirdPartyModules->dispatchEvent("beforeFailedPaymentOrderSave", $order);
 
         $order->addData(['quote_id' => null]);


### PR DESCRIPTION
# Description
- Merchants running with `M2_CANCEL_FAILED_PAYMENT_ORDERS_INSTEAD_OF_DELETING` hit a loop: after a failed payment the canceled order keeps its increment_id, the admin session quote still carries the same `bolt_reserved_order_id`, and the next attempt trips doesOrderExist → popup "Order was created. Please reload the page and try again".
- Same symptom also appears after a successful backoffice order when JS re-fetches the order token on the same admin page.

Fix

- `Helper/Order::dispatchPostCheckoutEvents `- null bolt_reserved_order_id + reserved_order_id on the parent quote after checkout_submit_all_after dispatch (so observers still see the id).
- H`elper/Order::cancelFailedPaymentOrder` - same null-out after cancellation (guarded by if ($parentQuote)).

Fixes: (link ticket)

#changelog Legacy mode fix: release reserved increment_id after cancel/submit to…

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
