### PR TITLE
ci: migrate CI from CircleCI to GitHub Actions (build matrix)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,20 +249,6 @@ jobs:
           name: Rebase and Magento Integration Test
           command: bash .circleci/scripts/rebase-and-magento-integration-test.sh << pipeline.parameters.rebase_and_magento_integration_test_branch_name >>
 
-  phpcs:
-    docker:
-      - image: boltdev/m2-installed-plugin-ci-php72:2.3.0-v1
-        auth:
-          username: $DOCKERHUB_USER
-          password: $DOCKERHUB_PASS
-      - image: cimg/mysql:5.7
-    steps:
-      - checkout
-      - run:
-          name: Magento Coding Standard Test
-          command: |
-            Test/scripts/phpcs_meqp2.sh
-
 workflows:
   version: 2
   build:
@@ -272,7 +258,6 @@ workflows:
       - integration-magento-php74-magento24
       - integration-magento-php72-magento23
       - integration-magento-php71-magento22
-      - phpcs
   integration-tests:
     triggers:
       - schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,37 +6,72 @@ name: CI
 # auto-rebase, merchant-branch fan-out via the swissknife orb + remote triggers)
 # are intentionally NOT ported here.
 #
-# Requires the org-level Docker Hub secrets GHA_DOCKER_USER / GHA_DOCKER_PASSWORD
-# (same ones BoltApp/source uses) to be scoped to this repo, to pull the private
-# boltdev/m2-installed-plugin-ci-* images that ship Magento pre-installed.
+# ---------------------------------------------------------------------------
+# Why `docker run` instead of a job `container:`
+#
+# The boltdev/m2-installed-plugin-ci-* images ship Magento pre-installed, but
+# they are ~7 years old and inherit circleci/php:7.x-…-legacy = Debian Stretch,
+# glibc 2.24. GitHub Actions injects a Node 24 runtime into a job `container:`
+# to run actions/checkout, and that Node needs GLIBC_2.28 / CXXABI_1.3.11 — so
+# every job dies before a single test runs.
+#
+# Rebuilding the images on a modern base is NOT an option: Packagist has dropped
+# its Composer 1 metadata API, and Magento 2.2.8 / 2.3.0 / 2.4.2 are all
+# Composer-1-era (2.2.8 literally requires `composer/composer @alpha`). Their
+# `composer create-project` can no longer resolve phpunit, php_codesniffer or
+# composer itself from packagist.org, on any base image. The existing images
+# survive only because they predate that change.
+#
+# So: check out and run the workflow on a modern ubuntu-latest host, and invoke
+# the old image with `docker run`. GHA's Node never enters the container, and the
+# images need no changes at all.
+#
+# Two hacks this also removes, versus running under `container:`:
+#   - the repo is mounted straight at /home/circleci/project, which is exactly
+#     where CircleCI put it (its default working_directory), so Test/scripts/*
+#     find the pre-installed Magento as a sibling at ../magento unmodified
+#   - `--network host` means MySQL really is on 127.0.0.1, as the scripts assume,
+#     so no socat port-bridging is needed
+# ---------------------------------------------------------------------------
 
 on:
   pull_request:
   push:
     branches: [master]
 
-# CircleCI checked the repo out at ~/project with Magento pre-installed at
-# ~/magento (sibling). The Test/scripts/*.sh do `cd ..` then work against
-# ./magento, so we reproduce that layout by checking out into ./project.
-env:
-  CODE_DIR: project
-
 jobs:
   phpcs:
     name: phpcs (Magento Coding Standard)
     runs-on: ubuntu-latest
-    container:
-      image: boltdev/m2-installed-plugin-ci-php72:2.3.0-v1
-      credentials:
-        username: ${{ secrets.GHA_DOCKER_USER }}
-        password: ${{ secrets.GHA_DOCKER_PASSWORD }}
+    services:
+      mysql:
+        image: cimg/mysql:5.7
+        ports: ["3306:3306"]
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+        options: >-
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=10s --health-timeout=5s --health-retries=10
     steps:
       - uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
         with:
