### PR TITLE
Add dedicated Google Maps API key for Magestore Store Pickup

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -193,11 +193,6 @@ class Config extends AbstractHelper
     const SAVE_EMAIL_ACTION = 'boltpay/cart/email';
 
     /**
-     * Customer account login URL path
-     */
-    const CUSTOMER_ACCOUNT_LOGIN = 'customer/account/login';
-
-    /**
      * Save order
      */
     const XML_PATH_SUCCESS_PAGE_REDIRECT = 'payment/boltpay/success_page';
@@ -453,9 +448,9 @@ class Config extends AbstractHelper
     const XML_PATH_IS_WEB_VIEW = 'payment/boltpay/is_web_view';
 
     /**
-     *
+     * Google Maps Key for Magestore Storepickup
      */
-    const XML_PATH_IS_AUTHENTICATION_POPUP_ENABLED = 'payment/boltpay/is_authentication_popup_enabled';
+    const XML_PATH_MAGESTORE_STOREPICKUP_GOOGLE_MAPS_KEY = 'payment/boltpay/magestore_storepickup_google_maps_key';
 
     /**
      * Default whitelisted shopping cart and checkout pages "Full Action Name" identifiers, <router_controller_action>
@@ -521,7 +516,7 @@ class Config extends AbstractHelper
         'instant_button_variant'             => self::XML_PATH_INSTANT_BUTTON_VARIANT,
         'instant_button_variant_ppc'         => self::XML_PATH_INSTANT_BUTTON_VARIANT_PPC,
         'is_web_view'                        => self::XML_PATH_IS_WEB_VIEW,
-        'is_authentication_popup_enabled'    => self::XML_PATH_IS_AUTHENTICATION_POPUP_ENABLED
+        'magestore_storepickup_google_maps_key' => self::XML_PATH_MAGESTORE_STOREPICKUP_GOOGLE_MAPS_KEY,
     ];
 
     /**
@@ -686,7 +681,7 @@ class Config extends AbstractHelper
     {
         if ($this->isSandboxModeSet()) {
             $url = $this->getCdnUrlFromAdditionalConfig($storeId) ?: $this->getCustomURLValueOrDefault(self::XML_PATH_CUSTOM_CDN, self::CDN_URL_SANDBOX);
-        } else if ($isAllowCustomURLForProduction) {
+        } elseif ($isAllowCustomURLForProduction) {
             $url = $this->getCdnUrlFromAdditionalConfig($storeId) ?: $this->getCustomURLValueOrDefault(self::XML_PATH_CUSTOM_CDN, self::CDN_URL_PRODUCTION);
         } else {
             $url = self::CDN_URL_PRODUCTION ?: '';
@@ -2104,6 +2099,9 @@ class Config extends AbstractHelper
         $boltSettings[] = $this->boltConfigSettingFactory->create()
             ->setName('instant_button_variant_ppc')
             ->setValue($this->getInstantPPCButtonVariant());
+        $boltSettings[] = $this->boltConfigSettingFactory->create()
+            ->setName('magestore_storepickup_google_maps_key')
+            ->setValue($this->getMagestoreStorepickupGoogleMapsKey());
 
         return $boltSettings;
     }
@@ -2761,18 +2759,18 @@ class Config extends AbstractHelper
     }
 
     /**
-     * Is authentication popup enabled
+     * Get Google Maps Key for Magestore Storepickup from config
      *
-     * @param int|string|null $websiteId
+     * @param int|string $storeId
      *
-     * @return bool
+     * @return string
      */
-    public function isAuthenticationPopupEnabled($websiteId = null)
+    public function getMagestoreStorepickupGoogleMapsKey($storeId = null)
     {
-        return $this->getScopeConfig()->isSetFlag(
-            self::XML_PATH_IS_AUTHENTICATION_POPUP_ENABLED,
-            ScopeInterface::SCOPE_WEBSITES,
-            $websiteId
-        );
+        return $this->getScopeConfig()->getValue(
+            self::XML_PATH_MAGESTORE_STOREPICKUP_GOOGLE_MAPS_KEY,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        ) ?: '';
     }
 }

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -453,9 +453,14 @@ class Config extends AbstractHelper
     const XML_PATH_IS_WEB_VIEW = 'payment/boltpay/is_web_view';
 
     /**
-     *
+     * Is authentication popup enabled
      */
     const XML_PATH_IS_AUTHENTICATION_POPUP_ENABLED = 'payment/boltpay/is_authentication_popup_enabled';
