### PR TITLE
Fix validateCustomUrl to accept boltapp.com custom URLs

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -2499,7 +2499,7 @@ class Config extends AbstractHelper
      */
     protected function validateCustomUrl($url)
     {
-        return $url && preg_match("/^https?:\/\/([a-zA-Z0-9-]+\.)+bolt.(me|com)\/?$/", $url);
+        return $url && preg_match("/^https?:\/\/([a-zA-Z0-9-]+\.)+bolt(app)?\.(me|com)\/?$/", $url);
     }
 
     /**


### PR DESCRIPTION
## Problem

The bolt.com→boltapp.com migration (#1973) updated the URL constants in `Helper/Config.php` but not **`validateCustomUrl()`** (`Helper/Config.php:2482`), whose regex only matched `bolt.me`/`bolt.com`:

```php
preg_match("/^https?:\/\/([a-zA-Z0-9-]+\.)+bolt.(me|com)\/?$/", $url)
```

`getCustomURLValueOrDefault()` gates the `custom_cdn` / `custom_api` / `custom_account` / `custom_merchant_dash` overrides through this validator and falls back to the default when it returns false. So any merchant setting one of those overrides to a **`boltapp.com`** URL has it **silently ignored** and reverts to the default host — the override never takes effect.

Verified live on a Magento test store: setting `custom_cdn=https://connect-staging.boltapp.com` was dropped and fell back to the sandbox default `connect-sandbox.boltapp.com`.

## Fix

Widen the regex to also accept `boltapp.(me|com)`, and escape the dot before the TLD group:

```php
preg_match("/^https?:\/\/([a-zA-Z0-9-]+\.)+bolt(app)?\.(me|com)\/?$/", $url)
```

Accepts `*.bolt.com`, `*.bolt.me`, `*.boltapp.com` (and `*.boltapp.me`); still rejects arbitrary third-party hosts.

Ref: I340 / the boltapp.com migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


#changelog Accept boltapp.com hosts in custom URL validation
- Fixed `validateCustomUrl()` rejecting `boltapp.com` values for the `custom_cdn` / `custom_api` / `custom_account` / `custom_merchant_dash` overrides, which caused them to be silently ignored and fall back to the defaults
