### PR TITLE
Default Bolt country selector to the merchant's store country

### DIFF
--- a/Helper/Cart.php
+++ b/Helper/Cart.php
@@ -36,6 +36,7 @@ use Magento\Checkout\Helper\Data as CheckoutHelper;
 use Magento\Customer\Api\CustomerRepositoryInterface as CustomerRepository;
 use Magento\Customer\Model\Address;
 use Magento\Customer\Model\Session as CustomerSession;
+use Magento\Directory\Model\CountryFactory;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\App\CacheInterface;
 use Magento\Framework\App\Helper\AbstractHelper;
@@ -293,6 +294,11 @@ class Cart extends AbstractHelper
     private $quoteIdMaskFactory;
 
     /**
+     * @var CountryFactory
+     */
+    private $countryFactory;
+
+    /**
      * @param Context $context
      * @param CheckoutSession $checkoutSession
      * @param ProductRepository $productRepository
@@ -328,6 +334,7 @@ class Cart extends AbstractHelper
      * @param Store $store
      * @param QuoteIdMaskResourceModel|null $quoteIdMaskResourceModel
      * @param QuoteIdMaskFactory|null $quoteIdMaskFactory
+     * @param CountryFactory|null $countryFactory
      */
     public function __construct(
         Context $context,
@@ -364,7 +371,8 @@ class Cart extends AbstractHelper
         PriceHelper $priceHelper,
         Store $store,
         ?QuoteIdMaskResourceModel $quoteIdMaskResourceModel = null,
-        ?QuoteIdMaskFactory $quoteIdMaskFactory = null
+        ?QuoteIdMaskFactory $quoteIdMaskFactory = null,
+        ?CountryFactory $countryFactory = null
     ) {
         parent::__construct($context);
         $this->checkoutSession = $checkoutSession;
@@ -403,6 +411,8 @@ class Cart extends AbstractHelper
             ObjectManager::getInstance()->get(QuoteIdMaskResourceModel::class);
         $this->quoteIdMaskFactory = $quoteIdMaskFactory ?:
             ObjectManager::getInstance()->get(QuoteIdMaskFactory::class);
+        $this->countryFactory = $countryFactory ?:
+            ObjectManager::getInstance()->get(CountryFactory::class);
     }
 
     /**
@@ -1150,6 +1160,28 @@ class Cart extends AbstractHelper
 
         if ($checkoutType === 'admin') {
             $hints['virtual_terminal_mode'] = true;
+        }
+
+        // Default the Bolt phone country-code selector to the merchant's country.
+        if ($checkoutType !== 'admin' && $this->deciderHelper->isDefaultPhoneCountryHintEnabled()) {
+            $storeId = $quote ? $quote->getStoreId() : null;
+            $scopeConfig = $this->configHelper->getScopeConfig();
+            $countryCode = ($hints['prefill']['country'] ?? null)
+                ?: $scopeConfig->getValue(
+                    'general/country/default',
+                    ScopeInterface::SCOPE_STORE,
+                    $storeId
+                );
+            if ($countryCode) {
+                $countryName = $this->countryFactory->create()->loadByCode($countryCode)->getName('en_US');
+                $hints['shipping'] = [
+                    'Country'     => $countryName ?: $countryCode,
+                    'CountryCode' => $countryCode,
+                ];
+                if (empty($hints['prefill']['country'])) {
+                    $hints['prefill']['country'] = $countryCode;
+                }
+            }
         }
 
         $hints['prefill'] = (object)$hints['prefill'];

--- a/Helper/FeatureSwitch/Decider.php
+++ b/Helper/FeatureSwitch/Decider.php
@@ -631,4 +631,15 @@ class Decider extends AbstractHelper
     {
         return $this->isSwitchEnabled(Definitions::M2_DISABLE_AUTO_OPENING_BOLT_MODAL);
     }
+
+    /**
+     * Determines if the default phone country hint is enabled.
+     *
+     * @return bool
+     * @throws LocalizedException
+     */
+    public function isDefaultPhoneCountryHintEnabled()
+    {
+        return $this->isSwitchEnabled(Definitions::M2_DEFAULT_PHONE_COUNTRY_HINT);
+    }
 }