+
+    /**
+     * Google Maps Key for Magestore Storepickup
+     */
+    const XML_PATH_MAGESTORE_STOREPICKUP_GOOGLE_MAPS_KEY = 'payment/boltpay/magestore_storepickup_google_maps_key';
 
     /**
      * Default whitelisted shopping cart and checkout pages "Full Action Name" identifiers, <router_controller_action>
@@ -521,7 +526,8 @@ class Config extends AbstractHelper
         'instant_button_variant'             => self::XML_PATH_INSTANT_BUTTON_VARIANT,
         'instant_button_variant_ppc'         => self::XML_PATH_INSTANT_BUTTON_VARIANT_PPC,
         'is_web_view'                        => self::XML_PATH_IS_WEB_VIEW,
-        'is_authentication_popup_enabled'    => self::XML_PATH_IS_AUTHENTICATION_POPUP_ENABLED
+        'is_authentication_popup_enabled'    => self::XML_PATH_IS_AUTHENTICATION_POPUP_ENABLED,
+        'magestore_storepickup_google_maps_key' => self::XML_PATH_MAGESTORE_STOREPICKUP_GOOGLE_MAPS_KEY,
     ];
 
     /**
@@ -686,7 +692,7 @@ class Config extends AbstractHelper
     {
         if ($this->isSandboxModeSet()) {
             $url = $this->getCdnUrlFromAdditionalConfig($storeId) ?: $this->getCustomURLValueOrDefault(self::XML_PATH_CUSTOM_CDN, self::CDN_URL_SANDBOX);
-        } else if ($isAllowCustomURLForProduction) {
+        } elseif ($isAllowCustomURLForProduction) {
             $url = $this->getCdnUrlFromAdditionalConfig($storeId) ?: $this->getCustomURLValueOrDefault(self::XML_PATH_CUSTOM_CDN, self::CDN_URL_PRODUCTION);
         } else {
             $url = self::CDN_URL_PRODUCTION ?: '';
@@ -2104,6 +2110,9 @@ class Config extends AbstractHelper
         $boltSettings[] = $this->boltConfigSettingFactory->create()
             ->setName('instant_button_variant_ppc')
             ->setValue($this->getInstantPPCButtonVariant());
+        $boltSettings[] = $this->boltConfigSettingFactory->create()
+            ->setName('magestore_storepickup_google_maps_key')
+            ->setValue($this->getMagestoreStorepickupGoogleMapsKey());
 
         return $boltSettings;
     }
@@ -2774,5 +2783,21 @@ class Config extends AbstractHelper
             ScopeInterface::SCOPE_WEBSITES,
             $websiteId
         );
+    }
+
+    /**
+     * Get Google Maps Key for Magestore Storepickup from config
+     *
+     * @param int|string $storeId
+     *
+     * @return string
+     */
+    public function getMagestoreStorepickupGoogleMapsKey($storeId = null)
+    {
+        return $this->getScopeConfig()->getValue(
+            self::XML_PATH_MAGESTORE_STOREPICKUP_GOOGLE_MAPS_KEY,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        ) ?: '';
     }
 }

--- a/ThirdPartyModules/Magestore/Storepickup.php
+++ b/ThirdPartyModules/Magestore/Storepickup.php
@@ -22,6 +22,7 @@ use Bolt\Boltpay\Api\Data\ShippingOptionInterfaceFactory;
 use Bolt\Boltpay\Api\Data\StoreAddressInterfaceFactory;
 use Bolt\Boltpay\Api\Data\ShipToStoreOptionInterfaceFactory;
 use Bolt\Boltpay\Helper\Bugsnag;
+use Bolt\Boltpay\Helper\Config;
 use Bolt\Boltpay\Helper\Geolocation;
 use Bolt\Boltpay\Helper\Shared\CurrencyUtils;
 
@@ -94,6 +95,11 @@ class Storepickup
     private $geolocation;
 
     /**
+     * @var Config
+     */
+    private $configHelper;
+
+    /**
      * @var Json
      */
     private $json;
@@ -126,7 +132,8 @@ class Storepickup
      * @param ShippingMethodExtensionFactory    $extensionFactory
      * @param Session                           $checkoutSession
      * @param Geolocation                       $geolocation
