### PR TITLE
Update documentation URLs from bolt.com to boltapp.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ Select ***Yes*** to enable it.
 > The Publishable Key is for the multi-step checkout by default. You can find other publishable keys (Payment Only and Back-Office) in the division dropdown at the top-right corner.
 
 > For production, these will be found at:
-> https://merchant.bolt.com
+> https://merchant.boltapp.com
 >
 > For sandbox mode, use the following URL:
-> https://merchant-sandbox.bolt.com"
+> https://merchant-sandbox.boltapp.com"
 
 
 + **API Key**
@@ -64,9 +64,9 @@ comma separated list of CSS selectors matching the elements to be replaced with 
 >> `|prepend` suffix - *example-selector|prepend*, inserts Bolt button right before the element
 ### 4. Bolt Merchant Dashboard configuration
 > #### Login to the Bolt Merchant Dashboard
-> **Production**: https://merchant.bolt.com
+> **Production**: https://merchant.boltapp.com
 >
-> **Sandbox**: https://merchant-sandbox.bolt.com"
+> **Sandbox**: https://merchant-sandbox.boltapp.com"
 
 + Navigate to `Developers`
 + Click on the `API` tab

--- a/Test/Load/setup-files/README.md
+++ b/Test/Load/setup-files/README.md
@@ -1,7 +1,7 @@
 # Load Test Setup 
 1. Setup M2 store on LightSail: [M2 LightSail Setup](https://www.notion.so/boltteam/Remote-dev-server-with-lightsail-8a053570b68c4ac78561cf04cbde8405)
 
-2. Configure your M2 store with Bolt: [M2 Bolt Configuration](https://docs.bolt.com/docs/magento-2-integration#section-2-plugin-configuration)
+2. Configure your M2 store with Bolt: [M2 Bolt Configuration](https://docs.boltapp.com/docs/magento-2-integration#section-2-plugin-configuration)
 
 3. Add the line below in `bolt-magento2/etc/di.xml`: 
 	```

--- a/docker-container/README.md
+++ b/docker-container/README.md
@@ -9,7 +9,7 @@
 [https://ngrok.com/](https://ngrok.com/)
 [https://ngrok.com/pricing](https://ngrok.com/pricing)
 
-In order for your docker container to communicate with the webhook and shipping & tax url set on [merchant.bolt.com](https://merchant.bolt.com/), one must set up an ngrok account to expose your store's docker ports to a public IP address. In order to do this one must have at least the Basic plan with ngrok to reserve a domain for themselves. 
+In order for your docker container to communicate with the webhook and shipping & tax url set on [merchant.boltapp.com](https://merchant.boltapp.com/), one must set up an ngrok account to expose your store's docker ports to a public IP address. In order to do this one must have at least the Basic plan with ngrok to reserve a domain for themselves.
 
 Once the initial configuration scripts are ran in your local environment and a public domain is reserved, run the following command 
 

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -35,7 +35,7 @@
                 </field>
                 <group id="keys" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Keys</label>
-                    <comment><![CDATA[Keys and URL Configurations can be found at <a target="_blank" href="https://merchant.bolt.com/settings">merchant.bolt.com/settings</a> or <a target="_blank" href="https://merchant-sandbox.bolt.com/settings">merchant-sandbox.bolt.com/settings</a>.]]></comment>
+                    <comment><![CDATA[Keys and URL Configurations can be found at <a target="_blank" href="https://merchant.boltapp.com/settings">merchant.boltapp.com/settings</a> or <a target="_blank" href="https://merchant-sandbox.boltapp.com/settings">merchant-sandbox.boltapp.com/settings</a>.]]></comment>
                     <attribute type="expanded">1</attribute>
                     <field id="api_key" translate="label" type="obscure" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="0">
                         <label>API Key</label>
@@ -409,7 +409,7 @@
                         <label>Bolt Authentication</label>
                         <config_path>payment/boltpay/connect_magento_integration_mode</config_path>
                         <frontend_model>Bolt\Boltpay\Block\System\Config\IntegrationConnection</frontend_model>
-                        <comment><![CDATA[ This will create an integration with the required permissions for your Magento installation to be used by Bolt.<br><a target="_blank" href="https://docs.bolt.com/developers/guides/checkout-guides/managed-checkout/adobe-commerce-setup-guide/adobe-installation/#why-do-i-need-to-send-my-magento-2-api-keys-to-bolt">Why does Bolt need my Magento API keys?</a>]]></comment>
+                        <comment><![CDATA[ This will create an integration with the required permissions for your Magento installation to be used by Bolt.<br><a target="_blank" href="https://docs.boltapp.com/developers/guides/checkout-guides/managed-checkout/adobe-commerce-setup-guide/adobe-installation/#why-do-i-need-to-send-my-magento-2-api-keys-to-bolt">Why does Bolt need my Magento API keys?</a>]]></comment>
                     </field>
                     <field id="new_plugin_version_notification" translate="label" type="select" sortOrder="115" showInDefault="1" showInWebsite="1" showInStore="0">
                         <label>New plugin version notification</label>


### PR DESCRIPTION
## Summary
Non-functional follow-up to #1973 (bolt.com → boltapp.com migration). Documentation/text-only changes:

- `README.md`, `docker-container/README.md`, `Test/Load/setup-files/README.md`: merchant dashboard and docs links → `merchant.boltapp.com` / `docs.boltapp.com`
- `etc/adminhtml/system.xml`: admin-panel `<comment>` help text links → `merchant.boltapp.com/settings` / `docs.boltapp.com`

No behavior changes.

#changelog Update documentation URLs from bolt.com to boltapp.com
- Updated documentation and admin help-text links from bolt.com to boltapp.com

Link to Devin session: https://app.devin.ai/sessions/10a2aa9698544989880b051ac93f5815
Requested by: @SanthoshCharanBolt