### PR TITLE
Wrong contstructor param fix

### DIFF
--- a/ThirdPartyModules/Magestore/Storepickup.php
+++ b/ThirdPartyModules/Magestore/Storepickup.php
@@ -148,7 +148,7 @@ class Storepickup
         Session $checkoutSession,
         Geolocation $geolocation,
         Config $configHelper,
-        Json $json = null
+        ?Json $json = null
     ) {
         $this->bugsnagHelper            = $bugsnagHelper;
         $this->storeAddressFactory      = $storeAddressFactory;


### PR DESCRIPTION
# Description
Fix PHP 8.4 deprecation in Magestore/Storepickup.php: explicitly mark $json constructor parameter as nullable (?Json $json = null) to satisfy the new "implicitly nullable parameter is deprecated" rule. Matches the pattern used in Magento core (e.g. module-checkout/Model/PaymentInformationManagement.php).

Fixes: (link ticket)

#changelog Wrong contstructor param fix

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