-     * @param Json                         $json
+     * @param Config                            $configHelper
+     * @param Json|null                         $json
      */
     public function __construct(
         Bugsnag  $bugsnagHelper,
@@ -140,7 +147,8 @@ class Storepickup
         ShippingMethodExtensionFactory $extensionFactory,
         Session $checkoutSession,
         Geolocation $geolocation,
-        Json $json
+        Config $configHelper,
+        Json $json = null
     ) {
         $this->bugsnagHelper            = $bugsnagHelper;
         $this->storeAddressFactory      = $storeAddressFactory;
@@ -153,7 +161,8 @@ class Storepickup
         $this->extensionFactory         = $extensionFactory;
         $this->checkoutSession          = $checkoutSession;
         $this->geolocation              = $geolocation;
-        $this->json                     = $json;
+        $this->configHelper             = $configHelper;
+        $this->json                     = $json ?: ObjectManager::getInstance()->get(Json::class);
     }
 
     /**
@@ -307,7 +316,7 @@ class Storepickup
             if (!empty($stores)) {
                 $radius = $systemConfig->getDefaultRadius();
                 $distanceUnit = ($systemConfig->getDistanceUnit() == 'Km') ? 'km' : 'mile';
-                $shippingGeoData = $this->calShippingAddressGeo($addressData, $mageStoreHelper);
+                $shippingGeoData = $this->calShippingAddressGeo($addressData, $mageStoreHelper, $quote);
                 if (empty($shippingGeoData)) {
                     $this->bugsnagHelper->notifyError('Fail to get geolocation', var_export($addressData, true));
                 }
@@ -421,11 +430,12 @@ class Storepickup
      *
      * @return array
      */
-    protected function calShippingAddressGeo($addressData, $mageStoreHelper)
+    protected function calShippingAddressGeo($addressData, $mageStoreHelper, $quote)
     {
         $geoData = [];
         $address = ($addressData['street_address1'] ?? '') . ',' . ($addressData['locality'] ?? '') . ',' . ($addressData['region'] ?? '') . ' ' . ($addressData['postal_code'] ?? '') . ',' . ($addressData['country_code'] ?? '');
-        $googleMapApiKey = $mageStoreHelper->getGoogleApiKey();
+        $storeId = $quote->getStoreId();
+        $googleMapApiKey = $this->configHelper->getMagestoreStorepickupGoogleMapsKey($storeId) ?: $mageStoreHelper->getGoogleApiKey();
         $client = $this->clientFactory->create(['config' => [
             'base_uri' => 'https://maps.googleapis.com/'
         ]]);

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -427,12 +427,6 @@
                         <config_path>payment/boltpay/instant_button_variant_ppc</config_path>
                         <comment>The name of a button variant to be used for PPC pages.</comment>
                     </field>
-                    <field id="is_authentication_popup_enabled" translate="label" type="select" sortOrder="410" showInDefault="1" showInWebsite="1" showInStore="1">
-                        <label>Authentication Popup Enabled</label>
-                        <config_path>payment/boltpay/is_authentication_popup_enabled</config_path>
-                        <comment>If guest checkout is not allowed, an authentication popup will be shown; otherwise, the user will be redirected to the customer login page.</comment>
-                        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    </field>
                 </group>
                 <group id="third_party_modules" translate="label" type="text" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Third Party Modules Support</label>
@@ -477,6 +471,11 @@
                         <config_path>payment/boltpay/mageworx_reward_points_on_cart</config_path>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <if_module_enabled>MageWorx_RewardPoints</if_module_enabled>
+                    </field>
+                    <field id="magestore_storepickup_google_maps_key" translate="label" type="text" sortOrder="248" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Google Maps Key for Magestore Storepickup</label>
+                        <config_path>payment/boltpay/magestore_storepickup_google_maps_key</config_path>
+                        <if_module_enabled>Magestore_Storepickup</if_module_enabled>
                     </field>
                 </group>
                 <group id="catalog_ingestion" translate="label" type="text" sortOrder="80" showInDefault="1" showInWebsite="1" showInStore="0">

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -478,6 +478,11 @@
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <if_module_enabled>MageWorx_RewardPoints</if_module_enabled>
                     </field>
+                    <field id="magestore_storepickup_google_maps_key" translate="label" type="text" sortOrder="248" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Google Maps Key for Magestore Storepickup</label>
+                        <config_path>payment/boltpay/magestore_storepickup_google_maps_key</config_path>
+                        <if_module_enabled>Magestore_Storepickup</if_module_enabled>
+                    </field>
                 </group>
                 <group id="catalog_ingestion" translate="label" type="text" sortOrder="80" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Catalog Ingestion</label>


### PR DESCRIPTION
# Description
Add a new configuration field for the new IP-based restriction key.

Entering the key here allows it to work correctly with the Google Maps calculation in the backend for MageStore pickup. With this update, BOPIS is now fully functional within the Bolt checkout.

Fixes: https://app.devrev.ai/bolt-inc/works/ISS-21606

#changelog Add dedicated Google Maps API key for Magestore Store Pickup

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