-          path: ${{ env.CODE_DIR }}
+          username: ${{ secrets.GHA_DOCKER_USER }}
+          password: ${{ secrets.GHA_DOCKER_PASSWORD }}
+
       - name: Magento Coding Standard
-        working-directory: ${{ env.CODE_DIR }}
-        run: Test/scripts/phpcs_meqp2.sh
+        run: |
+          mkdir -p artifacts
+          docker run --rm --network host --user root \
+            -v "$PWD":/home/circleci/project -w /home/circleci/project \
+            -e TEST_ENV=php72 \
+            -e MAGENTO_VERSION=2.3.0 \
+            -e XDEBUG_MODE=coverage \
+            -e COMPOSER_MEMORY_LIMIT=5G \
+            boltdev/m2-installed-plugin-ci-php72:2.3.0-v1 \
+            bash -c 'Test/scripts/phpcs_meqp2.sh'
 
   integration:
     name: ${{ matrix.name }}
@@ -50,77 +85,54 @@ jobs:
             php_version: php74
             magento_version: "2.4.2"
             mysql_image: cimg/mysql:8.0
-            opensearch: true
           - name: php72 / Magento 2.3.0
             image: boltdev/m2-installed-plugin-ci-php72:2.3.0-v1
             php_version: php72
             magento_version: "2.3.0"
             mysql_image: cimg/mysql:5.7
-            opensearch: false
           - name: php71 / Magento 2.2.8
             image: boltdev/m2-installed-plugin-ci-php71:2.2.8
             php_version: php71
             magento_version: "2.2.8"
             mysql_image: cimg/mysql:5.7
-            opensearch: false
-    container:
-      image: ${{ matrix.image }}
-      credentials:
-        username: ${{ secrets.GHA_DOCKER_USER }}
-        password: ${{ secrets.GHA_DOCKER_PASSWORD }}
     services:
       mysql:
         image: ${{ matrix.mysql_image }}
+        ports: ["3306:3306"]
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
         options: >-
           --health-cmd="mysqladmin ping --silent"
           --health-interval=10s --health-timeout=5s --health-retries=10
-      # OpenSearch is only needed by Magento 2.4.x. It is declared for every
-      # matrix entry (services can't be made conditional) but is only exercised
-      # when the job's Magento version uses it.
-      opensearch:
-        image: opensearchproject/opensearch:2.5.0
-        env:
-          discovery.type: single-node
-          OPENSEARCH_JAVA_OPTS: "-Xms512m -Xmx512m"
-          plugins.security.disabled: "true"
-        options: >-
-          --health-cmd="curl -s http://localhost:9200/_cluster/health || exit 1"
-          --health-interval=15s --health-timeout=10s --health-retries=10
-    env:
-      MAGENTO_VERSION: ${{ matrix.magento_version }}
-      TEST_ENV: ${{ matrix.php_version }}
-      MAGENTO_DIR: magento
-      XDEBUG_MODE: coverage
-      COMPOSER_MEMORY_LIMIT: "4G"
     steps:
       - uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
         with:
-          path: ${{ env.CODE_DIR }}
+          username: ${{ secrets.GHA_DOCKER_USER }}
+          password: ${{ secrets.GHA_DOCKER_PASSWORD }}
 
-      # CircleCI reached MySQL/OpenSearch on 127.0.0.1 (shared network namespace).
-      # In a containerized GHA job, service containers resolve by their label
-      # hostname instead. The Test/scripts hardcode 127.0.0.1, so bridge
-      # 127.0.0.1:<port> -> <service>:<port> with socat to keep them unmodified.
-      - name: Bridge service ports to 127.0.0.1
-        run: |
-          (command -v socat >/dev/null 2>&1) || (apt-get update -y && apt-get install -y socat) || \
-            (yum install -y socat) || true
-          socat TCP-LISTEN:3306,fork,reuseaddr TCP:mysql:3306 &
-          socat TCP-LISTEN:9200,fork,reuseaddr TCP:opensearch:9200 &
-          sleep 2 && echo "port bridges up"
-
+      # Magento 2.4.2 needs Elasticsearch 7, which its image has installed and
+      # install_magento.sh starts itself (`sudo service elasticsearch start`).
+      # It is not a service container here; --network host covers it too.
       - name: Run Magento integration tests
