### PR TITLE
test: stop recharge_withException calling the live Bolt API

### DIFF
--- a/Test/Unit/Model/CustomerCreditCardTest.php
+++ b/Test/Unit/Model/CustomerCreditCardTest.php
@@ -17,7 +17,6 @@
 
 namespace Bolt\Boltpay\Test\Unit\Model;
 
-use Bolt\Boltpay\Helper\Config as ConfigHelper;
 use Bolt\Boltpay\Model\CustomerCreditCard;
 use Bolt\Boltpay\Model\CustomerCreditCardFactory;
 use Bolt\Boltpay\Test\Unit\BoltTestCase;
@@ -68,11 +67,6 @@ class CustomerCreditCardTest extends BoltTestCase
     private $order;
 
     /**
-     * @var ConfigHelper
-     */
-    private $configHelper;
-
-    /**
      * Setup for CustomerCreditCardTest Class
      */
     public function setUpInternal()
@@ -81,7 +75,6 @@ class CustomerCreditCardTest extends BoltTestCase
             return;
         }
         $this->objectManager = Bootstrap::getObjectManager();
-        $this->configHelper = $this->objectManager->get(ConfigHelper::class);
         $this->customerCreditCard = $this->objectManager->create(CustomerCreditCard::class);
         $store = $this->objectManager->get(StoreManagerInterface::class);
         $storeId = $store->getStore()->getId();
@@ -125,13 +118,30 @@ class CustomerCreditCardTest extends BoltTestCase
     public function recharge_withException()
     {
         $exceptionMsg = "Authentication error. Authorization required.";
-        // in magento version under 2.3.0 zend framework contains a bug in header response regexp parser in class Zend_Http_Response::extractHeaders
-        // which is throwing the "Invalid header line detected" exception if response has: "HTTP/2 401" header line.
-        if (version_compare($this->configHelper->getStoreVersion(), '2.3.0', '<')) {
-            $exceptionMsg = "Invalid header line detected";
-        }
+
+        $apiHelper = $this->createPartialMock(ApiHelper::class, ['buildRequest', 'sendRequest']);
+        $apiHelper->expects(self::once())->method('buildRequest')->willReturnSelf();
+        $apiHelper->expects(self::once())->method('sendRequest')
+            ->willThrowException(new LocalizedException(__($exceptionMsg)));
+        TestHelper::setProperty($this->customerCreditCard, 'apiHelper', $apiHelper);
+
         $this->expectException(LocalizedException::class);
         $this->expectExceptionMessage($exceptionMsg);
+        $this->customerCreditCard->recharge($this->order);
+    }
+
+    /**
+     * @test
+     */
+    public function recharge_withEmptyResponse()
+    {
+        $apiHelper = $this->createPartialMock(ApiHelper::class, ['buildRequest', 'sendRequest']);
+        $apiHelper->expects(self::once())->method('buildRequest')->willReturnSelf();
+        $apiHelper->expects(self::once())->method('sendRequest')->willReturn(null);
+        TestHelper::setProperty($this->customerCreditCard, 'apiHelper', $apiHelper);
+
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage('Bad payment response from boltpay');
         $this->customerCreditCard->recharge($this->order);
     }
 


### PR DESCRIPTION
## Problem

`CustomerCreditCardTest::recharge_withException` makes a **live HTTP request to
Bolt's API** and asserts on the error message that comes back.

With no valid API key in CI the request 401s, and the assertion depends on that
response body being exactly:

```json
{"errors":[{"message":"Authentication error. Authorization required."}]}
```

Anything else — a WAF page, a proxy error, an HTML body — takes a different
branch in `ApiUtils::getJSONFromResponseBody` and raises
`JSON Parse Error: Syntax error, malformed JSON` instead.

That is exactly what was seen during the GitHub Actions migration: the test
failed on php72 / Magento 2.3.0 while **the same commit passed on php71 and
php74**, then passed on a re-run. Same code, different network — a flake, not a
defect.

It is also testing the wrong unit. Neither message originates in
`CustomerCreditCard::recharge`; both come from `ApiHelper::sendRequest` parsing
a real response.

## Fix

Mock `ApiHelper::sendRequest` to throw the `LocalizedException` directly,
matching what the neighbouring `recharge()` test already does two methods below.

**The assertion is unchanged** — same exception class, same message. It is now
deterministic and makes no outbound request.

The Magento `< 2.3.0` special case goes away with it: it worked around a Zend
header-parser bug that only manifests on a real `HTTP/2 401` response, which can
no longer occur. That removes the last use of `ConfigHelper` in this class, so
the import and property go too.

## Bonus coverage

Adds `recharge_withEmptyResponse`, covering the `Bad payment response from
boltpay` branch in `CustomerCreditCard::recharge` — real logic in the class
under test that had no test at all.

## Verification

The three integration jobs run this test on Magento 2.2.8 / 2.3.0 / 2.4.2. No
local PHP or Docker on hand, so CI is the check — and php72 / 2.3.0, the lane
that flaked, is the one that matters.

#changelog Make CustomerCreditCardTest::recharge_withException deterministic