--- a/Helper/FeatureSwitch/Definitions.php
+++ b/Helper/FeatureSwitch/Definitions.php
@@ -347,6 +347,12 @@ class Definitions
      */
     const M2_DISABLE_AUTO_OPENING_BOLT_MODAL = 'M2_DISABLE_AUTO_OPENING_BOLT_MODAL';
 
+    /**
+     * Seed hints.shipping.Country from the store config so the Bolt phone
+     * country-code selector defaults to the merchant's country.
+     */
+    const M2_DEFAULT_PHONE_COUNTRY_HINT = 'M2_DEFAULT_PHONE_COUNTRY_HINT';
+
     const DEFAULT_SWITCH_VALUES = [
         self::M2_SAMPLE_SWITCH_NAME => [
             self::NAME_KEY        => self::M2_SAMPLE_SWITCH_NAME,
@@ -716,6 +722,12 @@ class Definitions
         ],
         self::M2_DISABLE_AUTO_OPENING_BOLT_MODAL => [
             self::NAME_KEY        => self::M2_DISABLE_AUTO_OPENING_BOLT_MODAL,
+            self::VAL_KEY         => true,
+            self::DEFAULT_VAL_KEY => false,
+            self::ROLLOUT_KEY     => 0
+        ],
+        self::M2_DEFAULT_PHONE_COUNTRY_HINT => [
+            self::NAME_KEY        => self::M2_DEFAULT_PHONE_COUNTRY_HINT,
             self::VAL_KEY         => true,
             self::DEFAULT_VAL_KEY => false,
             self::ROLLOUT_KEY     => 0

--- a/Test/Unit/Helper/CartTest.php
+++ b/Test/Unit/Helper/CartTest.php
@@ -457,11 +457,12 @@ class CartTest extends BoltTestCase
             ['ifShouldDisablePrefillAddressForLoggedInCustomer', 'handleVirtualProductsAsPhysical',
              'isIncludeUserGroupIntoCart', 'isAddSessionIdToCartMetadata', 'isCustomizableOptionsSupport',
              'isPreventBoltCartForQuotesWithError','isAPIDrivenIntegrationEnabled','isUseRuleNameIfDescriptionEmpty',
-             'isEnabledFetchCartViaApi', 'isMSRPPriceDisabled'
+             'isEnabledFetchCartViaApi', 'isMSRPPriceDisabled', 'isDefaultPhoneCountryHintEnabled'
             ]
         );
         $this->deciderHelper->method('isEnabledFetchCartViaApi')->willReturn(false);
         $this->deciderHelper->method('isMSRPPriceDisabled')->willReturn(false);
+        $this->deciderHelper->method('isDefaultPhoneCountryHintEnabled')->willReturn(false);
         $this->eventsForThirdPartyModules = $this->createPartialMock(EventsForThirdPartyModules::class, ['runFilter','dispatchEvent']);
         $this->eventsForThirdPartyModules->method('runFilter')->will($this->returnArgument(1));
         $this->eventsForThirdPartyModules->method('dispatchEvent')->willReturnSelf();


### PR DESCRIPTION
# Description
Shoppers used to see "United States" as the default country in Bolt's phone-number selector regardless of which store they were checking out on. This forced non-US customers to manually change it every time. The change makes the selector default to the merchant's own country (configured in Magento under General → Store Information), so a New Zealand store now opens with 🇳🇿 +64, a UK store with 🇬🇧 +44, and so on. Behaviour is gated behind a feature switch (`M2_DEFAULT_PHONE_COUNTRY_HINT`) so it can be rolled out gradually and turned off without redeploying.

Fixes: https://app.devrev.ai/bolt-inc/works/ISS-23022

#changelog default Bolt country selector to the merchant's store country

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

# For PR Reviewer 

- [ ] Reviewed unit tests to make sure we are using real components rather than mocks as much as possible?
- [ ] For any major change (observer, new Bolt feature, core Magento interaction) we must add a feature switch, did you verify this?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my ticket link and provided a changelog message.