-        working-directory: ${{ env.CODE_DIR }}
         run: |
-          mkdir -p ./artifacts
-          Test/scripts/ci-magento-integration.sh
+          mkdir -p artifacts
+          docker run --rm --network host --user root \
+            -v "$PWD":/home/circleci/project -w /home/circleci/project \
+            -e TEST_ENV=${{ matrix.php_version }} \
+            -e MAGENTO_VERSION=${{ matrix.magento_version }} \
+            -e MAGENTO_DIR=magento \
+            -e XDEBUG_MODE=coverage \
+            -e COMPOSER_MEMORY_LIMIT=4G \
+            ${{ matrix.image }} \
+            bash -c 'Test/scripts/ci-magento-integration.sh'
 
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: artifacts-${{ matrix.php_version }}-${{ matrix.magento_version }}
-          path: ${{ env.CODE_DIR }}/artifacts
+          path: artifacts
           if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ name: CI
 # auto-rebase, merchant-branch fan-out via the swissknife orb + remote triggers)
 # are intentionally NOT ported here.
 #
-# Requires the org-level Docker Hub secrets CCI_DOCKER_USER / CCI_DOCKER_PASSWORD
+# Requires the org-level Docker Hub secrets GHA_DOCKER_USER / GHA_DOCKER_PASSWORD
 # (same ones BoltApp/source uses) to be scoped to this repo, to pull the private
 # boltdev/m2-installed-plugin-ci-* images that ship Magento pre-installed.
 
@@ -28,8 +28,8 @@ jobs:
     container:
       image: boltdev/m2-installed-plugin-ci-php72:2.3.0-v1
       credentials:
-        username: ${{ secrets.CCI_DOCKER_USER }}
-        password: ${{ secrets.CCI_DOCKER_PASSWORD }}
+        username: ${{ secrets.GHA_DOCKER_USER }}
+        password: ${{ secrets.GHA_DOCKER_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -66,8 +66,8 @@ jobs:
     container:
       image: ${{ matrix.image }}
       credentials:
-        username: ${{ secrets.CCI_DOCKER_USER }}
-        password: ${{ secrets.CCI_DOCKER_PASSWORD }}
+        username: ${{ secrets.GHA_DOCKER_USER }}
+        password: ${{ secrets.GHA_DOCKER_PASSWORD }}
     services:
       mysql:
         image: ${{ matrix.mysql_image }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,126 @@
+name: CI
+
+# Migrated from CircleCI (.circleci/config.yml) to GitHub Actions.
+# Ports the PR-gating `build` workflow: phpcs + the Magento-integration matrix.
+# Non-PR CircleCI workflows (nightly integration-tests with live-API secrets,
+# auto-rebase, merchant-branch fan-out via the swissknife orb + remote triggers)
+# are intentionally NOT ported here.
+#
+# Requires the org-level Docker Hub secrets CCI_DOCKER_USER / CCI_DOCKER_PASSWORD
+# (same ones BoltApp/source uses) to be scoped to this repo, to pull the private
+# boltdev/m2-installed-plugin-ci-* images that ship Magento pre-installed.
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+# CircleCI checked the repo out at ~/project with Magento pre-installed at
+# ~/magento (sibling). The Test/scripts/*.sh do `cd ..` then work against
+# ./magento, so we reproduce that layout by checking out into ./project.
+env:
+  CODE_DIR: project
+
+jobs:
+  phpcs:
+    name: phpcs (Magento Coding Standard)
+    runs-on: ubuntu-latest
+    container:
+      image: boltdev/m2-installed-plugin-ci-php72:2.3.0-v1
+      credentials:
+        username: ${{ secrets.CCI_DOCKER_USER }}
+        password: ${{ secrets.CCI_DOCKER_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: ${{ env.CODE_DIR }}
+      - name: Magento Coding Standard
+        working-directory: ${{ env.CODE_DIR }}
+        run: Test/scripts/phpcs_meqp2.sh
+
+  integration:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: php74 / Magento 2.4.2
+            image: boltdev/m2-installed-plugin-ci-php74:2.4.6
+            php_version: php74
+            magento_version: "2.4.2"
+            mysql_image: cimg/mysql:8.0
+            opensearch: true
+          - name: php72 / Magento 2.3.0
+            image: boltdev/m2-installed-plugin-ci-php72:2.3.0-v1
+            php_version: php72
+            magento_version: "2.3.0"
+            mysql_image: cimg/mysql:5.7
+            opensearch: false
+          - name: php71 / Magento 2.2.8
+            image: boltdev/m2-installed-plugin-ci-php71:2.2.8
+            php_version: php71
+            magento_version: "2.2.8"
+            mysql_image: cimg/mysql:5.7
+            opensearch: false
+    container:
+      image: ${{ matrix.image }}
+      credentials:
+        username: ${{ secrets.CCI_DOCKER_USER }}
+        password: ${{ secrets.CCI_DOCKER_PASSWORD }}
+    services:
+      mysql:
+        image: ${{ matrix.mysql_image }}
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+        options: >-
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=10s --health-timeout=5s --health-retries=10
+      # OpenSearch is only needed by Magento 2.4.x. It is declared for every
+      # matrix entry (services can't be made conditional) but is only exercised
+      # when the job's Magento version uses it.
+      opensearch:
+        image: opensearchproject/opensearch:2.5.0
+        env:
+          discovery.type: single-node
+          OPENSEARCH_JAVA_OPTS: "-Xms512m -Xmx512m"
+          plugins.security.disabled: "true"
+        options: >-
+          --health-cmd="curl -s http://localhost:9200/_cluster/health || exit 1"
+          --health-interval=15s --health-timeout=10s --health-retries=10
+    env:
+      MAGENTO_VERSION: ${{ matrix.magento_version }}
+      TEST_ENV: ${{ matrix.php_version }}
+      MAGENTO_DIR: magento
+      XDEBUG_MODE: coverage
+      COMPOSER_MEMORY_LIMIT: "4G"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: ${{ env.CODE_DIR }}
+
+      # CircleCI reached MySQL/OpenSearch on 127.0.0.1 (shared network namespace).
+      # In a containerized GHA job, service containers resolve by their label
+      # hostname instead. The Test/scripts hardcode 127.0.0.1, so bridge
+      # 127.0.0.1:<port> -> <service>:<port> with socat to keep them unmodified.
+      - name: Bridge service ports to 127.0.0.1
+        run: |
+          (command -v socat >/dev/null 2>&1) || (apt-get update -y && apt-get install -y socat) || \
+            (yum install -y socat) || true
+          socat TCP-LISTEN:3306,fork,reuseaddr TCP:mysql:3306 &
+          socat TCP-LISTEN:9200,fork,reuseaddr TCP:opensearch:9200 &
+          sleep 2 && echo "port bridges up"
+
+      - name: Run Magento integration tests
+        working-directory: ${{ env.CODE_DIR }}
+        run: |
+          mkdir -p ./artifacts
+          Test/scripts/ci-magento-integration.sh
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-${{ matrix.php_version }}-${{ matrix.magento_version }}
+          path: ${{ env.CODE_DIR }}/artifacts
+          if-no-files-found: ignore

--- a/operations/docker/README.md
+++ b/operations/docker/README.md
@@ -2,6 +2,27 @@
 
 In order to speed up our build pipeline, we pre-build the images we need with all the stuff pre-installed. The docker files for the images we use are in this directory.
 
+## ⚠️ php71 / php72 / php74 can no longer be rebuilt
+
+Do not spend time trying. Packagist has [dropped its Composer 1 metadata
+API](https://blog.packagist.com/deprecating-composer-1-support/), and Magento
+2.2.8 / 2.3.0 / 2.4.2 are all Composer-1-era (2.2.8 requires
+`composer/composer @alpha`). `--repository-url=repo.magento.com` only supplies
+`magento/*`, so `composer create-project` can no longer resolve phpunit,
+php_codesniffer or composer itself, on **any** base image. The published images
+work only because they predate that change — treat them as immutable artifacts.
+
+Two consequences:
+
+- These images cannot run under a GitHub Actions job `container:` either: they are
+  Debian Stretch (glibc 2.24) and GHA injects a Node 24 runtime to run
+  `actions/checkout`, which needs GLIBC_2.28. `.github/workflows/ci.yml` therefore
+  invokes them with `docker run` from a modern `ubuntu-latest` host instead.
+- Adding a dependency to one of these Magento versions means patching it at test
+  time in `Test/scripts/*`, not baking it into the image.
+
+`php8.4` (Magento 2.4.8) is Composer-2-era and *can* still be rebuilt, per below.
+
 ## Updating an Image
 
 If you want add a dependency  to one of these images you need update the image by following the steps below


### PR DESCRIPTION
## Problem

CircleCI is being decommissioned, so this repo's PR gating (phpcs + the Magento
integration matrix) has to move to GitHub Actions.

A straight port doesn't work. The `boltdev/m2-installed-plugin-ci-*` images ship
Magento pre-installed, but they are ~7 years old and inherit
`circleci/php:7.x-apache-node-browsers-legacy` = Debian Stretch, **glibc 2.24**.
GitHub Actions injects a **Node 24** runtime into a job `container:` to run
`actions/checkout`, and that Node needs `GLIBC_2.28` / `CXXABI_1.3.11`. So every
job died before a single test ran — a structural failure, nothing to do with the
test suite.

## Why the images aren't rebuilt

The obvious fix — rebuild them on a modern base — **is not possible.** Packagist
has [dropped its Composer 1 metadata API](https://blog.packagist.com/deprecating-composer-1-support/),
and Magento 2.2.8 / 2.3.0 / 2.4.2 are all Composer-1-era (2.2.8 literally requires
`composer/composer @alpha`). `--repository-url=repo.magento.com` only supplies
`magento/*`, so `composer create-project` can no longer resolve phpunit,
php_codesniffer or composer itself, on **any** base image. I confirmed this by
building it: Ubuntu 22.04 + `ppa:ondrej/php` installs PHP 7.1 fine, then dies at
dependency resolution.

The published images work only because they predate that change. They are
effectively immutable artifacts now, and `operations/docker/README.md` says so, so
the next person doesn't repeat the experiment.

## Fix

Run the workflow on a modern `ubuntu-latest` host and invoke the old image with
**`docker run`**. GHA's Node never enters the container, so the structural failure
disappears with no image change at all.

This also turned out simpler than running under `container:` would have been:

- the repo is mounted at `/home/circleci/project` — exactly CircleCI's own default
  `working_directory` — so `Test/scripts/*` find the pre-installed Magento as a
  sibling at `../magento` and run **unmodified** (no staging copy, no patching of
  scripts that CircleCI still drives until it's switched off)
- `--network host` means MySQL genuinely is on `127.0.0.1` as the scripts assume,
  so there's **no socat port-bridging**

## Verification

Green: https://github.com/BoltApp/bolt-magento2/actions/runs/30335749317

All four jobs pass, and the tests really ran — assertion counts are **identical to
the failing run** (1841 tests; 4417 / 4411 / 4409 assertions; 30 skipped, per
version), now with zero failures. Nothing was skipped or weakened to get green.

Every deterministic failure before this was #1975's `validateCustomUrl` regex
(`ConfigTest::validateCustomUrl` data sets #3/#4 and the two
`JsTest::getPayByLinkUrl` cases falling back off a rejected `boltapp.com` custom
URL). #1975 is now merged, so they're gone.

One flake observed and worth a follow-up, not a blocker here:
`CustomerCreditCardTest::recharge_withException` failed once on php72 only
(`JSON Parse Error` instead of the expected `Authentication error…`) and passed on
re-run. It makes a live call and asserts on the returned message; it wants mocking.

## Not in this PR

Deleting `.circleci/` is deliberately left out. Master's **required** status checks
are `Peril` plus the three `ci/circleci: integration-*` contexts, and a required
check that never reports blocks merges **permanently**. So the `.circleci/` removal
has to land together with a branch-protection change swapping those contexts for
these GHA job names — admin-only, and safer as its own step now that these are
green.

#changelog Migrate CI from CircleCI to GitHub Actions
- Internal CI change only; no functional plugin change

Ref: I340 / the boltapp.com migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
